### PR TITLE
Fixing a NPE in isWiFi

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/NetworkUtils.java
@@ -58,6 +58,9 @@ public class NetworkUtils {
 
     if (Build.VERSION.SDK_INT >= 23) {
       NetworkInfo network = connectivity.getActiveNetworkInfo();
+      if (network == null) {
+        return false;
+      }
       return network.getType() == ConnectivityManager.TYPE_WIFI;
     } else {
       NetworkInfo wifi = connectivity.getNetworkInfo(ConnectivityManager.TYPE_WIFI);


### PR DESCRIPTION
A minor fix that was uncovered by running our automated tests on devices without an internet connection (but WiFi had networks available).

I mimiced the behaviour of the lines earlier in the method. It might be worth revising the code soon as it's not entirely accurate these days.

Fixes #722 
