### PR TITLE
Feature/macgills/#1126 remove deleted file from webview

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/data/ZimContentProvider.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/data/ZimContentProvider.java
@@ -28,6 +28,7 @@ import android.os.ParcelFileDescriptor;
 import android.os.ParcelFileDescriptor.AutoCloseOutputStream;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
+import androidx.annotation.NonNull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -94,7 +95,7 @@ public class ZimContentProvider extends ContentProvider {
     return file;
   }
 
-  public synchronized static String setZimFile(String fileName) {
+  public synchronized static String setZimFile(@NonNull String fileName) {
     if (!new File(fileName).exists()) {
       Log.e(TAG_KIWIX, "Unable to find the ZIM file " + fileName);
       zimFileName = null;

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/MainActivity.java
@@ -1317,6 +1317,10 @@ public class MainActivity extends BaseActivity implements WebViewCallback,
       recreate();
     }
     presenter.loadCurrentZimBookmarksUrl();
+    if (ZimContentProvider.zimFileName == null &&
+      !HOME_URL.equals(getCurrentWebView().getUrl())) {
+      showHomePage();
+    }
     if (getResources().getConfiguration().orientation == ORIENTATION_LANDSCAPE) {
       if (menu != null) {
         menu.getItem(4).setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/effects/DeleteFiles.kt
@@ -2,6 +2,7 @@ package org.kiwix.kiwixmobile.zim_manager.fileselect_view.effects
 
 import android.app.Activity
 import org.kiwix.kiwixmobile.R.string
+import org.kiwix.kiwixmobile.data.ZimContentProvider
 import org.kiwix.kiwixmobile.database.newdb.dao.NewBookDao
 import org.kiwix.kiwixmobile.extensions.toast
 import org.kiwix.kiwixmobile.utils.DialogShower
@@ -21,6 +22,9 @@ class DeleteFiles(private val booksOnDiskListItem: List<BookOnDisk>) :
     booksOnDiskListItem.forEach {
       dialogShower.show(DeleteZim(it), {
         if (deleteSpecificZimFile(it)) {
+          if (it.file.absolutePath.equals(ZimContentProvider.zimFileName)) {
+            ZimContentProvider.setZimFile("")
+          }
           activity.toast(string.delete_specific_zim_toast)
         } else {
           activity.toast(string.delete_zim_failed)


### PR DESCRIPTION
Fixes #1126

Changes: Set file in ZimContentProvider to null if we are deleting it and in onResume of mainActivity load the home page when that is null
