### PR TITLE
Replaced hardcoded URL with hostname to make tests more portable.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,7 +186,7 @@ android {
 
     local_download_server {
       initWith(buildTypes.debug)
-      buildConfigField "String", "KIWIX_DOWNLOAD_URL", "\"http://192.168.1.196/\""
+      buildConfigField "String", "KIWIX_DOWNLOAD_URL", "\"http://kiwix-download-server/\""
       matchingFallbacks = ['debug', 'release']
     }
 


### PR DESCRIPTION
Tested locally using a Raspberry Pi with the new hostname `kiwix-download-server`