### PR TITLE
Place `google()` as the first priority repository

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,9 +2,9 @@ import groovy.json.JsonSlurper
 
 buildscript {
   repositories {
+    google()
     mavenCentral()
     jcenter()
-    google()
   }
 
   dependencies {
@@ -19,12 +19,12 @@ apply plugin: 'checkstyle'
 apply plugin: 'testdroid'
 
 repositories {
+  google()
   mavenCentral()
-  jcenter()
   maven {
     url 'https://maven.google.com'
   }
-  google()
+  jcenter()
 }
 
 String[] archs = ['arm64-v8a', 'armeabi', 'mips', 'mips64', 'x86', 'x86_64']

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
-    jcenter()
     google()
+    jcenter()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:3.1.4"
@@ -36,8 +36,8 @@ ext {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    jcenter()
   }
 }
 


### PR DESCRIPTION
Closes #879

Changes: Place `google()` as the first priority repository in `build.gradle` files
