### PR TITLE
Language name overlap resolved

### DIFF
--- a/app/src/main/res/layout/language_check_item.xml
+++ b/app/src/main/res/layout/language_check_item.xml
@@ -20,17 +20,20 @@
     tools:checked="false" />
 
   <LinearLayout
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_centerVertical="true"
+    android:layout_toLeftOf="@id/language_entries_count"
     android:layout_toRightOf="@id/language_checkbox"
     android:gravity="center_vertical"
-    android:orientation="horizontal">
+    android:orientation="vertical">
 
     <TextView
       android:id="@+id/language_name"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:layout_marginLeft="@dimen/dimen_10dp"
+      android:textColor="@color/primary"
       android:textSize="@dimen/dimen_18sp"
       tools:text="German" />
 
@@ -40,7 +43,7 @@
       android:layout_height="wrap_content"
       android:layout_marginLeft="@dimen/dimen_10dp"
       android:textColor="@color/grey"
-      android:textSize="@dimen/dimen_18sp"
+      android:textSize="@dimen/dimen_14sp"
       tools:text="(Deutsch)" />
 
   </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,6 +19,7 @@
   <dimen name="dimen_24dp">24dp</dimen>
   <dimen name="dimen_100dp">100dp</dimen>
   <dimen name="dimen_0dp">0dp</dimen>
+  <dimen name="dimen_14sp">14sp</dimen>
   <dimen name="dimen_18sp">18sp</dimen>
   <dimen name="dimen_20sp">20sp</dimen>
   <dimen name="navigation_width">260dp</dimen>


### PR DESCRIPTION
Fixes #528 

Screenshots/GIF for the change:
New:

![screenshot_20180301-180932](https://user-images.githubusercontent.com/28982436/36846099-45c8e0a8-1d7f-11e8-9bdb-7454f898bed2.png)

Old:
![screenshot_20180228-112200](https://user-images.githubusercontent.com/28982436/36846116-57e03b10-1d7f-11e8-827a-477b2f0386fd.png)
