### PR TITLE
Feature/jhbiggs/#932 no adb zim file backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.kiwix.kiwixmobile">
 
-  <application android:name=".KiwixApp">
+  <application android:name=".KiwixApp"
+    android:allowBackup="true"
+    android:fullBackupContent="@xml/backup_rules">
     <activity
       android:name=".main.KiwixMainActivity"
       android:configChanges="orientation|keyboardHidden|screenSize|locale"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -16,7 +16,9 @@
   ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
   ~
   -->
+
+<!-- excludes any external files in the ./Kiwix folder, therefore .zim files. -->
 <full-backup-content>
-  <exclude domain="file" />
+  <exclude domain="external" path="./Kiwix"/>
 </full-backup-content>
 

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2019 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<full-backup-content>
+  <exclude domain="file" />
+</full-backup-content>
+


### PR DESCRIPTION
#932 
Fixes backup issue where size limit is exceeded.  Excludes zim files from adb backup.