### PR TITLE
Hotfix: Add "no zim open" check for Add Note Dialog in case of fresh install

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
@@ -70,6 +70,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
 
   private Unbinder unbinder;
 
+  private String zimFileName;
   private String zimFileTitle;
   private String articleTitle;
   private String zimNoteDirectoryName;  // Corresponds to "ZimFileName" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
@@ -89,13 +90,22 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
 
     setStyle(DialogFragment.STYLE_NORMAL, sharedPreferenceUtil.nightMode() ? R.style.AddNoteDialogStyle_Night : R.style.AddNoteDialogStyle);
 
-    zimFileTitle = ZimContentProvider.getZimFileTitle();
-    articleTitle = ((MainActivity)getActivity()).getCurrentWebView().getTitle();
+    zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
 
-    zimNoteDirectoryName = getZimNoteDirectoryName();
-    articleNotefileName = getArticleNotefileName();
+    if(zimFileName != null) { // No zim file currently opened
+      zimFileTitle = ZimContentProvider.getZimFileTitle();
+      articleTitle = ((MainActivity)getActivity()).getCurrentWebView().getTitle();
 
-    ZIM_NOTES_DIRECTORY = NOTES_DIRECTORY + zimNoteDirectoryName + "/";
+      zimNoteDirectoryName = getZimNoteDirectoryName();
+      articleNotefileName = getArticleNotefileName();
+
+      ZIM_NOTES_DIRECTORY = NOTES_DIRECTORY + zimNoteDirectoryName + "/";
+
+    } else {
+      showToast(R.string.error_filenotfound, Toast.LENGTH_LONG);
+      closeKeyboard();
+      getFragmentManager().beginTransaction().remove(AddNoteDialog.this).commit();
+    }
   }
 
   @Override
@@ -159,7 +169,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   }
 
   private @NonNull String getZimNoteDirectoryName() {
-    String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
+    /*String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"*/
 
     String noteDirectoryName = getTextAfterLastSlashWithoutExtension(zimFileName);
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
@@ -76,16 +76,16 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   private String zimNoteDirectoryName;  // Corresponds to "ZimFileName" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
   private String articleNotefileName;   // Corresponds to "ArticleUrl" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
   private boolean noteFileExists = false;
-  private boolean noteEdited = false;   // Keeps track of state of the note (whether edited since last save)
+  boolean noteEdited = false;   // Keeps track of state of the note (whether edited since last save)
 
   private String ZIM_NOTES_DIRECTORY;   // Stores path to directory for the currently open zim's notes
 
-  public AddNoteDialog(SharedPreferenceUtil sharedPreferenceUtil) {
+  public AddNoteDialog(@NonNull SharedPreferenceUtil sharedPreferenceUtil) {
     this.sharedPreferenceUtil = sharedPreferenceUtil;
   }
 
   @Override
-  public void onCreate(Bundle savedInstanceState) {
+  public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     setStyle(DialogFragment.STYLE_NORMAL, sharedPreferenceUtil.nightMode() ? R.style.AddNoteDialogStyle_Night : R.style.AddNoteDialogStyle);
@@ -109,7 +109,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   }
 
   @Override
-  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+  public @NonNull View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     View view = inflater.inflate(R.layout.dialog_add_note, container, false);
     unbinder = ButterKnife.bind(this, view);
@@ -214,7 +214,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     };
   }
 
-  private void exitAddNoteDialog() {
+  void exitAddNoteDialog() {
     if(noteEdited) {
       Fragment previousInstance = getActivity().getSupportFragmentManager().findFragmentByTag(ConfirmationAlertDialogFragment.TAG);
 
@@ -244,7 +244,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     }
   }
 
-  private void enableSaveNoteMenuItem() {
+  void enableSaveNoteMenuItem() {
     if(toolbar.getMenu() != null) {
       MenuItem saveItem = toolbar.getMenu().findItem(R.id.save_note);
       saveItem.setEnabled(true);
@@ -255,7 +255,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     }
   }
 
-  private void enableShareNoteMenuItem() {
+  void enableShareNoteMenuItem() {
     if(toolbar.getMenu() != null) {
       MenuItem shareItem = toolbar.getMenu().findItem(R.id.share_note);
       shareItem.setEnabled(true);
@@ -277,17 +277,17 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     }
   }
 
-  public void showKeyboard(){
+  private void showKeyboard(){
     InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
   }
 
-  public void closeKeyboard(){
+  void closeKeyboard(){
     InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     inputMethodManager.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
   }
 
-  private void saveNote(String noteText) {
+  void saveNote(String noteText) {
 
     /* String content of the EditText, given by noteText, is saved into the text file given by:
      *    "{External Storage}/Kiwix/Notes/ZimFileTitle/ArticleTitle.txt"
@@ -349,26 +349,17 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
       noteFileExists = true;
 
       StringBuilder contents = new StringBuilder();
-      try {
+      try(BufferedReader input = new BufferedReader(new java.io.FileReader(noteFile))) {
+        String line = null;
 
-        BufferedReader input = new BufferedReader(new java.io.FileReader(noteFile));
-        try {
-          String line = null;
-
-          while((line = input.readLine()) != null) {
-            contents.append(line);
-            contents.append(System.getProperty("line.separator"));
-          }
-        } catch (IOException e) {
-          e.printStackTrace();
-          Log.d(TAG, "Error reading line with BufferedReader");
-        } finally {
-          input.close();
+        while((line = input.readLine()) != null) {
+          contents.append(line);
+          contents.append(System.getProperty("line.separator"));
         }
 
       } catch (IOException e) {
         e.printStackTrace();
-        Log.d(TAG, "Error closing BufferedReader");
+        Log.d(TAG, "Error reading line with BufferedReader");
       }
 
       addNoteEditText.setText(contents.toString()); // Display the note content
@@ -379,7 +370,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     // No action in case the note file for the currently open article doesn't exist
   }
 
-  private void shareNote() {
+  void shareNote() {
 
     /* The note text file corresponding to the currently open article, given at:
      *    "{External Storage}/Kiwix/Notes/ZimFileTitle/ArticleTitle.txt"
@@ -421,7 +412,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     }
   }
 
-  public static boolean isExternalStorageWritable() {
+  static boolean isExternalStorageWritable() {
     return Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState());
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/AddNoteDialog.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
@@ -49,13 +48,14 @@ import static org.kiwix.kiwixmobile.utils.Constants.NOTES_DIRECTORY;
 /**
  * Created by @author Aditya-Sood (21/05/19) as a part of GSoC 2019
  *
- * AddNoteDialog extends DialogFragment and is used to display the note corresponding to a particular
- * article (of a particular zim file/wiki/book) as a full-screen dialog fragment.
+ * AddNoteDialog extends DialogFragment and is used to display the note corresponding to a
+ * particular article (of a particular zim file/wiki/book) as a full-screen dialog fragment.
  *
  * Notes are saved as text files at location: "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
- * */
+ */
 
-public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDialogFragment.UserClickListener {
+public class AddNoteDialog extends DialogFragment
+    implements ConfirmationAlertDialogFragment.UserClickListener {
 
   public static final String TAG = "AddNoteDialog";
 
@@ -73,12 +73,14 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   private String zimFileName;
   private String zimFileTitle;
   private String articleTitle;
-  private String zimNoteDirectoryName;  // Corresponds to "ZimFileName" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
-  private String articleNotefileName;   // Corresponds to "ArticleUrl" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
+  // Corresponds to "ZimFileName" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
+  private String zimNoteDirectoryName;
+  // Corresponds to "ArticleUrl" of "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
+  private String articleNotefileName;
   private boolean noteFileExists = false;
   boolean noteEdited = false;   // Keeps track of state of the note (whether edited since last save)
 
-  private String ZIM_NOTES_DIRECTORY;   // Stores path to directory for the currently open zim's notes
+  private String ZIM_NOTES_DIRECTORY; // Stores path to directory for the currently open zim's notes
 
   public AddNoteDialog(@NonNull SharedPreferenceUtil sharedPreferenceUtil) {
     this.sharedPreferenceUtil = sharedPreferenceUtil;
@@ -88,19 +90,21 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    setStyle(DialogFragment.STYLE_NORMAL, sharedPreferenceUtil.nightMode() ? R.style.AddNoteDialogStyle_Night : R.style.AddNoteDialogStyle);
+    setStyle(DialogFragment.STYLE_NORMAL,
+        sharedPreferenceUtil.nightMode() ? R.style.AddNoteDialogStyle_Night
+            : R.style.AddNoteDialogStyle);
 
-    zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
+    // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
+    zimFileName = ZimContentProvider.getZimFile();
 
-    if(zimFileName != null) { // No zim file currently opened
+    if (zimFileName != null) { // No zim file currently opened
       zimFileTitle = ZimContentProvider.getZimFileTitle();
-      articleTitle = ((MainActivity)getActivity()).getCurrentWebView().getTitle();
+      articleTitle = ((MainActivity) getActivity()).getCurrentWebView().getTitle();
 
       zimNoteDirectoryName = getZimNoteDirectoryName();
       articleNotefileName = getArticleNotefileName();
 
       ZIM_NOTES_DIRECTORY = NOTES_DIRECTORY + zimNoteDirectoryName + "/";
-
     } else {
       showToast(R.string.error_filenotfound, Toast.LENGTH_LONG);
       closeKeyboard();
@@ -109,7 +113,8 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   }
 
   @Override
-  public @NonNull View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+  public @NonNull View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+      @Nullable Bundle savedInstanceState) {
     super.onCreateView(inflater, container, savedInstanceState);
     View view = inflater.inflate(R.layout.dialog_add_note, container, false);
     unbinder = ButterKnife.bind(this, view);
@@ -152,7 +157,8 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
 
     addNoteEditText.addTextChangedListener(new TextWatcher() {
       @Override
-      public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+      public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+      }
 
       @Override
       public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -162,26 +168,26 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
       }
 
       @Override
-      public void afterTextChanged(Editable s) {}
+      public void afterTextChanged(Editable s) {
+      }
     });
 
     return view;
   }
 
   private @NonNull String getZimNoteDirectoryName() {
-    /*String zimFileName = ZimContentProvider.getZimFile(); // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"*/
-
     String noteDirectoryName = getTextAfterLastSlashWithoutExtension(zimFileName);
 
-    return (!noteDirectoryName.isEmpty()) ? noteDirectoryName : zimFileTitle;  // Incase the required ZIM file name couldn't be extracted
+    return (!noteDirectoryName.isEmpty()) ? noteDirectoryName : zimFileTitle;
   }
 
   private @NonNull String getArticleNotefileName() {
-    String articleUrl = ((MainActivity) getActivity()).getCurrentWebView().getUrl(); // Returns url of the form: "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html"
+    // Returns url of the form: "content://org.kiwix.kiwixmobile.zim.base/A/Main_Page.html"
+    String articleUrl = ((MainActivity) getActivity()).getCurrentWebView().getUrl();
 
     String notefileName = getTextAfterLastSlashWithoutExtension(articleUrl);
 
-    return (!notefileName.isEmpty()) ? notefileName : articleTitle; // Incase the required html file name couldn't be extracted
+    return (!notefileName.isEmpty()) ? notefileName : articleTitle;
   }
 
   private @NonNull String getTextAfterLastSlashWithoutExtension(@NonNull String path) {
@@ -195,8 +201,8 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     int rightmostSlash = path.lastIndexOf('/');
     int rightmostDot = path.lastIndexOf('.');
 
-    if(rightmostSlash > -1 && rightmostDot > -1) {
-      return (path.substring(rightmostSlash+1, rightmostDot));
+    if (rightmostSlash > -1 && rightmostDot > -1) {
+      return (path.substring(rightmostSlash + 1, rightmostDot));
     }
 
     return ""; // If couldn't find the dot and/or slash
@@ -215,15 +221,17 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   }
 
   void exitAddNoteDialog() {
-    if(noteEdited) {
-      Fragment previousInstance = getActivity().getSupportFragmentManager().findFragmentByTag(ConfirmationAlertDialogFragment.TAG);
+    if (noteEdited) {
+      Fragment previousInstance = getActivity().getSupportFragmentManager()
+          .findFragmentByTag(ConfirmationAlertDialogFragment.TAG);
 
-      if(previousInstance == null) {
+      if (previousInstance == null) {
         // Custom AlertDialog for taking user confirmation before closing note dialog in case of unsaved changes
-        DialogFragment newFragment = new ConfirmationAlertDialogFragment(sharedPreferenceUtil, TAG, R.string.confirmation_alert_dialog_message);
-        newFragment.show(getActivity().getSupportFragmentManager(), ConfirmationAlertDialogFragment.TAG);
+        DialogFragment newFragment = new ConfirmationAlertDialogFragment(sharedPreferenceUtil, TAG,
+            R.string.confirmation_alert_dialog_message);
+        newFragment.show(getActivity().getSupportFragmentManager(),
+            ConfirmationAlertDialogFragment.TAG);
       }
-
     } else {
       // Closing unedited note dialog straightaway
       dismissAddNoteDialog();
@@ -231,36 +239,33 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   }
 
   private void disableMenuItems() {
-    if(toolbar.getMenu() != null) {
+    if (toolbar.getMenu() != null) {
       MenuItem saveItem = toolbar.getMenu().findItem(R.id.save_note);
       MenuItem shareItem = toolbar.getMenu().findItem(R.id.share_note);
       saveItem.setEnabled(false);
       shareItem.setEnabled(false);
       saveItem.getIcon().setAlpha(130);
       shareItem.getIcon().setAlpha(130);
-
     } else {
       Log.d(TAG, "Toolbar without inflated menu");
     }
   }
 
   void enableSaveNoteMenuItem() {
-    if(toolbar.getMenu() != null) {
+    if (toolbar.getMenu() != null) {
       MenuItem saveItem = toolbar.getMenu().findItem(R.id.save_note);
       saveItem.setEnabled(true);
       saveItem.getIcon().setAlpha(255);
-
     } else {
       Log.d(TAG, "Toolbar without inflated menu");
     }
   }
 
   void enableShareNoteMenuItem() {
-    if(toolbar.getMenu() != null) {
+    if (toolbar.getMenu() != null) {
       MenuItem shareItem = toolbar.getMenu().findItem(R.id.share_note);
       shareItem.setEnabled(true);
       shareItem.getIcon().setAlpha(255);
-
     } else {
       Log.d(TAG, "Toolbar without inflated menu");
     }
@@ -270,20 +275,22 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
 
-    if(!noteFileExists) {
+    if (!noteFileExists) {
       // Prepare for input in case of empty/new note
       addNoteEditText.requestFocus();
       showKeyboard();
     }
   }
 
-  private void showKeyboard(){
-    InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+  private void showKeyboard() {
+    InputMethodManager inputMethodManager =
+        (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
   }
 
-  void closeKeyboard(){
-    InputMethodManager inputMethodManager = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+  void closeKeyboard() {
+    InputMethodManager inputMethodManager =
+        (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     inputMethodManager.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
   }
 
@@ -293,9 +300,10 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
      *    "{External Storage}/Kiwix/Notes/ZimFileTitle/ArticleTitle.txt"
      * */
 
-    if(isExternalStorageWritable()) {
+    if (isExternalStorageWritable()) {
 
-      if(ContextCompat.checkSelfPermission(getContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+      if (ContextCompat.checkSelfPermission(getContext(),
+          Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
         Log.d(TAG, "WRITE_EXTERNAL_STORAGE permission not granted");
         showToast(R.string.note_save_unsuccessful, Toast.LENGTH_LONG);
         return;
@@ -304,12 +312,12 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
       File notesFolder = new File(ZIM_NOTES_DIRECTORY);
       boolean folderExists = true;
 
-      if(!notesFolder.exists()) {
+      if (!notesFolder.exists()) {
         // Try creating folder if it doesn't exist
         folderExists = notesFolder.mkdirs();
       }
 
-      if(folderExists) {
+      if (folderExists) {
         File noteFile = new File(notesFolder.getAbsolutePath(), articleNotefileName + ".txt");
 
         // Save note text-file code:
@@ -319,21 +327,17 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
           fileOutputStream.close();
           showToast(R.string.note_save_successful, Toast.LENGTH_SHORT);
           noteEdited = false; // As no unsaved changes remain
-
         } catch (IOException e) {
           e.printStackTrace();
           showToast(R.string.note_save_unsuccessful, Toast.LENGTH_LONG);
         }
-
       } else {
         showToast(R.string.note_save_unsuccessful, Toast.LENGTH_LONG);
         Log.d(TAG, "Required folder doesn't exist");
       }
-    }
-    else {
+    } else {
       showToast(R.string.note_save_error_storage_not_writable, Toast.LENGTH_LONG);
     }
-
   }
 
   private void displayNote() {
@@ -345,18 +349,17 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
 
     File noteFile = new File(ZIM_NOTES_DIRECTORY + articleNotefileName + ".txt");
 
-    if(noteFile.exists()) {
+    if (noteFile.exists()) {
       noteFileExists = true;
 
       StringBuilder contents = new StringBuilder();
-      try(BufferedReader input = new BufferedReader(new java.io.FileReader(noteFile))) {
+      try (BufferedReader input = new BufferedReader(new java.io.FileReader(noteFile))) {
         String line = null;
 
-        while((line = input.readLine()) != null) {
+        while ((line = input.readLine()) != null) {
           contents.append(line);
           contents.append(System.getProperty("line.separator"));
         }
-
       } catch (IOException e) {
         e.printStackTrace();
         Log.d(TAG, "Error reading line with BufferedReader");
@@ -377,36 +380,38 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
      * is shared via an app-chooser intent
      * */
 
-    if(noteEdited) {
-     saveNote(addNoteEditText.getText().toString()); // Save edited note before sharing the text file
+    if (noteEdited) {
+      saveNote(
+          addNoteEditText.getText().toString()); // Save edited note before sharing the text file
     }
 
     File noteFile = new File(ZIM_NOTES_DIRECTORY + articleNotefileName + ".txt");
 
     Uri noteFileUri = null;
-    if(noteFile.exists()) {
+    if (noteFile.exists()) {
 
       if (Build.VERSION.SDK_INT >= 24) {
         // From Nougat 7 (API 24) access to files is shared temporarily with other apps
         // Need to use FileProvider for the same
-        noteFileUri = FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID+".fileprovider", noteFile);
-
+        noteFileUri =
+            FileProvider.getUriForFile(getContext(), BuildConfig.APPLICATION_ID + ".fileprovider",
+                noteFile);
       } else {
         noteFileUri = Uri.fromFile(noteFile);
       }
-
     } else {
       showToast(R.string.note_share_error_file_missing, Toast.LENGTH_SHORT);
     }
 
-    if(noteFileUri != null) {
+    if (noteFileUri != null) {
       Intent noteFileShareIntent = new Intent(Intent.ACTION_SEND);
       noteFileShareIntent.setType("application/octet-stream");
       noteFileShareIntent.putExtra(Intent.EXTRA_STREAM, noteFileUri);
       noteFileShareIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-      Intent shareChooser = Intent.createChooser(noteFileShareIntent, getString(R.string.note_share_app_chooser_title));
+      Intent shareChooser = Intent.createChooser(noteFileShareIntent,
+          getString(R.string.note_share_app_chooser_title));
 
-      if(noteFileShareIntent.resolveActivity(getActivity().getPackageManager()) != null) {
+      if (noteFileShareIntent.resolveActivity(getActivity().getPackageManager()) != null) {
         startActivity(shareChooser);
       }
     }
@@ -441,7 +446,7 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
     super.onStart();
 
     Dialog dialog = getDialog();
-    if(dialog != null) {
+    if (dialog != null) {
       int width = ViewGroup.LayoutParams.MATCH_PARENT;
       int height = ViewGroup.LayoutParams.MATCH_PARENT;
       dialog.getWindow().setLayout(width, height);
@@ -455,5 +460,4 @@ public class AddNoteDialog extends DialogFragment implements ConfirmationAlertDi
       unbinder.unbind();
     }
   }
-
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -939,7 +939,7 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   }
 
   /** Method to delete all user notes */
-  private void clearAllNotes() {
+  void clearAllNotes() {
 
     boolean result = true; // Result of all delete() calls is &&-ed to this variable
 
@@ -995,7 +995,8 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
       *  returning null means that the AddNoteDialog is currently not on display (as doesn't exist)
       **/
       AddNoteDialog dialogFragment = new AddNoteDialog(sharedPreferenceUtil);
-      dialogFragment.show(fragmentTransaction, AddNoteDialog.TAG); // For DialogFragments, show() handles the fragment commit and display
+      dialogFragment.show(fragmentTransaction, AddNoteDialog.TAG);
+      // For DialogFragments, show() handles the fragment commit and display
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -154,7 +154,7 @@ import static org.kiwix.kiwixmobile.utils.StyleUtils.dialogStyle;
 import static org.kiwix.kiwixmobile.utils.UpdateUtils.reformatProviderUrl;
 
 public class MainActivity extends BaseActivity implements WebViewCallback,
-    MainContract.View{
+    MainContract.View {
 
   private static final String NEW_TAB = "NEW_TAB";
   private static final String HOME_URL = "file:///android_asset/home.html";
@@ -276,7 +276,6 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     }
   };
 
-
   private static void updateWidgets(Context context) {
     Intent intent = new Intent(context.getApplicationContext(), KiwixSearchWidget.class);
     intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
@@ -359,13 +358,13 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
     wasHideToolbar = isHideToolbar;
     booksAdapter = new BooksOnDiskAdapter(
-       new BookOnDiskDelegate.BookDelegate(sharedPreferenceUtil,
-           bookOnDiskItem -> {
-             open(bookOnDiskItem);
-             return Unit.INSTANCE;
-           },
-           null,
-           null),
+        new BookOnDiskDelegate.BookDelegate(sharedPreferenceUtil,
+            bookOnDiskItem -> {
+              open(bookOnDiskItem);
+              return Unit.INSTANCE;
+            },
+            null,
+            null),
         BookOnDiskDelegate.LanguageDelegate.INSTANCE
     );
 
@@ -846,14 +845,14 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
         break;
 
       case R.id.menu_add_note:
-        if(requestExternalStorageWritePermissionForNotes()) {
+        if (requestExternalStorageWritePermissionForNotes()) {
           // Check permission since notes are stored in the public-external storage
           showAddNoteDialog();
         }
         break;
 
       case R.id.menu_clear_notes:
-        if(requestExternalStorageWritePermissionForNotes()) { // Check permission since notes are stored in the public-external storage
+        if (requestExternalStorageWritePermissionForNotes()) { // Check permission since notes are stored in the public-external storage
           showClearAllNotesDialog();
         }
         break;
@@ -943,8 +942,9 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
     boolean result = true; // Result of all delete() calls is &&-ed to this variable
 
-    if(AddNoteDialog.isExternalStorageWritable()) {
-      if(ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+    if (AddNoteDialog.isExternalStorageWritable()) {
+      if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+          != PackageManager.PERMISSION_GRANTED) {
         Log.d("MainActivity", "WRITE_EXTERNAL_STORAGE permission not granted");
         showToast(R.string.ext_storage_permission_not_granted, Toast.LENGTH_LONG);
         return;
@@ -955,17 +955,17 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
       File notesDirectory = new File(NOTES_DIRECTORY);
       File[] filesInNotesDirectory = notesDirectory.listFiles();
 
-      if(filesInNotesDirectory == null) { // Notes folder doesn't exist
+      if (filesInNotesDirectory == null) { // Notes folder doesn't exist
         showToast(R.string.notes_deletion_none_found, Toast.LENGTH_LONG);
         return;
       }
 
-      for(File wikiFileDirectory : filesInNotesDirectory) {
-        if(wikiFileDirectory.isDirectory()) {
+      for (File wikiFileDirectory : filesInNotesDirectory) {
+        if (wikiFileDirectory.isDirectory()) {
           File[] filesInWikiDirectory = wikiFileDirectory.listFiles();
 
-          for(File noteFile : filesInWikiDirectory) {
-            if(noteFile.isFile()) {
+          for (File noteFile : filesInWikiDirectory) {
+            if (noteFile.isFile()) {
               result = result && noteFile.delete();
             }
           }
@@ -974,10 +974,11 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
         result = result && wikiFileDirectory.delete(); // Wiki specific notes directory deleted
       }
 
-      result = result && notesDirectory.delete(); // "{External Storage}/Kiwix/Notes" directory deleted
+      result =
+          result && notesDirectory.delete(); // "{External Storage}/Kiwix/Notes" directory deleted
     }
 
-    if(result) {
+    if (result) {
       showToast(R.string.notes_deletion_successful, Toast.LENGTH_SHORT);
     } else {
       showToast(R.string.notes_deletion_unsuccessful, Toast.LENGTH_SHORT);
@@ -990,10 +991,10 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     Fragment previousInstance = getSupportFragmentManager().findFragmentByTag(AddNoteDialog.TAG);
 
     // To prevent multiple instances of the DialogFragment
-    if(previousInstance == null) {
+    if (previousInstance == null) {
       /* Since the DialogFragment is never added to the back-stack, so findFragmentByTag()
-      *  returning null means that the AddNoteDialog is currently not on display (as doesn't exist)
-      **/
+       *  returning null means that the AddNoteDialog is currently not on display (as doesn't exist)
+       **/
       AddNoteDialog dialogFragment = new AddNoteDialog(sharedPreferenceUtil);
       dialogFragment.show(fragmentTransaction, AddNoteDialog.TAG);
       // For DialogFragments, show() handles the fragment commit and display
@@ -1001,13 +1002,13 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
   }
 
   private boolean requestExternalStorageWritePermissionForNotes() {
-    if(Build.VERSION.SDK_INT >= 23) { // For Marshmallow & higher API levels
+    if (Build.VERSION.SDK_INT >= 23) { // For Marshmallow & higher API levels
 
-      if(checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+      if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+          == PackageManager.PERMISSION_GRANTED) {
         return true;
-
       } else {
-        if(shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+        if (shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
           /* shouldShowRequestPermissionRationale() returns false when:
            *  1) User has previously checked on "Don't ask me again", and/or
            *  2) Permission has been disabled on device
@@ -1015,9 +1016,9 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
           showToast(R.string.ext_storage_permission_rationale_add_note, Toast.LENGTH_LONG);
         }
 
-        requestPermissions(new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE);
+        requestPermissions(new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE },
+            REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE);
       }
-
     } else { // For Android versions below Marshmallow 6.0 (API 23)
       return true; // As already requested at install time
     }
@@ -1203,12 +1204,12 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
 
       case REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE: {
 
-        if(grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
           // Successfully granted permission, so opening the note keeper
           showAddNoteDialog();
-
         } else {
-          Toast.makeText(getApplicationContext(), getString(R.string.ext_storage_write_permission_denied_add_note), Toast.LENGTH_LONG);
+          Toast.makeText(getApplicationContext(),
+              getString(R.string.ext_storage_write_permission_denied_add_note), Toast.LENGTH_LONG);
         }
 
         break;
@@ -1328,7 +1329,8 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     //Check maybe need refresh
     String articleUrl = getCurrentWebView().getUrl();
     boolean isBookmark = false;
-    BookmarkItem bookmark = BookmarkItem.fromZimContentProvider(getCurrentWebView().getTitle(),articleUrl);
+    BookmarkItem bookmark =
+        BookmarkItem.fromZimContentProvider(getCurrentWebView().getTitle(), articleUrl);
     if (articleUrl != null && !bookmarks.contains(articleUrl)) {
       if (ZimContentProvider.getId() != null) {
         presenter.saveBookmark(bookmark);
@@ -1979,7 +1981,8 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
     String url = getCurrentWebView().getUrl();
     if (url != null && !url.equals(HOME_URL)) {
       final long timeStamp = System.currentTimeMillis();
-      SimpleDateFormat sdf = new SimpleDateFormat("d MMM yyyy", LanguageUtils.getCurrentLocale(this));
+      SimpleDateFormat sdf =
+          new SimpleDateFormat("d MMM yyyy", LanguageUtils.getCurrentLocale(this));
       HistoryListItem.HistoryItem history = new HistoryListItem.HistoryItem(
           0L,
           ZimContentProvider.getId(),


### PR DESCRIPTION
Fixes #1302 

Changes: Added a check in `onCreate()` of Add Note Dialog for fresh installs (with no zim file opened previously)
