### PR TITLE
Fix language selector crash.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -177,7 +177,7 @@ public class LibraryAdapter extends BaseAdapter {
     return convertView;
   }
 
-  private boolean langaugeActive(Book book) {
+  private boolean languageActive(Book book) {
     return Observable.from(languages)
         .takeFirst(language -> language.languageCode.equals(book.getLanguage()))
         .map(language -> language.active).toBlocking().firstOrDefault(false);
@@ -206,7 +206,7 @@ public class LibraryAdapter extends BaseAdapter {
       List<Book> finalBooks;
       if (s.length() == 0) {
         finalBooks = Observable.from(allBooks)
-            .filter(LibraryAdapter.this::langaugeActive)
+            .filter(LibraryAdapter.this::languageActive)
             .filter(book -> !books.contains(book))
             .filter(book -> !DownloadFragment.mDownloads.values().contains(book))
             .filter(book -> !LibraryFragment.downloadingBooks.contains(book))
@@ -230,10 +230,10 @@ public class LibraryAdapter extends BaseAdapter {
     protected void publishResults(CharSequence constraint, FilterResults results) {
       List<Book> filtered = (List<Book>) results.values;
       if (filtered != null) {
+        filteredBooks.clear();
         if (filtered.isEmpty()) {
-          filteredBooks = allBooks;
+          filteredBooks.addAll(allBooks);
         } else {
-          filteredBooks.clear();
           filteredBooks.addAll(filtered);
         }
       }
@@ -245,7 +245,7 @@ public class LibraryAdapter extends BaseAdapter {
     return bookFilter;
   }
 
-  public void updateNetworklanguages() {
+  public void updateNetworkLanguages() {
     new SaveNetworkLanguages().execute(languages);
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -258,12 +258,13 @@ public class ZimManageActivity extends AppCompatActivity {
       Toast.makeText(this, getResources().getString(R.string.wait_for_load), Toast.LENGTH_LONG).show();
       return;
     }
-    LanguageArrayAdapter languageArrayAdapter = new LanguageArrayAdapter(this, 0, mSectionsPagerAdapter.libraryFragment.libraryAdapter.languages);
+    LanguageArrayAdapter languageArrayAdapter = new LanguageArrayAdapter(
+            this, 0, mSectionsPagerAdapter.libraryFragment.libraryAdapter.languages);
     listView.setAdapter(languageArrayAdapter);
     new AlertDialog.Builder(this, dialogStyle())
         .setView(view)
         .setPositiveButton(android.R.string.ok, (dialogInterface, i) -> {
-          mSectionsPagerAdapter.libraryFragment.libraryAdapter.updateNetworklanguages();
+          mSectionsPagerAdapter.libraryFragment.libraryAdapter.updateNetworkLanguages();
           mSectionsPagerAdapter.libraryFragment.libraryAdapter.getFilter().filter("");
         })
         .show();

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -250,10 +250,7 @@ public class ZimManageActivity extends AppCompatActivity {
     int size = 0;
     try {
       size = mSectionsPagerAdapter.libraryFragment.libraryAdapter.languages.size();
-    } catch (NullPointerException e) {
-      Toast.makeText(this, getResources().getString(R.string.wait_for_load), Toast.LENGTH_LONG).show();
-      return;
-    }
+    } catch (NullPointerException e) { }
     if (size == 0) {
       Toast.makeText(this, getResources().getString(R.string.wait_for_load), Toast.LENGTH_LONG).show();
       return;


### PR DESCRIPTION
When going from no filters to any filter the app would crash, because the
filteredBooks list would be set to the immutable allBooks and couldn't be
cleared anymore. Instead do a deep copy of the elements.

Also some minor fixes (typos, style).