### PR TITLE
Addition to #1198

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/data/ZimContentProvider.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/data/ZimContentProvider.java
@@ -115,10 +115,17 @@ public class ZimContentProvider extends ContentProvider {
     return zimFileName;
   }
 
+  /** Returns path to the current ZIM file */
   public static String getZimFile() {
     return zimFileName;
   }
 
+  /**
+   * Returns title associated with the current ZIM file.
+   *
+   * Note that the value returned is NOT unique for each zim file. Versions of the same wiki
+   * (complete, nopic, novid, etc) may return the same title.
+   * */
   public static String getZimFileTitle() {
     if (currentJNIReader == null || zimFileName == null) {
       return null;

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
@@ -58,27 +58,26 @@ import static org.kiwix.kiwixmobile.utils.Constants.NOTES_DIRECTORY;
 public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDialogFragment.UserClickListener {
 
   public static final String TAG = "AddNoteDialog";
-  private static final int BeginIndexForZimNoteDirectoryName = 6;
 
   private SharedPreferenceUtil sharedPreferenceUtil;
 
   @BindView(R.id.add_note_toolbar)
-  Toolbar toolbar;  // Displays options for the note dialog
+  Toolbar toolbar;          // Displays options for the note dialog
   @BindView(R.id.add_note_text_view)
   TextView addNoteTextView; // Displays article title
   @BindView(R.id.add_note_edit_text)
-  EditText addNoteEditText; // Displays zim file title (wiki name)
+  EditText addNoteEditText; // Displays the note text
 
   private Unbinder unbinder;
 
   private String zimFileTitle;
   private String articleTitle;
-  private String zimNoteDirectoryName;
-  private String articleNotefileName;
+  private String zimNoteDirectoryName;  // Corresponds to "ZimFileName" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
+  private String articleNotefileName;   // Corresponds to "ArticleUrl" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
   private boolean noteFileExists = false;
-  private boolean noteEdited = false; // Keeps track of state of the note (whether edited since last save)
+  private boolean noteEdited = false;   // Keeps track of state of the note (whether edited since last save)
 
-  private String ZIM_NOTES_DIRECTORY;
+  private String ZIM_NOTES_DIRECTORY;   // Stores path to directory for the currently open zim's notes
 
   public AddNoteDialog(SharedPreferenceUtil sharedPreferenceUtil) {
     this.sharedPreferenceUtil = sharedPreferenceUtil;
@@ -94,75 +93,9 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     articleTitle = ((MainActivity)getActivity()).getCurrentWebView().getTitle();
 
     zimNoteDirectoryName = getZimNoteDirectoryName();
-    Log.d(TAG, "Note Directory Name: " + zimNoteDirectoryName);
-
     articleNotefileName = getArticleNotefileName();
-    Log.d(TAG, "Article Notefile Name: " + articleNotefileName);
 
     ZIM_NOTES_DIRECTORY = NOTES_DIRECTORY + zimNoteDirectoryName + "/";
-  }
-
-  private String getZimNoteDirectoryName() {
-    //String zimFileName = ZimContentProvider.getName(); // Returns name of the form "kiwix.psiram_en_all"
-    String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
-    Log.d(TAG, "Zim name: " + zimFileName);
-    //Log.d(TAG, "Zim file name: " + ZimContentProvider.getZimFile());
-
-    //return (zimFileName.substring(BeginIndexForZimNoteDirectoryName)); // Returns "psiram_en_all" by removing "kiwix." prefix
-    String noteDirectoryName = getTextAfterLastSlashWithoutExtension(zimFileName);
-
-    if(noteDirectoryName != null) {
-      return noteDirectoryName;
-    } else {
-      return (zimFileTitle); // Incase the required ZIM file name couldn't be extracted
-    }
-  }
-
-  private String getArticleNotefileName() {
-    // Returns url of the form: "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html"
-    String articleUrl = ((MainActivity) getActivity()).getCurrentWebView().getUrl();
-
-    String notefileName = getTextAfterLastSlashWithoutExtension(articleUrl);
-
-    if(notefileName != null) {
-      return notefileName;
-    } else {
-      return (articleTitle); // Incase the required html file name couldn't be extracted
-    }
-  }
-
-  private String getTextAfterLastSlashWithoutExtension(String path) {
-    /*
-    * That's about exactly what it does.
-    *
-    * From ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim", returns "granbluefantasy_en_all_all_nopic_2018-10"
-    * From "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html", returns "Main_Page"
-    *
-    * For null input or on being unable to find said text, returns null
-    * */
-
-    if(path == null) return null;
-
-    int rightmostSlash = -1;
-    int rightmostDot = -1;
-
-    for(int i = path.length()-1; i >= 0; i--) {
-
-      if(path.charAt(i) == '.' && rightmostDot < 0) rightmostDot = i;
-
-      if(path.charAt(i) == '/') {
-        rightmostSlash = i;
-        break;
-      }
-    }
-
-    //Log.d(TAG, "Method output: " + path.substring(rightmostSlash+1, rightmostDot));
-
-    if(rightmostSlash > -1 && rightmostDot > -1) {
-      return (path.substring(rightmostSlash+1, rightmostDot));
-    }
-
-    return null;
   }
 
   @Override
@@ -223,6 +156,60 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     });
 
     return view;
+  }
+
+  private String getZimNoteDirectoryName() {
+    String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
+
+    String noteDirectoryName = getTextAfterLastSlashWithoutExtension(zimFileName);
+
+    if(noteDirectoryName != null) {
+      return noteDirectoryName;
+    } else {
+      return (zimFileTitle); // Incase the required ZIM file name couldn't be extracted
+    }
+  }
+
+  private String getArticleNotefileName() {
+    String articleUrl = ((MainActivity) getActivity()).getCurrentWebView().getUrl(); // Returns url of the form: "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html"
+
+    String notefileName = getTextAfterLastSlashWithoutExtension(articleUrl);
+
+    if(notefileName != null) {
+      return notefileName;
+    } else {
+      return (articleTitle); // Incase the required html file name couldn't be extracted
+    }
+  }
+
+  private String getTextAfterLastSlashWithoutExtension(String path) {
+    /* That's about exactly what it does.
+     *
+     * From ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim", returns "granbluefantasy_en_all_all_nopic_2018-10"
+     * From "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html", returns "Main_Page"
+     * For null input or on being unable to find required text, returns null
+     * */
+    if(path == null) return null;
+
+    int rightmostSlash = -1;
+    int rightmostDot = -1;
+
+    for(int i = path.length()-1; i >= 0; i--) {
+
+      if(path.charAt(i) == '.' && rightmostDot < 0)
+        rightmostDot = i;
+
+      if(path.charAt(i) == '/') {
+        rightmostSlash = i;
+        break;
+      }
+    }
+
+    if(rightmostSlash > -1 && rightmostDot > -1) {
+      return (path.substring(rightmostSlash+1, rightmostDot));
+    }
+
+    return null;
   }
 
   // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
@@ -158,58 +158,38 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     return view;
   }
 
-  private String getZimNoteDirectoryName() {
+  private @NonNull String getZimNoteDirectoryName() {
     String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
 
     String noteDirectoryName = getTextAfterLastSlashWithoutExtension(zimFileName);
 
-    if(noteDirectoryName != null) {
-      return noteDirectoryName;
-    } else {
-      return (zimFileTitle); // Incase the required ZIM file name couldn't be extracted
-    }
+    return (!noteDirectoryName.isEmpty()) ? noteDirectoryName : zimFileTitle;  // Incase the required ZIM file name couldn't be extracted
   }
 
-  private String getArticleNotefileName() {
+  private @NonNull String getArticleNotefileName() {
     String articleUrl = ((MainActivity) getActivity()).getCurrentWebView().getUrl(); // Returns url of the form: "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html"
 
     String notefileName = getTextAfterLastSlashWithoutExtension(articleUrl);
 
-    if(notefileName != null) {
-      return notefileName;
-    } else {
-      return (articleTitle); // Incase the required html file name couldn't be extracted
-    }
+    return (!notefileName.isEmpty()) ? notefileName : articleTitle; // Incase the required html file name couldn't be extracted
   }
 
-  private String getTextAfterLastSlashWithoutExtension(String path) {
+  private @NonNull String getTextAfterLastSlashWithoutExtension(@NonNull String path) {
     /* That's about exactly what it does.
      *
      * From ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim", returns "granbluefantasy_en_all_all_nopic_2018-10"
      * From "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html", returns "Main_Page"
      * For null input or on being unable to find required text, returns null
      * */
-    if(path == null) return null;
 
-    int rightmostSlash = -1;
-    int rightmostDot = -1;
-
-    for(int i = path.length()-1; i >= 0; i--) {
-
-      if(path.charAt(i) == '.' && rightmostDot < 0)
-        rightmostDot = i;
-
-      if(path.charAt(i) == '/') {
-        rightmostSlash = i;
-        break;
-      }
-    }
+    int rightmostSlash = path.lastIndexOf('/');
+    int rightmostDot = path.lastIndexOf('.');
 
     if(rightmostSlash > -1 && rightmostDot > -1) {
       return (path.substring(rightmostSlash+1, rightmostDot));
     }
 
-    return null;
+    return ""; // If couldn't find the dot and/or slash
   }
 
   // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -529,7 +529,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
     drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
     closeAllTabsButton.setImageDrawable(
-        ContextCompat.getDrawable(this, R.drawable.ic_close_white_24dp));
+        ContextCompat.getDrawable(this, R.drawable.ic_close_black_24dp));
     tabSwitcherRoot.setVisibility(View.GONE);
     progressBar.setVisibility(View.VISIBLE);
     contentFrame.setVisibility(View.VISIBLE);

--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/AnimationUtils.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/AnimationUtils.java
@@ -86,7 +86,7 @@ public class AnimationUtils {
 
       public void onAnimationStart(Animation animation) {
         v.setImageDrawable(
-            ContextCompat.getDrawable(v.getContext(), R.drawable.ic_close_white_24dp));
+            ContextCompat.getDrawable(v.getContext(), R.drawable.ic_close_black_24dp));
       }
     });
   }

--- a/app/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    android:width="24dp">
+  <path
+      android:fillColor="#000000"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/tab_switcher.xml
+++ b/app/src/main/res/layout/tab_switcher.xml
@@ -25,6 +25,6 @@
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:srcCompat="@drawable/ic_close_white_24dp"
+      app:srcCompat="@drawable/ic_close_black_24dp"
       />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Fixes:** Previously file storage in [feature/NoteKeeper](https://github.com/kiwix/kiwix-android/pull/1198) used the zim file title to name the directory for notes corresponding to a particular zim file; which is not unique for each zim file.

Commits in this PR correspond to:
1. Changing that path to `.../Kiwix/Notes/ZimFileName/ArticleUrl.txt` (previously ".../Notes/ZimFileTitle/ArticleTitle.txt")
2. Bug relating to the use of resource close icon - [Commit](https://github.com/kiwix/kiwix-android/commit/865b579057692f3165645f1f5b98ad31b88e9c1b)

@mhutti1 @macgills could you review this?