### PR TITLE
Close tab switcher on clicking again

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -1519,7 +1519,14 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     View tabSwitcher = menu.findItem(R.id.menu_tab_switcher).getActionView();
     tabSwitcherIcon = tabSwitcher.findViewById(R.id.ic_tab_switcher_text);
     updateTabSwitcherIcon();
-    tabSwitcher.setOnClickListener(v -> showTabSwitcher());
+    tabSwitcher.setOnClickListener(v -> {
+      if (tabSwitcherRoot.getVisibility() == View.VISIBLE) {
+        hideTabSwitcher();
+        selectTab(currentWebViewIndex);
+      } else {
+        showTabSwitcher();
+      }
+    });
     return true;
   }
 


### PR DESCRIPTION
Fixes #1049
 
Changes: 

Now, the tab switcher would close and user would be taken to the previously open tab when the tab switcher button is clicked again.

GIF for the change: 

![ezgif com-video-to-gif 56](https://user-images.githubusercontent.com/35566748/53729531-7aa50980-3e9b-11e9-8551-49a0a1cbf89a.gif)