### PR TITLE
In downloading fragment the last image is not fully visible #954

### DIFF
--- a/app/src/main/res/layout/download_management.xml
+++ b/app/src/main/res/layout/download_management.xml
@@ -23,8 +23,9 @@
   <ListView
       android:id="@+id/zim_downloader_list"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
+      android:layout_height="match_parent"
       android:background="?attr/listBackground"
+      android:paddingBottom="@dimen/library_article_list_padding"
       />
 
 </RelativeLayout>


### PR DESCRIPTION
In downloading fragment the last image is not fully
 visible #954

Changes: Add padding in Downloading Fragment.

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
![androidimag](https://user-images.githubusercontent.com/26791135/52713768-2dc9c380-2fbe-11e9-8906-091490594f68.jpeg)