### PR TITLE
Fixed a hard to find quirk where the tests failed on devices with a hardware menu key

### DIFF
--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
@@ -20,12 +20,9 @@ import org.kiwix.kiwixmobile.utils.SplashActivity;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
-
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
@@ -105,7 +102,7 @@ public class DownloadTest {
 
     onData(withContent("ray_charles")).inAdapterView(withId(R.id.zimfilelist)).perform(click());
 
-    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    openContextualActionModeOverflowMenu();
 
     onView(withText("Get Content"))
         .perform(click());

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/NetworkTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/NetworkTest.java
@@ -40,7 +40,7 @@ import okio.Buffer;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.action.ViewActions.scrollTo;
@@ -143,7 +143,7 @@ public class NetworkTest {
             isDisplayed()));
     linearLayout2.perform(click());
 
-    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    openContextualActionModeOverflowMenu();
 
     onView(withText(R.string.menu_zim_manager))
         .perform(click());

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
@@ -37,7 +37,7 @@ import javax.inject.Inject;
 
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -84,7 +84,7 @@ public class ZimTest {
 
     mActivityTestRule.launchActivity(intent);
 
-    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    openContextualActionModeOverflowMenu();
 
     onView(withText("Home"))
         .perform(click());
@@ -139,7 +139,7 @@ public class ZimTest {
             isDisplayed()));
     textView4.check(matches(withText("Covers")));
 
-    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    openContextualActionModeOverflowMenu();
 
     onView(withText("Help"))
         .perform(click());

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/StandardActions.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/utils/StandardActions.java
@@ -1,8 +1,7 @@
 package org.kiwix.kiwixmobile.utils;
 
-import static android.support.test.InstrumentationRegistry.getInstrumentation;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
@@ -13,7 +12,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 public class StandardActions {
 
   public static void enterHelp() {
-    openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+    openContextualActionModeOverflowMenu();
 
     onView(withText("Help"))
         .perform(click());


### PR DESCRIPTION
The tests passed on devices that didn't have a hardware menu key but failed on those that did. 

Espresso contains two similar calls to launch the menu. Either are OK on devices that don't have a menu key (the vast majority of devices) so this bug was latent until I tested on a wider mix of devices.

See
https://developer.android.com/training/testing/espresso/recipes.html#matching-view-inside-action-bar
and keep reading until you reach the example for "contextual action
bar".

See #213 for the
historical context where this problem was initially exposed. It took
working with Isaac in person for us to discover the cause.