### PR TITLE
Fix intent on help Screen

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.help;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.RecyclerView;
@@ -48,12 +49,13 @@ public class HelpActivity extends BaseActivity {
 
   @OnClick({R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view})
   void sendFeedback() {
-    Intent intent = new Intent(Intent.ACTION_SEND);
+    Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setType("plain/text");
-    intent.putExtra(Intent.EXTRA_EMAIL, new String[]{CONTACT_EMAIL_ADDRESS});
-    intent.putExtra(Intent.EXTRA_SUBJECT, "Feedback in " +
-        LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
-    startActivity(Intent.createChooser(intent, ""));
+    String uriText = "mailto:" + Uri.encode(CONTACT_EMAIL_ADDRESS) +
+        "?subject=" + Uri.encode("Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
+    Uri uri = Uri.parse(uriText);
+    intent.setData(uri);
+    startActivity(Intent.createChooser(intent, "Send Feedback via Email"));
   }
 
   private void populateMap(int title, int descriptionArray) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -1,3 +1,21 @@
+/*
+ * Kiwix Android
+ * Copyright (C) 2018  Kiwix <android.kiwix.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.kiwix.kiwixmobile.help;
 
 import android.content.Intent;


### PR DESCRIPTION
Fixes #810 

Changes: 
The Intent structure was changed. The intent action is now ACTION_SENDTO instead of ACTION_SEND. Using this intent action, putExtra does not work. Therefore Uri has been used to add the email id , and the subject to the email.

Screenshots/GIF for the change:
![aaaaaaa](https://user-images.githubusercontent.com/32238400/42846157-c2fe187c-8a35-11e8-8619-8cbb926407ae.png)
