### PR TITLE
Fixed Pending Intent For Multiple Download Notifications 

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/downloader/DownloadService.java
@@ -380,9 +380,10 @@ public class DownloadService extends Service {
                 }
               }
               target.putExtra(EXTRA_NOTIFICATION_ID, notificationID);
+              target.setAction(Long.toString(System.currentTimeMillis()));
               PendingIntent pendingIntent = PendingIntent.getActivity
                   (getBaseContext(), 0,
-                      target, PendingIntent.FLAG_CANCEL_CURRENT);
+                      target, PendingIntent.FLAG_ONE_SHOT);
               book.downloaded = true;
               dataSource.deleteBook(book)
                   .subscribe(new CompletableObserver() {


### PR DESCRIPTION
### Fixes #1005 

### Changes: [Add here what changes were made in this issue and if possible provide links.]
* Set some dummy action on the Intent, otherwise extras are dropped. For example
```
intent.setAction(Long.toString(System.currentTimeMillis())) 
```
* And using 
``` FLAG_ONE_SHOT ```
instead of
 ``` PendingIntent.FLAG_CANCEL_CURRENT ```

**REFERENCE:**  [Stackoverflow](https://stackoverflow.com/questions/3168484/pendingintent-works-correctly-for-the-first-notification-but-incorrectly-for-the)
### Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
<img src = "https://user-images.githubusercontent.com/36811908/53022863-e475ea00-347d-11e9-8273-d9cbb393d7c2.gif" height="700" width="394">
