### PR TITLE
Support absolute path when specifying zim_file in info.json for custom app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,7 +242,10 @@ android {
           jsonFile = file(directory + '/info.json')
         }
         def parsedJson = new JsonSlurper().parseText(jsonFile.text)
-        def sourceFile = file(directory + "/" + parsedJson.zim_file)
+        def sourceFile = file(parsedJson.zim_file)
+        if (!sourceFile.exists()) {
+          sourceFile = file(directory + "/" + parsedJson.zim_file)
+        }
         if (parsedJson.embed_zim) {
          // Place content in each lib directory for embeded zims
           for (String archName : archs) {


### PR DESCRIPTION
Test if the zim_file path is existing. If yes, it is used as it is.

If not, we assume it is a local path relative to the custom directory
(as before).

This is needed to be able to custom app with embedded zims.