### PR TITLE
#681 specify round icon in Android manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
       android:allowBackup="true"
       android:hardwareAccelerated="true"
       android:icon="@mipmap/kiwix_icon"
+      android:roundIcon="@mipmap/kiwix_icon_round"
       android:label="@string/app_name"
       android:networkSecurityConfig="@xml/network_security_config"
       android:supportsRtl="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,9 +17,9 @@
       android:allowBackup="true"
       android:hardwareAccelerated="true"
       android:icon="@mipmap/kiwix_icon"
-      android:roundIcon="@mipmap/kiwix_icon_round"
       android:label="@string/app_name"
       android:networkSecurityConfig="@xml/network_security_config"
+      android:roundIcon="@mipmap/kiwix_icon_round"
       android:supportsRtl="true"
       android:theme="@style/AppTheme">
 


### PR DESCRIPTION
Fixes #681 easily sets round icon in APIs which require them.
