### PR TITLE
[WIP] Added ongoing downloads notification channel

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -123,4 +123,8 @@ public final class Constants {
     public static final String EXTRA_BOOKMARK_CONTENTS = "bookmark_contents";
 
     public static final String EXTRA_SEARCH_TEXT = "searchText";
+
+    // Notification Channel Constants
+    public static final String ONGOING_DOWNLOAD_CHANNEL_ID = "ongoing_downloads_channel_id";
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,4 +170,6 @@
   <string name="your_languages">Selected languages:</string>
   <string name="other_languages">Other languages:</string>
   <string name="no_items_msg">No items available</string>
+  <string name="ongoing_download_channel_name">Ongoing Downloads</string>
+  <string name="ongoing_download_channel_desc">Category for ongoing zim file downloads.</string>
 </resources>


### PR DESCRIPTION
First steps for issue #702.

Changes: Added a notification channel named "Ongoing Downloads".

Pending Tasks:
- [ ] Add a preference in the settings screen to take the user to the [notification settings](https://developer.android.com/training/notify-user/channels.html#UpdateChannel) in Android Oreo.
- [ ] Create a separate notification (with different notification ID) and a separate channel for the notification which is shown when the Zim is downloaded.
    This will be beneficial as user can then change the settings for these notifications independently. For e.g. - A user may choose to increase the _importance_ (or _priority_) of the "zim downloaded notification" so that he/she gets a [Heads-up notification](https://developer.android.com/guide/topics/ui/notifiers/notifications.html#Heads-up) for the download complete event.

Screenshots/GIF for the change: 
Kiwix Notification is now visible in the notification drawer.
![screenshot_20180416-054412_01](https://user-images.githubusercontent.com/24610859/38785170-f0f148f2-4139-11e8-89c6-70fe6175bce9.jpg)
App settings screen for notification channel.
![screenshot_20180416-054437](https://user-images.githubusercontent.com/24610859/38785173-f63bdb38-4139-11e8-95c8-8d28378c3bba.jpg)

