### PR TITLE
Fixes dialog box style issue and download restarting issue.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -166,22 +166,26 @@ public class DownloadService extends Service {
 
     NotificationCompat.Action pause = new NotificationCompat.Action(R.drawable.ic_pause_black_24dp, getString(R.string.download_pause), pausePending);
     NotificationCompat.Action stop = new NotificationCompat.Action(R.drawable.ic_stop_black_24dp, getString(R.string.download_stop), stopPending);
+    if(flags == START_FLAG_REDELIVERY && book.file == null) {
+      return START_NOT_STICKY;
+    }
+    else {
+      notification.put(notificationID, new NotificationCompat.Builder(this)
+              .setContentTitle(getResources().getString(R.string.zim_file_downloading) + " " + notificationTitle)
+              .setProgress(100, 0, false)
+              .setSmallIcon(R.drawable.kiwix_notification)
+              .setColor(Color.BLACK)
+              .setContentIntent(pendingIntent)
+              .addAction(pause)
+              .addAction(stop)
+              .setOngoing(true));
 
-    notification.put(notificationID , new NotificationCompat.Builder(this)
-        .setContentTitle(getResources().getString(R.string.zim_file_downloading) + " " + notificationTitle)
-        .setProgress(100, 0, false)
-        .setSmallIcon(R.drawable.kiwix_notification)
-        .setColor(Color.BLACK)
-        .setContentIntent(pendingIntent)
-        .addAction(pause)
-        .addAction(stop)
-        .setOngoing(true));
-
-    notificationManager.notify(notificationID, notification.get(notificationID).build());
-    downloadStatus.put(notificationID, PLAY);
-    LibraryFragment.downloadingBooks.remove(book);
-    String url = intent.getExtras().getString(DownloadIntent.DOWNLOAD_URL_PARAMETER);
-    downloadBook(url, notificationID, book);
+      notificationManager.notify(notificationID, notification.get(notificationID).build());
+      downloadStatus.put(notificationID, PLAY);
+      LibraryFragment.downloadingBooks.remove(book);
+      String url = intent.getExtras().getString(DownloadIntent.DOWNLOAD_URL_PARAMETER);
+      downloadBook(url, notificationID, book);
+    }
     return START_REDELIVER_INTENT;
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
@@ -259,6 +259,7 @@ public class KiwixSettingsActivity extends AppCompatActivity {
       }
       if (key.equals(PREF_NIGHTMODE)) {
         KiwixMobileActivity.refresh = true;
+        KiwixMobileActivity.nightMode = nightMode(sharedPreferences);
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
       }
@@ -267,6 +268,7 @@ public class KiwixSettingsActivity extends AppCompatActivity {
       }
       if(key.equals(PREF_AUTONIGHTMODE)){
         KiwixMobileActivity.refresh = true;
+        KiwixMobileActivity.nightMode = nightMode(sharedPreferences);
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
       }


### PR DESCRIPTION
Fixes #433 and #426 

Changes: 433- Checked if the intent was redelivered, if it was stopped then book.file would be null, by giving that check it was possible not to restart the stopped downloads.
426 - Setting the KiwixMobileActivity.nightmode variable in settingsActivity only as the dialogstyle depends on it.

