### PR TITLE
Fix widget's wrong work.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -507,6 +507,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
     } else {
       backToTopAppearDaily();
     }
+
+    handleIntent(getIntent());
   }
 
   private void backToTopAppearDaily() {
@@ -1259,9 +1261,17 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         menuBookmarks.setVisible(true);
       }
     }
+  }
 
-    Log.d(TAG_KIWIX, "action" + getIntent().getAction());
-    Intent intent = getIntent();
+  /**
+   * Handle incoming intent, specially widget intent.
+   * When widget button is clicked, handleIntent method do what user want.
+   *
+   * @param intent: incoming intent
+   * @return return result that intent is handled or not
+   */
+  private boolean handleIntent(Intent intent) {
+    Log.d(TAG_KIWIX, "action" + intent.getAction());
     if (intent.getAction() != null) {
 
       if (intent.getAction().equals(Intent.ACTION_PROCESS_TEXT)) {
@@ -1272,16 +1282,16 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
           i.putExtra(Intent.EXTRA_PROCESS_TEXT, intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT));
         }
-        intent.setAction("");
+        intent.setAction(null);
         startActivityForResult(i, REQUEST_FILE_SEARCH);
-      } else if (intent.getAction().equals(KiwixSearchWidget.TEXT_CLICKED)){
-        intent.setAction("");
+      } else if (intent.getAction().equals(KiwixSearchWidget.TEXT_CLICKED)) {
+        intent.setAction(null);
         goToSearch(false);
       } else if (intent.getAction().equals(KiwixSearchWidget.STAR_CLICKED)) {
-        intent.setAction("");
+        intent.setAction(null);
         goToBookmarks();
       } else if (intent.getAction().equals(KiwixSearchWidget.MIC_CLICKED)) {
-        intent.setAction("");
+        intent.setAction(null);
         goToSearch(true);
       } else if (intent.getAction().equals(Intent.ACTION_VIEW)) {
         final String zimFile = ZimContentProvider.getZimFile();
@@ -1292,14 +1302,21 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
         intent.setAction("");
         startActivityForResult(i, REQUEST_FILE_SEARCH);
       }
-
+      updateWidgets(this);
+      return true;
     }
-    updateWidgets(this);
+    return false;
   }
 
   @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
+
+    boolean handled = handleIntent(intent);
+    if (handled) {
+      return;
+    }
+
     boolean isWidgetSearch = intent.getBooleanExtra(EXTRA_IS_WIDGET_SEARCH, false);
     boolean isWidgetVoiceSearch = intent.getBooleanExtra(EXTRA_IS_WIDGET_VOICE, false);
     boolean isWidgetStar = intent.getBooleanExtra(EXTRA_IS_WIDGET_STAR, false);

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixSearchWidget.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/KiwixSearchWidget.java
@@ -47,25 +47,30 @@ public class KiwixSearchWidget extends AppWidgetProvider {
     for (int id : appWidgetIds) {
       RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.kiwix_search_widget);
       views.setTextViewText(R.id.search_widget_text, "Search " + appName);
+
       /** Search Kiwix intent **/
       Intent mainIntent = new Intent(context, KiwixMobileActivity.class);
       mainIntent.setAction(TEXT_CLICKED);
+      mainIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
       PendingIntent searchPendingIntent = PendingIntent.getActivity(context, (int) (System.currentTimeMillis() % Integer.MAX_VALUE), mainIntent, 0);
 
       /** Kiwix icon intent to main app **/
       Intent kiwixIconIntent = new Intent(context, KiwixMobileActivity.class);
       kiwixIconIntent.setAction(ICON_CLICKED);
+      mainIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
       PendingIntent mainAppPendingIntent = PendingIntent.getActivity(context, (int) (System.currentTimeMillis() % Integer.MAX_VALUE), kiwixIconIntent, 0);
 
       /** Star icon intent to bookmarks **/
       Intent starIntent = new Intent(context, KiwixMobileActivity.class);
       starIntent.setAction(STAR_CLICKED);
+      mainIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
       PendingIntent starPendingIntent = PendingIntent.getActivity(context, (int) (System.currentTimeMillis() % Integer.MAX_VALUE), starIntent, 0);
 
 
       /** Microphone icon intent for voice search **/
       Intent voiceIntent = new Intent(context, KiwixMobileActivity.class);
       voiceIntent.setAction(MIC_CLICKED);
+      mainIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
       PendingIntent voicePendingIntent = PendingIntent.getActivity(context, (int) (System.currentTimeMillis() % Integer.MAX_VALUE), voiceIntent, 0);
 
       views.setOnClickPendingIntent(R.id.search_widget_text, searchPendingIntent);


### PR DESCRIPTION
Fixes #625

### Problem 
Widget works not properly in specific case.

### Changes: 

Before fix it, handling intent is called on `onResume` method. But I think it is not good to handle intent in that place.

When widget is clicked to start activity, I add `SINGLE_TOP` flag on intent.
So ...

1) If activity already exist, then intent is handled in `onNewIntent` callback.

2) Starting new activity, intent is handled in `onCreate` callback.

`handleIntent` what I made do handle widget's intent.

Review plz :) @mhutti1 @kelson42 