### PR TITLE
Added 'Today' and 'Yesterday' instead of specific dates in History

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,8 @@ repositories {
 String[] archs = ['arm64-v8a', 'armeabi', 'mips', 'mips64', 'x86', 'x86_64']
 
 dependencies {
+  // use jdk8 java.time backport, as long app < Build.VERSION_CODES.O
+  implementation("com.jakewharton.threetenabp:threetenabp:1.1.1")
   // Get kiwixlib online if it is not populated locally
   if (file("../kiwixlib/src/main").list().length == 1) {
     implementation 'org.kiwix.kiwixlib:kiwixlib:1.0.11'
@@ -170,7 +172,7 @@ android {
   testServer new TestDroidUpload();
 
   defaultConfig {
-    minSdkVersion 14
+    minSdkVersion 15
     targetSdkVersion 28
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     // See https://github.com/linkedin/dexmaker/issues/65 for why we need the following line.

--- a/app/src/main/java/org/kiwix/kiwixmobile/KiwixApplication.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/KiwixApplication.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.inject.Inject;
 import org.kiwix.kiwixmobile.di.components.ApplicationComponent;
 import org.kiwix.kiwixmobile.di.components.DaggerApplicationComponent;
+import com.jakewharton.threetenabp.AndroidThreeTen;
 import org.kiwix.kiwixmobile.di.modules.ApplicationModule;
 
 public class KiwixApplication extends MultiDexApplication implements HasActivityInjector {
@@ -71,6 +72,7 @@ public class KiwixApplication extends MultiDexApplication implements HasActivity
   @Override
   public void onCreate() {
     super.onCreate();
+    AndroidThreeTen.init(this);
     if (isExternalStorageWritable()) {
       File appDirectory = new File(Environment.getExternalStorageDirectory() + "/Kiwix");
       logFile = new File(appDirectory, "logcat.txt");

--- a/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryAdapter.java
@@ -10,9 +10,11 @@ import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import org.threeten.bp.LocalDate;
 import java.util.List;
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.data.local.entity.History;
+import org.threeten.bp.format.DateTimeFormatter;
 
 import static org.kiwix.kiwixmobile.library.LibraryAdapter.createBitmapFromEncodedString;
 
@@ -60,7 +62,18 @@ class HistoryAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
       item.itemView.setOnLongClickListener(v ->
           itemClickListener.onItemLongClick(item.favicon, history));
     } else {
-      ((Category) holder).date.setText(historyList.get(position + 1).getDate());
+      String date = historyList.get(position + 1).getDate();
+      String todaysDate, yesterdayDate;
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMM d, yyyy");
+      todaysDate = LocalDate.now().format(formatter);
+      yesterdayDate = LocalDate.now().minusDays(1).format(formatter);
+      if (todaysDate.contentEquals(date)) {
+        ((Category) holder).date.setText(R.string.time_today);
+      } else if (yesterdayDate.contentEquals(date)) {
+        ((Category) holder).date.setText(R.string.time_yesterday);
+      } else {
+        ((Category) holder).date.setText(date);
+      }
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,8 @@
   <string name="time_minute">min</string>
   <string name="time_second">s</string>
   <string name="time_left">left</string>
+  <string name="time_today">Today</string>
+  <string name="time_yesterday">Yesterday</string>
   <string name="pref_bottomtoolbar">Enable bottom toolbar</string>
   <string name="pref_bottomtoolbar_summary">Display a toolbar with quick actions at the bottom of the screen</string>
   <string name="pref_autonightmode_summary">Automatically switch between day and night mode.</string>

--- a/kiwixlib/build.gradle
+++ b/kiwixlib/build.gradle
@@ -4,7 +4,7 @@ android {
   compileSdkVersion 28
 
   defaultConfig {
-    minSdkVersion 14
+    minSdkVersion 15
     targetSdkVersion 28
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }


### PR DESCRIPTION
Fixes #949 

## Changes
* In the HistoryAdapter.java, before setting text, I get today's date, format it, convert it into a string.
* Then compare it with the history dates, if it's Today's date, "Today" should be written.
* Similarly, I implement a logic to get yesterday's date.
* And then compare it with History dates.
* Used Java 8's classes LocalDate which works for API 26 and onwards.
* Added JakeWharton's ABPThreeTen For BackwardCompatibility before API 26.
[ThreeTenAbp JakeWharton](https://mvnrepository.com/artifact/com.jakewharton.threetenabp/threetenabp)
* Hence, I had to increase the minSdkversion to 15 as it doesn't works with 14.
[Android versions](https://en.wikipedia.org/wiki/Android_version_history) Suggests this should be safe.
* I've tested this on both API>=26 and API<26 and it's working fine.
### Alternative:
The alternative would've been to use the traditional Date and Calendar APIs but as the whole Kiwix App is on Java 8+. That wouldn't have been a good choice.

### Special Thanks To:
@soloturn Helped me a lot with this PR and he's the man who suggested me to use ThreeTenABP.

### Screenshots/GIF for the change:
<img src="https://user-images.githubusercontent.com/36811908/53249193-5dbd4900-36d9-11e9-8cd4-645170031e22.gif" height="700" width="394">

