### PR TITLE
Refactor manageExternalLaunchAndRestoringViewState

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -1803,22 +1803,19 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
 
           if (!FileUtils.doesFileExist(filePath, BuildConfig.ZIM_FILE_SIZE, false)) {
 
-            AlertDialog.Builder zimFileMissingBuilder = new AlertDialog.Builder(this, dialogStyle());
-            zimFileMissingBuilder.setTitle(R.string.app_name);
-            zimFileMissingBuilder.setMessage(R.string.customapp_missing_content);
-            zimFileMissingBuilder.setIcon(R.mipmap.kiwix_icon);
-            final Activity activity = this;
-            zimFileMissingBuilder.setPositiveButton(getString(R.string.go_to_play_store),
-                    (dialog, which) -> {
-                      String market_uri = "market://details?id=" + BuildConfig.APPLICATION_ID;
-                      Intent intent = new Intent(Intent.ACTION_VIEW);
-                      intent.setData(Uri.parse(market_uri));
-                      startActivity(intent);
-                      activity.finish();
-                    });
-            zimFileMissingBuilder.setCancelable(false);
-            AlertDialog zimFileMissingDialog = zimFileMissingBuilder.create();
-            zimFileMissingDialog.show();
+            new AlertDialog.Builder(this, dialogStyle())
+                .setTitle(R.string.app_name)
+                .setMessage(R.string.customapp_missing_content)
+                .setIcon(R.mipmap.kiwix_icon)
+                .setCancelable(false)
+                .setPositiveButton(getString(R.string.go_to_play_store), (dialog, which) -> {
+                  String market_uri = "market://details?id=" + BuildConfig.APPLICATION_ID;
+                  Intent intent = new Intent(Intent.ACTION_VIEW);
+                  intent.setData(Uri.parse(market_uri));
+                  startActivity(intent);
+                  finish();
+                })
+                .show();
           } else {
             openZimFile(new File(filePath), true);
           }

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -1376,13 +1376,9 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     // since it seems the onUpdate() is only fired on that:
     AppWidgetManager widgetManager = AppWidgetManager.getInstance(context);
     int[] ids = widgetManager.getAppWidgetIds(new ComponentName(context, KiwixSearchWidget.class));
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-      widgetManager.notifyAppWidgetViewDataChanged(ids, android.R.id.list);
-
-      intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
-      context.sendBroadcast(intent);
-    }
+    widgetManager.notifyAppWidgetViewDataChanged(ids, android.R.id.list);
+    intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
+    context.sendBroadcast(intent);
   }
 
   private void setUpWebView() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -20,7 +20,6 @@
 package org.kiwix.kiwixmobile;
 
 import android.Manifest;
-import android.app.Activity;
 import android.appwidget.AppWidgetManager;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
@@ -75,7 +74,14 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
-
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.inject.Inject;
+import okhttp3.OkHttpClient;
 import org.json.JSONArray;
 import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.bookmarks_view.BookmarksActivity;
@@ -103,18 +109,9 @@ import org.kiwix.kiwixmobile.views.web.ToolbarStaticKiwixWebView;
 import org.kiwix.kiwixmobile.zim_manager.ZimManageActivity;
 import org.kiwix.kiwixmobile.zim_manager.library_view.LibraryFragment;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
-import javax.inject.Inject;
-
-import butterknife.BindView;
-import butterknife.ButterKnife;
-import okhttp3.OkHttpClient;
-
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES;
 import static org.kiwix.kiwixmobile.TableDrawerAdapter.DocumentSection;
 import static org.kiwix.kiwixmobile.TableDrawerAdapter.TableClickListener;
 import static org.kiwix.kiwixmobile.search.SearchActivity.EXTRA_SEARCH_IN_TEXT;
@@ -147,8 +144,6 @@ import static org.kiwix.kiwixmobile.utils.Constants.TAG_CURRENT_TAB;
 import static org.kiwix.kiwixmobile.utils.Constants.TAG_FILE_SEARCHED;
 import static org.kiwix.kiwixmobile.utils.Constants.TAG_KIWIX;
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES;
 
 public class KiwixMobileActivity extends BaseActivity implements WebViewCallback {
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
@@ -126,7 +126,7 @@ public class FileUtils {
    * @param deleteFileOnMismatch if the file sizes do not match, delete the file
    * @return true if it does exist, false otherwise
    */
-  static public boolean doesFileExist(String fileName, long fileSize,
+  static public boolean doesValidFileExist(String fileName, long fileSize,
                                       boolean deleteFileOnMismatch) {
 
     Log.d(TAG_KIWIX, "Looking for '" + fileName + "' with size=" + fileSize);


### PR DESCRIPTION
- rename method to loadZimFile because manageExternalLaunchAndRestoringViewState
is a very confusing name
- remove unnecessary logs and added comments instead
- reduced nesting

This does not add any new functionality. It's just reducing complexity.