### PR TITLE
Fix provider domain when updating from 2.2

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixMobileActivity.java
@@ -146,6 +146,7 @@ import static org.kiwix.kiwixmobile.utils.Constants.TAG_CURRENT_TAB;
 import static org.kiwix.kiwixmobile.utils.Constants.TAG_FILE_SEARCHED;
 import static org.kiwix.kiwixmobile.utils.Constants.TAG_KIWIX;
 import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
+import static org.kiwix.kiwixmobile.utils.UpdateUtils.reformatProviderUrl;
 
 public class KiwixMobileActivity extends BaseActivity implements WebViewCallback {
 
@@ -1726,11 +1727,11 @@ public class KiwixMobileActivity extends BaseActivity implements WebViewCallback
       JSONArray urls = new JSONArray(zimArticles);
       JSONArray positions = new JSONArray(zimPositions);
       int i = 0;
-      getCurrentWebView().loadUrl(urls.getString(i));
+      getCurrentWebView().loadUrl(reformatProviderUrl(urls.getString(i)));
       getCurrentWebView().setScrollY(positions.getInt(i));
       i++;
       for (; i < urls.length(); i++) {
-        newTab(urls.getString(i));
+        newTab(reformatProviderUrl(urls.getString(i)));
         getCurrentWebView().setScrollY(positions.getInt(i));
       }
       selectTab(currentTab);

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/BookmarksDao.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/BookmarksDao.java
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.database;
 
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
+import com.yahoo.squidb.sql.Update;
 
 import org.kiwix.kiwixmobile.database.entity.Bookmarks;
 
@@ -96,4 +97,26 @@ public class BookmarksDao {
     mDb.deleteWhere(Bookmarks.class, Bookmarks.BOOKMARK_URL.eq(favArticle).and(Bookmarks.ZIM_ID.eq(ZimId).or(Bookmarks.ZIM_NAME.eq(ZimName))) );
   }
 
+  public void processBookmark(StringOperation operation) {
+    SquidCursor<Bookmarks> bookmarkCursor = mDb.query(
+        Bookmarks.class,
+        Query.select(Bookmarks.ID, Bookmarks.BOOKMARK_URL));
+    try {
+      while (bookmarkCursor.moveToNext()) {
+        String url = bookmarkCursor.get(Bookmarks.BOOKMARK_URL);
+        url = operation.apply(url);
+        if (url != null) {
+          mDb.update(Update.table(Bookmarks.TABLE)
+              .where(Bookmarks.ID.eq(bookmarkCursor.get(Bookmarks.ID)))
+              .set(Bookmarks.BOOKMARK_URL, url));
+        }
+      }
+    } finally {
+      bookmarkCursor.close();
+    }
+  }
+
+  public interface StringOperation {
+    String apply(String string);
+  }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/database/KiwixDatabase.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/database/KiwixDatabase.java
@@ -32,6 +32,7 @@ import org.kiwix.kiwixmobile.database.entity.Bookmarks;
 import org.kiwix.kiwixmobile.database.entity.LibraryDatabaseEntity;
 import org.kiwix.kiwixmobile.database.entity.NetworkLanguageDatabaseEntity;
 import org.kiwix.kiwixmobile.database.entity.RecentSearch;
+import org.kiwix.kiwixmobile.utils.UpdateUtils;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -47,7 +48,7 @@ import static org.kiwix.kiwixmobile.utils.Constants.TAG_KIWIX;
 @Singleton
 public class KiwixDatabase extends SquidDatabase {
 
-  private static final int VERSION = 14;
+  private static final int VERSION = 15;
   private Context context;
 
   @Inject
@@ -129,6 +130,9 @@ public class KiwixDatabase extends SquidDatabase {
       tryDropTable(BookDatabaseEntity.TABLE);
       tryCreateTable(BookDatabaseEntity.TABLE);
     }
+    if (newVersion >= 15 && oldVersion < 15) {
+      reformatBookmarks();
+    }
     return true;
   }
 
@@ -164,6 +168,12 @@ public class KiwixDatabase extends SquidDatabase {
         }
       }
     }
+  }
+
+  // Reformat bookmark urls to use correct provider
+  private void reformatBookmarks() {
+    BookmarksDao bookmarksDao = new BookmarksDao(this);
+    bookmarksDao.processBookmark(UpdateUtils::reformatProviderUrl);
   }
 }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -17,6 +17,8 @@
  */
 package org.kiwix.kiwixmobile.utils;
 
+import org.kiwix.kiwixmobile.BuildConfig;
+
 public final class Constants {
 
     public static final String TAG_KIWIX = "kiwix";
@@ -126,5 +128,9 @@ public final class Constants {
 
     // Notification Channel Constants
     public static final String ONGOING_DOWNLOAD_CHANNEL_ID = "ongoing_downloads_channel_id";
+
+    public static final String OLD_PROVIDER_DOMAIN = "org.kiwix.zim.base";
+
+    public static final String NEW_PROVIDER_DOMAIN = BuildConfig.APPLICATION_ID + ".zim.base";
 
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/UpdateUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/UpdateUtils.java
@@ -1,0 +1,10 @@
+package org.kiwix.kiwixmobile.utils;
+
+import static org.kiwix.kiwixmobile.utils.Constants.NEW_PROVIDER_DOMAIN;
+import static org.kiwix.kiwixmobile.utils.Constants.OLD_PROVIDER_DOMAIN;
+
+public class UpdateUtils {
+  public static String reformatProviderUrl(String url) {
+    return url.replace(OLD_PROVIDER_DOMAIN, NEW_PROVIDER_DOMAIN);
+  }
+}


### PR DESCRIPTION
Fixes #706 

Changes: Correctly updates URL paths from org.kiwix.zim.base to the correct app specific path.
