### PR TITLE
Fixed: Unregister Receiver

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.java
@@ -207,6 +207,15 @@ public class ZimManageActivity extends AppCompatActivity implements ZimManageVie
   }
 
   @Override
+  protected void onStop() {
+    if (LibraryFragment.isReceiverRegistered) {
+      unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
+      LibraryFragment.isReceiverRegistered = false;
+    }
+    super.onStop();
+  }
+
+  @Override
   public boolean onCreateOptionsMenu(Menu menu) {
     // Inflate the menu; this adds items to the action bar if it is present.
     getMenuInflater().inflate(R.menu.menu_zim_manager, menu);


### PR DESCRIPTION
Fixes #600 

Changes: Added unregisterReceiver() in onStop() to stop the crash. 
```
unregisterReceiver(LibraryFragment.networkBroadcastReceiver);
```    
 