### PR TITLE
Remove unused imports

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/database/KiwixDatabaseTest.java
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/database/KiwixDatabaseTest.java
@@ -26,9 +26,6 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kiwix.kiwixmobile.database.BookmarksDao;
-import org.kiwix.kiwixmobile.database.KiwixDatabase;
-
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -38,7 +35,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 
 
 @RunWith(AndroidJUnit4.class)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.java
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.java
@@ -1,11 +1,6 @@
 package org.kiwix.kiwixmobile.testutils;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.InstrumentationRegistry.getTargetContext;
-import static org.kiwix.kiwixmobile.utils.NetworkUtils.parseURL;
-
 import android.Manifest;
-import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.test.InstrumentationRegistry;
@@ -15,9 +10,12 @@ import android.support.test.uiautomator.UiObject;
 import android.support.test.uiautomator.UiObjectNotFoundException;
 import android.support.test.uiautomator.UiSelector;
 import android.support.v4.content.ContextCompat;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
 /**
  * Created by mhutti1 on 07/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/components/TestComponent.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/components/TestComponent.java
@@ -1,13 +1,15 @@
 package org.kiwix.kiwixmobile.di.components;
 
-import dagger.Component;
-import javax.inject.Singleton;
 import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
 import org.kiwix.kiwixmobile.di.modules.TestJNIModule;
 import org.kiwix.kiwixmobile.di.modules.TestNetworkModule;
 import org.kiwix.kiwixmobile.tests.NetworkTest;
-import org.kiwix.kiwixmobile.utils.TestNetworkInterceptor;
 import org.kiwix.kiwixmobile.tests.ZimTest;
+import org.kiwix.kiwixmobile.utils.TestNetworkInterceptor;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
 
 /**
  * Created by mhutti1 on 13/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/modules/TestJNIModule.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/modules/TestJNIModule.java
@@ -1,23 +1,22 @@
 package org.kiwix.kiwixmobile.di.modules;
 
+import org.apache.commons.io.IOUtils;
+import org.kiwix.kiwixlib.JNIKiwix;
+import org.kiwix.kiwixlib.JNIKiwixString;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
-
-import android.content.Context;
-import dagger.Module;
-import dagger.Provides;
-import java.io.IOException;
-import java.io.InputStream;
-import javax.inject.Singleton;
-import org.apache.commons.io.IOUtils;
-import org.kiwix.kiwixlib.JNIKiwix;
-import org.kiwix.kiwixlib.JNIKiwixString;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Created by mhutti1 on 13/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/modules/TestNetworkModule.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/di/modules/TestNetworkModule.java
@@ -1,14 +1,17 @@
 package org.kiwix.kiwixmobile.di.modules;
 
 
-import dagger.Module;
-import dagger.Provides;
-import java.io.IOException;
-import javax.inject.Singleton;
-import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockWebServer;
 import org.kiwix.kiwixmobile.network.KiwixService;
 import org.kiwix.kiwixmobile.utils.TestNetworkInterceptor;
+
+import java.io.IOException;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Created by mhutti1 on 14/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/BasicTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/BasicTest.java
@@ -1,21 +1,6 @@
 package org.kiwix.kiwixmobile.tests;
 
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.Espresso.pressBack;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withParent;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.is;
-import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
-
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.rule.ActivityTestRule;
@@ -25,6 +10,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -34,6 +20,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.utils.SplashActivity;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ContentTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ContentTest.java
@@ -1,6 +1,24 @@
 package org.kiwix.kiwixmobile.tests;
 
 
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.testutils.TestUtils;
+import org.kiwix.kiwixmobile.utils.SplashActivity;
+
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
@@ -11,25 +29,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
-
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.LargeTest;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.kiwix.kiwixmobile.R;
-import org.kiwix.kiwixmobile.testutils.TestUtils;
-import org.kiwix.kiwixmobile.utils.SplashActivity;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
@@ -1,6 +1,27 @@
 package org.kiwix.kiwixmobile.tests;
 
 
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingPolicies;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.utils.KiwixIdlingResource;
+import org.kiwix.kiwixmobile.utils.SplashActivity;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
@@ -12,29 +33,9 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.core.Is.is;
 import static org.kiwix.kiwixmobile.testutils.TestUtils.withContent;
 import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
-
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.IdlingPolicies;
-import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.LargeTest;
-import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.kiwix.kiwixmobile.R;
-import org.kiwix.kiwixmobile.utils.KiwixIdlingResource;
-import org.kiwix.kiwixmobile.utils.SplashActivity;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/NetworkTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/NetworkTest.java
@@ -1,20 +1,5 @@
 package org.kiwix.kiwixmobile.tests;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.longClick;
-import static android.support.test.espresso.action.ViewActions.scrollTo;
-import static android.support.test.espresso.action.ViewActions.swipeLeft;
-import static android.support.test.espresso.action.ViewActions.swipeRight;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withParent;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
-import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
-
 import android.support.test.espresso.Espresso;
 import android.support.test.espresso.IdlingPolicies;
 import android.support.test.espresso.ViewInteraction;
@@ -22,14 +7,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import okhttp3.OkHttpClient;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okio.Buffer;
+
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -48,6 +26,29 @@ import org.kiwix.kiwixmobile.di.components.TestComponent;
 import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
 import org.kiwix.kiwixmobile.testutils.TestUtils;
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.longClick;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
 
 /**
  * Created by mhutti1 on 14/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
@@ -1,36 +1,11 @@
 package org.kiwix.kiwixmobile.tests;
 
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
-import static android.support.test.espresso.Espresso.onData;
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.scrollTo;
-import static android.support.test.espresso.action.ViewActions.swipeLeft;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withParent;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static android.support.test.espresso.web.assertion.WebViewAssertions.webMatches;
-import static android.support.test.espresso.web.sugar.Web.onWebView;
-import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
-import static android.support.test.espresso.web.webdriver.DriverAtoms.getText;
-import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.kiwix.kiwixmobile.utils.NetworkUtils.parseURL;
-
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.test.espresso.ViewInteraction;
-import android.support.test.espresso.action.ViewActions;
 import android.support.test.espresso.contrib.DrawerActions;
-import android.support.test.espresso.matcher.BoundedMatcher;
 import android.support.test.espresso.web.webdriver.Locator;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -39,11 +14,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-import javax.inject.Inject;
-import net.bytebuddy.matcher.StringMatcher;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -55,13 +26,27 @@ import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.ZimContentProvider;
-import org.kiwix.kiwixmobile.di.components.DaggerApplicationComponent;
 import org.kiwix.kiwixmobile.di.components.DaggerTestComponent;
 import org.kiwix.kiwixmobile.di.components.TestComponent;
 import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
-import org.kiwix.kiwixmobile.library.LibraryAdapter;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
-import org.kiwix.kiwixmobile.testutils.TestUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.web.sugar.Web.onWebView;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
+import static org.hamcrest.Matchers.allOf;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/KiwixIdlingResource.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/KiwixIdlingResource.java
@@ -1,8 +1,8 @@
 package org.kiwix.kiwixmobile.utils;
 
 import android.support.test.espresso.IdlingResource;
+
 import org.kiwix.kiwixmobile.utils.TestingUtils.IdleListener;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 
 /**
  * Created by mhutti1 on 19/04/17.

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/TestNetworkInterceptor.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/TestNetworkInterceptor.java
@@ -1,13 +1,16 @@
 package org.kiwix.kiwixmobile.utils;
 
+import org.kiwix.kiwixmobile.KiwixApplication;
+import org.kiwix.kiwixmobile.di.components.TestComponent;
+
 import java.io.IOException;
+
 import javax.inject.Inject;
+
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockWebServer;
-import org.kiwix.kiwixmobile.KiwixApplication;
-import org.kiwix.kiwixmobile.di.components.TestComponent;
 
 /**
  * Created by mhutti1 on 18/04/17.

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixApplication.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixApplication.java
@@ -1,11 +1,8 @@
 package org.kiwix.kiwixmobile;
 
-import android.app.Application;
-
 import android.content.Context;
-import android.support.multidex.MultiDex;
 import android.support.multidex.MultiDexApplication;
-import android.util.Log;
+
 import org.kiwix.kiwixmobile.di.components.ApplicationComponent;
 import org.kiwix.kiwixmobile.di.components.DaggerApplicationComponent;
 import org.kiwix.kiwixmobile.di.modules.ApplicationModule;

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -73,14 +73,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import javax.inject.Inject;
-import okhttp3.OkHttpClient;
+
 import org.json.JSONArray;
 import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.bookmarks_view.BookmarksActivity;
@@ -96,7 +89,6 @@ import org.kiwix.kiwixmobile.utils.LanguageUtils;
 import org.kiwix.kiwixmobile.utils.NetworkUtils;
 import org.kiwix.kiwixmobile.utils.RateAppCounter;
 import org.kiwix.kiwixmobile.utils.StyleUtils;
-import org.kiwix.kiwixmobile.utils.TestingUtils;
 import org.kiwix.kiwixmobile.utils.files.FileReader;
 import org.kiwix.kiwixmobile.utils.files.FileUtils;
 import org.kiwix.kiwixmobile.views.AnimatedProgressBar;
@@ -105,8 +97,18 @@ import org.kiwix.kiwixmobile.views.web.KiwixWebView;
 import org.kiwix.kiwixmobile.views.web.ToolbarScrollingKiwixWebView;
 import org.kiwix.kiwixmobile.views.web.ToolbarStaticKiwixWebView;
 import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
-import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
 import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import javax.inject.Inject;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import okhttp3.OkHttpClient;
 
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 import static org.kiwix.kiwixmobile.TableDrawerAdapter.DocumentSection;

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixWebViewClient.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixWebViewClient.java
@@ -10,8 +10,9 @@ import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import java.util.HashMap;
 import org.kiwix.kiwixmobile.utils.StyleUtils;
+
+import java.util.HashMap;
 
 public class KiwixWebViewClient extends WebViewClient {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/SearchActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/SearchActivity.java
@@ -17,23 +17,21 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.animation.Animation;
-import android.view.animation.AnimationUtils;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import org.kiwix.kiwixmobile.database.KiwixDatabase;
+import org.kiwix.kiwixmobile.database.RecentSearchDao;
+import org.kiwix.kiwixmobile.views.AutoCompleteAdapter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import org.kiwix.kiwixmobile.database.KiwixDatabase;
-import org.kiwix.kiwixmobile.database.RecentSearchDao;
-import org.kiwix.kiwixmobile.utils.DimenUtils;
-import org.kiwix.kiwixmobile.views.AutoCompleteAdapter;
 
-import static android.provider.Settings.System.ALWAYS_FINISH_ACTIVITIES;
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 
 public class SearchActivity extends AppCompatActivity

--- a/app/src/main/java/org/kiwix/kiwixmobile/TabDrawerAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/TabDrawerAdapter.java
@@ -6,10 +6,13 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import org.kiwix.kiwixmobile.views.web.KiwixWebView;
+
+import java.util.List;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import java.util.List;
-import org.kiwix.kiwixmobile.views.web.KiwixWebView;
 
 public class TabDrawerAdapter extends RecyclerView.Adapter<TabDrawerAdapter.ViewHolder> {
   private TabClickListener listener;

--- a/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
@@ -2,7 +2,6 @@ package org.kiwix.kiwixmobile;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.support.v7.widget.RecyclerView;
 import android.util.TypedValue;
@@ -10,10 +9,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import butterknife.BindView;
-import butterknife.ButterKnife;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 
 public class TableDrawerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
@@ -28,6 +28,12 @@ import android.os.ParcelFileDescriptor;
 import android.os.ParcelFileDescriptor.AutoCloseOutputStream;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
+
+import org.kiwix.kiwixlib.JNIKiwix;
+import org.kiwix.kiwixlib.JNIKiwixInt;
+import org.kiwix.kiwixlib.JNIKiwixString;
+import org.kiwix.kiwixmobile.utils.files.FileUtils;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -37,11 +43,8 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.inject.Inject;
-import org.kiwix.kiwixmobile.utils.files.FileUtils;
-import org.kiwix.kiwixlib.JNIKiwix;
-import org.kiwix.kiwixlib.JNIKiwixString;
-import org.kiwix.kiwixlib.JNIKiwixInt;
 
 public class ZimContentProvider extends ContentProvider {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/base/Presenter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/base/Presenter.java
@@ -1,7 +1,5 @@
 package org.kiwix.kiwixmobile.base;
 
-import org.kiwix.kiwixmobile.base.ViewCallback;
-
 /**
  * Created by EladKeyshawn on 05/04/2017.
  */

--- a/app/src/main/java/org/kiwix/kiwixmobile/bookmarks_view/BookmarksActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/bookmarks_view/BookmarksActivity.java
@@ -44,9 +44,9 @@ import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 
-import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.di.components.ApplicationComponent;
 
 import java.util.ArrayList;

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/BookDao.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/BookDao.java
@@ -4,14 +4,9 @@ package org.kiwix.kiwixmobile.database;
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
 
-import org.kiwix.kiwixmobile.database.entity.BookDataSource;
 import org.kiwix.kiwixmobile.database.entity.BookDatabaseEntity;
-import org.kiwix.kiwixmobile.database.entity.Bookmarks;
-import org.kiwix.kiwixmobile.database.entity.RecentSearch;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 import org.kiwix.kiwixmobile.utils.files.FileUtils;
-
 
 import java.io.File;
 import java.util.ArrayList;

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/BookmarksDao.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/BookmarksDao.java
@@ -3,8 +3,10 @@ package org.kiwix.kiwixmobile.database;
 
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
-import java.util.ArrayList;
+
 import org.kiwix.kiwixmobile.database.entity.Bookmarks;
+
+import java.util.ArrayList;
 
 /**
  * Dao class for bookmarks.

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/KiwixDatabase.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/KiwixDatabase.java
@@ -21,22 +21,24 @@ package org.kiwix.kiwixmobile.database;
 
 import android.content.Context;
 import android.util.Log;
+
 import com.yahoo.squidb.data.SquidDatabase;
 import com.yahoo.squidb.data.adapter.SQLiteDatabaseWrapper;
 import com.yahoo.squidb.sql.Table;
+
+import org.kiwix.kiwixmobile.KiwixMobileActivity;
+import org.kiwix.kiwixmobile.ZimContentProvider;
+import org.kiwix.kiwixmobile.database.entity.BookDatabaseEntity;
+import org.kiwix.kiwixmobile.database.entity.Bookmarks;
+import org.kiwix.kiwixmobile.database.entity.LibraryDatabaseEntity;
+import org.kiwix.kiwixmobile.database.entity.NetworkLanguageDatabaseEntity;
+import org.kiwix.kiwixmobile.database.entity.RecentSearch;
+
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.ZimContentProvider;
-import org.kiwix.kiwixmobile.database.entity.BookDatabaseEntity;
-import org.kiwix.kiwixmobile.database.entity.Bookmarks;
-import org.kiwix.kiwixmobile.database.entity.BookmarksSpec;
-import org.kiwix.kiwixmobile.database.entity.LibraryDatabaseEntity;
-import org.kiwix.kiwixmobile.database.entity.NetworkLanguageDatabaseEntity;
-import org.kiwix.kiwixmobile.database.entity.RecentSearch;
 
 public class KiwixDatabase extends SquidDatabase {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/NetworkLanguageDao.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/NetworkLanguageDao.java
@@ -22,15 +22,13 @@ package org.kiwix.kiwixmobile.database;
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 import org.kiwix.kiwixmobile.database.entity.NetworkLanguageDatabaseEntity;
 import org.kiwix.kiwixmobile.library.LibraryAdapter;
-
+import org.kiwix.kiwixmobile.library.LibraryAdapter.Language;
 
 import java.util.ArrayList;
-import org.kiwix.kiwixmobile.library.LibraryAdapter.Language;
+import java.util.Collections;
+import java.util.List;
 
 public class NetworkLanguageDao {
   private KiwixDatabase mDb;

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/RecentSearchDao.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/RecentSearchDao.java
@@ -2,10 +2,12 @@ package org.kiwix.kiwixmobile.database;
 
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.kiwix.kiwixmobile.ZimContentProvider;
 import org.kiwix.kiwixmobile.database.entity.RecentSearch;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Dao class for recent searches.

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/PerActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/PerActivity.java
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.di;
 
 import java.lang.annotation.Retention;
+
 import javax.inject.Scope;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/components/ApplicationComponent.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/components/ApplicationComponent.java
@@ -1,19 +1,19 @@
 package org.kiwix.kiwixmobile.di.components;
 
-import dagger.Component;
+import org.kiwix.kiwixmobile.KiwixMobileActivity;
+import org.kiwix.kiwixmobile.ZimContentProvider;
+import org.kiwix.kiwixmobile.bookmarks_view.BookmarksActivity;
+import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
+import org.kiwix.kiwixmobile.di.modules.JNIModule;
+import org.kiwix.kiwixmobile.di.modules.NetworkModule;
+import org.kiwix.kiwixmobile.downloader.DownloadService;
+import org.kiwix.kiwixmobile.library.LibraryAdapter;
+import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
+import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 
 import javax.inject.Singleton;
 
-import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.ZimContentProvider;
-import org.kiwix.kiwixmobile.di.modules.JNIModule;
-import org.kiwix.kiwixmobile.library.LibraryAdapter;
-import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
-import org.kiwix.kiwixmobile.bookmarks_view.BookmarksActivity;
-import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
-import org.kiwix.kiwixmobile.di.modules.NetworkModule;
-import org.kiwix.kiwixmobile.downloader.DownloadService;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+import dagger.Component;
 
 @Singleton
 @Component(modules = {

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/ApplicationModule.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/ApplicationModule.java
@@ -2,12 +2,14 @@ package org.kiwix.kiwixmobile.di.modules;
 
 import android.app.NotificationManager;
 import android.content.Context;
-import dagger.Module;
-import dagger.Provides;
-import javax.inject.Singleton;
-import org.kiwix.kiwixlib.JNIKiwix;
+
 import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.utils.BookUtils;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
 
 @Module public class ApplicationModule {
   private final KiwixApplication application;

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/JNIModule.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/JNIModule.java
@@ -1,9 +1,11 @@
 package org.kiwix.kiwixmobile.di.modules;
 
+import org.kiwix.kiwixlib.JNIKiwix;
+
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
-import javax.inject.Singleton;
-import org.kiwix.kiwixlib.JNIKiwix;
 
 /**
  * Created by mhutti1 on 14/04/17.

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
@@ -1,16 +1,14 @@
 package org.kiwix.kiwixmobile.di.modules;
 
-import dagger.Module;
-import dagger.Provides;
-import javax.inject.Singleton;
-import okhttp3.OkHttpClient;
 import org.kiwix.kiwixmobile.BuildConfig;
 import org.kiwix.kiwixmobile.network.KiwixService;
 import org.kiwix.kiwixmobile.network.UserAgentInterceptor;
-import retrofit2.Retrofit;
-import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
-import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
-import rx.schedulers.Schedulers;
+
+import javax.inject.Singleton;
+
+import dagger.Module;
+import dagger.Provides;
+import okhttp3.OkHttpClient;
 
 @Module public class NetworkModule {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/ChunkUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/ChunkUtils.java
@@ -1,8 +1,9 @@
 package org.kiwix.kiwixmobile.downloader;
 
+import org.kiwix.kiwixmobile.utils.StorageUtils;
+
 import java.util.ArrayList;
 import java.util.List;
-import org.kiwix.kiwixmobile.utils.StorageUtils;
 
 public class ChunkUtils {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadFragment.java
@@ -4,7 +4,6 @@ package org.kiwix.kiwixmobile.downloader;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
@@ -25,18 +24,18 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
+import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
 import org.kiwix.kiwixmobile.settings.KiwixSettingsActivity;
 import org.kiwix.kiwixmobile.utils.NetworkUtils;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
-import org.kiwix.kiwixmobile.R;
-import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
-import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
 import org.kiwix.kiwixmobile.utils.files.FileUtils;
+import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
+import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
+import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -1,8 +1,5 @@
 package org.kiwix.kiwixmobile.downloader;
 
-import static org.kiwix.kiwixmobile.utils.files.FileUtils.getCurrentSize;
-
-import android.app.AlertDialog;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -15,36 +12,41 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
-import android.util.Log;
 import android.util.Pair;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
 import android.widget.Toast;
-import java.io.File;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
-import javax.inject.Inject;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-import okio.BufferedSource;
+
 import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.utils.NetworkUtils;
-import org.kiwix.kiwixmobile.utils.TestingUtils;
-import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.database.BookDao;
 import org.kiwix.kiwixmobile.database.KiwixDatabase;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
 import org.kiwix.kiwixmobile.network.KiwixService;
+import org.kiwix.kiwixmobile.utils.NetworkUtils;
 import org.kiwix.kiwixmobile.utils.StorageUtils;
+import org.kiwix.kiwixmobile.utils.TestingUtils;
 import org.kiwix.kiwixmobile.utils.files.FileUtils;
+import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
+import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okio.BufferedSource;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
+
+import static org.kiwix.kiwixmobile.utils.files.FileUtils.getCurrentSize;
 
 public class DownloadService extends Service {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -19,10 +19,6 @@
 
 package org.kiwix.kiwixmobile.library;
 
-import static android.support.test.InstrumentationRegistry.getContext;
-
-import static org.kiwix.kiwixmobile.utils.NetworkUtils.parseURL;
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -38,6 +34,16 @@ import android.widget.TextView;
 
 import com.google.common.collect.ImmutableList;
 
+import org.kiwix.kiwixmobile.KiwixApplication;
+import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.database.BookDao;
+import org.kiwix.kiwixmobile.database.KiwixDatabase;
+import org.kiwix.kiwixmobile.database.NetworkLanguageDao;
+import org.kiwix.kiwixmobile.downloader.DownloadFragment;
+import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
+import org.kiwix.kiwixmobile.utils.BookUtils;
+import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,18 +52,10 @@ import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
-import org.kiwix.kiwixmobile.KiwixApplication;
-import org.kiwix.kiwixmobile.utils.BookUtils;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
-import org.kiwix.kiwixmobile.R;
-import org.kiwix.kiwixmobile.database.BookDao;
-import org.kiwix.kiwixmobile.database.KiwixDatabase;
-import org.kiwix.kiwixmobile.database.NetworkLanguageDao;
-import org.kiwix.kiwixmobile.downloader.DownloadFragment;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 
 import rx.Observable;
-import rx.functions.Func2;
+
+import static org.kiwix.kiwixmobile.utils.NetworkUtils.parseURL;
 
 public class LibraryAdapter extends BaseAdapter {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/library/entity/LibraryNetworkEntity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/entity/LibraryNetworkEntity.java
@@ -18,15 +18,13 @@
  */
 package org.kiwix.kiwixmobile.library.entity;
 
-import java.io.File;
-import java.io.Serializable;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
-
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.LinkedList;
 
 @Root(name = "library", strict = false)
 public class LibraryNetworkEntity {

--- a/app/src/main/java/org/kiwix/kiwixmobile/network/UserAgentInterceptor.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/network/UserAgentInterceptor.java
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.network;
 
 import java.io.IOException;
+
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
@@ -40,13 +40,9 @@ import android.webkit.WebView;
 import android.widget.BaseAdapter;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
-import eu.mhutti1.utils.storage.StorageDevice;
-import eu.mhutti1.utils.storage.StorageSelectDialog;
-import java.io.File;
-import java.util.Locale;
+
 import org.kiwix.kiwixmobile.BuildConfig;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.database.KiwixDatabase;
 import org.kiwix.kiwixmobile.database.RecentSearchDao;
@@ -54,6 +50,12 @@ import org.kiwix.kiwixmobile.utils.LanguageUtils;
 import org.kiwix.kiwixmobile.utils.StyleUtils;
 import org.kiwix.kiwixmobile.views.SliderPreference;
 import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryUtils;
+
+import java.io.File;
+import java.util.Locale;
+
+import eu.mhutti1.utils.storage.StorageDevice;
+import eu.mhutti1.utils.storage.StorageSelectDialog;
 
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/DocumentParser.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/DocumentParser.java
@@ -4,11 +4,13 @@ import android.os.Handler;
 import android.os.Looper;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.kiwix.kiwixmobile.TableDrawerAdapter;
 
-import static org.kiwix.kiwixmobile.TableDrawerAdapter.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.kiwix.kiwixmobile.TableDrawerAdapter.DocumentSection;
 
 public class DocumentParser {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixSearchWidget.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixSearchWidget.java
@@ -26,7 +26,6 @@ import android.appwidget.AppWidgetProvider;
 import android.content.Context;
 import android.content.Intent;
 import android.widget.RemoteViews;
-import android.widget.TextView;
 
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/LanguageUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/LanguageUtils.java
@@ -34,6 +34,9 @@ import android.view.InflateException;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
+
+import org.kiwix.kiwixmobile.utils.files.FileUtils;
+
 import java.lang.reflect.Field;
 import java.text.Collator;
 import java.util.ArrayList;
@@ -43,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
-import org.kiwix.kiwixmobile.utils.files.FileUtils;
 
 public class LanguageUtils {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
@@ -5,9 +5,11 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import android.util.Log;
-import java.util.UUID;
+
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
+
+import java.util.UUID;
 
 public class NetworkUtils {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/StorageUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/StorageUtils.java
@@ -4,6 +4,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
 import android.util.Log;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/StyleUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/StyleUtils.java
@@ -24,7 +24,6 @@ import android.os.Build;
 import android.support.annotation.XmlRes;
 import android.text.Html;
 import android.text.Spanned;
-import android.text.SpannedString;
 import android.util.AttributeSet;
 import android.util.Xml;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/TestingUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/TestingUtils.java
@@ -1,6 +1,5 @@
 package org.kiwix.kiwixmobile.utils;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileSearch.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileSearch.java
@@ -19,7 +19,6 @@
 
 package org.kiwix.kiwixmobile.utils.files;
 
-import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
@@ -27,14 +26,17 @@ import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Log;
-import eu.mhutti1.utils.storage.StorageDevice;
-import eu.mhutti1.utils.storage.StorageDeviceUtils;
+
+import org.kiwix.kiwixmobile.ZimContentProvider;
+import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Collection;
 import java.util.Vector;
-import org.kiwix.kiwixmobile.ZimContentProvider;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
+
+import eu.mhutti1.utils.storage.StorageDevice;
+import eu.mhutti1.utils.storage.StorageDeviceUtils;
 
 public class FileSearch {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
@@ -8,14 +8,16 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.util.Log;
+
+import org.kiwix.kiwixmobile.BuildConfig;
+import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.kiwix.kiwixmobile.BuildConfig;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 
 public class FileUtils {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/AnimatedProgressBar.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/AnimatedProgressBar.java
@@ -14,6 +14,7 @@ import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.Transformation;
 import android.widget.LinearLayout;
+
 import org.kiwix.kiwixmobile.R;
 
 public class AnimatedProgressBar extends LinearLayout {

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/AutoCompleteAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/AutoCompleteAdapter.java
@@ -11,14 +11,14 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.TextView;
 
-import javax.inject.Inject;
 import org.kiwix.kiwixlib.JNIKiwix;
+import org.kiwix.kiwixmobile.KiwixMobileActivity;
+import org.kiwix.kiwixmobile.ZimContentProvider;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.ZimContentProvider;
+import javax.inject.Inject;
 
 public class AutoCompleteAdapter extends ArrayAdapter<String> implements Filterable {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/CompatFindActionModeCallback.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/CompatFindActionModeCallback.java
@@ -32,8 +32,10 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
 import android.widget.EditText;
-import java.lang.reflect.Method;
+
 import org.kiwix.kiwixmobile.R;
+
+import java.lang.reflect.Method;
 
 public class CompatFindActionModeCallback
     implements ActionMode.Callback, TextWatcher, View.OnClickListener {

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/SliderPreference.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/SliderPreference.java
@@ -7,6 +7,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
+
 import org.kiwix.kiwixmobile.R;
 
 public class SliderPreference extends DialogPreference {

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/web/KiwixWebView.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/web/KiwixWebView.java
@@ -41,13 +41,13 @@ import org.kiwix.kiwixmobile.KiwixWebChromeClient;
 import org.kiwix.kiwixmobile.KiwixWebViewClient;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.WebViewCallback;
+import org.kiwix.kiwixmobile.utils.LanguageUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.kiwix.kiwixmobile.utils.LanguageUtils;
 
 public class KiwixWebView extends WebView {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -26,18 +26,17 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
-import java.util.ArrayList;
+
+import org.kiwix.kiwixmobile.KiwixMobileActivity;
+import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.downloader.DownloadFragment;
+import org.kiwix.kiwixmobile.downloader.DownloadService;
+import org.kiwix.kiwixmobile.library.LibraryAdapter;
+import org.kiwix.kiwixmobile.library.LibraryAdapter.Language;
+import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
+import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 
 import java.util.List;
-import org.kiwix.kiwixmobile.KiwixMobileActivity;
-import org.kiwix.kiwixmobile.downloader.DownloadService;
-import org.kiwix.kiwixmobile.library.LibraryAdapter.Language;
-import org.kiwix.kiwixmobile.utils.TestingUtils;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
-import org.kiwix.kiwixmobile.R;
-import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment;
-import org.kiwix.kiwixmobile.downloader.DownloadFragment;
-import org.kiwix.kiwixmobile.library.LibraryAdapter;
 
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
@@ -45,11 +45,6 @@ import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 
 import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
@@ -65,7 +60,12 @@ import org.kiwix.kiwixmobile.utils.TestingUtils;
 import org.kiwix.kiwixmobile.utils.files.FileSearch;
 import org.kiwix.kiwixmobile.utils.files.FileUtils;
 import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
-import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 import javax.inject.Inject;
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -1,7 +1,5 @@
 package org.kiwix.kiwixmobile.zim_manager.library_view;
 
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
@@ -13,36 +11,24 @@ import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Button;
-import android.widget.Filter.FilterListener;
 import android.widget.LinearLayout;
 import android.widget.ListView;
-import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import eu.mhutti1.utils.storage.StorageDevice;
-import eu.mhutti1.utils.storage.support.StorageSelectDialog;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
-import javax.inject.Inject;
 
 import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
@@ -57,6 +43,18 @@ import org.kiwix.kiwixmobile.utils.StorageUtils;
 import org.kiwix.kiwixmobile.utils.StyleUtils;
 import org.kiwix.kiwixmobile.utils.TestingUtils;
 import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import eu.mhutti1.utils.storage.StorageDevice;
+import eu.mhutti1.utils.storage.support.StorageSelectDialog;
 
 import static org.kiwix.kiwixmobile.downloader.DownloadService.KIWIX_ROOT;
 import static org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryViewCallback.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryViewCallback.java
@@ -1,11 +1,10 @@
 package org.kiwix.kiwixmobile.zim_manager.library_view;
 
-import java.util.ArrayList;
 import org.kiwix.kiwixmobile.base.ViewCallback;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
+import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 
 import java.util.LinkedList;
-import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 
 /**
  * Created by EladKeyshawn on 06/04/2017.

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
   <style name="AppTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
     <item name="colorPrimary">@color/primary</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
   <style name="AppTheme" parent="AppTheme.Base" />
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/library/entity/MetaLinkNetworkEntityTest.java
+++ b/app/src/test/java/org/kiwix/kiwixmobile/library/entity/MetaLinkNetworkEntityTest.java
@@ -6,7 +6,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Assert;
 import org.junit.Test;
-import org.kiwix.kiwixmobile.library.entity.MetaLinkNetworkEntity;
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
 

--- a/kiwixlib/src/main/java/org/kiwix/kiwixlib/JNIKiwix.java
+++ b/kiwixlib/src/main/java/org/kiwix/kiwixlib/JNIKiwix.java
@@ -19,10 +19,6 @@
 
 package org.kiwix.kiwixlib;
 
-import org.kiwix.kiwixlib.JNIKiwixString;
-import org.kiwix.kiwixlib.JNIKiwixBool;
-import org.kiwix.kiwixlib.JNIKiwixInt;
-
 public class JNIKiwix {
 
   static {


### PR DESCRIPTION
This is an automatic cleanup of Android Studio. Hopefully it will help to remove some of dependencies ProGuard is complaining about.