### PR TITLE
Save the back stack of visited pages before exiting from app

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -85,10 +85,6 @@ public final class Constants {
 
     public static final String TAG_CURRENT_FILE = "currentzimfile";
 
-    public static final String TAG_CURRENT_ARTICLES = "currentarticles";
-
-    public static final String TAG_CURRENT_POSITIONS = "currentpositions";
-
     public static final String TAG_CURRENT_TAB = "currenttab";
 
     // Extras
@@ -121,4 +117,7 @@ public final class Constants {
     public static final String EXTRA_WEBVIEWS_LIST = "webviewsList";
 
     public static final String EXTRA_BOOKMARK_CONTENTS = "bookmark_contents";
+
+    // Keys
+    public static final String KEY_SAVED_STATE_BUNDLE = "bookmark_contents";
 }


### PR DESCRIPTION
Fixes #398 

Changes: Saved a webview state bundle to a file and restored the webview's state via that bundle on app startup. All I/O operations have been done on a new thread. 

Screenshots/GIF for the change: ![back_forward_history](https://user-images.githubusercontent.com/24610859/37247876-229e0bb4-24e9-11e8-9d59-02eaa081895c.gif)

