### PR TITLE
Fixes ##938 Resolving Menu Option "Stop Reading aloud"

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -822,6 +822,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
       case R.id.menu_read_aloud:
         if (TTSControls.getVisibility() == View.GONE) {
+          tts.readAloud(getCurrentWebView());
           if (isBackToTopEnabled) {
             backToTopButton.hide();
           }
@@ -829,8 +830,9 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
           if (isBackToTopEnabled) {
             backToTopButton.show();
           }
+         stopTts();
         }
-        tts.readAloud(getCurrentWebView());
+
         break;
 
       case R.id.menu_fullscreen:


### PR DESCRIPTION
Fixes ##938

Changes: 
* When the menu option "stop reading aloud' is clicked, we should check if the visibility of tts is VISIBLE.
* If it is, we should stop the audio by calling the stopTts() method.
* The audio player is disappeared
* And then, the label on the option "stop reading aloud" is changed
 with "Read aloud".

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
<img src = "https://user-images.githubusercontent.com/36811908/52418938-e56b5b00-2b10-11e9-967f-132fb2c13a26.gif" height="700" width="394">
