### PR TITLE
Saving time and resources when list reload in Library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadFragment.java
@@ -34,6 +34,7 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
@@ -58,20 +59,19 @@ import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 
 public class DownloadFragment extends BaseFragment {
 
-  public static LinkedHashMap<Integer, LibraryNetworkEntity.Book> mDownloads =
+  public static LinkedHashMap<Integer, LibraryNetworkEntity.Book> downloads =
       new LinkedHashMap<>();
-  public static LinkedHashMap<Integer, String> mDownloadFiles = new LinkedHashMap<>();
-  public static DownloadAdapter downloadAdapter;
-  public RelativeLayout relLayout;
-  public ListView listView;
-  CoordinatorLayout mainLayout;
+  public static LinkedHashMap<Integer, String> downloadFiles = new LinkedHashMap<>();
+  static DownloadAdapter downloadAdapter;
+  ListView listView;
   @Inject
   SharedPreferenceUtil sharedPreferenceUtil;
+  private CoordinatorLayout mainLayout;
   private ZimManageActivity zimManageActivity;
-  private Activity faActivity;
+  private Activity activity;
   private boolean hasArtificiallyPaused;
 
-  public static String toHumanReadableTime(int seconds) {
+  static String toHumanReadableTime(int seconds) {
     final double MINUTES = 60;
     final double HOURS = 60 * MINUTES;
     final double DAYS = 24 * HOURS;
@@ -97,31 +97,32 @@ public class DownloadFragment extends BaseFragment {
   }
 
   @Override
-  public View onCreateView(LayoutInflater inflater, ViewGroup container,
+  public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
-    faActivity = super.getActivity();
-    relLayout = (RelativeLayout) inflater.inflate(R.layout.download_management, container, false);
+    activity = getActivity();
+    RelativeLayout relLayout =
+        (RelativeLayout) inflater.inflate(R.layout.download_management, container, false);
 
     zimManageActivity = (ZimManageActivity) super.getActivity();
     listView = relLayout.findViewById(R.id.zim_downloader_list);
-    downloadAdapter = new DownloadAdapter(mDownloads);
+    downloadAdapter = new DownloadAdapter(downloads);
     downloadAdapter.registerDataSetObserver(this);
     listView.setAdapter(downloadAdapter);
-    mainLayout = faActivity.findViewById(R.id.zim_manager_main_activity);
+    mainLayout = activity.findViewById(R.id.zim_manager_main_activity);
     return relLayout;
   }
 
   @Override
-  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
     updateNoDownloads();
   }
 
   private void updateNoDownloads() {
-    if (faActivity == null) {
+    if (activity == null) {
       return;
     }
-    TextView noDownloadsText = faActivity.findViewById(R.id.download_management_no_downloads);
+    TextView noDownloadsText = activity.findViewById(R.id.download_management_no_downloads);
     if (noDownloadsText == null) return;
     if (listView.getCount() == 0) {
       noDownloadsText.setVisibility(View.VISIBLE);
@@ -136,7 +137,7 @@ public class DownloadFragment extends BaseFragment {
     downloadAdapter.unRegisterDataSetObserver();
   }
 
-  public void showNoWiFiWarning(Context context, Runnable yesAction) {
+  private void showNoWiFiWarning(Context context, Runnable yesAction) {
     new AlertDialog.Builder(context)
         .setTitle(R.string.wifi_only_title)
         .setMessage(R.string.wifi_only_msg)
@@ -150,14 +151,14 @@ public class DownloadFragment extends BaseFragment {
         .show();
   }
 
-  public void addDownload(int position, LibraryNetworkEntity.Book book, String fileName) {
-    mDownloads.put(position, book);
-    mDownloadFiles.put(position, fileName);
+  void addDownload(int position, LibraryNetworkEntity.Book book, String fileName) {
+    downloads.put(position, book);
+    downloadFiles.put(position, fileName);
     downloadAdapter.notifyDataSetChanged();
     updateNoDownloads();
   }
 
-  public Bitmap StringToBitMap(String encodedString) {
+  private Bitmap StringToBitMap(String encodedString) {
     try {
       byte[] encodeByte = Base64.decode(encodedString, Base64.DEFAULT);
       return BitmapFactory.decodeByteArray(encodeByte, 0, encodeByte.length);
@@ -169,23 +170,23 @@ public class DownloadFragment extends BaseFragment {
 
   public class DownloadAdapter extends BaseAdapter {
 
-    private LinkedHashMap<Integer, LibraryNetworkEntity.Book> mData = new LinkedHashMap<>();
-    private Integer[] mKeys;
+    private LinkedHashMap<Integer, LibraryNetworkEntity.Book> data;
+    private Integer[] keys;
     private DataSetObserver dataSetObserver;
 
-    public DownloadAdapter(LinkedHashMap<Integer, LibraryNetworkEntity.Book> data) {
-      mData = data;
-      mKeys = mData.keySet().toArray(new Integer[data.size()]);
+    DownloadAdapter(LinkedHashMap<Integer, LibraryNetworkEntity.Book> data) {
+      this.data = data;
+      keys = this.data.keySet().toArray(new Integer[data.size()]);
     }
 
     @Override
     public int getCount() {
-      return mData.size();
+      return data.size();
     }
 
     @Override
     public LibraryNetworkEntity.Book getItem(int position) {
-      return mData.get(mKeys[position]);
+      return data.get(keys[position]);
     }
 
     @Override
@@ -193,22 +194,22 @@ public class DownloadFragment extends BaseFragment {
       return arg0;
     }
 
-    public void complete(int notificationID) {
+    void complete(int notificationID) {
       if (!isAdded()) {
         return;
       }
-      int position = Arrays.asList(mKeys).indexOf(notificationID);
+      int position = Arrays.asList(keys).indexOf(notificationID);
       ViewGroup viewGroup =
           (ViewGroup) listView.getChildAt(position - listView.getFirstVisiblePosition());
       if (viewGroup == null) {
-        mDownloads.remove(mKeys[position]);
-        mDownloadFiles.remove(mKeys[position]);
+        downloads.remove(keys[position]);
+        downloadFiles.remove(keys[position]);
         downloadAdapter.notifyDataSetChanged();
         updateNoDownloads();
       }
       ImageView pause = viewGroup.findViewById(R.id.pause);
       pause.setEnabled(false);
-      String fileName = FileUtils.getFileName(mDownloadFiles.get(mKeys[position]));
+      String fileName = FileUtils.getFileName(downloadFiles.get(keys[position]));
       {
         Snackbar completeSnack =
             Snackbar.make(mainLayout, getResources().getString(R.string.download_complete_snackbar),
@@ -221,15 +222,15 @@ public class DownloadFragment extends BaseFragment {
       ZimFileSelectFragment zimFileSelectFragment =
           (ZimFileSelectFragment) zimManageActivity.mSectionsPagerAdapter.getItem(0);
       zimFileSelectFragment.addBook(fileName);
-      mDownloads.remove(mKeys[position]);
-      mDownloadFiles.remove(mKeys[position]);
+      downloads.remove(keys[position]);
+      downloadFiles.remove(keys[position]);
       downloadAdapter.notifyDataSetChanged();
       updateNoDownloads();
     }
 
-    public void updateProgress(int progress, int notificationID) {
+    void updateProgress(int progress, int notificationID) {
       if (isAdded()) {
-        int position = Arrays.asList(mKeys).indexOf(notificationID);
+        int position = Arrays.asList(keys).indexOf(notificationID);
         ViewGroup viewGroup =
             (ViewGroup) listView.getChildAt(position - listView.getFirstVisiblePosition());
         if (viewGroup == null) {
@@ -238,7 +239,7 @@ public class DownloadFragment extends BaseFragment {
         ProgressBar downloadProgress = viewGroup.findViewById(R.id.downloadProgress);
         downloadProgress.setProgress(progress);
         TextView timeRemaining = viewGroup.findViewById(R.id.time_remaining);
-        int secLeft = LibraryFragment.mService.timeRemaining.get(mKeys[position], -1);
+        int secLeft = LibraryFragment.downloadService.timeRemaining.get(keys[position], -1);
         if (secLeft != -1) {
           timeRemaining.setText(toHumanReadableTime(secLeft));
         }
@@ -247,14 +248,14 @@ public class DownloadFragment extends BaseFragment {
 
     private void setPlayState(ImageView pauseButton, int position, int newPlayState) {
       if (newPlayState == DownloadService.PLAY) { //Playing
-        if (LibraryFragment.mService.playDownload(mKeys[position])) {
+        if (LibraryFragment.downloadService.playDownload(keys[position])) {
           pauseButton.setImageDrawable(
-              ContextCompat.getDrawable(getActivity(), R.drawable.ic_pause_black_24dp));
+              ContextCompat.getDrawable(activity, R.drawable.ic_pause_black_24dp));
         }
       } else { //Pausing
-        LibraryFragment.mService.pauseDownload(mKeys[position]);
+        LibraryFragment.downloadService.pauseDownload(keys[position]);
         pauseButton.setImageDrawable(
-            ContextCompat.getDrawable(getActivity(), R.drawable.ic_play_arrow_black_24dp));
+            ContextCompat.getDrawable(activity, R.drawable.ic_play_arrow_black_24dp));
       }
     }
 
@@ -264,9 +265,9 @@ public class DownloadFragment extends BaseFragment {
       // Check if an existing view is being reused, otherwise inflate the view
       if (convertView == null) {
         convertView =
-            LayoutInflater.from(faActivity).inflate(R.layout.download_item, parent, false);
+            LayoutInflater.from(activity).inflate(R.layout.download_item, parent, false);
       }
-      mKeys = mData.keySet().toArray(new Integer[mData.size()]);
+      keys = data.keySet().toArray(new Integer[0]);
       // Lookup view for data population
       //downloadProgress.setProgress(download.progress);
       // Populate the data into the template view using the data object
@@ -281,34 +282,34 @@ public class DownloadFragment extends BaseFragment {
       ProgressBar downloadProgress = convertView.findViewById(R.id.downloadProgress);
       ImageView pause = convertView.findViewById(R.id.pause);
 
-      if (LibraryFragment.mService.downloadStatus.get(mKeys[position]) == 0) {
+      if (LibraryFragment.downloadService.downloadStatus.get(keys[position]) == 0) {
         downloadProgress.setProgress(0);
         pause.setImageDrawable(
-            ContextCompat.getDrawable(getActivity(), R.drawable.ic_pause_black_24dp));
+            ContextCompat.getDrawable(activity, R.drawable.ic_pause_black_24dp));
       } else {
         downloadProgress.setProgress(
-            LibraryFragment.mService.downloadProgress.get(mKeys[position]));
-        if (LibraryFragment.mService.downloadStatus.get(mKeys[position]) == DownloadService.PAUSE) {
+            LibraryFragment.downloadService.downloadProgress.get(keys[position]));
+        if (LibraryFragment.downloadService.downloadStatus.get(keys[position])
+            == DownloadService.PAUSE) {
           pause.setImageDrawable(
-              ContextCompat.getDrawable(getActivity(), R.drawable.ic_play_arrow_black_24dp));
+              ContextCompat.getDrawable(activity, R.drawable.ic_play_arrow_black_24dp));
         }
-        if (LibraryFragment.mService.downloadStatus.get(mKeys[position]) == DownloadService.PLAY) {
+        if (LibraryFragment.downloadService.downloadStatus.get(keys[position])
+            == DownloadService.PLAY) {
           pause.setImageDrawable(
-              ContextCompat.getDrawable(getActivity(), R.drawable.ic_pause_black_24dp));
+              ContextCompat.getDrawable(activity, R.drawable.ic_pause_black_24dp));
         }
       }
 
       pause.setOnClickListener(v -> {
         int newPlayPauseState =
-            LibraryFragment.mService.downloadStatus.get(mKeys[position]) == DownloadService.PLAY
-                ? DownloadService.PAUSE : DownloadService.PLAY;
+            LibraryFragment.downloadService.downloadStatus.get(keys[position])
+                == DownloadService.PLAY ? DownloadService.PAUSE : DownloadService.PLAY;
 
         if (newPlayPauseState == DownloadService.PLAY
             && MainActivity.wifiOnly
-            && !NetworkUtils.isWiFi(getContext())) {
-          showNoWiFiWarning(getContext(), () -> {
-            setPlayState(pause, position, newPlayPauseState);
-          });
+            && !NetworkUtils.isWiFi(activity)) {
+          showNoWiFiWarning(getContext(), () -> setPlayState(pause, position, newPlayPauseState));
           return;
         }
 
@@ -319,21 +320,21 @@ public class DownloadFragment extends BaseFragment {
 
       ImageView stop = convertView.findViewById(R.id.stop);
       stop.setOnClickListener(v -> {
-        hasArtificiallyPaused =
-            LibraryFragment.mService.downloadStatus.get(mKeys[position]) == DownloadService.PLAY;
+        hasArtificiallyPaused = LibraryFragment.downloadService.downloadStatus.get(keys[position])
+            == DownloadService.PLAY;
         setPlayState(pause, position, DownloadService.PAUSE);
-        new AlertDialog.Builder(faActivity, dialogStyle())
+        new AlertDialog.Builder(activity, dialogStyle())
             .setTitle(R.string.confirm_stop_download_title)
             .setMessage(R.string.confirm_stop_download_msg)
             .setPositiveButton(R.string.yes, (dialog, i) -> {
-              LibraryFragment.mService.stopDownload(mKeys[position]);
-              mDownloads.remove(mKeys[position]);
-              mDownloadFiles.remove(mKeys[position]);
+              LibraryFragment.downloadService.stopDownload(keys[position]);
+              downloads.remove(keys[position]);
+              downloadFiles.remove(keys[position]);
               downloadAdapter.notifyDataSetChanged();
               updateNoDownloads();
               if (zimManageActivity.mSectionsPagerAdapter.libraryFragment.libraryAdapter != null) {
                 zimManageActivity.mSectionsPagerAdapter.libraryFragment.libraryAdapter.getFilter()
-                    .filter(((ZimManageActivity) getActivity()).searchView.getQuery());
+                    .filter(((ZimManageActivity) activity).searchView.getQuery());
               }
             })
             .setNegativeButton(R.string.no, (dialog, i) -> {
@@ -349,7 +350,7 @@ public class DownloadFragment extends BaseFragment {
       return convertView;
     }
 
-    public void registerDataSetObserver(DownloadFragment downloadFragment) {
+    void registerDataSetObserver(DownloadFragment downloadFragment) {
       if (dataSetObserver == null) {
         dataSetObserver = new DataSetObserver() {
           @Override
@@ -369,7 +370,7 @@ public class DownloadFragment extends BaseFragment {
       }
     }
 
-    public void unRegisterDataSetObserver() {
+    void unRegisterDataSetObserver() {
       if (dataSetObserver != null) {
         unregisterDataSetObserver(dataSetObserver);
       }

--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -231,9 +231,9 @@ public class DownloadService extends Service {
     synchronized (pauseLock) {
       pauseLock.notify();
     }
-    if (!DownloadFragment.mDownloads.isEmpty()) {
-      DownloadFragment.mDownloads.remove(notificationID);
-      DownloadFragment.mDownloadFiles.remove(notificationID);
+    if (!DownloadFragment.downloads.isEmpty()) {
+      DownloadFragment.downloads.remove(notificationID);
+      DownloadFragment.downloadFiles.remove(notificationID);
       DownloadFragment.downloadAdapter.notifyDataSetChanged();
     }
     updateForeground();
@@ -428,10 +428,10 @@ public class DownloadService extends Service {
   }
 
   private void updateDownloadFragmentProgress(int progress, int notificationID) {
-    if (DownloadFragment.mDownloads != null
-        && DownloadFragment.mDownloads.get(notificationID) != null) {
+    if (DownloadFragment.downloads != null
+        && DownloadFragment.downloads.get(notificationID) != null) {
       handler.post(() -> {
-        if (DownloadFragment.mDownloads.get(notificationID) != null) {
+        if (DownloadFragment.downloads.get(notificationID) != null) {
           DownloadFragment.downloadAdapter.updateProgress(progress, notificationID);
         }
       });
@@ -439,10 +439,10 @@ public class DownloadService extends Service {
   }
 
   private void updateDownloadFragmentComplete(int notificationID) {
-    if (DownloadFragment.mDownloads != null
-        && DownloadFragment.mDownloads.get(notificationID) != null) {
+    if (DownloadFragment.downloads != null
+        && DownloadFragment.downloads.get(notificationID) != null) {
       handler.post(() -> {
-        if (DownloadFragment.mDownloads.get(notificationID) != null) {
+        if (DownloadFragment.downloads.get(notificationID) != null) {
           DownloadFragment.downloadAdapter.complete(notificationID);
         }
       });
@@ -526,8 +526,8 @@ public class DownloadService extends Service {
         downloaded += output.length();
 
         if (chunk.getStartByte() == 0) {
-          if (!DownloadFragment.mDownloads.isEmpty()) {
-            LibraryNetworkEntity.Book book = DownloadFragment.mDownloads
+          if (!DownloadFragment.downloads.isEmpty()) {
+            LibraryNetworkEntity.Book book = DownloadFragment.downloads
                 .get(chunk.getNotificationID());
             book.remoteUrl = book.getUrl();
             book.file = fullFile;

--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -59,10 +59,11 @@ import static org.kiwix.kiwixmobile.utils.NetworkUtils.parseURL;
 public class LibraryAdapter extends BaseAdapter {
   private static final int LIST_ITEM_TYPE_BOOK = 0;
   private static final int LIST_ITEM_TYPE_DIVIDER = 1;
+  public final HashMap<String, Integer> languageCounts = new HashMap<>();
   private final Context context;
   private final LayoutInflater layoutInflater;
   private final BookFilter bookFilter = new BookFilter();
-  public HashMap<String, Integer> languageCounts = new HashMap<>();
+  private final List<ListItem> listItems = new ArrayList<>();
   public ArrayList<Language> languages = new ArrayList<>();
   @Inject BookUtils bookUtils;
   @Inject
@@ -72,7 +73,6 @@ public class LibraryAdapter extends BaseAdapter {
   @Inject
   DataSource dataSource;
   private List<Book> allBooks;
-  private List<ListItem> listItems = new ArrayList<>();
   private Disposable saveNetworkLanguageDisposable;
 
   public LibraryAdapter(Context context) {
@@ -355,7 +355,7 @@ public class LibraryAdapter extends BaseAdapter {
         List<Book> selectedLanguages = Observable.fromIterable(allBooks)
             .filter(LibraryAdapter.this::languageActive)
             .filter(book -> !books.contains(book))
-            .filter(book -> !DownloadFragment.mDownloads.values().contains(book))
+            .filter(book -> !DownloadFragment.downloads.values().contains(book))
             .filter(book -> !LibraryFragment.downloadingBooks.contains(book))
             .filter(book -> !book.url.contains("/stack_exchange/")) // Temp filter see #694
             .toList()
@@ -364,7 +364,7 @@ public class LibraryAdapter extends BaseAdapter {
         List<Book> unselectedLanguages = Observable.fromIterable(allBooks)
             .filter(book -> !languageActive(book))
             .filter(book -> !books.contains(book))
-            .filter(book -> !DownloadFragment.mDownloads.values().contains(book))
+            .filter(book -> !DownloadFragment.downloads.values().contains(book))
             .filter(book -> !LibraryFragment.downloadingBooks.contains(book))
             .filter(book -> !book.url.contains("/stack_exchange/")) // Temp filter see #694
             .toList()
@@ -380,7 +380,7 @@ public class LibraryAdapter extends BaseAdapter {
         List<Book> selectedLanguages = Observable.fromIterable(allBooks)
             .filter(LibraryAdapter.this::languageActive)
             .filter(book -> !books.contains(book))
-            .filter(book -> !DownloadFragment.mDownloads.values().contains(book))
+            .filter(book -> !DownloadFragment.downloads.values().contains(book))
             .filter(book -> !LibraryFragment.downloadingBooks.contains(book))
             .filter(book -> !book.url.contains("/stack_exchange/")) // Temp filter see #694
             .flatMap(book -> getMatches(book, s.toString()))
@@ -392,7 +392,7 @@ public class LibraryAdapter extends BaseAdapter {
         List<Book> unselectedLanguages = Observable.fromIterable(allBooks)
             .filter(book -> !languageActive(book))
             .filter(book -> !books.contains(book))
-            .filter(book -> !DownloadFragment.mDownloads.values().contains(book))
+            .filter(book -> !DownloadFragment.downloads.values().contains(book))
             .filter(book -> !LibraryFragment.downloadingBooks.contains(book))
             .filter(book -> !book.url.contains("/stack_exchange/")) // Temp filter see #694
             .flatMap(book -> getMatches(book, s.toString()))
@@ -415,7 +415,7 @@ public class LibraryAdapter extends BaseAdapter {
 
     @Override
     protected void publishResults(CharSequence constraint, FilterResults results) {
-      List<ListItem> filtered = (List<ListItem>) results.values;
+      @SuppressWarnings("unchecked") List<ListItem> filtered = (List<ListItem>) results.values;
       if (filtered != null) {
         if (filtered.isEmpty()) {
           addBooks(allBooks);
@@ -426,10 +426,10 @@ public class LibraryAdapter extends BaseAdapter {
   }
 
   private class ListItem {
-    public Object data;
-    public int type;
+    final Object data;
+    final int type;
 
-    public ListItem(Object data, int type) {
+    ListItem(Object data, int type) {
       this.data = data;
       this.type = type;
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -385,7 +385,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     }
     if (i.hasExtra(EXTRA_ZIM_FILE)) {
       File file = new File(FileUtils.getFileName(i.getStringExtra(EXTRA_ZIM_FILE)));
-      LibraryFragment.mService.cancelNotification(i.getIntExtra(EXTRA_NOTIFICATION_ID, 0));
+      LibraryFragment.downloadService.cancelNotification(i.getIntExtra(EXTRA_NOTIFICATION_ID, 0));
       Uri uri = Uri.fromFile(file);
 
       finish();
@@ -880,9 +880,9 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
       case R.id.menu_support_kiwix:
         Uri uriSupportKiwix = Uri.parse("https://www.kiwix.org/support");
-        Intent intertSupportKiwix = new Intent(Intent.ACTION_VIEW, uriSupportKiwix);
-        intertSupportKiwix.putExtra(EXTRA_EXTERNAL_LINK, true);
-        openExternalUrl(intertSupportKiwix);
+        Intent intentSupportKiwix = new Intent(Intent.ACTION_VIEW, uriSupportKiwix);
+        intentSupportKiwix.putExtra(EXTRA_EXTERNAL_LINK, true);
+        openExternalUrl(intentSupportKiwix);
 
       default:
         break;

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -82,7 +82,7 @@ public class LibraryFragment extends BaseFragment
       new CountingIdlingResource("Library Fragment Idling Resource");
   public static final List<Book> downloadingBooks = new ArrayList<>();
   private static final String EXTRA_BOOKS_ONLINE = "books_online";
-  public static DownloadService mService = new DownloadService();
+  public static DownloadService downloadService = new DownloadService();
   private static NetworkBroadcastReceiver networkBroadcastReceiver;
   private static boolean isReceiverRegistered = false;
   public LibraryAdapter libraryAdapter;
@@ -95,14 +95,14 @@ public class LibraryFragment extends BaseFragment
   @BindView(R.id.library_swiperefresh)
   SwipeRefreshLayout swipeRefreshLayout;
   @Inject
-  ConnectivityManager conMan;
+  ConnectivityManager connectivityManager;
   @Inject
   LibraryPresenter presenter;
   @Inject
   SharedPreferenceUtil sharedPreferenceUtil;
   private LinkedList<Book> books;
-  private boolean mBound;
-  private DownloadServiceConnection mConnection = new DownloadServiceConnection();
+  private boolean bound;
+  private DownloadServiceConnection downloadServiceConnection = new DownloadServiceConnection();
   private ZimManageActivity activity;
 
   @Override
@@ -124,7 +124,7 @@ public class LibraryFragment extends BaseFragment
 
     DownloadService.setDownloadFragment(activity.mSectionsPagerAdapter.getDownloadFragment());
 
-    NetworkInfo network = conMan.getActiveNetworkInfo();
+    NetworkInfo network = connectivityManager.getActiveNetworkInfo();
     if (network == null || !network.isConnected()) {
       displayNoNetworkConnection();
     }
@@ -218,7 +218,7 @@ public class LibraryFragment extends BaseFragment
   }
 
   private void refreshFragment() {
-    NetworkInfo network = conMan.getActiveNetworkInfo();
+    NetworkInfo network = connectivityManager.getActiveNetworkInfo();
     if (network == null || !network.isConnected()) {
       Toast.makeText(super.getActivity(), R.string.no_network_connection, Toast.LENGTH_LONG).show();
       swipeRefreshLayout.setRefreshing(false);
@@ -231,9 +231,9 @@ public class LibraryFragment extends BaseFragment
   public void onDestroyView() {
     presenter.detachView();
     super.onDestroyView();
-    if (mBound && super.getActivity() != null) {
-      super.getActivity().unbindService(mConnection.downloadServiceInterface);
-      mBound = false;
+    if (bound && super.getActivity() != null) {
+      super.getActivity().unbindService(downloadServiceConnection.downloadServiceInterface);
+      bound = false;
     }
   }
 
@@ -266,7 +266,7 @@ public class LibraryFragment extends BaseFragment
         return;
       }
 
-      if (DownloadFragment.mDownloadFiles
+      if (DownloadFragment.downloadFiles
           .containsValue(KIWIX_ROOT + StorageUtils.getFileNameFromUrl(((Book) parent.getAdapter()
               .getItem(position)).getUrl()))) {
         Toast.makeText(super.getActivity(), getString(R.string.zim_already_downloading),
@@ -274,7 +274,7 @@ public class LibraryFragment extends BaseFragment
             .show();
       } else {
 
-        NetworkInfo network = conMan.getActiveNetworkInfo();
+        NetworkInfo network = connectivityManager.getActiveNetworkInfo();
         if (network == null || !network.isConnected()) {
           Toast.makeText(super.getActivity(), getString(R.string.no_network_connection),
               Toast.LENGTH_LONG)
@@ -315,8 +315,9 @@ public class LibraryFragment extends BaseFragment
     service.putExtra(DownloadIntent.DOWNLOAD_ZIM_TITLE, book.getTitle());
     service.putExtra(EXTRA_BOOK, book);
     activity.startService(service);
-    mConnection = new DownloadServiceConnection();
-    activity.bindService(service, mConnection.downloadServiceInterface, Context.BIND_AUTO_CREATE);
+    downloadServiceConnection = new DownloadServiceConnection();
+    activity.bindService(service, downloadServiceConnection.downloadServiceInterface,
+        Context.BIND_AUTO_CREATE);
     activity.displayDownloadInterface();
   }
 
@@ -363,8 +364,8 @@ public class LibraryFragment extends BaseFragment
       public void onServiceConnected(ComponentName className, IBinder service) {
         // We've bound to LocalService, cast the IBinder and get LocalService instance
         DownloadService.LocalBinder binder = (DownloadService.LocalBinder) service;
-        mService = binder.getService();
-        mBound = true;
+        downloadService = binder.getService();
+        bound = true;
       }
 
       @Override
@@ -376,7 +377,7 @@ public class LibraryFragment extends BaseFragment
   public class NetworkBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-      NetworkInfo network = conMan.getActiveNetworkInfo();
+      NetworkInfo network = connectivityManager.getActiveNetworkInfo();
 
       if (network == null || !network.isConnected()) {
         displayNoNetworkConnection();
@@ -388,8 +389,6 @@ public class LibraryFragment extends BaseFragment
         permissionButton.setVisibility(GONE);
         networkText.setVisibility(GONE);
         libraryList.setVisibility(View.VISIBLE);
-      } else {
-        stopScanningContent();
       }
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -40,6 +40,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.test.espresso.idling.CountingIdlingResource;
@@ -80,6 +81,7 @@ public class LibraryFragment extends BaseFragment
   public static final CountingIdlingResource IDLING_RESOURCE =
       new CountingIdlingResource("Library Fragment Idling Resource");
   public static final List<Book> downloadingBooks = new ArrayList<>();
+  private static final String EXTRA_BOOKS_ONLINE = "books_online";
   public static DownloadService mService = new DownloadService();
   private static NetworkBroadcastReceiver networkBroadcastReceiver;
   private static boolean isReceiverRegistered = false;
@@ -98,6 +100,7 @@ public class LibraryFragment extends BaseFragment
   LibraryPresenter presenter;
   @Inject
   SharedPreferenceUtil sharedPreferenceUtil;
+  private LinkedList<Book> books;
   private boolean mBound;
   private DownloadServiceConnection mConnection = new DownloadServiceConnection();
   private ZimManageActivity activity;
@@ -151,7 +154,7 @@ public class LibraryFragment extends BaseFragment
       IDLING_RESOURCE.decrement();
       return;
     }
-
+    this.books = books;
     Log.i("kiwix-showBooks", "Contains:" + books.size());
     libraryAdapter.setAllBooks(books);
     if (activity.searchView != null) {
@@ -331,6 +334,22 @@ public class LibraryFragment extends BaseFragment
     }
   }
 
+  @Override
+  public void onSaveInstanceState(@NonNull Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putSerializable(EXTRA_BOOKS_ONLINE, books);
+  }
+
+  @Override
+  public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+    super.onViewStateRestored(savedInstanceState);
+    if ((savedInstanceState != null && savedInstanceState.containsKey(EXTRA_BOOKS_ONLINE))) {
+      //noinspection unchecked
+      books = (LinkedList<Book>) savedInstanceState.getSerializable(EXTRA_BOOKS_ONLINE);
+      showBooks(books);
+    }
+  }
+
   class DownloadServiceConnection {
     final DownloadServiceInterface downloadServiceInterface;
 
@@ -369,6 +388,8 @@ public class LibraryFragment extends BaseFragment
         permissionButton.setVisibility(GONE);
         networkText.setVisibility(GONE);
         libraryList.setVisibility(View.VISIBLE);
+      } else {
+        stopScanningContent();
       }
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryPresenter.java
@@ -54,7 +54,7 @@ public class LibraryPresenter extends BasePresenter<LibraryViewCallback> {
 
   void loadRunningDownloadsFromDb() {
     for (LibraryNetworkEntity.Book book : bookDao.getDownloadingBooks()) {
-      if (!DownloadFragment.mDownloads.containsValue(book)) {
+      if (!DownloadFragment.downloads.containsValue(book)) {
         book.url = book.remoteUrl;
         view.downloadFile(book);
       }


### PR DESCRIPTION
Fixes #538 @GeVic comment.

Changes: [Add here what changes were made in this issue and if possible provide links.]
Use Fragment methods onSaveInstanceState and onViewStateRestored to reload the books. Now the app don't use Internet every time the user rotates the device. As you can see on the GIF the reload is quite faster.
Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
![](https://media.giphy.com/media/55tELYEheb1GAf4MgV/giphy.gif)