### PR TITLE
Unregister receiver when LibraryFragment is destroyed in the fragment itself

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -183,15 +183,6 @@ public class ZimManageActivity extends AppCompatActivity implements ZimManageVie
   }
 
   @Override
-  public void finish() {
-    if (LibraryFragment.isReceiverRegistered) {
-      unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
-      LibraryFragment.isReceiverRegistered = false;
-    }
-    super.finish();
-  }
-
-  @Override
   public boolean onCreateOptionsMenu(Menu menu) {
     // Inflate the menu; this adds items to the action bar if it is present.
     getMenuInflater().inflate(R.menu.menu_zim_manager, menu);

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -243,6 +243,10 @@ public class LibraryFragment extends Fragment
       super.getActivity().unbindService(mConnection.downloadServiceInterface);
       mBound = false;
     }
+    if (isReceiverRegistered) {
+      faActivity.unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
+      isReceiverRegistered = false;
+    }
   }
 
   @Override

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.java
@@ -244,7 +244,7 @@ public class LibraryFragment extends Fragment
       mBound = false;
     }
     if (isReceiverRegistered) {
-      faActivity.unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
+      faActivity.unregisterReceiver(networkBroadcastReceiver);
       isReceiverRegistered = false;
     }
   }

--- a/app/src/main/res/layout/zim_list.xml
+++ b/app/src/main/res/layout/zim_list.xml
@@ -28,7 +28,6 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_below="@id/toolbar"
-      android:background="?attr/listBackground"
       android:divider="@null"
       android:paddingBottom="@dimen/zimfilelist_padding_bottom" />
 


### PR DESCRIPTION
Fixes #550

Changes: Moved unregistering of broadcast receiver from ```ZimManageActivity``` to the ```LibraryFragment```.
