### PR TITLE
Refactored code and added a try catch block.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -22,12 +22,15 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Toast;
+
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.OnClick;
+
 import java.util.HashMap;
+
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.utils.LanguageUtils;
@@ -64,17 +67,15 @@ public class HelpActivity extends BaseActivity {
     recyclerView.setAdapter(helpAdapter);
   }
 
-  @OnClick({ R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view })
+  @OnClick({R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view})
   void sendFeedback() {
     Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("mailto:"));
-    intent.putExtra(Intent.EXTRA_EMAIL,new String[]{ CONTACT_EMAIL_ADDRESS });
+    intent.putExtra(Intent.EXTRA_EMAIL, new String[]{CONTACT_EMAIL_ADDRESS});
     intent.putExtra(Intent.EXTRA_SUBJECT, "Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
-
     try {
       startActivity(Intent.createChooser(intent, "Send Feedback via Email"));
-    }
-    catch(android.content.ActivityNotFoundException ex){
+    } catch (android.content.ActivityNotFoundException ex) {
       Toast.makeText(HelpActivity.this, "No email app on device.", Toast.LENGTH_SHORT).show();
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -64,7 +64,7 @@ public class HelpActivity extends BaseActivity {
     recyclerView.setAdapter(helpAdapter);
   }
 
-  @OnClick({R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view})
+  @OnClick({ R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view })
   void sendFeedback() {
     Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("mailto:"));

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -68,7 +68,7 @@ public class HelpActivity extends BaseActivity {
   void sendFeedback() {
     Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("mailto:"));
-    intent.putExtra(Intent.EXTRA_EMAIL,{ CONTACT_EMAIL_ADDRESS });
+    intent.putExtra(Intent.EXTRA_EMAIL,new String[]{ CONTACT_EMAIL_ADDRESS });
     intent.putExtra(Intent.EXTRA_SUBJECT, "Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
 
     try {

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -22,15 +22,12 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Toast;
-
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.OnClick;
-
 import java.util.HashMap;
-
 import org.kiwix.kiwixmobile.R;
 import org.kiwix.kiwixmobile.base.BaseActivity;
 import org.kiwix.kiwixmobile.utils.LanguageUtils;

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.help;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.widget.Toast;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.RecyclerView;
@@ -65,14 +66,21 @@ public class HelpActivity extends BaseActivity {
 
   @OnClick({ R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view })
   void sendFeedback() {
+
+    String[] addresses = { CONTACT_EMAIL_ADDRESS };
+
     Intent intent = new Intent(Intent.ACTION_SENDTO);
-    intent.setType("plain/text");
-    String uriText = "mailto:" + Uri.encode(CONTACT_EMAIL_ADDRESS) +
-        "?subject=" + Uri.encode(
-        "Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
-    Uri uri = Uri.parse(uriText);
-    intent.setData(uri);
-    startActivity(Intent.createChooser(intent, "Send Feedback via Email"));
+    intent.setData(Uri.parse("mailto:"));
+    intent.putExtra(Intent.EXTRA_EMAIL, addresses);
+    intent.putExtra(Intent.EXTRA_SUBJECT, "Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
+
+    try {
+      startActivity(Intent.createChooser(intent, "Send Feedback via Email"));
+    }
+    catch(android.content.ActivityNotFoundException ex)
+    {
+      Toast.makeText(HelpActivity.this, "No email app on device.", Toast.LENGTH_SHORT).show();
+    }
   }
 
   private void populateMap(int title, int descriptionArray) {
@@ -84,3 +92,4 @@ public class HelpActivity extends BaseActivity {
     titleDescriptionMap.put(getString(title), description.toString());
   }
 }
+

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/HelpActivity.java
@@ -66,19 +66,15 @@ public class HelpActivity extends BaseActivity {
 
   @OnClick({ R.id.activity_help_feedback_text_view, R.id.activity_help_feedback_image_view })
   void sendFeedback() {
-
-    String[] addresses = { CONTACT_EMAIL_ADDRESS };
-
     Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("mailto:"));
-    intent.putExtra(Intent.EXTRA_EMAIL, addresses);
+    intent.putExtra(Intent.EXTRA_EMAIL,{ CONTACT_EMAIL_ADDRESS });
     intent.putExtra(Intent.EXTRA_SUBJECT, "Feedback in " + LanguageUtils.getCurrentLocale(this).getDisplayLanguage());
 
     try {
       startActivity(Intent.createChooser(intent, "Send Feedback via Email"));
     }
-    catch(android.content.ActivityNotFoundException ex)
-    {
+    catch(android.content.ActivityNotFoundException ex){
       Toast.makeText(HelpActivity.this, "No email app on device.", Toast.LENGTH_SHORT).show();
     }
   }
@@ -92,4 +88,3 @@ public class HelpActivity extends BaseActivity {
     titleDescriptionMap.put(getString(title), description.toString());
   }
 }
-


### PR DESCRIPTION
Fixes #1105 

Explanation: The incorrect intent seems to be an issue with the Udacity App. I tried to filter the email applications in several ways like setting the intent type to be "message/rfc822" and trying to filter with support library ShareCompat, but the intent chooser options remained the same.

Changes: Refactored the code instead and added a try catch block which was earlier missing(so as to handle the case in which no email applications are present on the device).

