### PR TITLE
fix: Blocked content underneath fullscreen_exit button

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -45,7 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_margin="@dimen/fullscreen_control_button_margin"
-            android:background="@color/back_to_top_background"
+            android:background="@null"
             android:hint="@string/menu_exitfullscreen"
             android:src="@drawable/fullscreen_exit"
             android:visibility="invisible" />


### PR DESCRIPTION
Fixes #490

Changes: Changed the background of `fullscreen_exit` button from `@color/back_to_top_background` to `@null`

Screenshots/GIF for the change: 

![screenshot_20180223-100832](https://user-images.githubusercontent.com/18366144/36578197-9d524d08-1881-11e8-953a-d89ff398fd86.png)

