### PR TITLE
Fixes NullPointerExceptions due to callbacks in MainActivity

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -532,15 +532,20 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   }
 
   private void updateBottomToolbarArrowsAlpha() {
-    if (getCurrentWebView().canGoForward()) {
-      bottomToolbarArrowForward.setAlpha(1f);
-    } else {
-      bottomToolbarArrowForward.setAlpha(0.6f);
+    if (checkNull(bottomToolbarArrowBack)) {
+      if (getCurrentWebView().canGoForward()) {
+        bottomToolbarArrowForward.setAlpha(1f);
+      } else {
+        bottomToolbarArrowForward.setAlpha(0.6f);
+      }
     }
-    if (getCurrentWebView().canGoBack()) {
-      bottomToolbarArrowBack.setAlpha(1f);
-    } else {
-      bottomToolbarArrowBack.setAlpha(0.6f);
+
+    if (checkNull(bottomToolbarArrowForward)) {
+      if (getCurrentWebView().canGoBack()) {
+        bottomToolbarArrowBack.setAlpha(1f);
+      } else {
+        bottomToolbarArrowBack.setAlpha(0.6f);
+      }
     }
   }
 
@@ -1284,20 +1289,22 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   }
 
   private void updateBottomToolbarVisibility() {
-    if (sharedPreferenceUtil.getPrefBottomToolbar() && !HOME_URL.equals(
-        getCurrentWebView().getUrl())
-        && tabSwitcherRoot.getVisibility() != View.VISIBLE) {
-      bottomToolbar.setVisibility(View.VISIBLE);
-      if (getCurrentWebView() instanceof ToolbarStaticKiwixWebView
-          && sharedPreferenceUtil.getPrefBottomToolbar()) {
-        contentFrame.setPadding(0, 0, 0,
-            (int) getResources().getDimension(R.dimen.bottom_toolbar_height));
+    if (checkNull(bottomToolbar)) {
+      if (sharedPreferenceUtil.getPrefBottomToolbar() && !HOME_URL.equals(
+          getCurrentWebView().getUrl())
+          && tabSwitcherRoot.getVisibility() != View.VISIBLE) {
+        bottomToolbar.setVisibility(View.VISIBLE);
+        if (getCurrentWebView() instanceof ToolbarStaticKiwixWebView
+            && sharedPreferenceUtil.getPrefBottomToolbar()) {
+          contentFrame.setPadding(0, 0, 0,
+              (int) getResources().getDimension(R.dimen.bottom_toolbar_height));
+        } else {
+          contentFrame.setPadding(0, 0, 0, 0);
+        }
       } else {
+        bottomToolbar.setVisibility(View.GONE);
         contentFrame.setPadding(0, 0, 0, 0);
       }
-    } else {
-      bottomToolbar.setVisibility(View.GONE);
-      contentFrame.setPadding(0, 0, 0, 0);
     }
   }
 
@@ -1574,14 +1581,16 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   }
 
   private void refreshBookmarkSymbol() {
-    if (getCurrentWebView().getUrl() != null &&
-        ZimContentProvider.getId() != null &&
-        !getCurrentWebView().getUrl().equals(HOME_URL)) {
-      int icon = bookmarks.contains(getCurrentWebView().getUrl()) ? R.drawable.ic_bookmark_24dp
-          : R.drawable.ic_bookmark_border_24dp;
-      bottomToolbarBookmark.setImageResource(icon);
-    } else {
-      bottomToolbarBookmark.setImageResource(R.drawable.ic_bookmark_border_24dp);
+    if (checkNull(bottomToolbarBookmark)) {
+      if (getCurrentWebView().getUrl() != null &&
+          ZimContentProvider.getId() != null &&
+          !getCurrentWebView().getUrl().equals(HOME_URL)) {
+        int icon = bookmarks.contains(getCurrentWebView().getUrl()) ? R.drawable.ic_bookmark_24dp
+            : R.drawable.ic_bookmark_border_24dp;
+        bottomToolbarBookmark.setImageResource(icon);
+      } else {
+        bottomToolbarBookmark.setImageResource(R.drawable.ic_bookmark_border_24dp);
+      }
     }
   }
 
@@ -1832,16 +1841,18 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
   @Override
   public void webViewProgressChanged(int progress) {
-    progressBar.setProgress(progress);
-    if (progress == 100) {
-      if (requestClearHistoryAfterLoad) {
-        Log.d(TAG_KIWIX,
-            "Loading article finished and requestClearHistoryAfterLoad -> clearHistory");
-        getCurrentWebView().clearHistory();
-        requestClearHistoryAfterLoad = false;
-      }
+    if (checkNull(progressBar)) {
+      progressBar.setProgress(progress);
+      if (progress == 100) {
+        if (requestClearHistoryAfterLoad) {
+          Log.d(TAG_KIWIX,
+              "Loading article finished and requestClearHistoryAfterLoad -> clearHistory");
+          getCurrentWebView().clearHistory();
+          requestClearHistoryAfterLoad = false;
+        }
 
-      Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView().getUrl());
+        Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView().getUrl());
+      }
     }
   }
 
@@ -1949,5 +1960,9 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     } else {
       fileSearch.scan(sharedPreferenceUtil.getPrefStorage());
     }
+  }
+
+  public boolean checkNull(View view) {
+    return view != null;
   }
 }


### PR DESCRIPTION
Fixes #891 #895 

Issues #891 and #895 have a common root to callbacks which gives NullPointerExceptions.
Changes:
1. Added a function named CheckNull. 
2. CheckNull checks for NullPointerException for views in MainActivity.

**Screenshots**
![checknull](https://user-images.githubusercontent.com/34706326/53682368-d72ceb00-3d1a-11e9-8ff4-9d2b4f28a710.gif)
