### PR TITLE
Moved Play-Store URI constants to Network Utils 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,9 +89,9 @@ dependencies {
   implementation 'commons-io:commons-io:2.5'
 
   // Square
-  implementation 'com.squareup.okhttp3:okhttp:3.7.0'
+  implementation 'com.squareup.okhttp3:okhttp:3.8.0'
   implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
-  implementation 'com.squareup.retrofit2:retrofit:2.1.0'
+  implementation 'com.squareup.retrofit2:retrofit:2.3.0'
   implementation 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
   implementation('com.squareup.retrofit2:converter-simplexml:2.1.0') {
     exclude group: 'xpp3', module: 'xpp3'
@@ -102,8 +102,8 @@ dependencies {
   androidTestImplementation 'com.squareup.spoon:spoon-client:1.7.1'
 
   // Butterknife
-  implementation 'com.jakewharton:butterknife:8.0.1'
-  annotationProcessor 'com.jakewharton:butterknife-compiler:8.0.1'
+  implementation 'com.jakewharton:butterknife:8.6.0'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
 
   // RxJava
   implementation 'io.reactivex:rxandroid:1.1.0'
@@ -254,7 +254,7 @@ android {
           sourceFile = file(directory + "/" + parsedJson.zim_file)
         }
         if (parsedJson.embed_zim) {
-         // Place content in each lib directory for embeded zims
+         // Place content in each lib directory for embedded zims
           for (String archName : archs) {
            copy {
              from sourceFile

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -182,10 +182,6 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
 
   public static boolean wifiOnly;
 
-  private static Uri KIWIX_LOCAL_MARKET_URI;
-
-  private static Uri KIWIX_BROWSER_MARKET_URI;
-
   private String documentParserJs;
 
   public static boolean nightMode;
@@ -525,8 +521,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
   }
 
   private void initPlayStoreUri() {
-    KIWIX_LOCAL_MARKET_URI = Uri.parse("market://details?id=" + getPackageName());
-    KIWIX_BROWSER_MARKET_URI =
+    NetworkUtils.KIWIX_LOCAL_MARKET_URI = Uri.parse("market://details?id=" + getPackageName());
+    NetworkUtils.KIWIX_BROWSER_MARKET_URI =
         Uri.parse("http://play.google.com/store/apps/details?id=" + getPackageName());
   }
 
@@ -590,7 +586,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
 
   private void goToRateApp() {
 
-    Intent goToMarket = new Intent(Intent.ACTION_VIEW, KIWIX_LOCAL_MARKET_URI);
+    Intent goToMarket = new Intent(Intent.ACTION_VIEW, NetworkUtils.KIWIX_LOCAL_MARKET_URI);
 
     goToMarket.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY |
         Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET |
@@ -600,7 +596,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
       startActivity(goToMarket);
     } catch (ActivityNotFoundException e) {
       startActivity(new Intent(Intent.ACTION_VIEW,
-          KIWIX_BROWSER_MARKET_URI));
+          NetworkUtils.KIWIX_BROWSER_MARKET_URI));
     }
   }
 
@@ -1318,7 +1314,7 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     }
   }
 
-  // TODO: change saving bookbark by zim name not id
+  // TODO: change saving bookmark by zim name not id
   private void saveBookmark(String articleUrl, String articleTitle) {
     bookmarksDao.saveBookmark(articleUrl, articleTitle, ZimContentProvider.getId(), ZimContentProvider.getName());
     refreshBookmarks();
@@ -1402,7 +1398,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     // However, it must notify the bookmark system when a page is finished loading
     // so that it can refresh the menu.
 
-    backToTopButton.setOnClickListener(view -> KiwixMobileActivity.this.runOnUiThread(() -> getCurrentWebView().pageUp(true)));
+    backToTopButton.setOnClickListener(view -> KiwixMobileActivity.this.
+            runOnUiThread(() -> getCurrentWebView().pageUp(true)));
     tts.initWebView(getCurrentWebView());
   }
 
@@ -1472,7 +1469,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
       case REQUEST_FILE_SEARCH:
         if (resultCode == RESULT_OK) {
           String title =
-              data.getStringExtra(TAG_FILE_SEARCHED).replace("<b>", "").replace("</b>", "");
+              data.getStringExtra(TAG_FILE_SEARCHED).replace("<b>", "").replace("</b>",
+                      "");
           searchForTitle(title);
         } else { //TODO: Inform the User
           Log.w(TAG_KIWIX, "Unhandled search failure");
@@ -1740,7 +1738,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
       String filePath = FileUtils.getLocalFilePathByUri(getApplicationContext(), getIntent().getData());
 
       if (filePath == null || !new File(filePath).exists()) {
-        Toast.makeText(KiwixMobileActivity.this, getString(R.string.error_filenotfound), Toast.LENGTH_LONG).show();
+        Toast.makeText(KiwixMobileActivity.this, getString(R.string.error_filenotfound),
+                Toast.LENGTH_LONG).show();
         return;
       }
 
@@ -1760,7 +1759,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
       } else {
 
         if (BuildConfig.IS_CUSTOM_APP) {
-          Log.d(TAG_KIWIX, "Kiwix Custom App starting for the first time. Checking Companion ZIM: " + BuildConfig.ZIM_FILE_NAME);
+          Log.d(TAG_KIWIX, "Kiwix Custom App starting for the first time. Checking Companion ZIM: "
+                  + BuildConfig.ZIM_FILE_NAME);
 
           String currentLocaleCode = Locale.getDefault().toString();
           // Custom App recommends to start off a specific language

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
@@ -3,6 +3,7 @@ package org.kiwix.kiwixmobile.utils;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
 
@@ -13,6 +14,9 @@ import java.util.UUID;
 import static org.kiwix.kiwixmobile.utils.Constants.TAG_KIWIX;
 
 public class NetworkUtils {
+
+  public static Uri KIWIX_LOCAL_MARKET_URI;
+  public static Uri KIWIX_BROWSER_MARKET_URI;
 
   public static boolean isNetworkAvailable(Context context) {
     ConnectivityManager connectivity = (ConnectivityManager) context

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -10,7 +10,6 @@ import android.support.design.widget.AppBarLayout;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SearchView;
@@ -18,7 +17,6 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.Toast;
 
 import org.kiwix.kiwixmobile.KiwixApplication;
@@ -116,7 +114,7 @@ public class ZimManageActivity extends AppCompatActivity implements ZimManageVie
 
     // Disable scrolling for the AppBarLayout on top of the screen
     // User can only scroll the PageViewer component
-    AppBarLayout appBarLayout = (AppBarLayout) findViewById(R.id.appbar);
+    AppBarLayout appBarLayout = findViewById(R.id.appbar);
     if (appBarLayout.getLayoutParams() != null) {
       CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams) appBarLayout.getLayoutParams();
       AppBarLayout.Behavior appBarLayoutBehaviour = new AppBarLayout.Behavior();


### PR DESCRIPTION
Fixes  #563 

Changes: Play store URI constants `KIWIX_LOCAL_MARKET_URI` and `KIWIX_BROWSER_MARKET_URI` moved from `KiwixMobileActivity ` class to `NetworkUtils ` class.

![screen shot 2018-03-04 at 1 57 25 pm](https://user-images.githubusercontent.com/31950172/36943735-2dde31f0-1fb4-11e8-810a-76c10075c89e.png)

![screen shot 2018-03-04 at 1 56 28 pm](https://user-images.githubusercontent.com/31950172/36943738-34fb1458-1fb4-11e8-8f3c-1a72ab943895.png)
