### PR TITLE
Now using @SdkSuppress

### DIFF
--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
@@ -1,6 +1,5 @@
 package org.kiwix.kiwixmobile.tests;
 
-
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -8,9 +7,10 @@ import android.os.Build;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.espresso.web.webdriver.Locator;
+import android.support.test.filters.LargeTest;
+import android.support.test.filters.SdkSuppress;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.LargeTest;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,7 +48,6 @@ import static android.support.test.espresso.web.sugar.Web.onWebView;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
 import static org.hamcrest.Matchers.allOf;
-import static org.junit.Assert.assertTrue;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -72,18 +71,9 @@ public class ZimTest {
     new ZimContentProvider().setupDagger();
   }
 
-
   @Test
+  @SdkSuppress(minSdkVersion = Build.VERSION_CODES.KITKAT)
   public void zimTest() {
-    // 20170823 JulianHarty I'd prefer to have the test runner select the tests to run, rather
-    // than 'pass' them if they can't run on various devices. The embedded WebView changed in
-    // KitKat (Android 4.4) and this test fails on older versions of Android. For now, we return
-    // a 'pass' on older devices. I hope we'll find a better approach.
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-      assertTrue("Skipping this test as the Android version is too low.", true);
-      return;
-    }
-
     Intent intent = new Intent();
     File file = new File(context.getFilesDir(), "test.zim");
     try {


### PR DESCRIPTION
`@SdkSuppress` enables us to cleanly control whether to run a test or not. It's simple to use and works well.