### PR TITLE
Fixes#943 Resolving Deprecated API Usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,8 +65,9 @@ dependencies {
   }
 
   androidTestImplementation "androidx.annotation:annotation:$annotationVersion"
-  androidTestImplementation 'androidx.test:runner:1.1.1'
+  androidTestImplementation "androidx.test.ext:junit:1.1.0"
   androidTestImplementation 'androidx.test:rules:1.1.1'
+  androidTestImplementation 'androidx.test:core:1.1.0'
 
   // Tab indicator
   implementation "com.pacioianu.david:ink-page-indicator:$inkPageIndicatorVersion"
@@ -380,6 +381,6 @@ testdroid {
   testRunName "Auto Test " + buildNumber
 
   fullRunConfig {
-    instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    instrumentationRunner = "androidx.test.ext.runner.AndroidJUnitRunner"
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/data/local/KiwixDatabaseTest.java
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/data/local/KiwixDatabaseTest.java
@@ -20,9 +20,9 @@
 package org.kiwix.kiwixmobile.data.local;
 
 import android.content.Context;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.filters.SmallTest;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.yahoo.squidb.data.SquidCursor;
 import com.yahoo.squidb.sql.Query;
 import java.io.BufferedWriter;
@@ -45,7 +45,7 @@ public class KiwixDatabaseTest {
   private final Context context;
 
   public KiwixDatabaseTest() {
-    context = InstrumentationRegistry.getTargetContext();
+    context = InstrumentationRegistry.getInstrumentation().getTargetContext();
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.java
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.java
@@ -25,8 +25,8 @@ import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 import androidx.core.content.ContextCompat;
-import androidx.test.InstrumentationRegistry;
 import androidx.test.espresso.matcher.BoundedMatcher;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.runner.screenshot.Screenshot;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
@@ -41,8 +41,6 @@ import java.util.Date;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.kiwix.kiwixmobile.library.entity.LibraryNetworkEntity.Book;
-
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
 
 /**
  * Created by mhutti1 on 07/04/17.
@@ -63,15 +61,17 @@ public class TestUtils {
    */
 
   public static boolean hasStoragePermission() {
-    return ContextCompat.checkSelfPermission(InstrumentationRegistry.getTargetContext(),
+    return ContextCompat.checkSelfPermission(
+        InstrumentationRegistry.getInstrumentation().getTargetContext(),
         Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED &&
-        ContextCompat.checkSelfPermission(InstrumentationRegistry.getTargetContext(),
+        ContextCompat.checkSelfPermission(
+            InstrumentationRegistry.getInstrumentation().getTargetContext(),
             Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
   }
 
   public static void allowPermissionsIfNeeded() {
     if (Build.VERSION.SDK_INT >= 23 && !hasStoragePermission()) {
-      UiDevice device = UiDevice.getInstance(getInstrumentation());
+      UiDevice device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
       UiObject allowPermissions =
           device.findObject(new UiSelector().clickable(true).checkable(false).index(1));
       if (allowPermissions.exists()) {
@@ -139,7 +139,7 @@ public class TestUtils {
   }
 
   public static String getResourceString(int id) {
-    Context targetContext = InstrumentationRegistry.getTargetContext();
+    Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
     return targetContext.getResources().getString(id);
   }
 }


### PR DESCRIPTION
## Resolve Deprecated API Usage

## Fixes #943 

### Changes:
* In build.gradle. I added.
When you're using Android X you need to make sure you have the following in your app's build.gradle file.
androidTestImplementation "androidx.test.ext:junit:1.1.0"
androidTestImplementation 'androidx.test:core:1.1.0'

* In KiwixDatabaseTest.java
I added import androidx.test.platform.app.InstrumentationRegistry because it is the latest class according to Android Developers documentation
Reference: https://developer.android.com/reference/androidx/test/platform/app/InstrumentationRegistry#getInstrumentation()

* Same was done in the TestUtils.java class and method calls are made accordingly.


