### PR TITLE
Show "no items available" if returned library XML is empty

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -141,7 +141,7 @@ public class LibraryFragment extends Fragment
 
     NetworkInfo network = conMan.getActiveNetworkInfo();
     if (network == null || !network.isConnected()) {
-      noNetworkConnection();
+      displayNoNetworkConnection();
     }
 
     networkBroadcastReceiver = new NetworkBroadcastReceiver();
@@ -160,6 +160,11 @@ public class LibraryFragment extends Fragment
 
   @Override
   public void showBooks(LinkedList<Book> books) {
+    if (books == null) {
+      displayNoItemsAvailable();
+      return;
+    }
+
     Log.i("kiwix-showBooks", "Contains:" + books.size());
     libraryAdapter.setAllBooks(books);
     if (faActivity.searchView != null) {
@@ -180,11 +185,25 @@ public class LibraryFragment extends Fragment
       return;
     }
 
-    networkText.setText(R.string.no_network_msg);
+    networkText.setText(R.string.no_network_connection);
     networkText.setVisibility(View.VISIBLE);
     permissionButton.setVisibility(View.GONE);
     swipeRefreshLayout.setRefreshing(false);
     swipeRefreshLayout.setEnabled(false);
+    TestingUtils.unbindResource(LibraryFragment.class);
+  }
+
+  @Override
+  public void displayNoItemsAvailable() {
+    if (books.size() != 0) {
+      Toast.makeText(super.getActivity(), R.string.no_items_available, Toast.LENGTH_LONG).show();
+      return;
+    }
+
+    networkText.setText(R.string.no_items_available);
+    networkText.setVisibility(View.VISIBLE);
+    permissionButton.setVisibility(View.GONE);
+    swipeRefreshLayout.setRefreshing(false);
     TestingUtils.unbindResource(LibraryFragment.class);
   }
 
@@ -206,10 +225,6 @@ public class LibraryFragment extends Fragment
     permissionButton.setVisibility(View.GONE);
     swipeRefreshLayout.setRefreshing(false);
     TestingUtils.unbindResource(LibraryFragment.class);
-  }
-
-  public void noNetworkConnection() {
-    displayNoNetworkConnection();
   }
 
   public void refreshFragment() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryViewCallback.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryViewCallback.java
@@ -16,6 +16,8 @@ public interface LibraryViewCallback extends ViewCallback {
 
   void displayNoNetworkConnection();
 
+  void displayNoItemsAvailable();
+
   void displayScanningContent();
 
   void stopScanningContent();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
   <string name="zim_novid">No Videos</string>
   <string name="open_partial_zim">This file could be incomplete. Do you wish to attempt to open it?</string>
   <string name="no_network_connection">No network connection</string>
+  <string name="no_items_available">No items available to download</string>
   <string name="get_library_over_network">Use network to download content list. (Approximately 6MB)</string>
   <string name="proceed">Proceed</string>
   <string name="wait_for_load">Content Still Loading</string>
@@ -157,7 +158,6 @@
   <string name="internal_storage">Internal</string>
   <string name="external_storage">External</string>
   <string name="zim_already_downloading">Zim is already downloading</string>
-  <string name="no_network_msg">No network connection</string>
   <string name="yes">Yes</string>
   <string name="no">No</string>
   <string name="confirm_stop_download_title">Stop download?</string>


### PR DESCRIPTION
Tested locally using a web server to return this empty XML file:
```
<?xml version="1.0" encoding="UTF-8"?>
<library>
</library>
```

![screenshot_1516477915](https://user-images.githubusercontent.com/28547847/35187423-cd025d9a-fe23-11e7-83f7-ca95b7afc533.png)

Signed-off-by: David Sn <divad.nnamtdeis@gmail.com>