### PR TITLE
Fixes history tracing onBackPressed

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/history/HistoryActivity.java
@@ -27,6 +27,7 @@ import org.kiwix.kiwixmobile.main.MainActivity;
 
 import static org.kiwix.kiwixmobile.library.LibraryAdapter.createBitmapFromEncodedString;
 import static org.kiwix.kiwixmobile.utils.Constants.EXTRA_CHOSE_X_URL;
+import static org.kiwix.kiwixmobile.utils.Constants.RESULT_HISTORY_CLEARED;
 
 public class HistoryActivity extends BaseActivity implements HistoryContract.View,
     HistoryAdapter.OnItemClickListener {
@@ -34,6 +35,7 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
   private final List<History> historyList = new ArrayList<>();
   private final List<History> fullHistory = new ArrayList<>();
   private final List<History> deleteList = new ArrayList<>();
+  private boolean isHistoryCleared = false;
 
   @BindView(R.id.toolbar)
   Toolbar toolbar;
@@ -166,6 +168,7 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
 
       case R.id.menu_history_clear:
         presenter.deleteHistory(new ArrayList<>(fullHistory));
+        isHistoryCleared = true;
         fullHistory.clear();
         historyList.clear();
         historyAdapter.notifyDataSetChanged();
@@ -239,6 +242,17 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
 
     if (deleteList.size() == 0) {
       actionMode.finish();
+    }
+  }
+
+  @Override
+  public void onBackPressed() {
+    if (isHistoryCleared) {
+      Intent intent = new Intent(this, MainActivity.class);
+      setResult(RESULT_HISTORY_CLEARED, intent);
+      finish();
+    } else {
+      super.onBackPressed();
     }
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -880,6 +880,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
         break;
 
       case R.id.menu_history:
+        saveTabStates();
         startActivityForResult(new Intent(this, HistoryActivity.class),
             REQUEST_HISTORY_ITEM_CHOSEN);
         return true;
@@ -1489,6 +1490,10 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
           } else if (title != null) {
             getCurrentWebView().loadUrl(ZimContentProvider.getPageUrlFromTitle(title));
           }
+        } else if (resultCode == RESULT_HISTORY_CLEARED) {
+          webViewList.clear();
+          tabsAdapter.notifyDataSetChanged();
+          restoreTabStates();
         }
         return;
       default:


### PR DESCRIPTION
Fixes #1031 

Changes:
1. Override onBackPressed in History
2. SaveTabStates before going to History screen
3. Defined a variable `isHistoryCleared` to check if history is cleared by the user and clear history accordingly
4. RestoreTabs on coming back to Main Activity

Screenshots/GIF for the change: 
![tracehistory](https://user-images.githubusercontent.com/34706326/54020121-04faaf80-41b3-11e9-850e-95f9a9586fff.gif)
