### PR TITLE
Fix: App minimizing on back pressed in fullscreen mode

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -1137,6 +1137,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         case KeyEvent.KEYCODE_BACK:
           if (getCurrentWebView().canGoBack()) {
             getCurrentWebView().goBack();
+          } else if (isFullscreenOpened) {
+            closeFullScreen();
           } else {
             finish();
           }


### PR DESCRIPTION
Fixes #569.

Changes: Implemented the back button action using `onKeyDown()` to support going back till the parent WebView and then exit the full-screen.

Screenshots/GIF for the change: Attached in the issue itself.
