### PR TITLE
Implement ZIM offline files reorder

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/Constants.java
@@ -84,6 +84,7 @@ public final class Constants {
 
   public static final String PREF_SHOW_INTRO = "showIntro";
 
+  public static final String PREF_LAST_BOOK_OPENED = "pref_last_book_opened";
   // Tags
   public static final String TAG_FILE_SEARCHED = "searchedarticle";
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
@@ -16,6 +16,7 @@ import static org.kiwix.kiwixmobile.utils.Constants.PREF_FULLSCREEN;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_HIDE_TOOLBAR;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_IS_FIRST_RUN;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_LANG;
+import static org.kiwix.kiwixmobile.utils.Constants.PREF_LAST_BOOK_OPENED;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_NEW_TAB_BACKGROUND;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_NIGHTMODE;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_SHOW_INTRO;
@@ -171,5 +172,13 @@ public class SharedPreferenceUtil {
     sharedPreferences.edit()
         .putBoolean(PREF_SHOW_BOOKMARKS_CURRENT_BOOK, prefShowBookmarksFromCurrentBook)
         .apply();
+  }
+
+  public void updateLastBookOpened(String id){
+      sharedPreferences.edit().putString(PREF_LAST_BOOK_OPENED,id).apply();
+  }
+
+  public String getLastBookOpened(){
+      return sharedPreferences.getString(PREF_LAST_BOOK_OPENED,"null");
   }
 }


### PR DESCRIPTION
Last opened file show up on top

Fixes #1081

Changes: I felt that when a User opens the application, the ZIM file which was opened the last time should be located at the top. So I implemented this feature. In the gif I attached, I opened Granblue Fantasy Wiki which was listed after Wiktionary. After reopening the same fragment, Granblue Fantasy Wiki was listed prior to Wiktionary. This feature won't be very effective for a small list but for a long list, it would be effective.

Screenshots/GIF for the change: 
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/29261743/54555874-a072f800-49dd-11e9-8c52-cd207c0f768b.gif)


