### PR TITLE
Unregister the receiver when fragment is destroyed. Refactor code.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -159,41 +159,12 @@ public class LibraryAdapter extends BaseAdapter {
       holder.favicon.setImageBitmap(createBitmapFromEncodedString(book.getFavicon(), context));
 
       // Check if no value is empty. Set the view to View.GONE, if it is. To View.VISIBLE, if not.
-      if (book.getTitle() == null || book.getTitle().isEmpty()) {
-        holder.title.setVisibility(View.GONE);
-      } else {
-        holder.title.setVisibility(View.VISIBLE);
-      }
-
-      if (book.getDescription() == null || book.getDescription().isEmpty()) {
-        holder.description.setVisibility(View.GONE);
-      } else {
-        holder.description.setVisibility(View.VISIBLE);
-      }
-
-      if (book.getCreator() == null || book.getCreator().isEmpty()) {
-        holder.creator.setVisibility(View.GONE);
-      } else {
-        holder.creator.setVisibility(View.VISIBLE);
-      }
-
-      if (book.getPublisher() == null || book.getPublisher().isEmpty()) {
-        holder.publisher.setVisibility(View.GONE);
-      } else {
-        holder.publisher.setVisibility(View.VISIBLE);
-      }
-
-      if (book.getDate() == null || book.getDate().isEmpty()) {
-        holder.date.setVisibility(View.GONE);
-      } else {
-        holder.date.setVisibility(View.VISIBLE);
-      }
-
-      if (book.getSize() == null || book.getSize().isEmpty()) {
-        holder.size.setVisibility(View.GONE);
-      } else {
-        holder.size.setVisibility(View.VISIBLE);
-      }
+      hideIfEmpty(book.getTitle(), holder.title);
+      hideIfEmpty(book.getDescription(), holder.description);
+      hideIfEmpty(book.getCreator(), holder.creator);
+      hideIfEmpty(book.getPublisher(), holder.publisher);
+      hideIfEmpty(book.getDate(), holder.date);
+      hideIfEmpty(book.getSize(), holder.size);
 
       return convertView;
     } else {
@@ -212,6 +183,10 @@ public class LibraryAdapter extends BaseAdapter {
 
       return convertView;
     }
+  }
+
+  private void hideIfEmpty(String s, View v) {
+    v.setVisibility((s == null || s.isEmpty()) ? View.GONE : View.VISIBLE);
   }
 
   private boolean languageActive(Book book) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -188,15 +188,6 @@ public class ZimManageActivity extends AppCompatActivity implements ZimManageVie
   }
 
   @Override
-  public void finish() {
-    if (LibraryFragment.isReceiverRegistered) {
-      unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
-      LibraryFragment.isReceiverRegistered = false;
-    }
-    super.finish();
-  }
-
-  @Override
   public boolean onCreateOptionsMenu(Menu menu) {
     // Inflate the menu; this adds items to the action bar if it is present.
     getMenuInflater().inflate(R.menu.menu_zim_manager, menu);

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -244,6 +244,7 @@ public class LibraryFragment extends Fragment
       super.getActivity().unbindService(mConnection.downloadServiceInterface);
       mBound = false;
     }
+    faActivity.unregisterReceiver(networkBroadcastReceiver);
   }
 
   @Override

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -3,7 +3,6 @@ package org.kiwix.kiwixmobile.zim_manager.library_view;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
@@ -19,7 +18,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.widget.SwipeRefreshLayout;
-import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -28,7 +26,6 @@ import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.ListView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -65,50 +62,35 @@ import static org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_BOOK;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_STORAGE;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_STORAGE_TITLE;
-import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 
 public class LibraryFragment extends Fragment
     implements AdapterView.OnItemClickListener, StorageSelectDialog.OnSelectListener, LibraryViewCallback {
 
 
+  public static DownloadService mService = new DownloadService();
+  public static List<Book> downloadingBooks = new ArrayList<>();
+  public LinearLayout llLayout;
+  public LibraryAdapter libraryAdapter;
   @BindView(R.id.library_list)
   ListView libraryList;
   @BindView(R.id.network_permission_text)
   TextView networkText;
   @BindView(R.id.network_permission_button)
   Button permissionButton;
-
   @Inject
   KiwixService kiwixService;
-
-  public LinearLayout llLayout;
-
   @BindView(R.id.library_swiperefresh)
   SwipeRefreshLayout swipeRefreshLayout;
-
-  private ArrayList<Book> books = new ArrayList<>();
-
-  public static DownloadService mService = new DownloadService();
-
-  private boolean mBound;
-
-  public LibraryAdapter libraryAdapter;
-
-  private DownloadServiceConnection mConnection = new DownloadServiceConnection();
-
   @Inject
   ConnectivityManager conMan;
-
-  private ZimManageActivity faActivity;
-
-  public static NetworkBroadcastReceiver networkBroadcastReceiver;
-
-  public static List<Book> downloadingBooks = new ArrayList<>();
-
-  public static boolean isReceiverRegistered = false;
-
   @Inject
   LibraryPresenter presenter;
+  private NetworkBroadcastReceiver networkBroadcastReceiver;
+  private boolean isReceiverRegistered = false;
+  private ArrayList<Book> books = new ArrayList<>();
+  private boolean mBound;
+  private DownloadServiceConnection mConnection = new DownloadServiceConnection();
+  private ZimManageActivity faActivity;
 
   private void setupDagger() {
     KiwixApplication.getInstance().getApplicationComponent().inject(this);
@@ -234,7 +216,10 @@ public class LibraryFragment extends Fragment
       swipeRefreshLayout.setRefreshing(false);
       return;
     }
-    networkBroadcastReceiver.onReceive(super.getActivity(), null);
+    if (isReceiverRegistered) {
+      networkBroadcastReceiver.onReceive(super.getActivity(), null);
+      isReceiverRegistered = false;
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes: I think there isn't an Issue for this

Changes: I add the code to unregister the networkBroadcastReceiver when the fragment is destroyed. If you want to check the behaviour here is the official guid for [Broadcasts](https://developer.android.com/guide/components/broadcasts.html)

