### PR TITLE
Fixes Access A Deleted File After Closing All Tabs

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -777,14 +777,17 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
           updateTabSwitcherIcon();
         })
         .show();
+    openDefaultTab();
+    updateTabSwitcherIcon();
+  }
+
+  private void openDefaultTab() {
     new Handler().postDelayed(() -> {
       if (webViewList.size() == 0) {
         newTab(HOME_URL);
       }
-    }, 1500);
-    updateTabSwitcherIcon();
+    }, 100);
   }
-
   private void selectTab(int position) {
     currentWebViewIndex = position;
     tabsAdapter.setSelected(position);
@@ -1152,11 +1155,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   void closeAllTabs() {
     webViewList.clear();
     tabsAdapter.notifyDataSetChanged();
-    new Handler().postDelayed(() -> {
-      if (webViewList.size() == 0) {
-        newTab(HOME_URL);
-      }
-    }, 1500);
+    openDefaultTab();
     updateTabSwitcherIcon();
   }
 


### PR DESCRIPTION
Fixes #1034

### Changes: 
* Add a method to check if there are zero tabs.
* Call the method where required.
* Time of 1500ms removed.
* Now, when the user closes the last opened tab or tries to close all tabs at once using the CloseAllTab Floating Action Button, the default tab("HOME PAGE") opens immediately.

### Screenshots/GIF for the change: [If possible, please add relevant screenshots/GIF]
<img src="https://user-images.githubusercontent.com/36811908/53500757-c4bd7200-3acc-11e9-81af-b5bca44194f2.gif" height="700" width="394">
