### PR TITLE
Fix Bug #905: Launch activity (night-mode) inverts colour of icons

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/BooksAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/BooksAdapter.java
@@ -1,6 +1,11 @@
+/**
+ * Adapter class for book-items list displayed in the home page webview
+ * Use LibraryAdapter for list items in the downloads library
+ * */
 package org.kiwix.kiwixmobile.main;
 
 import android.content.Context;
+import android.graphics.ColorMatrixColorFilter;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -10,9 +15,11 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import org.kiwix.kiwixmobile.KiwixApplication;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.library.LibraryAdapter;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity;
+import org.kiwix.kiwixmobile.utils.SharedPreferenceUtil;
 
 import java.text.DecimalFormat;
 import java.util.List;
@@ -28,6 +35,7 @@ public class BooksAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
   private static int TYPE_ITEM = 1;
   private List<LibraryNetworkEntity.Book> books;
   private OnItemClickListener itemClickListener;
+  private final SharedPreferenceUtil sharedPreferenceUtil = new SharedPreferenceUtil(KiwixApplication.getInstance());
 
   interface OnItemClickListener {
     void openFile(String url);
@@ -59,9 +67,13 @@ public class BooksAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
       item.date.setText(book.getDate());
       item.description.setText(book.getDescription());
       item.size.setText(createGbString(book.getSize()));
-      item.articleCount.setText(getArticleCountString(item.articleCount.getContext(),
-          book.getArticleCount()));
+      item.articleCount.setText(getArticleCountString(item.articleCount.getContext(), book.getArticleCount()));
       item.icon.setImageBitmap(LibraryAdapter.createBitmapFromEncodedString(book.getFavicon(), item.icon.getContext()));
+
+      if(sharedPreferenceUtil.nightMode()) {  ////Fix Bug #905: Launch activity (night-mode) inverts colour of icons
+        item.icon.getDrawable().mutate().setColorFilter(new ColorMatrixColorFilter(KiwixWebView.getNightModeColors()));
+      }
+
       item.itemView.setOnClickListener(v -> itemClickListener.openFile(book.file.getPath()));
       if (book.file.getPath().contains("nopic")) {
         item.pictureLabel.setVisibility(View.GONE);

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixWebView.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixWebView.java
@@ -96,6 +96,10 @@ public class KiwixWebView extends WebView {
     setLayerType(View.LAYER_TYPE_HARDWARE, paint);
   }
 
+  public static float[] getNightModeColors() {
+    return NIGHT_MODE_COLORS;
+  }
+
   @Override
   public boolean performLongClick() {
     HitTestResult result = getHitTestResult();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 android.enableD8=true
 android.enableD8.desugaring=true
-org.gradle.configureondemand=false
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
Fixes #905 

Changes: 

- Since this home page is actually within a web view and not a regular activity, the colour inversion for its night-mode is handled like that for other web pages - Complete inversion (by the GPU) of the screen currently being rendered
- This PR checks if the night-mode is enabled, and then renders inverted icons for the books list - which get inverted again by the GPU to give original colours

Screenshots/GIF for the change: <p align="center">
  <img src="https://user-images.githubusercontent.com/15438998/51388709-3ca09000-1b50-11e9-9a05-d78fdade2045.png" width="350" title="Screenshot after the fix">
</p>
