### PR TITLE
Added two build variants to help us control the scope of our testing of network operations.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,12 +162,24 @@ android {
   }
 
   buildTypes {
+
     // Main build type for debugging
     debug {
+      buildConfigField "String", "KIWIX_DOWNLOAD_URL", "\"http://download.kiwix.org/\""
       // True breaks local variables being shown in breakpoints
       testCoverageEnabled false
       // Needed for instrumentation tests on Pre 5.0
       multiDexKeepProguard file('multidex-instrumentation-config.pro')
+    }
+
+    mock_network {
+      initWith(buildTypes.debug)
+      // TODO add DI for the mock network
+    }
+
+    local_download_server {
+      initWith(buildTypes.debug)
+      buildConfigField "String", "KIWIX_DOWNLOAD_URL", "\"http://192.168.1.55/\""
     }
 
     // Used to assess code coverage
@@ -178,8 +190,9 @@ android {
 
     // Release Type
     release {
-
+      buildConfigField "String", "KIWIX_DOWNLOAD_URL", "\"http://download.kiwix.org/\""
     }
+
   }
 
   productFlavors {

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
@@ -15,7 +15,7 @@ import okhttp3.OkHttpClient;
 
 @Module public class NetworkModule {
 
-  public static String KIWIX_DOWNLOAD_URL = "http://download.kiwix.org/";
+  public static String KIWIX_DOWNLOAD_URL = BuildConfig.KIWIX_DOWNLOAD_URL; //"http://download.kiwix.org/";
   private final static String useragent = "kiwix-android-version:" + BuildConfig.VERSION_CODE;
 
   @Provides @Singleton OkHttpClient provideOkHttpClient() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.zim_manager.library_view;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.kiwix.kiwixmobile.base.BasePresenter;
 import org.kiwix.kiwixmobile.database.BookDao;
@@ -33,6 +34,7 @@ public class LibraryPresenter extends BasePresenter<LibraryViewCallback> {
         .subscribe(library -> {
           getMvpView().showBooks(library.getBooks());
         }, error -> {
+          Log.w("kiwixLibrary", error.getLocalizedMessage());
           getMvpView().displayNoNetworkConnection();
         });
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
@@ -34,7 +34,8 @@ public class LibraryPresenter extends BasePresenter<LibraryViewCallback> {
         .subscribe(library -> {
           getMvpView().showBooks(library.getBooks());
         }, error -> {
-          Log.w("kiwixLibrary", error.getLocalizedMessage());
+          String msg = error.getLocalizedMessage();
+          Log.w("kiwixLibrary", "Error:" + (msg != null ? msg : "(null)"));
           getMvpView().displayNoNetworkConnection();
         });
   }


### PR DESCRIPTION
This is the initial skeleton that proves the approach can work. Future work will enable us to control whether to fully mock network operations, have a local download server, or use the public Kiwix download server.