### PR TITLE
Force ZIM_FILE_SIZE literal to be a long.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -229,10 +229,10 @@ android {
         buildConfigField "String", "ZIM_FILE_NAME", "\"$filename\""
         if (project.hasProperty('zim_file_size')) {
           def length = Long.parseLong(project.property('zim_file_size'))
-          buildConfigField "long", "ZIM_FILE_SIZE", "$length"
+          buildConfigField "long", "ZIM_FILE_SIZE", "${length}L"
         } else {
           long length = sourceFile.length()
-          buildConfigField "long", "ZIM_FILE_SIZE", "$length"
+          buildConfigField "long", "ZIM_FILE_SIZE", "${length}L"
         }
         if (project.hasProperty('version_code')) {
           def version_code = project.property('version_code')

--- a/templates/Constants.java
+++ b/templates/Constants.java
@@ -5,7 +5,7 @@ public class Constants {
   public static final String CUSTOM_APP_ID = "~package~";
   public static final boolean CUSTOM_APP_HAS_EMBEDDED_ZIM = ~embed_zim~;
   public static final String CUSTOM_APP_ZIM_FILE_NAME = "~zim_name~";
-  public static final long CUSTOM_APP_ZIM_FILE_SIZE = ~zim_size~;
+  public static final long CUSTOM_APP_ZIM_FILE_SIZE = ~zim_size~L;
   public static final String CUSTOM_APP_VERSION_NAME = "~version_name~";
   public static final int CUSTOM_APP_VERSION_CODE = ~version_code~;
   public static final int CUSTOM_APP_CONTENT_VERSION_CODE = ~content_version_code~;


### PR DESCRIPTION
By default, literal numbers are `int`. If the size of a zim doesn't fit in
a `int`, java will complains.

By appending a `L` at the end of the literal number, java will interpret
it as a `long` and will accept it.