### PR TITLE
Added variable to keep track of initial seekBar value

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
@@ -33,6 +33,8 @@ public class SliderPreference extends DialogPreference {
 
   protected int mSeekBarValue;
 
+  protected int mInitialSeekBarValue;
+
   protected CharSequence[] mSummaries;
 
   private TextView mMessage;
@@ -127,6 +129,7 @@ public class SliderPreference extends DialogPreference {
     SeekBar seekbar = view.findViewById(R.id.slider_preference_seekbar);
     seekbar.setMax(SEEKBAR_MAX);
     seekbar.setProgress(mSeekBarValue);
+    mInitialSeekBarValue = mSeekBarValue;
     seekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
 
       @Override
@@ -152,6 +155,8 @@ public class SliderPreference extends DialogPreference {
   protected void onDialogClosed(boolean positiveResult) {
     if (positiveResult && callChangeListener(mSeekBarValue)) {
       setValue(mSeekBarValue);
+    } else {
+      mSeekBarValue = mInitialSeekBarValue;
     }
     super.onDialogClosed(positiveResult);
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
@@ -33,7 +33,7 @@ public class SliderPreference extends DialogPreference {
 
   protected int mSeekBarValue;
 
-  protected int mInitialSeekBarValue;
+  protected int initialSeekBarValue;
 
   protected CharSequence[] mSummaries;
 
@@ -129,7 +129,7 @@ public class SliderPreference extends DialogPreference {
     SeekBar seekbar = view.findViewById(R.id.slider_preference_seekbar);
     seekbar.setMax(SEEKBAR_MAX);
     seekbar.setProgress(mSeekBarValue);
-    mInitialSeekBarValue = mSeekBarValue;
+    initialSeekBarValue = mSeekBarValue;
     seekbar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
 
       @Override
@@ -156,7 +156,7 @@ public class SliderPreference extends DialogPreference {
     if (positiveResult && callChangeListener(mSeekBarValue)) {
       setValue(mSeekBarValue);
     } else {
-      mSeekBarValue = mInitialSeekBarValue;
+      mSeekBarValue = initialSeekBarValue;
     }
     super.onDialogClosed(positiveResult);
   }


### PR DESCRIPTION
Fixes #914 

Changes: Added variable to keep track of initial seekBar value and reset seekBar value when zoom change is cancelled.


