### PR TITLE
Specify round icon in AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
       android:hardwareAccelerated="true"
       android:icon="@mipmap/kiwix_icon"
       android:label="@string/app_name"
+      android:roundIcon="@mipmap/kiwix_icon_round"
       android:supportsRtl="true"
       android:theme="@style/AppTheme">
     <activity


### PR DESCRIPTION
Fixes #681 

The circular icon was not specified in **AndroidManifest**, therefore, it was not used. Although the circular icon was present in the mipmaps.

Screenshot:
![image](https://user-images.githubusercontent.com/20206262/38167986-2facdea4-355e-11e8-8312-050f1c4f7ab9.png)

