### PR TITLE
Handling screen orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -143,7 +143,6 @@
       <!-- TODO -->
       <intent-filter>
         <action android:name="android.intent.action.GET_CONTENT"/>
-
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.OPENABLE"/>
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/bookmark/BookmarksActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/bookmark/BookmarksActivity.java
@@ -3,6 +3,7 @@ package org.kiwix.kiwixmobile.bookmark;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -12,6 +13,7 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import java.io.File;
@@ -34,6 +36,7 @@ public class BookmarksActivity extends BaseActivity implements BookmarksContract
   private final List<Bookmark> bookmarksList = new ArrayList<>();
   private final List<Bookmark> allBookmarks = new ArrayList<>();
   private final List<Bookmark> deleteList = new ArrayList<>();
+  private static final String LIST_STATE_KEY = "recycler_list_state";
 
   @BindView(R.id.toolbar)
   Toolbar toolbar;
@@ -44,6 +47,8 @@ public class BookmarksActivity extends BaseActivity implements BookmarksContract
 
   private boolean refreshAdapter = true;
   private BookmarksAdapter bookmarksAdapter;
+  private LinearLayoutManager layoutManager;
+  private Parcelable listState;
   private ActionMode actionMode;
 
   private final ActionMode.Callback actionModeCallback = new ActionMode.Callback() {
@@ -104,12 +109,30 @@ public class BookmarksActivity extends BaseActivity implements BookmarksContract
 
     bookmarksAdapter = new BookmarksAdapter(bookmarksList, deleteList, this);
     recyclerView.setAdapter(bookmarksAdapter);
+    layoutManager = new LinearLayoutManager(this, RecyclerView.VERTICAL, false);
+    recyclerView.setLayoutManager(layoutManager);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
     presenter.loadBookmarks(sharedPreferenceUtil.getShowBookmarksCurrentBook());
+    if (listState != null) {
+      layoutManager.onRestoreInstanceState(listState);
+    }
+  }
+
+  protected void onSaveInstanceState(Bundle state) {
+    super.onSaveInstanceState(state);
+    listState = layoutManager.onSaveInstanceState();
+    state.putParcelable(LIST_STATE_KEY, listState);
+  }
+
+  protected void onRestoreInstanceState(Bundle state) {
+    super.onRestoreInstanceState(state);
+    if (state != null) {
+      listState = state.getParcelable(LIST_STATE_KEY);
+    }
   }
 
   @Override

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -21,8 +21,10 @@ package org.kiwix.kiwixmobile.help;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Parcelable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.OnClick;
@@ -36,7 +38,9 @@ import static org.kiwix.kiwixmobile.utils.Constants.CONTACT_EMAIL_ADDRESS;
 public class HelpActivity extends BaseActivity {
 
   private final HashMap<String, String> titleDescriptionMap = new HashMap<>();
-
+  private static final String LIST_STATE_KEY = "recycler_list_state";
+  private LinearLayoutManager layoutManager;
+  private Parcelable listState;
   @BindView(R.id.activity_help_toolbar)
   Toolbar toolbar;
   @BindView(R.id.activity_help_recycler_view)
@@ -61,6 +65,29 @@ public class HelpActivity extends BaseActivity {
     HelpAdapter helpAdapter =
         new HelpAdapter(titleDescriptionMap, sharedPreferenceUtil.nightMode());
     recyclerView.setAdapter(helpAdapter);
+    layoutManager = new LinearLayoutManager(this, RecyclerView.VERTICAL, false);
+    recyclerView.setLayoutManager(layoutManager);
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    if (listState != null) {
+      layoutManager.onRestoreInstanceState(listState);
+    }
+  }
+
+  protected void onSaveInstanceState(Bundle state) {
+    super.onSaveInstanceState(state);
+    listState = layoutManager.onSaveInstanceState();
+    state.putParcelable(LIST_STATE_KEY, listState);
+  }
+
+  protected void onRestoreInstanceState(Bundle state) {
+    super.onRestoreInstanceState(state);
+    if (state != null) {
+      listState = state.getParcelable(LIST_STATE_KEY);
+    }
   }
 
   @OnClick({ R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view })

--- a/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryActivity.java
@@ -3,6 +3,7 @@ package org.kiwix.kiwixmobile.history;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -13,6 +14,7 @@ import androidx.appcompat.view.ActionMode;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import java.io.File;
@@ -34,6 +36,7 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
   private final List<History> historyList = new ArrayList<>();
   private final List<History> fullHistory = new ArrayList<>();
   private final List<History> deleteList = new ArrayList<>();
+  private static final String LIST_STATE_KEY = "recycler_list_state";
 
   @BindView(R.id.toolbar)
   Toolbar toolbar;
@@ -43,6 +46,8 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
   RecyclerView recyclerView;
   private boolean refreshAdapter = true;
   private HistoryAdapter historyAdapter;
+  private LinearLayoutManager layoutManager;
+  private Parcelable listState;
   private ActionMode actionMode;
   private final ActionMode.Callback actionModeCallback = new ActionMode.Callback() {
     @Override
@@ -114,12 +119,30 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
 
     historyAdapter = new HistoryAdapter(historyList, deleteList, this);
     recyclerView.setAdapter(historyAdapter);
+    layoutManager = new LinearLayoutManager(this, RecyclerView.VERTICAL, false);
+    recyclerView.setLayoutManager(layoutManager);
   }
 
   @Override
   protected void onResume() {
     super.onResume();
     presenter.loadHistory(sharedPreferenceUtil.getShowHistoryCurrentBook());
+    if (listState != null) {
+      layoutManager.onRestoreInstanceState(listState);
+    }
+  }
+
+  protected void onSaveInstanceState(Bundle state) {
+    super.onSaveInstanceState(state);
+    listState = layoutManager.onSaveInstanceState();
+    state.putParcelable(LIST_STATE_KEY, listState);
+  }
+
+  protected void onRestoreInstanceState(Bundle state) {
+    super.onRestoreInstanceState(state);
+    if (state != null) {
+      listState = state.getParcelable(LIST_STATE_KEY);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes #1023 

Changes: 
1. Added `onSaveInstance` and `onRestoreInstance` to selected Activity only (History, Help, and Bookmark activity) to handle screen orientation. 
2. The changes introduced in the mentioned activities will make it orientation independent when selections are made for deletion/share similar to Gmail.

Screenshots/GIF for the change: 
![handling_orientation](https://user-images.githubusercontent.com/34706326/53692167-e78fa500-3db0-11e9-8442-6941c7c32b8d.gif)

