### PR TITLE
Fix Color Scheme in external link dialog box in night mode

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
   <style name="AppTheme" parent="AppTheme.Base" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -82,7 +82,7 @@
     <item name="android:colorBackground">@color/cardview_dark_background</item>
     <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
     <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
-    <item name="buttonBarNeutralButtonStyle" tools:targetApi="lollipop">@style/NeutralButtonStyle</item>
+    <item name="buttonBarNeutralButtonStyle">@style/NeutralButtonStyle</item>
   </style>
 
   <style name="NegativeButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
   <style name="AppTheme" parent="AppTheme.Base" />
 
@@ -82,6 +82,7 @@
     <item name="android:colorBackground">@color/cardview_dark_background</item>
     <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
     <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+    <item name="buttonBarNeutralButtonStyle" tools:targetApi="lollipop">@style/NeutralButtonStyle</item>
   </style>
 
   <style name="NegativeButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
@@ -89,6 +90,10 @@
   </style>
 
   <style name="PositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
+    <item name="android:textColor">@color/accent</item>
+  </style>
+
+  <style name="NeutralButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
     <item name="android:textColor">@color/accent</item>
   </style>
 </resources>


### PR DESCRIPTION
Changes: 
added the **buttonBarNeutralButtonStyle** item to the style **AppTheme.Dialog.Night** and set it to **@color/accent**.

Screenshots/GIF for the change:
Before:
![odl](https://user-images.githubusercontent.com/32238400/42849009-2b318cfe-8a3f-11e8-984d-2da3a1f06a0a.png)

After:
![new](https://user-images.githubusercontent.com/32238400/42849013-2ce6cf8c-8a3f-11e8-8055-6450b8f18c1c.png)