### PR TITLE
Separate partially downloaded zim files until download finishes. 

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/ChunkUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/ChunkUtils.java
@@ -26,7 +26,7 @@ public class ChunkUtils {
 
   public static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
   public static final String ZIM_EXTENSION = ".zim";
-  public static final String PART = ".part";
+  public static final String PART = ".part.part";
   public static final long CHUNK_SIZE = 1024L * 1024L * 1024L * 2L;
 
   public static List<Chunk> getChunks(String url, long contentLength, int notificationID) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -68,6 +68,9 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okio.BufferedSource;
 
+import static org.kiwix.kiwixmobile.downloader.ChunkUtils.ALPHABET;
+import static org.kiwix.kiwixmobile.downloader.ChunkUtils.PART;
+import static org.kiwix.kiwixmobile.downloader.ChunkUtils.ZIM_EXTENSION;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_BOOK;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_LIBRARY;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_NOTIFICATION_ID;
@@ -310,6 +313,35 @@ public class DownloadService extends Service {
             notification.get(notificationID).setContentText(getString(R.string.zim_file_downloaded));
             final Intent target = new Intent(this, KiwixMobileActivity.class);
             target.putExtra(EXTRA_ZIM_FILE, KIWIX_ROOT + StorageUtils.getFileNameFromUrl(book.getUrl()));
+            //Remove the extra ".part" from files
+            String filename = book.file.getPath();
+            if(filename.endsWith(ZIM_EXTENSION)) {
+              filename = filename + PART;
+              File partFile = new File(filename);
+              if(partFile.exists()) {
+                partFile.renameTo(new File(partFile.getPath().replaceAll(".part", "")));
+              }
+            } else {
+              for (int i = 0; true; i++) {
+                char first = ALPHABET.charAt(i / 26);
+                char second = ALPHABET.charAt(i % 26);
+                String chunkExtension = String.valueOf(first) + second;
+                filename = book.file.getPath();
+                filename = filename.replaceAll(".zim([a-z][a-z]){0,1}$", ".zim");
+                filename = filename + chunkExtension + ".part";
+                File partFile = new File(filename);
+                if(partFile.exists()) {
+                  partFile.renameTo(new File(partFile.getPath().replaceAll(".part$", "")));
+                } else {
+                  File lastChunkFile = new File(filename + ".part");
+                  if(lastChunkFile.exists()) {
+                    lastChunkFile.renameTo(new File(partFile.getPath().replaceAll(".part", "")));
+                  } else {
+                    break;
+                  }
+                }
+              }
+            }
             target.putExtra(EXTRA_NOTIFICATION_ID, notificationID);
             PendingIntent pendingIntent = PendingIntent.getActivity
                 (getBaseContext(), 0,
@@ -414,7 +446,7 @@ public class DownloadService extends Service {
         // Create chunk file
         File file = new File(KIWIX_ROOT, chunk.getFileName());
         file.getParentFile().mkdirs();
-        File fullFile = new File(file.getPath().substring(0, file.getPath().length() - 5));
+        File fullFile = new File(file.getPath().substring(0, file.getPath().length() - PART.length()));
 
         long downloaded = Long.parseLong(chunk.getRangeHeader().split("-")[0]);
         if (fullFile.exists() && fullFile.length() == chunk.getSize()) {
@@ -539,16 +571,16 @@ public class DownloadService extends Service {
         if (downloadStatus.get(chunk.getNotificationID()) == CANCEL) {
           String path = file.getPath();
           Log.i(KIWIX_TAG, "Download Cancelled, deleting file: " + path);
-          if (path.substring(path.length() - 8).equals("zim.part")) {
-            path = path.substring(0, path.length() - 5);
+          if (path.substring(path.length() - (ZIM_EXTENSION + PART).length()).equals(ZIM_EXTENSION + PART)) {
+            path = path.substring(0, path.length() - PART.length() + 1);
             FileUtils.deleteZimFile(path);
           } else {
-            path = path.substring(0, path.length() - 7) + "aa";
+            path = path.substring(0, path.length() - (ZIM_EXTENSION + PART).length() + 2) + "aa";
             FileUtils.deleteZimFile(path);
           }
         } else {
-          Log.i(KIWIX_TAG, "Download completed, renaming file ([" + file.getPath() + "] -> .zim)");
-          file.renameTo(new File(file.getPath().replace(".part", "")));
+          Log.i(KIWIX_TAG, "Download completed, renaming file ([" + file.getPath() + "] -> .zim.part)");
+          file.renameTo(new File(file.getPath().replaceAll(".part$", "")));
         }
         // Mark chunk status as downloaded
         chunk.isDownloaded = true;

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.java
@@ -27,6 +27,7 @@ import android.provider.DocumentsContract;
 import android.util.Log;
 
 import org.kiwix.kiwixmobile.BuildConfig;
+import org.kiwix.kiwixmobile.downloader.ChunkUtils;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
 
 import java.io.File;
@@ -61,8 +62,8 @@ public class FileUtils {
   }
 
   public static synchronized void deleteZimFile(String path) {
-    if (path.substring(path.length() - 5).equals(".part")) {
-      path = path.substring(0, path.length() - 5);
+    if (path.substring(path.length() - ChunkUtils.PART.length()).equals(ChunkUtils.PART)) {
+      path = path.substring(0, path.length() - ChunkUtils.PART.length());
     }
     Log.i("kiwix", "Deleting file: " + path);
     File file = new File(path);
@@ -86,10 +87,16 @@ public class FileUtils {
   }
 
   private static synchronized boolean deleteZimFileParts(String path) {
-    File file = new File(path + ".part");
+    File file = new File(path + ChunkUtils.PART);
     if (file.exists()) {
       file.delete();
       return true;
+    } else {
+      File singlePart = new File(path + ".part");
+      if (singlePart.exists()) {
+        singlePart.delete();
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
Fixes #355 

Changes:

1. Changed code to accommodate the new `.part.part` scheme in `DownloadService#downloadChunk`. Now it changed `.part.part` -> `.part`
2. Added code to remove the `.part` from chunks after the entire book has finished downloading.
3. Changed file removal methods to take into consideration the new naming scheme in  `FileUtils`.
