### PR TITLE
Remove duplicate badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Kiwix Android is written in [Kotlin](https://kotlinlang.org/) (with a few old
 pieces in Java).
 
 [![Build Status](https://travis-ci.org/kiwix/kiwix-android.svg?branch=develop)](https://travis-ci.org/kiwix/kiwix-android)
-[![IRC Web](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](http://chat.kiwix.org)
 [![codecov](https://codecov.io/gh/kiwix/kiwix-android/branch/develop/graph/badge.svg)](https://codecov.io/gh/kiwix/kiwix-android)
 [![CodeFactor](https://www.codefactor.io/repository/github/kiwix/kiwix-android/badge)](https://www.codefactor.io/repository/github/kiwix/kiwix-android)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)


### PR DESCRIPTION
chat on freenode duplicates chat public badge.
