### PR TITLE
Added limited (basic) Http logging to help us diagnose network issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
   }
 
   androidTestCompile 'com.android.support.test.espresso:espresso-web:3.0.0'
+  androidTestCompile 'com.android.support.test.espresso:espresso-intents:3.0.0'
   androidTestCompile 'com.android.support.test.espresso:espresso-idling-resource:3.0.0'
   androidTestCompile 'com.android.support.test.espresso:espresso-contrib:3.0.0', {
     exclude group: 'com.android.support', module: 'support-v4'
@@ -91,6 +92,7 @@ dependencies {
 
   // Square
   compile 'com.squareup.okhttp3:okhttp:3.6.0'
+  compile 'com.squareup.okhttp3:logging-interceptor:3.6.0'
   compile 'com.squareup.retrofit2:retrofit:2.1.0'
   compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
   compile('com.squareup.retrofit2:converter-simplexml:2.1.0') {

--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/KiwixMobileActivityTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/KiwixMobileActivityTest.java
@@ -1,0 +1,8 @@
+package org.kiwix.kiwixmobile.tests;
+
+/**
+ * Created by julianharty on 22/09/2017.
+ */
+
+public class KiwixMobileActivityTest {
+}

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/NetworkModule.java
@@ -12,6 +12,7 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
 
 @Module public class NetworkModule {
 
@@ -19,7 +20,11 @@ import okhttp3.OkHttpClient;
   private final static String useragent = "kiwix-android-version:" + BuildConfig.VERSION_CODE;
 
   @Provides @Singleton OkHttpClient provideOkHttpClient() {
+    HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+    logging.setLevel(HttpLoggingInterceptor.Level.BASIC);
+
     return new OkHttpClient().newBuilder().followRedirects(true).followSslRedirects(true)
+        .addNetworkInterceptor(logging)
         .addNetworkInterceptor(new UserAgentInterceptor(useragent)).build();
   }
 


### PR DESCRIPTION
Added limited (basic) Http request and response logging to augment the current logging used in the DownloadService. Hopefully the extra log messages will help us debug problems when tests fail, particularly remotely e.g. on BitBar's TestDroid service.

I've used the packaged Logging Interceptor https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor configured as a network level interceptor https://github.com/square/okhttp/wiki/Interceptors 

The logs are local to the device and don't contain any sensitive additional information. The extra information helps diagnose network issues when they occur during testing.

PS: I noticed that the logs don't necessarily report the end of the zim file download. We can infer this from the following log message

`I/kiwixdownloadservice(23748): Download completed, renaming file ([/storage/emulated/0/Kiwix/wikipedia_en_bollywood_nopic_2017-02.zim.part] -> .zim)`

I'll explore possible ways we can improve the logging to capture timing of the ZIM file download.