### PR TITLE
Fixed disabled view for night mode option

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/CustomSwitchPreference.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/CustomSwitchPreference.java
@@ -25,6 +25,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Switch;
+import org.kiwix.kiwixmobile.utils.SharedPreferenceUtil;
 
 public class CustomSwitchPreference extends SwitchPreference {
 
@@ -64,6 +65,8 @@ public class CustomSwitchPreference extends SwitchPreference {
     ViewGroup viewGroup = (ViewGroup) view;
     clearListenerInViewGroup(viewGroup);
     super.onBindView(view);
+    SharedPreferenceUtil sharedPreferenceUtil = new SharedPreferenceUtil(getContext());
+    sharedPreferenceUtil.disableNightMode(view);
   }
 
   /**

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/SharedPreferenceUtil.java
@@ -7,6 +7,9 @@ import android.preference.PreferenceManager;
 import java.util.Calendar;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import android.view.View;
+import android.graphics.Color;
+import android.widget.TextView;
 
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_AUTONIGHTMODE;
 import static org.kiwix.kiwixmobile.utils.Constants.PREF_BACK_TO_TOP;
@@ -160,6 +163,16 @@ public class SharedPreferenceUtil {
       return hour < 6 || hour > 18;
     } else {
       return getPrefNightMode();
+    }
+  }
+
+  public void disableNightMode(View view) {
+    boolean autoNightMode = getPrefAutoNightMode();
+    TextView title = view.findViewById(android.R.id.title);
+    TextView summary = view.findViewById(android.R.id.summary);
+    if (autoNightMode && title.getText().equals("Night mode")) {
+      title.setTextColor(Color.GRAY);
+      summary.setTextColor(Color.GRAY);
     }
   }
 


### PR DESCRIPTION
Fixes #1028 

Changes: 
Added a method disableNightMode in SharedPreferenceUtil which changes the colour of Night mode option in Settings to grey when Automated night mode is on. 
This conveys to the user that the Night mode option is currently disabled, and improves UX. 

Screenshots/GIF for the change: 
![1](https://user-images.githubusercontent.com/44517226/60170869-fbab5680-9826-11e9-958a-b58cfdf05c1c.jpeg)
![2](https://user-images.githubusercontent.com/44517226/60170888-02d26480-9827-11e9-8615-cf10fb5d762a.jpeg)