### PR TITLE
Fix Incorrect Tab headings in tab overview after deleting all zim files

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/TabsAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/TabsAdapter.java
@@ -128,6 +128,8 @@ public class TabsAdapter extends RecyclerView.Adapter<TabsAdapter.ViewHolder> {
     if (webViewTitle.contains("REPLACE_")) {
       webViewTitle =
           getResourceString(holder.title.getContext().getApplicationContext(), webViewTitle);
+    } else if (webViewTitle.contains("content://org.kiwix")) {
+      webViewTitle = activity.getString(R.string.menu_home);
     }
     holder.title.setText(webViewTitle);
     holder.close.setOnClickListener(v -> listener.onCloseTab(v, holder.getAdapterPosition()));


### PR DESCRIPTION
### Fixes ##966

### Changes: 
* Add an else if statement to check if the webViewTitle contains the URI
* Set the webViewTitle to "Home"

### Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
<img src="https://user-images.githubusercontent.com/36811908/52720249-0cbaa000-2fc9-11e9-8d8e-48b17fd37c0a.gif" height="700" width="394">
