### PR TITLE
Disable density splits

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,7 +140,7 @@ dependencies {
   androidTestImplementation "io.mockk:mockk-android:1.9"
   androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
   androidTestImplementation "org.assertj:assertj-core:3.11.1"
-  androidTestImplementation ("org.simpleframework:simple-xml:2.7.1"){
+  androidTestImplementation("org.simpleframework:simple-xml:2.7.1") {
     exclude module: 'stax'
     exclude module: 'stax-api'
     exclude module: 'xpp3'
@@ -275,7 +275,6 @@ android {
       java.srcDirs += "$projectDir/src/testShared"
     }
   }
-
 
   flavorDimensions "default"
 
@@ -451,7 +450,7 @@ android {
       universalApk true
     }
     density {
-      enable true
+      enable false
       reset()
       include "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi"
     }
@@ -459,7 +458,7 @@ android {
   applicationVariants.all { variant ->
     variant.outputs.each { output ->
       def baseAbiVersionCode = abiCodes.get(output.getFilter(OutputFile.ABI)) ?: 0
-      def baseDensityVersionCode = densityCodes.get(output.getFilter(OutputFile.DENSITY)) ?: 1
+      def baseDensityVersionCode = densityCodes.get(output.getFilter(OutputFile.DENSITY)) ?: 0
       output.versionCodeOverride =
         (baseDensityVersionCode * 10000000) +
           (baseAbiVersionCode * 1000000) +


### PR DESCRIPTION
Attempt to fix quickly #1410. App was failing to install on hdpi emulators. We will need to supply the missing resources for the respective densities, will be solved by #1274
