### PR TITLE
Got Code Coverage Reports working while preserving dev debugging!

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,6 +176,8 @@ android {
     cruncherEnabled true
   }
 
+  testBuildType "coverage"
+
   lintOptions {
     // Treat lint seriously
     abortOnError true


### PR DESCRIPTION
Wow, this 1 line change was painful to discover and apply. Many of the
details are in https://github.com/kiwix/kiwix-android/issues/836

NB: We've still to arrange and enable code coverage to be generated in
the CI process.

First steps for issues #836 We then need to decide and agree how to generate coverage as part of the build process.

Changes: enabled coverage to be a target for running the tests.

