### PR TITLE
Restyle the message in Notification Bar

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -274,7 +274,7 @@ public class DownloadService extends Service {
   public void pauseDownload(int notificationID) {
     Log.i(KIWIX_TAG, "Pausing ZIM Download for notificationID: " + notificationID);
     downloadStatus.put(notificationID, PAUSE);
-    notification.get(notificationID).mActions.get(0).title = getString(R.string.download_play);
+    notification.get(notificationID).mActions.get(0).title = getString(R.string.download_resume);
     notification.get(notificationID).mActions.get(0).icon = R.drawable.ic_play_arrow_black_24dp;
     notification.get(notificationID).setContentText(getString(R.string.download_paused));
     notificationManager.notify(notificationID, notification.get(notificationID).build());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
   <string name="zim_file_downloading">Downloading</string>
   <string name="zim_file_downloaded">Downloaded</string>
   <string name="download_pause">Pause</string>
-  <string name="download_play">Play</string>
+  <string name="download_resume">Resume</string>
   <string name="download_stop">Stop</string>
   <string name="download_paused">paused</string>
   <string name="no_downloads_here">No downloads here</string>


### PR DESCRIPTION
The notification bar shows an option of "Play" instead of "Resume" upon starting a download and pausing it. Fix the string resource and its corresponding reference. Only the strings.xml file has to be edited as the data for other languages is auto generated based on manual translations from translatewiki.net.
