### PR TITLE
Correct shade of bottom toolbar

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -108,7 +108,7 @@
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_gravity="bottom"
-        android:background="@color/grey"
+        android:background="@color/dark_grey"
         android:visibility="gone"
         app:tabGravity="fill"
         app:tabIndicatorColor="@color/grey"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,7 @@
   <color name="greyed_out_selected">#BDBDBD</color>
   <color name="black_regular_mat_design">#212121</color>
   <color name="grey">#5a5a5a</color>
+  <color name="dark_grey">#212121</color>
   <color name="blue_grey">#ECEFF1</color>
   <color name="foreground_material_dark">@android:color/white</color>
   <color name="back_to_top_background">#DDFFFFFF</color>


### PR DESCRIPTION
Fixes #611
Changes: Correct shade of grey for bottom toolbar
Added `<color name="dark_grey">#212121</color>` in 'colors.xml'

![tool](https://user-images.githubusercontent.com/29516629/37343690-4e6e083c-26ee-11e8-9677-8afbe2df2476.gif)

@mhutti1 Please review and merge.
