### PR TITLE
Alert Dialogs made uniform in both modes

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -75,6 +75,12 @@
   <style name="AppTheme.Dialog" parent="Theme.AppCompat.Light.Dialog.Alert">
     <item name="colorAccent">@color/accent</item>
     <item name="android:textColorPrimary">@color/primary_dark</item>
+    <item name="buttonBarNegativeButtonStyle">@style/NegativeButtonStyle</item>
+    <item name="buttonBarPositiveButtonStyle">@style/PositiveButtonStyle</item>
+    <item name="buttonBarNeutralButtonStyle">@style/NeutralButtonStyle</item>
+    <item name="android:textColorAlertDialogListItem">@color/primary_dark</item>
+    <item name="android:windowBackground">@color/white</item>
+    <item name="android:textColorSecondary">@color/primary_light</item>
   </style>
 
   <style name="AppTheme.Dialog.Night" parent="Theme.AppCompat.DayNight.Dialog.Alert">


### PR DESCRIPTION
Fixes Issue #913 

Changes: The dialog width was set to 95% of screen width and the styles for light theme were modified.

Screenshots/GIF for the change: 
![screenshot_2019-01-15-16-44-50-511_org kiwix kiwixcustomexample 1](https://user-images.githubusercontent.com/33036254/51177441-96e9e880-18e5-11e9-8657-fa480c247910.png)
![screenshot_2019-01-15-16-44-35-250_org kiwix kiwixcustomexample 1](https://user-images.githubusercontent.com/33036254/51177461-a79a5e80-18e5-11e9-9540-39d3139e6a07.png)
