### PR TITLE
#1445 stop crash on null return

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/utils/files/FileUtils.kt
@@ -184,7 +184,7 @@ object FileUtils {
     return context.contentResolver.query(uri, arrayOf(columnName), null, null, null)
       ?.use {
         if (it.moveToFirst() && it.getColumnIndex(columnName) != -1) {
-          it.get<String>(columnName)
+          it[columnName]
         } else null
       }
   }


### PR DESCRIPTION
Fixes #1445

Changes: null was being returned to a non nullable type, now that type is nullable (inferred from the function return type)
