### PR TITLE
fix string on help screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,8 +106,7 @@
   <string name="get_library_over_network">Use network to download content list. (Approximately 6MB)</string>
   <string name="proceed">Proceed</string>
   <string name="wait_for_load">Content Still Loading</string>
-  <string name="help_1">
-    x allows you offline access to websites such as Wikipedia in a highly compressed form.</string>
+  <string name="help_1">Kiwix gives you offline access to websites such as Wikipedia in a highly compressed form.</string>
   <string name="help_2">What does Kiwix do?</string>
   <string name="help_3">Kiwix is an offline content reader. It acts very much like a browser but instead of accessing online web pages, it reads content from a file in ZIM format.</string>
   <string name="help_4">While Kiwix has been originally designed to provide Wikipedia offline, it also reads other contents.</string>


### PR DESCRIPTION
The string 'help_1' on the help screen was changed from:
"x allows you offline access to websites such as Wikipedia in a highly compressed form."
to
"Kiwix gives you offline access to websites such as Wikipedia in a highly compressed form."