### PR TITLE
Fix: App directly minimizes on back pressed in Find in page

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -1166,11 +1166,10 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
             getCurrentWebView().goBack();
           } else if (isFullscreenOpened) {
             closeFullScreen();
+          } else if (compatCallback.mIsActive) {
+            compatCallback.finish();
           } else {
             finish();
-          }
-          if (compatCallback.mIsActive) {
-            compatCallback.finish();
           }
           return true;
         case KeyEvent.KEYCODE_MENU:


### PR DESCRIPTION
Fixes #672 

Changes: Implemented the back button action using `onKeyDown()` to close the `ActionMode` of `Find in page`. 

Screenshots/GIF for the change: Attached in the issue itself.
