### PR TITLE
The main change is to add support for Spoon to take screenshots.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'checkstyle'
 apply plugin: 'testdroid'
-
+apply plugin: 'spoon'
 
 repositories {
   mavenCentral()
@@ -100,6 +100,7 @@ dependencies {
     exclude group: 'stax', module: 'stax'
   }
   androidTestCompile 'com.squareup.okhttp3:mockwebserver:3.6.0'
+  androidTestCompile 'com.squareup.spoon:spoon-client:1.7.1'
 
   // Butterknife
   compile 'com.jakewharton:butterknife:8.0.1'

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
@@ -11,6 +11,8 @@ import android.support.test.rule.GrantPermissionRule;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.util.Log;
 
+import com.squareup.spoon.Spoon;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -19,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource;
-import org.kiwix.kiwixmobile.utils.SplashActivity;
+import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
 
 import java.util.concurrent.TimeUnit;
 
@@ -28,22 +30,20 @@ import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.longClick;
-import static android.support.test.espresso.action.ViewActions.scrollTo;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.kiwix.kiwixmobile.testutils.TestUtils.withContent;
-import static org.kiwix.kiwixmobile.utils.StandardActions.enterHelp;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class DownloadTest {
 
   @Rule
-  public ActivityTestRule<SplashActivity> mActivityTestRule = new ActivityTestRule<>(
-      SplashActivity.class);
+  public ActivityTestRule<ZimManageActivity> mActivityTestRule = new ActivityTestRule<>(
+      ZimManageActivity.class);
   @Rule
   public GrantPermissionRule readPermissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
   @Rule
@@ -63,11 +63,6 @@ public class DownloadTest {
 
   @Test
   public void downloadTest() {
-    enterHelp();
-    ViewInteraction appCompatButton = onView(
-        allOf(withId(R.id.get_content_card), withText("Get Content")));
-    appCompatButton.perform(scrollTo(), click());
-
     ViewInteraction appCompatTextView = onView(
         allOf(withText("Device"), isDisplayed()));
     appCompatTextView.perform(click());
@@ -90,11 +85,13 @@ public class DownloadTest {
       Log.d("kiwixDownloadTest", "Failed to click Network Permission Button", e);
     }
 
+    Spoon.screenshot(mActivityTestRule.getActivity(), "Before-checking-for-ZimManager-Main-Activity");
     ViewInteraction viewPager2 = onView(
         allOf(withId(R.id.container),
             withParent(allOf(withId(R.id.zim_manager_main_activity),
                 withParent(withId(android.R.id.content)))),
             isDisplayed()));
+    Spoon.screenshot(mActivityTestRule.getActivity(), "After-the-check-completed");
 
     onData(withContent("ray_charles")).inAdapterView(withId(R.id.library_list)).perform(click());
 
@@ -110,15 +107,17 @@ public class DownloadTest {
     onView(withId(R.id.menu_rescan_fs))
         .perform(click());
 
+/*
+Commented out the following as it uses another Activity.
+TODO Once we find a good way to run cross-activity re-implement
+this functionality in the tests.
+
     onData(withContent("ray_charles")).inAdapterView(withId(R.id.zimfilelist)).perform(click());
-
     openContextualActionModeOverflowMenu();
-
-    onView(withText("Get Content"))
-        .perform(click());
+    onView(withText("Get Content")).perform(click());
+*/
 
     onData(withContent("ray_charles")).inAdapterView(withId(R.id.zimfilelist)).perform(longClick());
-
     onView(withId(android.R.id.button1)).perform(click());
   }
 

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/DownloadTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.openContextualActionModeOverflowMenu;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.longClick;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.espresso.contrib.DrawerActions;
 import android.support.test.espresso.web.webdriver.Locator;
@@ -48,6 +49,7 @@ import static android.support.test.espresso.web.sugar.Web.onWebView;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
 import static org.hamcrest.Matchers.allOf;
+import static org.kiwix.kiwixmobile.utils.MenuUtilities.withMenuIdOrText;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -85,10 +87,14 @@ public class ZimTest {
 
     mActivityTestRule.launchActivity(intent);
 
-    openContextualActionModeOverflowMenu();
+    try {
+      onView(withId(R.id.menu_home)).perform(click());
+    } catch (NoMatchingViewException e) {
+      openContextualActionModeOverflowMenu();
+      onView(withText("Home")).perform(click());
+    }
 
-    onView(withText("Home"))
-        .perform(click());
+    onView(withMenuIdOrText(R.id.menu_home, R.string.menu_home)).perform(click());
 
     onWebView().withElement(findElement(Locator.LINK_TEXT, "A Fool for You"));
 

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/ZimTest.java
@@ -49,7 +49,6 @@ import static android.support.test.espresso.web.sugar.Web.onWebView;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
 import static android.support.test.espresso.web.webdriver.DriverAtoms.webClick;
 import static org.hamcrest.Matchers.allOf;
-import static org.kiwix.kiwixmobile.utils.MenuUtilities.withMenuIdOrText;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -93,9 +92,7 @@ public class ZimTest {
       openContextualActionModeOverflowMenu();
       onView(withText("Home")).perform(click());
     }
-
-    onView(withMenuIdOrText(R.id.menu_home, R.string.menu_home)).perform(click());
-
+    
     onWebView().withElement(findElement(Locator.LINK_TEXT, "A Fool for You"));
 
     onView(withId(R.id.drawer_layout)).perform(DrawerActions.open(Gravity.RIGHT));

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,9 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+      classpath 'com.android.tools.build:gradle:2.3.3'
+      classpath 'com.squareup.spoon:spoon-runner:1.7.1'
+      classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files


### PR DESCRIPTION
Once we are happy with using Spoon we can add code that automatically
takes a screenshot when tests fail. This may help us debug some of the
problems we encounter running the tests on various devices. Using Spoon
exposed a limitation/key behaviour of ActivityTestRule that references
the intended Activity under test. To account for this behaviour I
restructured DownloadTest so it simply tests the download, rather than
reading the contents of the file.

I also discovered that the tests would fail on wide-screens as the Home
menu option moves from the overflow menu to the main menu. I've modified
one test to cope. Again, once we're happy with this approach (which
involves a little extra code) we can revise all the tests so they can
run equally competently on various screen sizes.