### PR TITLE
Zoom level option color should be grayed when disabled #556

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/SliderPreference.java
@@ -19,12 +19,16 @@ package org.kiwix.kiwixmobile.settings;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import org.kiwix.kiwixmobile.R;
+
+import static org.kiwix.kiwixmobile.utils.Constants.PREF_NIGHTMODE;
+import static org.kiwix.kiwixmobile.utils.Constants.PREF_ZOOM_ENABLED;
 
 public class SliderPreference extends DialogPreference {
 
@@ -158,5 +162,30 @@ public class SliderPreference extends DialogPreference {
       mSeekBarValue = initialSeekBarValue;
     }
     super.onDialogClosed(positiveResult);
+  }
+
+  @Override
+  protected void onBindView(View view) {
+    super.onBindView(view);
+    setGrayState(view);
+  }
+
+  private void setGrayState(View view) {
+    boolean enabled = getPreferenceManager().getSharedPreferences().getBoolean(PREF_ZOOM_ENABLED, false);
+    boolean Nightmode = getPreferenceManager().getSharedPreferences().getBoolean(PREF_NIGHTMODE, false);
+    TextView titleView = view.findViewById(android.R.id.title);
+    TextView summaryTV = view.findViewById(android.R.id.summary);
+    if (!enabled) {
+      titleView.setTextColor(Color.GRAY);
+      summaryTV.setTextColor(Color.GRAY);
+    } else {
+      if (Nightmode) {
+        titleView.setTextColor(Color.WHITE);
+        summaryTV.setTextColor(Color.WHITE);
+      } else {
+        titleView.setTextColor(Color.BLACK);
+        summaryTV.setTextColor(Color.BLACK);
+      }
+    }
   }
 }


### PR DESCRIPTION
Zoom level option color should be grayed when disabled #556 

Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
![dark 2](https://user-images.githubusercontent.com/26791135/53243161-044f1d00-36cd-11e9-8f35-ec80669100e7.jpg)
![light](https://user-images.githubusercontent.com/26791135/53243195-22b51880-36cd-11e9-8e29-d2e5e64e93ab.jpg)
