### PR TITLE
Enabled bottom toolbar by default

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
@@ -57,7 +57,7 @@ public class SharedPreferenceUtil {
   }
 
   public boolean getPrefBottomToolbar() {
-    return sharedPreferences.getBoolean(PREF_BOTTOM_TOOLBAR, false);
+    return sharedPreferences.getBoolean(PREF_BOTTOM_TOOLBAR, true);
   }
 
   public boolean getPrefBackToTop() {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -28,7 +28,7 @@
         android:title="@string/pref_hidetoolbar"/>
 
     <org.kiwix.kiwixmobile.settings.CustomSwitchPreference
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="pref_bottomtoolbar"
         android:summary="@string/pref_bottomtoolbar_summary"
         android:title="@string/pref_bottomtoolbar"/>


### PR DESCRIPTION
Fixes #1079 

Changes: info from #973 : As of now, there is no way to add a bookmark without enabling the bottom toolbar. Enabled bottom toolbar by default, as long there is no other way in the dropdown.
