### PR TITLE
 In downloading fragment last image is not full visible #954

### DIFF
--- a/app/src/main/res/layout/download_management.xml
+++ b/app/src/main/res/layout/download_management.xml
@@ -21,7 +21,8 @@
   <ListView
     android:id="@+id/zim_downloader_list"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/listBackground" />
+    android:layout_height="match_parent"
+    android:background="?attr/listBackground"
+    android:paddingBottom="@dimen/library_article_list_padding"/>
 
 </RelativeLayout>


### PR DESCRIPTION
 In downloading fragment last image is not full visible #954

Changes: Add padding in Downloading Fragment.

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
![whatsapp image 2019-02-10 at 4 58 26 am](https://user-images.githubusercontent.com/26791135/52527663-78afb680-2cf2-11e9-93a8-09b9d289e5dc.jpeg)
