### PR TITLE
Cleaning up gradle dependencies and versions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,14 +46,13 @@ dependencies {
   compile 'eu.mhutti1.utils.storage:android-storage-devices:0.6.2'
 
   // Android Support
-  compile 'com.android.support:appcompat-v7:25.3.1'
-  compile 'com.android.support:support-v13:25.3.1'
-  compile 'com.android.support:support-v4:25.3.1'
-  compile 'com.android.support:design:25.3.1'
-  compile 'com.android.support:cardview-v7:25.3.1'
-
+  compile "com.android.support:appcompat-v7:$supportLibraryVersion"
+  compile "com.android.support:support-v13:$supportLibraryVersion"
+  compile "com.android.support:support-v4:$supportLibraryVersion"
+  compile "com.android.support:design:$supportLibraryVersion"
+  compile "com.android.support:cardview-v7:$supportLibraryVersion"
   compile 'com.android.support:multidex:1.0.1'
-  compile 'com.android.support.test:runner:1.0.0'
+
 
   androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
 
@@ -70,7 +69,7 @@ dependencies {
     exclude group: 'com.android.support', module: 'recyclerview-v7'
   }
 
-  androidTestCompile 'com.android.support:support-annotations:25.3.1'
+  androidTestCompile "com.android.support:support-annotations:$supportLibraryVersion"
   androidTestCompile 'com.android.support.test:runner:1.0.0'
   androidTestCompile 'com.android.support.test:rules:1.0.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ buildscript {
   }
 }
 
+ext {
+    supportLibraryVersion = '25.4.0'
+}
 
 allprojects {
     repositories {


### PR DESCRIPTION
I was irked by having a compile dependency on a testing library. 

Addressing the cause took several hours, it seemed to be there to address other side-effects. In the end I discovered we had incompatible library versions which weren't reconciled by Gradle unless the extraneous dependency was there.

The error was described in https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Resolving-conflicts-between-main-and-test-APK

The resolution was to align the version numbers for various Android support libraries to a common value: 25.4.0 for now although there are newer versions so we might want to migrate to the current releases soon. I applied the concepts others use, which is to specify the version once
and use it throughout, see https://segunfamisa.com/posts/android-gradle-extra-properties for a concise example.

For info on the latest support and testing libraries see
https://developer.android.com/topic/libraries/support-library/revisions.html
https://developer.android.com/topic/libraries/testing-support-library/release-notes.html

We might also want to update our builds to the latest release of Espresso.