### PR TITLE
SwipeLayout disabled after long press 

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
@@ -138,10 +138,16 @@ public class ZimFileSelectFragment extends BaseFragment
 
         if (checked) { // If the item was selected
           selectedViewPosition.add(position);
+          swipeRefreshLayout.setEnabled(
+              false);  //disabled to stop selected items getting deselected (issue #1019)
+          swipeRefreshLayout.setRefreshing(false);
           mode.setTitle("" + selectedViewPosition.size()); // Update title of the CAB
         } else {  // If the item was deselected
           selectedViewPosition.remove(Integer.valueOf(position));
           mode.setTitle("" + selectedViewPosition.size()); // Update title of the CAB
+          if (selectedViewPosition.isEmpty()) {
+            swipeRefreshLayout.setEnabled(true);
+          }
         }
       }
 
@@ -243,6 +249,7 @@ public class ZimFileSelectFragment extends BaseFragment
       @Override
       public void onDestroyActionMode(ActionMode mode) {
         // Upon closure of the CAB, empty the array list of selected list item positions
+        swipeRefreshLayout.setEnabled(true);
         selectedViewPosition.clear();
       }
     });

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.java
@@ -138,8 +138,7 @@ public class ZimFileSelectFragment extends BaseFragment
 
         if (checked) { // If the item was selected
           selectedViewPosition.add(position);
-          swipeRefreshLayout.setEnabled(
-              false);  //disabled to stop selected items getting deselected (issue #1019)
+          swipeRefreshLayout.setEnabled(false);  //disabled to stop selected items getting deselected (issue #1019)
           swipeRefreshLayout.setRefreshing(false);
           mode.setTitle("" + selectedViewPosition.size()); // Update title of the CAB
         } else {  // If the item was deselected


### PR DESCRIPTION
Fixes #1019 

Changes: 
1. When files are selected on long press, swipeRefreshLayout is disabled.
2. It is enabled back when CAB disappears.

Screenshots/GIF for the change: 

![swipe_before_delete](https://user-images.githubusercontent.com/34706326/53266499-ec948a80-3706-11e9-86e7-8aedb779cf18.gif)
