### PR TITLE
upgrade mockito, disable jetifying byte-buddy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ ext {
   set("apacheCommonsVersion", "2.6")
   set("multidexVersion", "2.0.1")
   set("jUnitVersion", "4.12")
-  set("mockitoVersion", "2.19.1")
+  set("mockitoVersion", "2.24.5")
   set("powerMockVersion", "1.6.6")
   set("powerMockJUnitVersion", "1.7.4")
   set("baristaVersion", "2.7.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ ext {
   set("okHttpVersion", "3.12.1")
   set("retrofitVersion", "2.5.0")
   set("javaxAnnotationVersion", "1.3.2")
-  set("daggerVersion", "2.16")
+  set("daggerVersion", "2.21")
   set("inkPageIndicatorVersion", "1.3.0")
   set("constraintLayoutVersion", "1.1.3")
   set("butterKnifeVersion", "10.0.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ android.enableJetifier=true
 #android.enableSeparateAnnotationProcessing=true
 # disable jetifying byte-buddy
 # https://stackoverflow.com/questions/52816022/failed-to-resolve-variable-project-groupid
-android.jetifier.blacklist=byte-buddy
+android.jetifier.blacklist=byte-buddy,adapter-rxjava2,converter-simplexml,logging-interceptor,mockwebserver,error_prone_annotations,guava
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@ android.enableD8=true
 android.enableD8.desugaring=true
 android.enableJetifier=true
 #android.enableSeparateAnnotationProcessing=true
+# disable jetifying byte-buddy
+# https://stackoverflow.com/questions/52816022/failed-to-resolve-variable-project-groupid
+android.jetifier.blacklist=byte-buddy
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
 


### PR DESCRIPTION
byte-buddy is a mockito dependency. it introduced java modules, and
jetifier cannot deal with it.  disable jetifying at the moment, as
suggested after considering:
https://stackoverflow.com/questions/52816022/failed-to-resolve-variable-project-groupid
https://issuetracker.google.com/issues/119135578#comment5
https://github.com/raphw/byte-buddy/issues/541

@mhutti1 this feature is experimental again, hope is ok.

Fixes #950 
