### PR TITLE
Fix Content Header stale value bug

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
@@ -79,7 +79,7 @@ public class TableDrawerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     if (position == 0) {
       vh.title.setTypeface(Typeface.DEFAULT_BOLD);
       vh.title.setTextColor(primary);
-      if (title != null) {
+      if (title != null && !title.isEmpty()) {
         vh.title.setText(title);
       } else {
         String empty = context.getString(R.string.no_section_info);

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/DocumentParser.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/DocumentParser.java
@@ -69,6 +69,7 @@ public class DocumentParser {
     @JavascriptInterface
     @SuppressWarnings("unused")
     public void start() {
+      title = "";
       sections = new ArrayList<>();
       new Handler(Looper.getMainLooper()).post(() -> listener.clearSections());
     }


### PR DESCRIPTION
Fixes #691 

Changes: Minor change made so that the right drawer's adapter doesn't get previous value of content header if it doesn't exist in the current article.
