### PR TITLE
Exit on double back press.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -216,6 +216,8 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
 
   private BookmarksDao bookmarksDao;
 
+  private static boolean backPressedOnce = false;
+
   @BindView(R.id.toolbar) Toolbar toolbar;
 
   @BindView(R.id.button_backtotop) Button backToTopButton;
@@ -1167,7 +1169,20 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
           } else if (isFullscreenOpened) {
             closeFullScreen();
           } else {
-            finish();
+            if (!backPressedOnce){
+              backPressedOnce = true;
+              Toast.makeText(this,"Please click BACK again to exit.", Toast.LENGTH_SHORT).show();
+
+              new Handler().postDelayed(new Runnable() {
+
+                @Override
+                public void run() {
+                  backPressedOnce = false;
+                }
+              }, 2000);
+            } else {
+              finish();
+            }
           }
           if (compatCallback.mIsActive) {
             compatCallback.finish();


### PR DESCRIPTION
Fixes #678 
While on the ZIM homescreen, the user has to double press back to exit the app.
Title: Double back press to exit.
Type: Implement exit on double press from homescreen.
