### PR TITLE
Fix scrolling toolbar

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -114,6 +114,8 @@ import butterknife.ButterKnife;
 import okhttp3.OkHttpClient;
 
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
+import static android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS;
+import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
 import static org.kiwix.kiwixmobile.TableDrawerAdapter.DocumentSection;
 import static org.kiwix.kiwixmobile.TableDrawerAdapter.TableClickListener;
 import static org.kiwix.kiwixmobile.utils.Constants.BOOKMARK_CHOSEN_REQUEST;
@@ -359,6 +361,12 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
   @Override
   public void onCreate(Bundle savedInstanceState) {
     getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      getWindow().clearFlags(FLAG_TRANSLUCENT_STATUS);
+      getWindow().addFlags(FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.primary_dark));
+    }
 
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     wifiOnly = sharedPreferences.getBoolean(PREF_WIFI_ONLY, true);

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -931,8 +931,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     isFullscreenOpened = false;
     getCurrentWebView().requestLayout();
     if (!isHideToolbar) {
-      toolbarContainer.setTranslationY(DimenUtils.getTranslucentStatusBarHeight(this));
-      this.getCurrentWebView().setTranslationY(DimenUtils.getToolbarAndStatusBarHeight(this));
+      this.getCurrentWebView().setTranslationY(DimenUtils.getToolbarHeight(this));
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -361,12 +361,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
   @Override
   public void onCreate(Bundle savedInstanceState) {
     getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      getWindow().clearFlags(FLAG_TRANSLUCENT_STATUS);
-      getWindow().addFlags(FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-      getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.primary_dark));
-    }
+    StyleUtils.styleStatusBar(this);
 
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     wifiOnly = sharedPreferences.getBoolean(PREF_WIFI_ONLY, true);

--- a/app/src/main/java/org/kiwix/kiwixmobile/bookmarks_view/BookmarksActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/bookmarks_view/BookmarksActivity.java
@@ -49,6 +49,7 @@ import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.di.components.ApplicationComponent;
 import org.kiwix.kiwixmobile.settings.KiwixSettingsActivity;
+import org.kiwix.kiwixmobile.utils.StyleUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,6 +81,7 @@ public class BookmarksActivity extends BaseActivity
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    StyleUtils.styleStatusBar(this);
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     if (KiwixSettingsActivity.nightMode(sharedPreferences)) {
       setTheme(R.style.AppTheme_Night);

--- a/app/src/main/java/org/kiwix/kiwixmobile/search/SearchActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/search/SearchActivity.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
+import org.kiwix.kiwixmobile.utils.StyleUtils;
 import org.kiwix.kiwixmobile.views.AutoCompleteAdapter;
 
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ public class SearchActivity extends AppCompatActivity
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    StyleUtils.styleStatusBar(this);
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
     if (sharedPreferences.getBoolean(PREF_NIGHTMODE, false)) {
       setTheme(R.style.AppTheme_Night);

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
@@ -85,6 +85,7 @@ public class KiwixSettingsActivity extends AppCompatActivity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
 
+    StyleUtils.styleStatusBar(this);
     if(nightMode(PreferenceManager.getDefaultSharedPreferences(this))){
       setTheme(R.style.AppTheme_Night);
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/StyleUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/StyleUtils.java
@@ -19,17 +19,23 @@
 
 package org.kiwix.kiwixmobile.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.support.annotation.XmlRes;
+import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.Spanned;
 import android.util.AttributeSet;
 import android.util.Xml;
+import android.view.Window;
 
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
 import org.xmlpull.v1.XmlPullParser;
+
+import static android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS;
+import static android.view.WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
 
 public class StyleUtils {
   public static int dialogStyle() {
@@ -62,6 +68,24 @@ public class StyleUtils {
       return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY);
     } else {
       return Html.fromHtml(source);
+    }
+  }
+
+  /**
+   * This method clears the {@link android.view.WindowManager.LayoutParams#FLAG_TRANSLUCENT_STATUS
+   * FLAG_TRANSLUCENT_STATUS} for kitkat and above devices so that the action bar doesn't overlaps
+   * with the status bar and the color of status bar is not white.
+   * For post lollipop devices, this method colors the status bar with colorPrimaryDark.
+   * @param activity The activity to style.
+   */
+  public static void styleStatusBar(Activity activity) {
+    Window window = activity.getWindow();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      window.clearFlags(FLAG_TRANSLUCENT_STATUS);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      window.addFlags(FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      window.setStatusBarColor(ContextCompat.getColor(activity, R.color.primary_dark));
     }
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/web/ToolbarScrollingKiwixWebView.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/web/ToolbarScrollingKiwixWebView.java
@@ -30,7 +30,6 @@ import org.kiwix.kiwixmobile.utils.DimenUtils;
 
 public class ToolbarScrollingKiwixWebView extends KiwixWebView {
 
-  private final int statusBarHeight = DimenUtils.getTranslucentStatusBarHeight(getContext());
   private final int toolbarHeight = DimenUtils.getToolbarHeight(getContext());
   private View toolbarView;
   private View bottombarView;
@@ -45,27 +44,27 @@ public class ToolbarScrollingKiwixWebView extends KiwixWebView {
 
   protected boolean moveToolbar(int scrollDelta) {
     float newTranslation;
-    float originalTranslation = toolbarView.getTranslationY() - statusBarHeight;
+    float originalTranslation = toolbarView.getTranslationY();
     if (scrollDelta > 0) {
       // scroll down
-      newTranslation = Math.max(-statusBarHeight - toolbarHeight, originalTranslation - scrollDelta);
+      newTranslation = Math.max(-toolbarHeight, originalTranslation - scrollDelta);
     } else {
       // scroll up
       newTranslation = Math.min(0, originalTranslation - scrollDelta);
     }
 
-    toolbarView.setTranslationY(newTranslation + statusBarHeight);
-    bottombarView.setTranslationY(newTranslation * -1 * (bottombarView.getHeight() / (float) (statusBarHeight + toolbarHeight)));
-    this.setTranslationY(newTranslation + toolbarHeight + statusBarHeight);
+    toolbarView.setTranslationY(newTranslation);
+    bottombarView.setTranslationY(newTranslation * -1 * (bottombarView.getHeight() / (float) (toolbarHeight)));
+    this.setTranslationY(newTranslation + toolbarHeight);
     if (listener != null && newTranslation != originalTranslation) {
-      if (newTranslation == -toolbarHeight -statusBarHeight) {
+      if (newTranslation == -toolbarHeight) {
         listener.onToolbarHidden();
       } else if (newTranslation == 0) {
         listener.onToolbarDisplayed();
       }
     }
 
-    return toolbarHeight + newTranslation != 0 && newTranslation != 0;
+    return newTranslation != -toolbarHeight && newTranslation != 0;
   }
 
   @Override

--- a/app/src/main/java/org/kiwix/kiwixmobile/views/web/ToolbarStaticKiwixWebView.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/views/web/ToolbarStaticKiwixWebView.java
@@ -18,9 +18,7 @@ public class ToolbarStaticKiwixWebView extends KiwixWebView {
 
   public ToolbarStaticKiwixWebView(Context context, WebViewCallback callback, ViewGroup toolbarLayout, AttributeSet attrs) {
     super(context, callback, attrs);
-    int statusBarHeight = DimenUtils.getTranslucentStatusBarHeight(context);
-    toolbarLayout.setTranslationY(statusBarHeight);
-    heightDifference = DimenUtils.getToolbarAndStatusBarHeight(context);
+    heightDifference = DimenUtils.getToolbarHeight(context);
     setTranslationY(heightDifference);
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -25,6 +25,7 @@ import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.KiwixMobileActivity;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.settings.KiwixSettingsActivity;
+import org.kiwix.kiwixmobile.utils.StyleUtils;
 import org.kiwix.kiwixmobile.views.LanguageSelectDialog;
 import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 
@@ -75,6 +76,7 @@ public class ZimManageActivity extends AppCompatActivity implements ZimManageVie
     if (KiwixSettingsActivity.nightMode(sharedPreferences)) {
       setTheme(R.style.AppTheme_Night);
     }
+    StyleUtils.styleStatusBar(this);
     super.onCreate(savedInstanceState);
     setContentView(R.layout.zim_manager);
     setupDagger();

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -4,21 +4,19 @@
   android:id="@+id/snackbar_layout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:fitsSystemWindows="false"
+  android:fitsSystemWindows="true"
   android:orientation="vertical">
 
 
   <android.support.v4.widget.DrawerLayout
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <android.support.design.internal.ScrimInsetsFrameLayout
       android:id="@+id/content_frame"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:fitsSystemWindows="true"
       android:orientation="vertical" />
 
     <RelativeLayout

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -17,6 +17,7 @@
       android:id="@+id/content_frame"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
+      app:insetForeground="@android:color/transparent"
       android:orientation="vertical" />
 
     <RelativeLayout


### PR DESCRIPTION
Fixes #226
### Description: 
The issue appeared because we were relying on the status bar to position our content on the screen. For example, the Toolbar's initial y position was set to be the status bar height(the root cause of the issue).
### Changes:
-  Removed the status bar height dependency while laying out action bar and webview by use of [fitsSystemWindows](https://developer.android.com/reference/android/view/View.html#attr_android:fitsSystemWindows).
- The status bar was colored so that the action bar isn't partially visible in this new implementation(while scrolling the action bar now only scrolls up max by its height).
- The [ScrimInsetFrameLayout](https://github.com/kiwix/kiwix-android/blob/master/app/src/main/res/layout/main.xml#L17)(in which the webview is placed) is used to color the insets applied by the system. These insets were visible directly on the webview. So, the insetColor was made transparent.
- On KitKat version, however, coloring of the status bar isn't possible. So, the status bar was made opaque(black color). This behavior is consistent with most apps on KitKat.

### Screenshots/GIF for the change: 
- [Old Implementation](https://drive.google.com/drive/folders/1041qltPQxkVcle0QlgJdhn9uyMKIdR3a?usp=sharing)
- [New Implementation](https://drive.google.com/drive/folders/1k1U4jaB5m8by0CyycTZwn8jdUR79qzSr?usp=sharing)
