### PR TITLE
Improve Show selected languages in library header as a subtitle

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -334,9 +334,8 @@ public class LibraryAdapter extends BaseAdapter {
   }
 
   private static class ViewHolder {
-
     TextView title;
-    
+
     TextView subTitle;
 
     TextView description;
@@ -383,9 +382,11 @@ public class LibraryAdapter extends BaseAdapter {
         // Get all selected displayed languages from books.
         HashSet<String> selectedLanguageSet = new HashSet<>();
         for (Book book : selectedLanguages) {
-          selectedLanguageSet.add(bookUtils.getLanguage(book.getLanguage()));
+          selectedLanguageSet.add(
+              bookUtils.getLanguage(
+                  book.getLanguage()));
         }
-        
+
         listItems.add(
             new ListItem(
                 new DividerItem(
@@ -467,16 +468,16 @@ public class LibraryAdapter extends BaseAdapter {
       this.type = type;
     }
   }
-  
+
   // Wrapper for the divider item object.
   private class DividerItem {
     final String title;
     String subTitle;
-    
+
     DividerItem(String title) {
       this.title = title;
     }
-    
+
     DividerItem(String title, String subTitle) {
       this.title = title;
       this.subTitle= subTitle;

--- a/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/library/LibraryAdapter.java
@@ -22,6 +22,7 @@ package org.kiwix.kiwixmobile.library;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -225,12 +226,19 @@ public class LibraryAdapter extends BaseAdapter {
         convertView = layoutInflater.inflate(R.layout.library_divider, null);
         holder = new ViewHolder();
         holder.title = convertView.findViewById(R.id.divider_text);
+        holder.subTitle = convertView.findViewById(R.id.divider_subtitle);
         convertView.setTag(holder);
       }
 
-      String dividerText = (String) listItems.get(position).data;
+      DividerItem dividerText = (DividerItem) listItems.get(position).data;
 
-      holder.title.setText(dividerText);
+      holder.title.setText(dividerText.title);
+      if (dividerText.subTitle != null) {
+        holder.subTitle.setText(dividerText.subTitle);
+        holder.subTitle.setVisibility(View.VISIBLE);
+      } else {
+        holder.subTitle.setVisibility(View.GONE);
+      }
 
       return convertView;
     }
@@ -328,6 +336,8 @@ public class LibraryAdapter extends BaseAdapter {
   private static class ViewHolder {
 
     TextView title;
+    
+    TextView subTitle;
 
     TextView description;
 
@@ -370,10 +380,24 @@ public class LibraryAdapter extends BaseAdapter {
             .toList()
             .blockingGet();
 
-        listItems.add(new ListItem(context.getResources().getString(R.string.your_languages),
+        // Get all selected displayed languages from books.
+        HashSet<String> selectedLanguageSet = new HashSet<>();
+        for (Book book : selectedLanguages) {
+          selectedLanguageSet.add(bookUtils.getLanguage(book.getLanguage()));
+        }
+        
+        listItems.add(
+            new ListItem(
+                new DividerItem(
+                    context.getResources().getString(R.string.your_languages),
+                    TextUtils.join(", ", selectedLanguageSet)),
             LIST_ITEM_TYPE_DIVIDER));
         addBooks(selectedLanguages);
-        listItems.add(new ListItem(context.getResources().getString(R.string.other_languages),
+
+        listItems.add(
+            new ListItem(
+                new DividerItem(
+                    context.getResources().getString(R.string.other_languages)),
             LIST_ITEM_TYPE_DIVIDER));
         addBooks(unselectedLanguages);
       } else {
@@ -401,9 +425,18 @@ public class LibraryAdapter extends BaseAdapter {
 
         Collections.sort(unselectedLanguages, new BookMatchComparator());
 
-        listItems.add(new ListItem("In your language:", LIST_ITEM_TYPE_DIVIDER));
+        listItems.add(
+            new ListItem(
+                new DividerItem(
+                    context.getString(R.string.in_your_language)),
+                LIST_ITEM_TYPE_DIVIDER));
         addBooks(selectedLanguages);
-        listItems.add(new ListItem("In other languages:", LIST_ITEM_TYPE_DIVIDER));
+
+        listItems.add(
+            new ListItem(
+                new DividerItem(
+                    context.getString(R.string.in_other_languages)),
+                LIST_ITEM_TYPE_DIVIDER));
         addBooks(unselectedLanguages);
       }
 
@@ -432,6 +465,21 @@ public class LibraryAdapter extends BaseAdapter {
     ListItem(Object data, int type) {
       this.data = data;
       this.type = type;
+    }
+  }
+  
+  // Wrapper for the divider item object.
+  private class DividerItem {
+    final String title;
+    String subTitle;
+    
+    DividerItem(String title) {
+      this.title = title;
+    }
+    
+    DividerItem(String title, String subTitle) {
+      this.title = title;
+      this.subTitle= subTitle;
     }
   }
 

--- a/app/src/main/res/layout/library_divider.xml
+++ b/app/src/main/res/layout/library_divider.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:paddingBottom="@dimen/dimen_medium_padding"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
@@ -17,4 +17,12 @@
       android:textAppearance="?android:textAppearanceLarge"
       />
 
+  <TextView
+      android:id="@+id/divider_subtitle"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:textAppearanceMedium"
+      android:maxLines="2"
+      android:ellipsize="end"
+      android:visibility="gone"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -245,4 +245,6 @@
   <string name="switch_tabs">Switch tabs</string>
   <string name="smiling_face">:D</string>
   <string name="close_all_tabs">Close all tabs</string>
+  <string name="in_your_language">In your language:</string>
+  <string name="in_other_languages">In other languages:</string>
 </resources>


### PR DESCRIPTION
Create a wrapper class for divider item to include subtitle information.
Get selected languages and convert them to the subtitle.
Add subtitle text view in the library divider layout file.
Extract two hardcoded strings to string res file.

Screenshots/GIF for the change: 
![Screenshot_20190407-130551](https://user-images.githubusercontent.com/47031169/55689525-8761c500-5953-11e9-9d5c-3f289f08aca2.png)
![Screenshot_20190407-130621](https://user-images.githubusercontent.com/47031169/55689533-9ba5c200-5953-11e9-91ab-4f0895c4d73d.png)
![Screenshot_20190407-163442](https://user-images.githubusercontent.com/47031169/55689535-a2ccd000-5953-11e9-9e31-3b6ed40f2b6d.png)

