### PR TITLE
<Fixes#967> Fix button names in download notification

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -274,7 +274,7 @@ public class DownloadService extends Service {
   public void pauseDownload(int notificationID) {
     Log.i(KIWIX_TAG, "Pausing ZIM Download for notificationID: " + notificationID);
     downloadStatus.put(notificationID, PAUSE);
-    notification.get(notificationID).mActions.get(0).title = getString(R.string.download_play);
+    notification.get(notificationID).mActions.get(0).title = getString(R.string.download_resume);
     notification.get(notificationID).mActions.get(0).icon = R.drawable.ic_play_arrow_black_24dp;
     notification.get(notificationID).setContentText(getString(R.string.download_paused));
     notificationManager.notify(notificationID, notification.get(notificationID).build());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,9 +93,9 @@
   <string name="zim_file_downloading">Downloading</string>
   <string name="zim_file_downloaded">Downloaded</string>
   <string name="download_pause">Pause</string>
-  <string name="download_play">Play</string>
   <string name="download_stop">Stop</string>
   <string name="download_paused">paused</string>
+  <string name="download_resume">Resume</string>
   <string name="no_downloads_here">No downloads here</string>
   <string name="no_files_here">No files here</string>
   <string name="download_complete_snackbar">Download complete</string>


### PR DESCRIPTION
### Fixes #967

### Changes:

* add Resume string value
* add this label to the download notification label instead of PLAY.

### Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
<img src = "https://user-images.githubusercontent.com/36811908/52570244-bc123e00-2e34-11e9-8ea2-d38f2a635546.gif" height="700" width="394">
