### PR TITLE
Pause/Resume other music when read aloud is enabled

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -618,7 +618,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         isSpeaking = true;
         runOnUiThread(() -> {
           menu.findItem(R.id.menu_read_aloud)
-                  .setTitle(createMenuItem(getResources().getString(R.string.menu_read_aloud_stop)));
+              .setTitle(createMenuItem(getResources().getString(R.string.menu_read_aloud_stop)));
           TTSControls.setVisibility(View.VISIBLE);
         });
       }
@@ -628,7 +628,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         isSpeaking = false;
         runOnUiThread(() -> {
           menu.findItem(R.id.menu_read_aloud)
-                  .setTitle(createMenuItem(getResources().getString(R.string.menu_read_aloud)));
+              .setTitle(createMenuItem(getResources().getString(R.string.menu_read_aloud)));
           TTSControls.setVisibility(View.GONE);
           pauseTTSButton.setText(R.string.tts_pause);
         });

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -636,14 +636,14 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     }, new AudioManager.OnAudioFocusChangeListener() {
       @Override
       public void onAudioFocusChange(int focusChange) {
-        Log.d("Focus has changed", String.valueOf(focusChange));
+        Log.d(TAG_KIWIX, "Focus change: " + String.valueOf(focusChange));
         if (tts.currentTTSTask == null) {
           tts.stop();
           return;
         }
         switch (focusChange) {
           case (AudioManager.AUDIOFOCUS_LOSS):
-            if(!tts.currentTTSTask.paused) tts.pauseOrResume();
+            if (!tts.currentTTSTask.paused) tts.pauseOrResume();
             pauseTTSButton.setText(R.string.tts_resume);
             break;
           case (AudioManager.AUDIOFOCUS_GAIN):

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
@@ -37,9 +37,9 @@ public class KiwixTextToSpeech {
 
   public TTSTask currentTTSTask = null;
 
-  private AudioManager audioManager;
+  private AudioManager am;
 
-  final Object mFocusLock;
+  final Object focuslock;
 
   private OnAudioFocusChangeListener onAudioFocusChangeListener;
 
@@ -59,8 +59,8 @@ public class KiwixTextToSpeech {
     this.context = context;
     this.onSpeakingListener = onSpeakingListener;
     this.onAudioFocusChangeListener = onAudioFocusChangeListener;
-    audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-    mFocusLock = new Object();
+    am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    focuslock = new Object();
     initTTS(onInitSucceedListener);
   }
 
@@ -120,10 +120,8 @@ public class KiwixTextToSpeech {
       } else {
         tts.setLanguage(locale);
 
-        if(requestAudioFocus() == true) {
+        if (requestAudioFocus()) {
           loadURL(webView);
-        } else {
-          return;
         }
       }
     }
@@ -155,18 +153,17 @@ public class KiwixTextToSpeech {
   }
 
   public Boolean requestAudioFocus() {
-    Log.d("Request for audio Focus", "Focus Requested");
-    int audioFocusRequest = audioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+    int audioFocusRequest = am.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
 
-    synchronized (mFocusLock) {
-      if(audioFocusRequest == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+    Log.d(TAG_KIWIX, "Audio Focus Requested");
+
+    synchronized (focuslock) {
+      if (audioFocusRequest == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
         return true;
-      } else if(audioFocusRequest == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
+      } else {
         return false;
       }
     }
-
-    return false;
   }
 
   public void pauseOrResume() {
@@ -174,7 +171,7 @@ public class KiwixTextToSpeech {
       return;
 
     if (currentTTSTask.paused) {
-      if(!requestAudioFocus()) return;
+      if (!requestAudioFocus()) return;
       currentTTSTask.start();
     }
     else {

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
@@ -2,6 +2,8 @@ package org.kiwix.kiwixmobile.utils;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.media.AudioManager;
+import android.media.AudioManager.OnAudioFocusChangeListener;
 import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
@@ -35,6 +37,12 @@ public class KiwixTextToSpeech {
 
   public TTSTask currentTTSTask = null;
 
+  private AudioManager audioManager;
+
+  final Object mFocusLock;
+
+  private OnAudioFocusChangeListener onAudioFocusChangeListener;
+
   /**
    * Constructor.
    *
@@ -46,10 +54,13 @@ public class KiwixTextToSpeech {
    */
   public KiwixTextToSpeech(Context context,
       final OnInitSucceedListener onInitSucceedListener,
-      final OnSpeakingListener onSpeakingListener) {
+      final OnSpeakingListener onSpeakingListener, final OnAudioFocusChangeListener onAudioFocusChangeListener) {
     Log.d(TAG_KIWIX, "Initializing TextToSpeech");
     this.context = context;
     this.onSpeakingListener = onSpeakingListener;
+    this.onAudioFocusChangeListener = onAudioFocusChangeListener;
+    audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    mFocusLock = new Object();
     initTTS(onInitSucceedListener);
   }
 
@@ -109,9 +120,19 @@ public class KiwixTextToSpeech {
       } else {
         tts.setLanguage(locale);
 
-        // We use JavaScript to get the content of the page conveniently, earlier making some
-        // changes in the page
-        webView.loadUrl("javascript:" +
+        if(requestAudioFocus() == true) {
+          loadURL(webView);
+        } else {
+          return;
+        }
+      }
+    }
+  }
+
+  public void loadURL(WebView webView) {
+    // We use JavaScript to get the content of the page conveniently, earlier making some
+    // changes in the page
+    webView.loadUrl("javascript:" +
             "body = document.getElementsByTagName('body')[0].cloneNode(true);" +
             // Remove some elements that are shouldn't be read (table of contents,
             // references numbers, thumbnail captions, duplicated title, etc.)
@@ -121,8 +142,6 @@ public class KiwixTextToSpeech {
             "    elem.parentElement.removeChild(elem);" +
             "});" +
             "tts.speakAloud(body.innerText);");
-      }
-    }
   }
 
   public void stop() {
@@ -135,14 +154,32 @@ public class KiwixTextToSpeech {
     }
   }
 
+  public Boolean requestAudioFocus() {
+    Log.d("Request for audio Focus", "Focus Requested");
+    int audioFocusRequest = audioManager.requestAudioFocus(onAudioFocusChangeListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+
+    synchronized (mFocusLock) {
+      if(audioFocusRequest == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        return true;
+      } else if(audioFocusRequest == AudioManager.AUDIOFOCUS_REQUEST_FAILED) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
   public void pauseOrResume() {
     if (currentTTSTask == null)
       return;
 
-    if (currentTTSTask.paused)
+    if (currentTTSTask.paused) {
+      if(!requestAudioFocus()) return;
       currentTTSTask.start();
-    else
+    }
+    else {
       currentTTSTask.pause();
+    }
   }
 
   public void initWebView(WebView webView) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixTextToSpeech.java
@@ -167,14 +167,12 @@ public class KiwixTextToSpeech {
   }
 
   public void pauseOrResume() {
-    if (currentTTSTask == null)
+    if (currentTTSTask == null) {
       return;
-
-    if (currentTTSTask.paused) {
+    } else if (currentTTSTask.paused) {
       if (!requestAudioFocus()) return;
       currentTTSTask.start();
-    }
-    else {
+    } else {
       currentTTSTask.pause();
     }
   }


### PR DESCRIPTION
Fixes #535 

Changes: Use audio manager to listen to audio focus changes and play / pause text-to-speech based on that.

Screenshots/GIF for the change: NA
