### PR TITLE
chore: Improve the README of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,43 @@
+# Kiwix-Android
+
+[![Build Status](https://travis-ci.org/kiwix/kiwix-android.svg?branch=master)](https://travis-ci.org/kiwix/kiwix-android)
+
 Kiwix is an offline reader for Web content. One of its main purposes is to make Wikipedia available offline. This is done by reading the content of a file in the ZIM format, a high compressed open format with additional meta-data.
+
+## Build Instructions
 
 Production releases of the app should be built with our companion build repository [kiwix-build](https://github.com/kiwix/kiwix-build).
 
-To build this repository alone for development purposes you can simply import the project into Android Studio and the hard work will be done for you. If you prefer to build without Android Studio you must first set up the Android SDK and then run the command:
-```./gradlew build ``` from the root directory of the project.
+To build this repository alone for development purposes you can simply import the project into Android Studio and the hard work will be done for you. If you prefer to build without Android Studio you must first set up the Android SDK and then run the command: ```./gradlew build ``` from the root directory of the project.
 
-<b>We utilize different build variants (flavours) to build various different versions of our app. Ensure your build variant is kiwixDebug to build the standard app.</b>
+We utilize different build variants (flavours) to build various different versions of our app. Ensure your build variant is **kiwixDebug** to build the standard app.
 
-Before contributing be sure to check out https://github.com/kiwix/kiwix-android/blob/master/CONTRIBUTING.md.
+## Contributing
+
+Before contributing be sure to check out the [CONTRIBUTION](https://github.com/kiwix/kiwix-android/blob/master/CONTRIBUTING.md) guidelines.
 
 We currently have a series of automated Unit and Integration tests. These can be run locally and are also run when submitting a pull request.
 
+## Code Style
+For contributions please read the [CODESTYLE](docs/codestyle.md) carefully. Pull requests that do not match the style will be rejected.
+
+## Commit Style
+For writing commit messages please read the [COMMITSTYLE](docs/commitstyle.md) carefully. Kindly adhere to the guidelines. Pull requests not matching the style will be rejected.  
+
+## Communication
+
+Please use IRC to discuss questions regarding the project: #kiwix on irc.freenode.net
+
+You can use IRC web interface on [http://chat.kiwix.org/](http://chat.kiwix.org/).
+
+Our other sources of communications include
+
+- Email: kiwix-developer@lists.sourceforge.net or contact@kiwix.org
+- Jabber: kelson@kiwix.org
+
+For more information, please refer to [http://wiki.kiwix.org/wiki/Communication](http://wiki.kiwix.org/wiki/Communication).
 
 
-*********************************************************************
-*************************** CONTACT *********************************
-*********************************************************************
-
-Email: kiwix-developer@lists.sourceforge.net or contact@kiwix.org
-Jabber: kelson@kiwix.org
-IRC: #kiwix on irc.freenode.net
-
-You can use IRC web interface on http://chat.kiwix.org/
-
-More... http://wiki.kiwix.org/wiki/Communication
-
-*********************************************************************
-********************** LEGAL & DISCLAIMER ***************************
-*********************************************************************
+## LEGAL & DISCLAIMER
 
 Read '../COPYING' file

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ To build this repository alone for development purposes you can simply import th
 
 We utilize different build variants (flavours) to build various different versions of our app. Ensure your build variant is **kiwixDebug** to build the standard app.
 
+## Libraries Used
+
+- [Dagger](https://github.com/google/dagger)
+- [Guava](https://github.com/google/guava)
+- [SquiDb](https://github.com/yahoo/squidb)
+- [Retrofit](http://square.github.io/retrofit/)
+- [Butterknife](http://jakewharton.github.io/butterknife/)
+- [RxJava1](https://github.com/ReactiveX/RxJava)
+- [Mockito](https://github.com/mockito/mockito)
+
 ## Contributing
 
 Before contributing be sure to check out the [CONTRIBUTION](https://github.com/kiwix/kiwix-android/blob/master/CONTRIBUTING.md) guidelines.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ We utilize different build variants (flavours) to build various different versio
 - [Dagger](https://github.com/google/dagger)
 - [Guava](https://github.com/google/guava)
 - [SquiDb](https://github.com/yahoo/squidb)
+- [Apache](https://github.com/apache/commons-io)
 - [Retrofit](http://square.github.io/retrofit/)
+- [OkHttp](https://github.com/square/okhttp)
 - [Butterknife](http://jakewharton.github.io/butterknife/)
-- [RxJava1](https://github.com/ReactiveX/RxJava)
+- [RxJava](https://github.com/ReactiveX/RxJava)
 - [Mockito](https://github.com/mockito/mockito)
+
 
 ## Contributing
 
@@ -50,4 +53,4 @@ For more information, please refer to [http://wiki.kiwix.org/wiki/Communication]
 
 ## LEGAL & DISCLAIMER
 
-Read '../COPYING' file
+Please refer to [COPYING](COPYING).

--- a/docs/codestyle.md
+++ b/docs/codestyle.md
@@ -1,0 +1,28 @@
+# Code Style Guidelines for Kiwix-Android
+
+Our code style guidelines is based on the [Android Code Style Guidelines for Contributors](https://source.android.com/source/code-style.html).
+
+Do take some time to read it.
+
+Only a few extra rules:
+
+- Line length is 120 characters
+- FIXME must not be committed in the repository use TODO instead. FIXME can be used in your own local repository only.
+
+You can run a checkstyle with most rules via a gradle command:
+
+```
+$ ./gradlew checkstyle
+```
+
+It generates a HTML report in `build/reports/checkstyle/checkstyle.html`.
+
+Try to remove as much warnings as possible, It's not completely possible to remove all the warnings, but over a period of time, we should try to make it as complete as possible.
+
+Some **DONT's**
+
+- Don't use Hungarian Notation like `mContext` `mCount` etc
+- Don't use underscores in variable names
+- All constants should be CAPS. e.g `MINIMUM_TIMEOUT_ERROR_EXTERNAL`
+- Always use `Locale.ENGLISH` when using `String.format()` unless the format itself is locale dependent e.g. `String query = String.format(Locale.ENGLISH,...`
+- Never concat `null` with `""` (Empty String). It will become `"null"` e.g. `String.equals("" + null, "null") == TRUE`

--- a/docs/codestyle.md
+++ b/docs/codestyle.md
@@ -1,6 +1,6 @@
 # Code Style Guidelines for Kiwix-Android
 
-Our code style guidelines is based on the [Android Code Style Guidelines for Contributors](https://source.android.com/source/code-style.html).
+Our code style guidelines is based on the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 
 Do take some time to read it.
 

--- a/docs/commitstyle.md
+++ b/docs/commitstyle.md
@@ -1,0 +1,47 @@
+# Commit Style Guidelines for Kiwix-Android
+
+### Message Structure
+Commit messages consist of three distinct parts, separated by a blank line: the title, an optional body/content, and an optional footer/metadata. The layout looks like this:
+
+type: subject
+
+body
+
+***
+
+### Title
+The title consists of the subject and type of the commit message.
+
+### Type
+The type is contained within the title and can be one of the following types:
+
+* **feat:** a new feature
+* **fix:** a bug fix
+* **docs:** changes to documentation
+* **style:** formatting, missing semi-colons, etc; no code change
+* **refactor:** refactoring production code
+* **test:** adding tests, refactoring test; no production code change
+* **chore:** updating build tasks, package manager configs, etc; no production code change
+
+### Subject
+The subject is a single short line summarising the change. It should be no greater than 50 characters, should begin with a capital letter and do not end with a period.
+
+Use an imperative tone to describe what a commit does, rather than what it did. For example, use fix; not fixed or fixes or fixing.
+
+For example:
+- fix: Typo in Commit Style guidelines
+- feat: Update UI of SearchActivity
+- fix: Remove deprecated methods
+- refactor: Implement SearchActivity using MVP pattern
+instead of writing the following:
+- Fixed bug with Y
+- Changing behaviour of X
+
+### Body
+The body includes the kind of information commit message (if any) should contain.
+
+Not every commit requires both a subject and a body. Sometimes a single line is fine, especially when the change is self-explanatory and no further context is necessary, therefore it is optional. The body is used to explain the what and why of a commit, not the how.
+
+When writing a body, the blank line between the title and the body is required and we should try to limit the length of each line to no more than 72 characters.
+
+***

--- a/docs/commitstyle.md
+++ b/docs/commitstyle.md
@@ -15,13 +15,14 @@ The title consists of the subject and type of the commit message.
 ### Type
 The type is contained within the title and can be one of the following types:
 
-* **feat:** a new feature
-* **fix:** a bug fix
-* **docs:** changes to documentation
-* **style:** formatting, missing semi-colons, etc; no code change
-* **refactor:** refactoring production code
-* **test:** adding tests, refactoring test; no production code change
-* **chore:** updating build tasks, package manager configs, etc; no production code change
+* **Implement:** Implemented a new feature
+* **Fix:** a bug fix
+* **Docs:** changes to documentation
+* **Remove:** removed redundant code
+* **Style:** formatting, missing semi-colons, etc; no code change
+* **Refactor:** refactoring production code
+* **Test:** adding tests, refactoring test; no production code change
+* **Chore:** updating build tasks, package manager configs, etc; no production code change
 
 ### Subject
 The subject is a single short line summarising the change. It should be no greater than 50 characters, should begin with a capital letter and do not end with a period.
@@ -29,10 +30,9 @@ The subject is a single short line summarising the change. It should be no great
 Use an imperative tone to describe what a commit does, rather than what it did. For example, use fix; not fixed or fixes or fixing.
 
 For example:
-- fix: Typo in Commit Style guidelines
-- feat: Update UI of SearchActivity
-- fix: Remove deprecated methods
-- refactor: Implement SearchActivity using MVP pattern
+- Fix: Typo in Commit Style guidelines
+- Implement: Add crash reporting via e-mail
+- Refactor: Implement SearchActivity using MVP pattern
 instead of writing the following:
 - Fixed bug with Y
 - Changing behaviour of X

--- a/docs/commitstyle.md
+++ b/docs/commitstyle.md
@@ -3,7 +3,7 @@
 ### Message Structure
 Commit messages consist of three distinct parts, separated by a blank line: the title, an optional body/content, and an optional footer/metadata. The layout looks like this:
 
-type: subject
+type subject
 
 body
 
@@ -15,14 +15,12 @@ The title consists of the subject and type of the commit message.
 ### Type
 The type is contained within the title and can be one of the following types:
 
-* **Implement:** Implemented a new feature
-* **Fix:** a bug fix
-* **Docs:** changes to documentation
-* **Remove:** removed redundant code
-* **Style:** formatting, missing semi-colons, etc; no code change
-* **Refactor:** refactoring production code
-* **Test:** adding tests, refactoring test; no production code change
-* **Chore:** updating build tasks, package manager configs, etc; no production code change
+* **Implement** feature x
+* **Fix** a bug in x feature
+* **Improve** documentation for x feature
+* **Remove** removed redundant code
+* **Restyle** formatting, missing semi-colons, etc; no code change
+* **Refactor** refactoring production code
 
 ### Subject
 The subject is a single short line summarising the change. It should be no greater than 50 characters, should begin with a capital letter and do not end with a period.
@@ -30,10 +28,11 @@ The subject is a single short line summarising the change. It should be no great
 Use an imperative tone to describe what a commit does, rather than what it did. For example, use fix; not fixed or fixes or fixing.
 
 For example:
-- Fix: Typo in Commit Style guidelines
-- Implement: Add crash reporting via e-mail
-- Refactor: Implement SearchActivity using MVP pattern
-instead of writing the following:
+- Fix typo in Commit Style guidelines
+- Add crash reporting via e-mail
+- Implement SearchActivity using MVP pattern
+
+Instead of writing the following:
 - Fixed bug with Y
 - Changing behaviour of X
 


### PR DESCRIPTION
Fixes #419 

Changes: Improved the README of the project by adding various informations.

Screenshots/GIF for the change: NA
To check the final rendered README, please switch to ```srv-twry/improvereadme``` branch.
@mhutti1 Can you suggest what to do with the ```Legal and Disclaimer``` section. It looks weird. I couldn't find the "COPYING" file.