### PR TITLE
controls added in notification for tts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -203,6 +203,7 @@
           android:name="android.support.PARENT_ACTIVITY"
           android:value="main.MainActivity"/>
     </activity>
+    <service android:name=".main.MainActivity$NotificationService" />
   </application>
 
 </manifest>

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixTextToSpeech.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixTextToSpeech.java
@@ -182,8 +182,10 @@ public class KiwixTextToSpeech {
     if (currentTTSTask.paused) {
       if (!requestAudioFocus()) return;
       currentTTSTask.start();
+      MainActivity.sendNotification(context.getString(R.string.tts_pause),context);
     } else {
       currentTTSTask.pause();
+      MainActivity.sendNotification(context.getString(R.string.tts_resume),context);
     }
   }
 


### PR DESCRIPTION
Fixes: #621 . 
Changes:
When the user chooses "read aloud" from menu, a notification pops up. It contains a "stop" button" and a "pause/resume" button. On clicking "stop", the TTS stops and notification disappears. Pause/Resume button works the similar way as in-app and text of button changes accordingly from "pause" to "resume" as it does in-app controls as well.

![Screenshot_20190313_171355](https://user-images.githubusercontent.com/29261743/54277072-cef36c00-45b4-11e9-8b2e-457eba7d2c7d.jpg)

![Screenshot_20190313_171353](https://user-images.githubusercontent.com/29261743/54277085-d4e94d00-45b4-11e9-8516-a12dd1aeab73.jpg)




