### PR TITLE
Add localized language and matching item count to language picker.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -48,8 +48,12 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -62,6 +66,7 @@ public class LibraryAdapter extends BaseAdapter {
   private ImmutableList<Book> allBooks;
   private List<Book> filteredBooks = new ArrayList<>();
   private final Context context;
+  public Map<String, Integer> languageCounts = new HashMap<>();
   public List<Language> languages = new ArrayList<>();
   private final NetworkLanguageDao networkLanguageDao;
   private final BookDao bookDao;
@@ -85,7 +90,8 @@ public class LibraryAdapter extends BaseAdapter {
 
   public void setAllBooks(List<Book> books) {
     allBooks = ImmutableList.copyOf(books);
-    getLanguages();
+    updateLanguageCounts();
+    updateLanguages();
   }
 
   @Override
@@ -247,34 +253,44 @@ public class LibraryAdapter extends BaseAdapter {
     new SaveNetworkLanguages().execute(languages);
   }
 
-  private void getLanguages() {
-    ArrayList<String> bookLanguages = new ArrayList<>();
-    if (languages.size() > 0) {
-      return;
-    }
-
-    if (networkLanguageDao.getFilteredLanguages().size() > 0) {
-      languages = networkLanguageDao.getFilteredLanguages();
-      return;
-    }
-
-    String[] languages = Locale.getISOLanguages();
+  private void updateLanguageCounts() {
+    languageCounts.clear();
     for (Book book : allBooks) {
-      if (!bookLanguages.contains(book.getLanguage())) {
-        bookLanguages.add(book.getLanguage());
+      Integer cnt = languageCounts.get(book.getLanguage());
+      if (cnt == null) {
+        languageCounts.put(book.getLanguage(), 1);
+      } else {
+        languageCounts.put(book.getLanguage(), cnt + 1);
       }
     }
+  }
+
+  private void updateLanguages() {
+    // Load previously stored languages and extract which ones were enabled. The new book list might
+    // have new languages, or be missing some old ones so we want to refresh it, but retain user's
+    // selections.
+    Set<String> enabled_languages = new HashSet<>();
+    for (Language language : networkLanguageDao.getFilteredLanguages()) {
+      if (language.active) {
+        enabled_languages.add(language.languageCode);
+      }
+    }
+
+    // Populate languages with all available locales, which appear in the current list of all books.
     this.languages = new ArrayList<>();
-    for (String language : languages) {
-      Locale locale = new Locale(language);
-      if (bookLanguages.contains(locale.getISO3Language())) {
-        if (locale.getISO3Language().equals(context.getResources().getConfiguration().locale.getISO3Language())) {
+    for (String iso_language : Locale.getISOLanguages()) {
+      Locale locale = new Locale(iso_language);
+      if (languageCounts.get(locale.getISO3Language()) != null) {
+        // Enable this language either if it was enabled previously, or if it is the device language.
+        if (enabled_languages.contains(locale.getISO3Language()) ||
+            context.getResources().getConfiguration().locale.getISO3Language().equals(locale.getISO3Language())) {
           this.languages.add(new Language(locale, true));
         } else {
           this.languages.add(new Language(locale, false));
         }
       }
     }
+
     new SaveNetworkLanguages().execute(this.languages);
   }
 
@@ -343,24 +359,25 @@ public class LibraryAdapter extends BaseAdapter {
 
   public static class Language {
     public String language;
+    public String languageLocalized;
     public String languageCode;
     public Boolean active;
 
     Language(Locale locale, Boolean active) {
       this.language = locale.getDisplayLanguage();
-      this.active = active;
+      this.languageLocalized = locale.getDisplayLanguage(locale);
       this.languageCode = locale.getISO3Language();
+      this.active = active;
     }
 
     public Language(String languageCode, Boolean active) {
-      this.language = new Locale(languageCode).getDisplayLanguage();
-      this.active = active;
-      this.languageCode = languageCode;
+      this(new Locale(languageCode), active);
     }
 
     @Override
     public boolean equals(Object obj) {
-      return ((Language) obj).language.equals(language) && ((Language) obj).active == ((Language) obj).active;
+      return ((Language) obj).language.equals(language) &&
+             ((Language) obj).active.equals(active);
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -24,6 +24,7 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -254,8 +255,8 @@ public class ZimManageActivity extends AppCompatActivity {
       Toast.makeText(this, getResources().getString(R.string.wait_for_load), Toast.LENGTH_LONG).show();
       return;
     }
-    LanguageArrayAdapter languageArrayAdapter = new LanguageArrayAdapter(
-            this, 0, mSectionsPagerAdapter.libraryFragment.libraryAdapter.languages);
+    LanguageArrayAdapter languageArrayAdapter =
+            new LanguageArrayAdapter(this, 0, mSectionsPagerAdapter.libraryFragment.libraryAdapter);
     listView.setAdapter(languageArrayAdapter);
     new AlertDialog.Builder(this, dialogStyle())
         .setView(view)
@@ -324,8 +325,9 @@ public class ZimManageActivity extends AppCompatActivity {
 
   private class LanguageArrayAdapter extends ArrayAdapter<LibraryAdapter.Language> {
 
-    public LanguageArrayAdapter(Context context, int textViewResourceId, List<Language> languages) {
-      super(context, textViewResourceId, languages);
+    public LanguageArrayAdapter(Context context, int textViewResourceId, LibraryAdapter library_adapter) {
+      super(context, textViewResourceId, library_adapter.languages);
+      this.library_adapter = library_adapter;
     }
 
     @Override
@@ -335,9 +337,11 @@ public class ZimManageActivity extends AppCompatActivity {
       if (convertView == null) {
         convertView = View.inflate(getContext(), R.layout.language_check_item, null);
         holder = new ViewHolder();
-        holder.row = (LinearLayout) convertView.findViewById(R.id.language_row);
+        holder.row = (ViewGroup) convertView.findViewById(R.id.language_row);
         holder.checkBox = (CheckBox) convertView.findViewById(R.id.language_checkbox);
         holder.language = (TextView) convertView.findViewById(R.id.language_name);
+        holder.languageLocalized = (TextView) convertView.findViewById(R.id.language_name_localized);
+        holder.languageEntriesCount = (TextView) convertView.findViewById(R.id.language_entries_count);
         convertView.setTag(holder);
       } else {
         holder = (ViewHolder) convertView.getTag();
@@ -347,19 +351,25 @@ public class ZimManageActivity extends AppCompatActivity {
       holder.row.setOnClickListener((view) -> holder.checkBox.toggle());
       holder.checkBox.setOnCheckedChangeListener((compoundButton, b) -> getItem(position).active = b);
 
-      holder.language.setText(getItem(position).language);
-      holder.checkBox.setChecked(getItem(position).active);
+      Language language = getItem(position);
+      holder.language.setText(language.language);
+      holder.languageLocalized.setText(language.languageLocalized);
+      holder.languageEntriesCount.setText("(" + library_adapter.languageCounts.get(language.languageCode) + ")");
+      holder.checkBox.setChecked(language.active);
 
       return convertView;
     }
 
+    private LibraryAdapter library_adapter;
     // We are using the ViewHolder pattern in order to optimize the ListView by reusing
     // Views and saving them to this mLibrary class, and not inflating the layout every time
     // we need to create a row.
     private class ViewHolder {
-      LinearLayout row;
+      ViewGroup row;
       CheckBox checkBox;
       TextView language;
+      TextView languageLocalized;
+      TextView languageEntriesCount;
     }
   }
 }

--- a/app/src/main/res/layout/language_check_item.xml
+++ b/app/src/main/res/layout/language_check_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/language_row"
   android:layout_width="match_parent"
@@ -15,13 +15,42 @@
     android:layout_margin="16dp"
     android:focusable="false"
     android:focusableInTouchMode="false"
-    tools:checked="true"/>
+    android:buttonTint="@color/accent"
+    tools:checked="false"/>
+
+  <LinearLayout
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_toRightOf="@id/language_checkbox"
+    android:layout_centerVertical="true"
+    android:orientation="vertical"
+    android:gravity="center_vertical">
+
+    <TextView
+      android:id="@+id/language_name"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textSize="18sp"
+      tools:text="German"/>
+    <TextView
+      android:id="@+id/language_name_localized"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textSize="18sp"
+      android:textColor="@color/grey"
+      tools:text="Deutsch"/>
+
+  </LinearLayout>
 
   <TextView
-    android:id="@+id/language_name"
+    android:id="@+id/language_entries_count"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:layout_alignParentRight="true"
+    android:layout_centerVertical="true"
+    android:layout_margin="16dp"
     android:textSize="18sp"
-    tools:text="German"/>
+    android:textColor="@color/grey"
+    tools:text="47"/>
 
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Shows the name of the language in that language for each choice in the
picker. Also shows number of matching items for that language.

A bit of refactoring, cleaning up the language population logic. Fixes
bug where after the initial language population & persisting no new
languages would be populated (if new item with that lang got downloaded).