### PR TITLE
change font color in clear history dialog box

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -76,6 +76,7 @@
 
   <style name="AppTheme.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
     <item name="colorAccent">@color/accent</item>
+    <item name="android:textColorPrimary">@color/primary_dark</item>
   </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -76,7 +76,6 @@
 
   <style name="AppTheme.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
     <item name="colorAccent">@color/accent</item>
-    <item name="android:textColorPrimary">@color/accent</item>
   </style>
 
 </resources>


### PR DESCRIPTION
#Fixes #453 
Changes: [Add here what changes were made in this issue and if possible provide links.]

Modified "textColorPrimary" attribute in the "Dialog" theme in styles.xml

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]

![screenshot_20180218-141622](https://user-images.githubusercontent.com/32238400/36350117-f087e2d0-14b7-11e8-8189-d279e9a956e4.png)
