### PR TITLE
Added 'Today' and 'Yesterday' instead of specific dates in History

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryAdapter.java
@@ -1,5 +1,6 @@
 package org.kiwix.kiwixmobile.history;
 
+import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +11,11 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 import java.util.List;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.data.local.entity.History;
@@ -17,6 +23,7 @@ import org.kiwix.kiwixmobile.data.local.entity.History;
 import static org.kiwix.kiwixmobile.library.LibraryAdapter.createBitmapFromEncodedString;
 
 class HistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
   private static final int TYPE_ITEM = 1;
   private final List<History> historyList;
   private final OnItemClickListener itemClickListener;
@@ -60,7 +67,26 @@ class HistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
       item.itemView.setOnLongClickListener(v ->
           itemClickListener.onItemLongClick(item.favicon, history));
     } else {
-      ((Category) holder).date.setText(historyList.get(position + 1).getDate());
+      String date = historyList.get(position + 1).getDate();
+      String todayDate, yesterdayDate;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d, yyyy");
+        todayDate = LocalDate.now().format(formatter);
+        yesterdayDate = LocalDate.now().minusDays(1).format(formatter);
+      } else {
+        DateFormat df = SimpleDateFormat.getDateInstance(DateFormat.MEDIUM);
+        todayDate = df.format(Calendar.getInstance().getTime());
+        final Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -1);
+        yesterdayDate = df.format(cal.getTime());
+      }
+      if (todayDate.contentEquals(date)) {
+        ((Category) holder).date.setText(R.string.date_today);
+      } else if (yesterdayDate.contentEquals(date)) {
+        ((Category) holder).date.setText(R.string.date_yesterday);
+      } else {
+        ((Category) holder).date.setText(date);
+      }
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
   <string name="menu_read_aloud">Read aloud</string>
   <string name="menu_read_aloud_stop">Stop reading aloud</string>
   <string name="save_media">Save Media</string>
+  <string name="date_yesterday">Yesterday</string>
+  <string name="date_today">Today</string>
   <string name="save_media_error">An error occurred when trying to save the media!</string>
   <string name="save_media_saved">Saved media as %s to Android/media/org.kiwix…/</string>
   <string name="rescan_fs_warning">Scanning for downloadable content, please wait…</string>


### PR DESCRIPTION
Fixes #949

## Changes
* In the HistoryAdapter.java, before setting text, I get today's date, format it, convert it into a string.
* Then compare it with the history dates, if it's Today's date, "Today" should be written.
* Similarly, I implement a logic to get yesterday's date.
* And then compare it with History dates.

### Screenshots/GIF for the change:

<img src="https://user-images.githubusercontent.com/36811908/52529605-795a4400-2d16-11e9-832b-21c89d4aeab4.gif" height="700" width="394">
