### PR TITLE
Text begin cut by the right edge on Home screen #968

### DIFF
--- a/app/src/main/res/layout/item_book.xml
+++ b/app/src/main/res/layout/item_book.xml
@@ -72,9 +72,12 @@
 
   <TextView
       android:id="@+id/item_book_description"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:layout_marginEnd="8dp"
+      android:layout_marginRight="8dp"
       android:textColor="@color/secondary_text"
+      app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="@id/item_book_title"
       app:layout_constraintTop_toBottomOf="@id/item_book_date"
       tools:text="All wikipedia articles"


### PR DESCRIPTION
Text begins cut by the right edge on Home screen #968 

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
![whatsapp image 2019-02-14 at 4 43 39 am](https://user-images.githubusercontent.com/26791135/52750880-76f83280-3013-11e9-9f9c-272bbb8ec55e.jpeg)
