### PR TITLE
Don't assume about icu data filename.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
@@ -265,24 +265,27 @@ public class ZimContentProvider extends ContentProvider {
   }
 
   private static String loadICUData(Context context, File workingDir) {
-    String icuFileName = "icudt.dat";
     try {
       File icuDir = new File(workingDir, "icu");
       if (!icuDir.exists()) {
         icuDir.mkdirs();
       }
-      File icuDataFile = new File(icuDir, icuFileName);
-      if (!icuDataFile.exists()) {
-        InputStream in = context.getAssets().open(icuFileName);
-        OutputStream out = new FileOutputStream(icuDataFile);
-        byte[] buf = new byte[1024];
-        int len;
-        while ((len = in.read(buf)) > 0) {
-          out.write(buf, 0, len);
-        }
-        in.close();
-        out.flush();
-        out.close();
+      String[] icuFileNames = context.getAssets().list("icu");
+      for (int i=0; i<icuFileNames.length; i++) {
+          String icuFileName = icuFileNames[i];
+          File icuDataFile = new File(icuDir, icuFileName);
+          if (!icuDataFile.exists()) {
+              InputStream in = context.getAssets().open("icu/"+icuFileName);
+              OutputStream out = new FileOutputStream(icuDataFile);
+              byte[] buf = new byte[1024];
+              int len;
+              while ((len = in.read(buf)) > 0) {
+                  out.write(buf, 0, len);
+              }
+              in.close();
+              out.flush();
+              out.close();
+          }
       }
       return icuDir.getAbsolutePath();
     } catch (Exception e) {


### PR DESCRIPTION
Instead of directly copying "icudt.dat" file, copy all file in "icu"
assets directory.

The icu data filename must include the version of icu lib.
But we don't want android code to be dependent of the icu lib version.
So let's copy all files in the icu directory.

Fixes #201.