### PR TITLE
Saving time and resources when list reload in Library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -102,4 +102,6 @@ public final class Constants {
     public static final String EXTRA_WEBVIEWS_LIST = "webviewsList";
 
     public static final String EXTRA_BOOKMARK_CONTENTS = "bookmark_contents";
+
+    public static final String EXTRA_BOOKS_ONLINE = "books_online";
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -394,6 +394,8 @@ public class LibraryFragment extends Fragment
         permissionButton.setVisibility(GONE);
         networkText.setVisibility(GONE);
         libraryList.setVisibility(View.VISIBLE);
+      }else{
+        stopScanningContent();
       }
 
     }


### PR DESCRIPTION
Fixes This is an improvement commented in #538 by @GeVic.

Changes: Use Fragment methods onSaveInstanceState and onViewStateRestored to reload the books so now the app don't use Internet every time the user rotates the device and as you can see on the GIF the reload is quite faster.

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]

![](https://media.giphy.com/media/55tELYEheb1GAf4MgV/giphy.gif)
