### PR TITLE
Fixed : Help in Bookmarks Tab in Bottom Nav Bar

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -338,7 +338,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
 
     @Override
     public void onBookmarkTabSelected() {
-      toggleBookmark();
+      if (!getCurrentWebView().getUrl().equals("file:///android_asset/help.html"))
+        toggleBookmark();
     }
 
     @Override


### PR DESCRIPTION
Fixes #610 

Changes: Added comparison so that app doesn't crash when someone accidentally clicks on Bookmark on the Help page.