### PR TITLE
#430 Inappropriate dialog box in downloading fragment - use androidX

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/AlertDialogShower.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/AlertDialogShower.kt
@@ -1,7 +1,7 @@
 package org.kiwix.kiwixmobile.utils
 
 import android.app.Activity
-import android.app.AlertDialog
+import androidx.appcompat.app.AlertDialog
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.utils.KiwixDialog.StartHotspotManually
 import javax.inject.Inject


### PR DESCRIPTION
Fixes #430

Changes: Use AndroidX Dialog instead of the standard

Screenshots/GIF for the change: 
![image](https://user-images.githubusercontent.com/3358282/64418684-654fa880-d093-11e9-9441-d88e8e5f4097.png)

