### PR TITLE
Use correct shade of blue in night mode

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
   <color name="primary_dark_night">#ff212121</color>
   <color name="primary_light">#ffffff</color>
   <color name="accent">#304e9a</color>
+  <color name="accent_night">#689AC7</color>
   <color name="white">#FAFAFA</color>
   <color name="gray_list_bg">#0d000000</color>
   <color name="drawer_background_day">#ffffff</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,7 +33,7 @@
   <style name="AppTheme.Night" parent="AppTheme.Base">
     <item name="colorPrimary">@color/primary_night</item>
     <item name="colorPrimaryDark">@color/primary_dark_night</item>
-    <item name="colorAccent">@color/accent</item>
+    <item name="colorAccent">@color/accent_night</item>
     <item name="progressBackgroundColor">@color/primary_dark_night</item>
     <item name="drawerBackground">@color/drawer_background_night</item>
     <item name="listBackground">@color/grey</item>


### PR DESCRIPTION
Fixes #532 

Changes: Add new blue shade for night mode.

Screenshots/GIF for the change: 

![screenshot_20180301-223747](https://user-images.githubusercontent.com/10378365/36858660-b678e060-1da1-11e8-8634-39c1de25d2f0.jpg)

