### PR TITLE
Closes opened table drawer on first back press

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -364,6 +364,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     searchFiles();
     tabRecyclerView.setAdapter(tabsAdapter);
     new ItemTouchHelper(tabCallback).attachToRecyclerView(tabRecyclerView);
+    drawerLayout.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
   }
 
   //End of onCreate


### PR DESCRIPTION
Fixes #1051 

Changes: 
1. Added below line in onCreate in MainActivity which will block its descendants from receiving focus.
     *drawerLayout.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);*


Screenshots/GIF for the change: 
![closenavdrawer](https://user-images.githubusercontent.com/34706326/53743368-ae465a80-3ec0-11e9-9c38-518d00583289.gif)

