### PR TITLE
Fixed zim file not opening issue.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ZimContentProvider.java
@@ -122,8 +122,8 @@ public class ZimContentProvider extends ContentProvider {
       if(!listedEntries.contains(reader.getId())) {
         listedEntries.add(reader.getId());
         jniSearcher.addKiwixReader(reader);
-        currentJNIReader = reader;
       }
+      currentJNIReader = reader;
       zimFileName = fileName;
     } catch (JNIKiwixException e) {
       Log.e(TAG_KIWIX, "Unable to open the ZIM file " + fileName);


### PR DESCRIPTION
Zim files now open according to the one being clicked.

Fixes #236 

Changes: Just changed a single line. Previously, only for the first time the file being clicked was opened and after that it was opening the same file.
Screenshots/GIF for the change:
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/24573296/36478906-a83e3c78-172c-11e8-88ec-0bb4b2bdf0e5.gif)

