### PR TITLE
#1226 create stalebot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,7 @@
+daysUntilStale: 60
+daysUntilClose: false
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be now be reviewed manually. Thank you
+  for your contributions.


### PR DESCRIPTION
Fixes #1226 

Changes: Stalebot will mark issues with 60 days inactivity with the label `stale`

