### PR TITLE
Use page title as toc header if h1 is not used

### DIFF
--- a/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/BasicTest.java
+++ b/app/src/androidTestKiwix/java/org/kiwix/kiwixmobile/tests/BasicTest.java
@@ -73,7 +73,7 @@ public class BasicTest {
     openDrawerWithGravity(R.id.drawer_layout, Gravity.RIGHT);
     assertDrawerIsOpenWithGravity(R.id.drawer_layout, Gravity.RIGHT);
 
-    assertDisplayed(R.string.no_section_info);
+    assertDisplayed(R.string.menu_help);
 
     closeDrawerWithGravity(R.id.drawer_layout, Gravity.RIGHT);
     assertDrawerIsClosedWithGravity(R.id.drawer_layout, Gravity.RIGHT);

--- a/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/TableDrawerAdapter.java
@@ -83,6 +83,9 @@ public class TableDrawerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
         vh.title.setText(title);
       } else {
         String empty = context.getString(R.string.no_section_info);
+        if (context instanceof KiwixMobileActivity) {
+          empty = ((KiwixMobileActivity) context).getCurrentWebView().getTitle();
+        }
         vh.title.setText(empty);
       }
       vh.itemView.setOnClickListener(v -> {


### PR DESCRIPTION
Work on #620 

Changes: Use page title as table of contents header if h1 is not set.
