### PR TITLE
'Get content' menu entry should be masked in custom apps #341

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -1584,6 +1584,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     StyleMenuButtons(menu);
     if (BuildConfig.IS_CUSTOM_APP) {
       menu.findItem(R.id.menu_help).setVisible(false);
+      menu.findItem(R.id.menu_openfile).setVisible(false);
     }
 
     if (requestInitAllMenuItems) {


### PR DESCRIPTION
It looks like this has been forgotten at the time the whole stuff as been migrated (to gradle if I correctly remember).