### PR TITLE
Fix text visibility in library screen in dark mode

### DIFF
--- a/app/src/main/res/layout/zim_list.xml
+++ b/app/src/main/res/layout/zim_list.xml
@@ -28,7 +28,6 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_below="@id/toolbar"
-      android:background="?attr/listBackground"
       android:divider="@null"
       android:paddingBottom="@dimen/zimfilelist_padding_bottom" />
 


### PR DESCRIPTION
Fixes #472 

Changes: Fix text visibility in night mode in library screen.

Screenshots/GIF for the change:
![screenshot_20180227-121638](https://user-images.githubusercontent.com/10378365/36714442-56a29a90-1bb8-11e8-9326-41ac07b70e47.jpg)
![screenshot_20180227-121611](https://user-images.githubusercontent.com/10378365/36714470-670c80da-1bb8-11e8-9c79-908252cc284c.jpg)



