### PR TITLE
Fix night-mode transitions

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
@@ -250,6 +250,7 @@ public class KiwixSettingsActivity extends BaseActivity {
         MainActivity.nightMode = sharedPreferenceUtil.nightMode();
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
+        getActivity().overridePendingTransition(R.anim.fade_in,R.anim.fade_out);
       }
       if (key.equals(PREF_WIFI_ONLY)) {
         MainActivity.wifiOnly = sharedPreferences.getBoolean(PREF_WIFI_ONLY, true);
@@ -259,6 +260,7 @@ public class KiwixSettingsActivity extends BaseActivity {
         MainActivity.nightMode = sharedPreferenceUtil.nightMode();
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
+        getActivity().overridePendingTransition(R.anim.fade_in,R.anim.fade_out);
       }
     }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivity.java
@@ -91,7 +91,6 @@ public class KiwixSettingsActivity extends BaseActivity {
     setUpToolbar();
   }
 
-
   @Override
   public void onBackPressed() {
     getWindow().setWindowAnimations(0);
@@ -143,7 +142,8 @@ public class KiwixSettingsActivity extends BaseActivity {
       }
 
       if (BuildConfig.IS_CUSTOM_APP) {
-        PreferenceCategory notificationsCategory = (PreferenceCategory) findPreference("pref_extras");
+        PreferenceCategory notificationsCategory =
+            (PreferenceCategory) findPreference("pref_extras");
         notificationsCategory.removePreference(findPreference("pref_wifi_only"));
       }
 
@@ -151,7 +151,8 @@ public class KiwixSettingsActivity extends BaseActivity {
       setSliderState();
       setStorage();
       setUpSettings();
-      new LanguageUtils(getActivity()).changeFont(getActivity().getLayoutInflater(), sharedPreferenceUtil);
+      new LanguageUtils(getActivity()).changeFont(getActivity().getLayoutInflater(),
+          sharedPreferenceUtil);
     }
 
     private void setStorage() {
@@ -159,11 +160,14 @@ public class KiwixSettingsActivity extends BaseActivity {
         getPreferenceScreen().removePreference(findPreference("pref_storage"));
       } else {
         if (Environment.isExternalStorageEmulated()) {
-          findPreference(PREF_STORAGE).setTitle(sharedPreferenceUtil.getPrefStorageTitle("Internal"));
+          findPreference(PREF_STORAGE).setTitle(
+              sharedPreferenceUtil.getPrefStorageTitle("Internal"));
         } else {
-          findPreference(PREF_STORAGE).setTitle(sharedPreferenceUtil.getPrefStorageTitle("External"));
+          findPreference(PREF_STORAGE).setTitle(
+              sharedPreferenceUtil.getPrefStorageTitle("External"));
         }
-        findPreference(PREF_STORAGE).setSummary(LibraryUtils.bytesToHuman(new File(sharedPreferenceUtil.getPrefStorage()).getFreeSpace()));
+        findPreference(PREF_STORAGE).setSummary(LibraryUtils.bytesToHuman(
+            new File(sharedPreferenceUtil.getPrefStorage()).getFreeSpace()));
       }
     }
 
@@ -204,7 +208,8 @@ public class KiwixSettingsActivity extends BaseActivity {
       String[] entries = new String[code.length];
       for (int index = 0; index < code.length; index++) {
         Locale locale = new Locale(code[index]);
-        entries[index] = locale.getDisplayLanguage() + " (" + locale.getDisplayLanguage(locale) + ") ";
+        entries[index] =
+            locale.getDisplayLanguage() + " (" + locale.getDisplayLanguage(locale) + ") ";
       }
       languagePref.setEntries(entries);
       languagePref.setEntryValues(code);
@@ -250,7 +255,7 @@ public class KiwixSettingsActivity extends BaseActivity {
         MainActivity.nightMode = sharedPreferenceUtil.nightMode();
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
-        getActivity().overridePendingTransition(R.anim.fade_in,R.anim.fade_out);
+        getActivity().overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
       }
       if (key.equals(PREF_WIFI_ONLY)) {
         MainActivity.wifiOnly = sharedPreferences.getBoolean(PREF_WIFI_ONLY, true);
@@ -260,7 +265,7 @@ public class KiwixSettingsActivity extends BaseActivity {
         MainActivity.nightMode = sharedPreferenceUtil.nightMode();
         getActivity().finish();
         startActivity(new Intent(getActivity(), KiwixSettingsActivity.class));
-        getActivity().overridePendingTransition(R.anim.fade_in,R.anim.fade_out);
+        getActivity().overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
       }
     }
 
@@ -277,7 +282,9 @@ public class KiwixSettingsActivity extends BaseActivity {
           .setPositiveButton(android.R.string.yes, (dialog, which) -> {
             presenter.clearHistory();
             allHistoryCleared = true;
-            Toast.makeText(getActivity(), getResources().getString(R.string.all_history_cleared_toast), Toast.LENGTH_SHORT).show();
+            Toast.makeText(getActivity(),
+                getResources().getString(R.string.all_history_cleared_toast), Toast.LENGTH_SHORT)
+                .show();
           })
           .setNegativeButton(android.R.string.no, (dialog, which) -> {
             // do nothing
@@ -287,7 +294,8 @@ public class KiwixSettingsActivity extends BaseActivity {
     }
 
     public void openCredits() {
-      WebView view = (WebView) LayoutInflater.from(getActivity()).inflate(R.layout.credits_webview, null);
+      WebView view =
+          (WebView) LayoutInflater.from(getActivity()).inflate(R.layout.credits_webview, null);
       view.loadUrl("file:///android_asset/credits.html");
       if (sharedPreferenceUtil.nightMode()) {
         view.getSettings().setJavaScriptEnabled(true);
@@ -301,15 +309,18 @@ public class KiwixSettingsActivity extends BaseActivity {
 
     @Override
     public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen,
-                                         Preference preference) {
-      if (preference.getKey().equalsIgnoreCase(PREF_CLEAR_ALL_HISTORY))
+        Preference preference) {
+      if (preference.getKey().equalsIgnoreCase(PREF_CLEAR_ALL_HISTORY)) {
         clearAllHistoryDialog();
+      }
 
-      if (preference.getKey().equalsIgnoreCase(PREF_CREDITS))
+      if (preference.getKey().equalsIgnoreCase(PREF_CREDITS)) {
         openCredits();
+      }
 
-      if (preference.getKey().equalsIgnoreCase(PREF_STORAGE))
+      if (preference.getKey().equalsIgnoreCase(PREF_STORAGE)) {
         openFolderSelect();
+      }
 
       return true;
     }
@@ -318,8 +329,10 @@ public class KiwixSettingsActivity extends BaseActivity {
       FragmentManager fm = getFragmentManager();
       StorageSelectDialog dialogFragment = new StorageSelectDialog();
       Bundle b = new Bundle();
-      b.putString(StorageSelectDialog.STORAGE_DIALOG_INTERNAL, getResources().getString(R.string.internal_storage));
-      b.putString(StorageSelectDialog.STORAGE_DIALOG_EXTERNAL, getResources().getString(R.string.external_storage));
+      b.putString(StorageSelectDialog.STORAGE_DIALOG_INTERNAL,
+          getResources().getString(R.string.internal_storage));
+      b.putString(StorageSelectDialog.STORAGE_DIALOG_EXTERNAL,
+          getResources().getString(R.string.external_storage));
       b.putInt(StorageSelectDialog.STORAGE_DIALOG_THEME, StyleUtils.dialogStyle());
       dialogFragment.setArguments(b);
       dialogFragment.setOnSelectListener(this);
@@ -332,10 +345,12 @@ public class KiwixSettingsActivity extends BaseActivity {
       sharedPreferenceUtil.putPrefStorage(storageDevice.getName());
       if (storageDevice.isInternal()) {
         findPreference(PREF_STORAGE).setTitle(getResources().getString(R.string.internal_storage));
-        sharedPreferenceUtil.putPrefStorageTitle(getResources().getString(R.string.internal_storage));
+        sharedPreferenceUtil.putPrefStorageTitle(
+            getResources().getString(R.string.internal_storage));
       } else {
         findPreference(PREF_STORAGE).setTitle(getResources().getString(R.string.external_storage));
-        sharedPreferenceUtil.putPrefStorageTitle(getResources().getString(R.string.external_storage));
+        sharedPreferenceUtil.putPrefStorageTitle(
+            getResources().getString(R.string.external_storage));
       }
     }
   }

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:duration="@android:integer/config_mediumAnimTime"
+        />
+</set>

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -4,5 +4,6 @@
         android:fromAlpha="0.0"
         android:toAlpha="1.0"
         android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/accelerate_interpolator"
         />
 </set>

--- a/app/src/main/res/anim/fade_in.xml
+++ b/app/src/main/res/anim/fade_in.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
-    <alpha
-        android:fromAlpha="0.0"
-        android:toAlpha="1.0"
-        android:duration="@android:integer/config_mediumAnimTime"
-        android:interpolator="@android:anim/accelerate_interpolator"
-        />
+  <alpha
+    android:duration="@android:integer/config_mediumAnimTime"
+    android:fromAlpha="0.0"
+    android:interpolator="@android:anim/accelerate_interpolator"
+    android:toAlpha="1.0" />
 </set>

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -4,5 +4,6 @@
         android:fromAlpha="1.0"
         android:toAlpha="0.0"
         android:duration="@android:integer/config_mediumAnimTime"
+        android:interpolator="@android:anim/accelerate_interpolator"
         />
 </set>

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:duration="@android:integer/config_mediumAnimTime"
+        />
+</set>

--- a/app/src/main/res/anim/fade_out.xml
+++ b/app/src/main/res/anim/fade_out.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <set xmlns:android="http://schemas.android.com/apk/res/android">
-    <alpha
-        android:fromAlpha="1.0"
-        android:toAlpha="0.0"
-        android:duration="@android:integer/config_mediumAnimTime"
-        android:interpolator="@android:anim/accelerate_interpolator"
-        />
+  <alpha
+    android:duration="@android:integer/config_mediumAnimTime"
+    android:fromAlpha="1.0"
+    android:interpolator="@android:anim/accelerate_interpolator"
+    android:toAlpha="0.0"/>
 </set>


### PR DESCRIPTION
### Fixes #910 

### Problem:
Right now we are using slide animations all throughout the app. However for mode change (from light to dark, and vice versa), the fade transition should be a much better option.
### Changes: 
1. Created the *res/anim* resource directory to store animation resource xml files.
2. Created two animation resource xml files to store the fade in and out animations in *fade_in.xml* and *fade_out.xml* respectively.
3. Implemented `overridePendingTransitions()` (in the *KiwixSettingsActivity.java* file) when the `PREF_NIGHTMODE` and `PREF_AUTONIGHTMODE` keys are changed. 

@siddharth2010 :)