### PR TITLE
Issue #978 fixed. Redundant toast removed.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -1926,8 +1926,8 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
           != PackageManager.PERMISSION_GRANTED) {
         if (ActivityCompat.shouldShowRequestPermissionRationale(this,
             Manifest.permission.READ_EXTERNAL_STORAGE)) {
-          Toast.makeText(this, R.string.request_storage,
-              Toast.LENGTH_LONG).show();
+//          Toast.makeText(this, R.string.request_storage,
+//              Toast.LENGTH_LONG).show();
         }
         ActivityCompat.requestPermissions(this,
             new String[] { Manifest.permission.READ_EXTERNAL_STORAGE },


### PR DESCRIPTION
Fixes #978

Changes: Toast(popup) even after the permissions were granted making it redundant which has been removed now.

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
