### PR TITLE
Basic tweak to show the text Get Content button in landscape mode.

### DIFF
--- a/app/src/main/res/layout/help.xml
+++ b/app/src/main/res/layout/help.xml
@@ -32,7 +32,7 @@
 
           <ImageView
             android:id="@+id/welcome_image"
-            android:layout_width="match_parent"
+            android:layout_width="400dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_horizontal"
             android:adjustViewBounds="true"


### PR DESCRIPTION
Potential fix for #693 however you're welcome to suggest better approaches. I've tested this tweak on various devices with different screen dimensions. We could consider using ConstraintLayouts but we'd need to change the code in https://github.com/kiwix/kiwix-android/blob/master/app/src/main/java/org/kiwix/kiwixmobile/KiwixWebViewClient.java which casts the content to `LinearLayout` currently (line 101)

Screenshots/GIF for the change: 
![portrait mode image 400dp](https://user-images.githubusercontent.com/785891/38582829-f1171670-3d08-11e8-8cb3-defc18de8b67.png)

![landscape mode image 400dp](https://user-images.githubusercontent.com/785891/38582833-f786aba6-3d08-11e8-934b-94a844ac9d71.png)

