### PR TITLE
Remove hash from branch naming convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Our branching strategy is based on [this article](https://nvie.com/posts/a-succe
 + **develop**  the actively worked on next release of the app, what we branch off of while working on new features and what we merge into upon feature completion
 + **feature/** or feature/\<username\>/ any branch under this directory is an actively developed feature, feature branches culminate in a PR, are merged and deleted.
  Typically a feature branch is off of develop and into develop but in rare scenarios if there is an issue in production a branch may be made off master to fix this issue, this type of feature branch must be merged to develop and master before being deleted.
-Branch names should be in the format **#\<issue-number\>-kebab-case-title**
+Branch names should be in the format **\<issue-number\>-kebab-case-title**
 
 All branches should have distinct history and should be visually easy to follow, for this reason only perform merge commits when merging code either by PR or when synchronising.
 


### PR DESCRIPTION
As zsh shows 'zsh: no matches found:' when checking out a branch with a # in it