### PR TITLE
Allow cleartext for kiwix.org

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
       android:icon="@mipmap/kiwix_icon"
       android:label="@string/app_name"
       android:supportsRtl="true"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:networkSecurityConfig="@xml/network_security_config">
     <activity
         android:name=".splash.SplashActivity"
         android:label="@string/app_name"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">kiwix.org</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
Fixes #993 
Changes: Adds kiwix.org the the network cleartext whitelist
