### PR TITLE
removing text inconsistency

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -10,9 +10,7 @@
       </value>
     </option>
     <option name="LINE_SEPARATOR" value="&#10;" />
-    <option name="RIGHT_MARGIN" value="100" />
     <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
       <option name="LAYOUT_SETTINGS">
         <value>
           <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
@@ -28,9 +26,6 @@
       <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value />
-      </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="" withSubpackages="true" static="false" />
@@ -59,7 +54,6 @@
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
     <XML>
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <ADDITIONAL_INDENT_OPTIONS fileType="php">

--- a/app/src/main/res/layout/activity_library.xml
+++ b/app/src/main/res/layout/activity_library.xml
@@ -10,16 +10,8 @@
 
   <TextView
       android:id="@+id/libraryErrorText"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:paddingBottom="@dimen/libraryErrorText_padding_bottom"
-      android:textSize="@dimen/libraryErrorText_text_size"
-      android:visibility="gone"
-      tools:visibility="visible"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
+      tools:ignore="MissingConstraints"
+      style="@style/CustomTextView"
       />
 
 

--- a/app/src/main/res/layout/activity_library.xml
+++ b/app/src/main/res/layout/activity_library.xml
@@ -11,7 +11,7 @@
   <TextView
       android:id="@+id/libraryErrorText"
       tools:ignore="MissingConstraints"
-      style="@style/CustomTextView"
+      style="@style/no_list_content_text"
       />
 
 

--- a/app/src/main/res/layout/activity_library.xml
+++ b/app/src/main/res/layout/activity_library.xml
@@ -12,6 +12,8 @@
       android:id="@+id/libraryErrorText"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
+      android:paddingBottom="@dimen/libraryErrorText_padding_bottom"
+      android:textSize="@dimen/libraryErrorText_text_size"
       android:visibility="gone"
       tools:visibility="visible"
       app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/layout_download_management.xml
+++ b/app/src/main/res/layout/layout_download_management.xml
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/zim_download_root"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:animateLayoutChanges="true"
-    >
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/zim_download_root"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+  android:animateLayoutChanges="true"
+  >
 
   <TextView
-      android:id="@+id/download_management_no_downloads"  
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      android:id="@+id/download_management_no_downloads"
       android:text="@string/no_downloads_here"
-      android:paddingBottom="@dimen/download_management_no_downloads_padding_bottom"
-      android:textSize="@dimen/download_management_no_downloads_text_size"
-      android:visibility="gone"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
+      tools:ignore="MissingConstraints"
+      style="@style/CustomTextView"
       />
 
   <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/layout_download_management.xml
+++ b/app/src/main/res/layout/layout_download_management.xml
@@ -9,10 +9,11 @@
     >
 
   <TextView
-      android:id="@+id/download_management_no_downloads"
+      android:id="@+id/download_management_no_downloads"  
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/no_downloads_here"
+      android:paddingBottom="@dimen/download_management_no_downloads_padding_bottom"
       android:textSize="@dimen/download_management_no_downloads_text_size"
       android:visibility="gone"
       app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/layout_download_management.xml
+++ b/app/src/main/res/layout/layout_download_management.xml
@@ -13,7 +13,7 @@
       android:id="@+id/download_management_no_downloads"
       android:text="@string/no_downloads_here"
       tools:ignore="MissingConstraints"
-      style="@style/CustomTextView"
+      style="@style/no_list_content_text"
       />
 
   <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/zim_list.xml
+++ b/app/src/main/res/layout/zim_list.xml
@@ -10,17 +10,9 @@
 
   <TextView
       android:id="@+id/file_management_no_files"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:paddingBottom="@dimen/file_management_no_files_padding_bottom"
       android:text="@string/no_files_here"
-      android:textSize="@dimen/file_management_no_files_text_size"
-      android:visibility="gone"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      tools:visibility="visible"
+      tools:ignore="MissingConstraints"
+      style="@style/CustomTextView"
       />
 
   <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/zim_list.xml
+++ b/app/src/main/res/layout/zim_list.xml
@@ -12,7 +12,7 @@
       android:id="@+id/file_management_no_files"
       android:text="@string/no_files_here"
       tools:ignore="MissingConstraints"
-      style="@style/CustomTextView"
+      style="@style/no_list_content_text"
       />
 
   <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,7 +19,10 @@
   <dimen name="title_text_margin">16dp</dimen>
   <dimen name="title_text_padding">16dp</dimen>
   <dimen name="slider_dialog_horizontal_padding">16dp</dimen>
+  <dimen name="download_management_no_downloads_padding_bottom">75dp</dimen>
   <dimen name="download_management_no_downloads_text_size">20sp</dimen>
+  <dimen name="libraryErrorText_padding_bottom">75dp</dimen>
+  <dimen name="libraryErrorText_text_size">20sp</dimen>
   <dimen name="kiwix_search_widget_padding">0dp</dimen>
   <dimen name="section_list_height">56dp</dimen>
   <dimen name="favicon_width">48dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,8 +8,9 @@
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>
   <dimen name="abc_dropdownitem_text_padding_right">8dip</dimen>
   <dimen name="kiwix_search_widget_layout_id_height">50dp</dimen>
-  <dimen name="file_management_no_files_padding_bottom">75dp</dimen>
-  <dimen name="file_management_no_files_text_size">20sp</dimen>
+  <dimen name="custom_text_view_text_size">20sp</dimen>
+  <dimen name="custom_text_view_horizontal_bias">0.5</dimen>
+  <dimen name="custom_text_view_vertical_bias">0.4</dimen>
   <dimen name="webview_search_edit_text_margin_right">10dip</dimen>
   <dimen name="progressbar_layout_margin_top">300dp</dimen>
   <dimen name="fullscreen_control_button_margin">7dp</dimen>
@@ -19,10 +20,6 @@
   <dimen name="title_text_margin">16dp</dimen>
   <dimen name="title_text_padding">16dp</dimen>
   <dimen name="slider_dialog_horizontal_padding">16dp</dimen>
-  <dimen name="download_management_no_downloads_padding_bottom">75dp</dimen>
-  <dimen name="download_management_no_downloads_text_size">20sp</dimen>
-  <dimen name="libraryErrorText_padding_bottom">75dp</dimen>
-  <dimen name="libraryErrorText_text_size">20sp</dimen>
   <dimen name="kiwix_search_widget_padding">0dp</dimen>
   <dimen name="section_list_height">56dp</dimen>
   <dimen name="favicon_width">48dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,9 +8,6 @@
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>
   <dimen name="abc_dropdownitem_text_padding_right">8dip</dimen>
   <dimen name="kiwix_search_widget_layout_id_height">50dp</dimen>
-  <dimen name="custom_text_view_text_size">20sp</dimen>
-  <dimen name="custom_text_view_horizontal_bias">0.5</dimen>
-  <dimen name="custom_text_view_vertical_bias">0.4</dimen>
   <dimen name="webview_search_edit_text_margin_right">10dip</dimen>
   <dimen name="progressbar_layout_margin_top">300dp</dimen>
   <dimen name="fullscreen_control_button_margin">7dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -149,4 +149,18 @@
     <item name="android:windowBackground">@color/cardview_dark_background</item>
   </style>
 
+  <style name="CustomTextView" parent="Widget.Design.TextInputLayout">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:textSize">@dimen/custom_text_view_text_size</item>
+    <item name="android:textColor">@color/grey</item>
+    <item name="android:visibility">gone</item>
+    <item name="layout_constraintHorizontal_bias">@dimen/custom_text_view_horizontal_bias</item>
+    <item name="layout_constraintLeft_toLeftOf">parent</item>
+    <item name="layout_constraintRight_toRightOf">parent</item>
+    <item name="layout_constraintVertical_bias">@dimen/custom_text_view_vertical_bias</item>
+    <item name="layout_constraintTop_toTopOf">parent</item>
+    <item name="layout_constraintBottom_toBottomOf">parent</item>
+  </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -152,13 +152,12 @@
   <style name="no_list_content_text" parent="TextAppearance.AppCompat">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
-    <item name="android:textSize">@dimen/custom_text_view_text_size</item>
+    <item name="android:textSize">20sp</item>
     <item name="android:textColor">@color/grey</item>
     <item name="android:visibility">gone</item>
-    <item name="layout_constraintHorizontal_bias">@dimen/custom_text_view_horizontal_bias</item>
     <item name="layout_constraintLeft_toLeftOf">parent</item>
     <item name="layout_constraintRight_toRightOf">parent</item>
-    <item name="layout_constraintVertical_bias">@dimen/custom_text_view_vertical_bias</item>
+    <item name="layout_constraintVertical_bias">0.4</item>
     <item name="layout_constraintTop_toTopOf">parent</item>
     <item name="layout_constraintBottom_toBottomOf">parent</item>
   </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -149,7 +149,7 @@
     <item name="android:windowBackground">@color/cardview_dark_background</item>
   </style>
 
-  <style name="CustomTextView" parent="Widget.Design.TextInputLayout">
+  <style name="no_list_content_text" parent="TextAppearance.AppCompat">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:textSize">@dimen/custom_text_view_text_size</item>


### PR DESCRIPTION
Fixes #390 

Changes: Fixed text inconsistency across the Device, Online and Downloading screens by changing the corresponding xml files.

Screenshots/GIF for the change: 
![Screenshot_20190827-201625](https://user-images.githubusercontent.com/32400008/63782640-520d4200-c909-11e9-84e4-e1437472d261.jpg) ![Screenshot_20190827-201633](https://user-images.githubusercontent.com/32400008/63782653-55a0c900-c909-11e9-9334-6324c5257905.jpg) ![Screenshot_20190827-201641](https://user-images.githubusercontent.com/32400008/63782656-59345000-c909-11e9-98e4-b581dbb61194.jpg)
