### PR TITLE
Prevent builds of pushed branches unless it is a tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   global:
     - ANDROID_TARGET=android-22
     - ANDROID_ABI=armeabi-v7a
+    -
+if: type != push OR tag IS present
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_82adfa9c3806_key -iv $encrypted_82adfa9c3806_iv -in secrets.tar.enc -out secrets.tar -d
@@ -79,7 +81,7 @@ deploy:
     file_glob: true
     skip_cleanup: true
     overwrite: true
-#    body: "$APP_CHANGELOG" broken because travis can't escape newlines
+    #body: "$APP_CHANGELOG" broken because travis can't escape newlines https://github.com/travis-ci/dpl/issues/155
     draft: true
     on:
       tags: true


### PR DESCRIPTION
Changes: To enable automatic publishing on tagging we must enable the option "build pushed branches" on travis, however we don't want every pushed banch to be built, only the tags.
