### PR TITLE
Remove help entry about big ZIM files

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpActivityTest.kt
@@ -38,9 +38,6 @@ class HelpActivityTest : BaseActivityTest<HelpActivity>() {
       clickOnWhereIsContent()
       assertWhereIsContentIsExpanded()
       clickOnWhereIsContent()
-      clickOnLargeZimFiles()
-      assertLargeZimsIsExpanded()
-      clickOnLargeZimFiles()
       clickOnSendFeedback()
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
@@ -66,26 +66,6 @@ class HelpRobot : BaseRobot() {
     )
   }
 
-  fun clickOnLargeZimFiles() {
-    clickOn(TextId(string.help_12))
-  }
-
-  fun assertLargeZimsIsExpanded() {
-    isVisible(
-      Text(
-        helpTextFormat(
-          string.help_13,
-          string.help_14,
-          string.help_15,
-          string.help_16,
-          string.help_17,
-          string.help_18,
-          string.help_19
-        )
-      )
-    )
-  }
-
   fun clickOnSendFeedback() {
     clickOn(ViewId(id.activity_help_feedback_text_view))
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpActivity.java
@@ -56,7 +56,6 @@ public class HelpActivity extends BaseActivity {
 
     populateMap(R.string.help_2, R.array.description_help_2);
     populateMap(R.string.help_5, R.array.description_help_5);
-    populateMap(R.string.help_12, R.array.description_help_12);
 
     recyclerView.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
     HelpAdapter helpAdapter =

--- a/core/src/main/res/values-af/strings.xml
+++ b/core/src/main/res/values-af/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Hulp</string>
   <string name="menu_home">Tuisblad</string>
@@ -29,7 +29,6 @@
   <string name="pref_language_chooser">Kies \'n taal</string>
   <string name="menu_bookmarks_list">Boekmerke</string>
   <string name="zim_manager">Biblioteek</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -41,14 +40,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-am/strings.xml
+++ b/core/src/main/res/values-am/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">እርዳታ</string>
   <string name="menu_home">መኖርያ ገጽ</string>
@@ -8,7 +8,6 @@
   <string name="menu_full_screen">ሙሉ መጋረጃ</string>
   <string name="search_label">ፍለጋ</string>
   <string name="pref_language_title">ቋንቋ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -20,14 +19,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">الحصول على المحتوى</string>
   <string name="menu_help">مساعدة</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 تتوفر أيضًا محتويات أخرى مثل ويكيليكس أو ويكي مصدر</string>
   <string name="help_10">يمكنك إما تنزيل ملفات ZIM المختارة داخل التطبيق أو اختيار التطبيق(ات) الذي تريده وتنزيله من حاسوب مكتبي قبل نقل ملفات ZIM إلى بطاقة SD الخاصة بك.</string>
   <string name="help_11">توجد ملفات ZIM القابلة للتنزيل داخل التطبيق في دليل التخزين الخارجي في مجلد بعنوان Kiwix.</string>
-  <string name="help_12">كيفية استخدام ملفات ZIM الكبيرة؟</string>
-  <string name="help_13">إذا كان حجم ملف ZIM أكبر من 4 غيغابايت، فقد لا تتمكن من تخزينه على بطاقة SD الخاصة بك بسبب قيود نظام الملفات.</string>
-  <string name="help_14">يؤدي تنزيل التطبيق آليا إلى التعامل مع الملفات الأكبر حجما، مما يؤدي إلى تقسيمها لك.</string>
-  <string name="help_15">إذا كنت تقوم بالتنزيل على جهاز آخر، فقد تحتاج إلى تقسيم ملف ZIM باستخدام البرنامج التالي:</string>
-  <string name="help_16">\u2022 في مايكروسوفت ويندوز: HJ-Split</string>
-  <string name="help_17">\u2022 في أبل ماك أو إس إكس: Split and Concat</string>
-  <string name="help_19">ملاحظة: يجب تسمية ملفاتك الناتجة باسم my_big_file.zimaa وmy_big_file.zimab وما إلى ذلك.</string>
   <string name="pref_storage">التخزين</string>
   <string name="pref_current_folder">المجلد الحالي</string>
   <string name="path_not_writable">لا يمكن الوصول إلى الدليل المطلوب، باستخدام الافتراضي، لإصلاح هذا; قم بإعادة تحديد الدليل المرغوب في إعدادات التطبيق.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">لا تسأل بعد الآن</string>
   <string name="your_languages">اللغات المختارة:</string>
   <string name="other_languages">لغات أخرى:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-as/strings.xml
+++ b/core/src/main/res/values-as/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">সহায়</string>
   <string name="menu_home">বেটুপাত</string>
@@ -15,7 +15,6 @@
   <string name="pref_language_title">ভাষা</string>
   <string name="menu_bookmarks_list">পত্ৰচিহ্নসমূহ</string>
   <string name="zim_manager">পুথিভৰাল</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -27,14 +26,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-az/strings.xml
+++ b/core/src/main/res/values-az/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Kömək</string>
   <string name="menu_home">Ana səhifə</string>
@@ -37,7 +37,6 @@
   <string name="rate_dialog_negative">Yox, sağ olun</string>
   <string name="rate_dialog_neutral">Daha sonra</string>
   <string name="zim_manager">Kitabxana</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -49,14 +48,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ba/strings.xml
+++ b/core/src/main/res/values-ba/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Ярҙам</string>
   <string name="menu_home">Төп Бит</string>
@@ -19,7 +19,6 @@
   <string name="rate_dialog_positive">Баһаларға!</string>
   <string name="rate_dialog_negative">Юҡ, рәхмәт</string>
   <string name="zim_manager">Китапхана</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -31,14 +30,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-be/strings.xml
+++ b/core/src/main/res/values-be/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Даведка</string>
   <string name="menu_home">Дадому</string>
@@ -49,7 +49,6 @@
   <string name="pref_newtab_background_title">Адкрыць новае вакенца на фоне</string>
   <string name="pref_newtab_background_summary">Пры адкрыцці новага вакенца, яно будзе адкрытае ў фоне</string>
   <string name="zim_manager">Бібліятэка</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -61,14 +60,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-bg/strings.xml
+++ b/core/src/main/res/values-bg/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Вземете съдържание</string>
   <string name="menu_help">Помощ</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Също така е налично и съдържание от други източници, като Уикилиийкс и Уикисорс.</string>
   <string name="help_10">Вие можете или да смъкнете избраните от вас ZIM файлове, докато сте в мобилното приложение, или да изберете внимателно желаните от вас и да ги смъкнете от десктоп компютър, след което да прехвърлите ZIM файловете във вашата SD карта.</string>
   <string name="help_11">ZIM файловете, които са смъкнати в мобилното приложение, се намират във външната памет, в папка с име Kiwix.</string>
-  <string name="help_12">Как да използвате големи ZIM файлове?</string>
-  <string name="help_13">В случай, че вашият ZIM файл е по-голям от 4GB, е възможно да бъдете възпрепятствани да го съхраните на вашата SD  карта поради ограничения на файловата система.</string>
-  <string name="help_14">Даунлоуда в мобилното приложение автоматично обработва по-големите файлове, разделяйки ги на по-малки парчета.</string>
-  <string name="help_15">В случай обаче, че извършвате даунлоуда на друго устройство, може да се наложи да разделите ZIM файла на по-малки парчета, като за целта използвате следния софтуер:</string>
-  <string name="help_16">\u2022 Под Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Под Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Забележка: файловете, които са в резултат на разделянето трябва да са наименувани по следния начин - my_big_file.zimaa, my_big_file.zimab, и т.н.</string>
   <string name="pref_storage">Съхраняване на данни</string>
   <string name="pref_current_folder">Текуща папка</string>
   <string name="path_not_writable">Няма достъп до желаната директория, използва се директорията по подразбиране. За да коригирате това, изберете отново желана директория в настройките на приложението.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">Не питайте отново за това</string>
   <string name="your_languages">Избрани езици:</string>
   <string name="other_languages">Други езици:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-bm/strings.xml
+++ b/core/src/main/res/values-bm/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Dɛmɛ</string>
   <string name="menu_home">Soba</string>
@@ -23,7 +23,6 @@
   <string name="pref_language_title">Kan</string>
   <string name="menu_bookmarks_list">Ɲɛ dogo</string>
   <string name="zim_manager">Gafeso</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -35,14 +34,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-bn/strings.xml
+++ b/core/src/main/res/values-bn/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">বিষয়বস্তু পান</string>
   <string name="menu_help">সাহায্য</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 এছাড়া উইকিপিডিয়া বা উইকিসংকলনের মত অন্যান্য সামগ্রীও উপলব্ধ</string>
   <string name="help_10">আপনি আপনার পছন্দসই ZIM ফাইলগুলি অ্যাপের মধ্যে ডাউনলোড করতে পারেন বা ZIM ফাইলগুলিকে সাবধানে নির্বাচন করুন এবং আপনার এসডি কার্ডে স্থানান্তর করার আগে আপনি যে ডেস্কটপ কম্পিউটার থেকে ডাউনলোড করতে চান তা নির্ধারণ করুন।</string>
   <string name="help_11">অ্যাপ্লিকেশনের মাধ্যমে ডাউনলোড করা ZIM ফাইলগুলি বাহ্যিক সঞ্চয়স্থানে Kiwix নামক ফোল্ডারে অবস্থিত।</string>
-  <string name="help_12">কিভাবে বড় ZIM ফাইল ব্যবহার করবেন?</string>
-  <string name="help_13">যদি আপনার ZIM ফাইলটি ৪ গিগাবাইটের চেয়ে বেশি হয়, তাহলে আপনি ফাইল-সিস্টেম সীমাবদ্ধতার কারণে আপনার এসডি কার্ডে এটিকে সংরক্ষণ করতে পারবেন না।</string>
-  <string name="help_14">স্বয়ংক্রিয়ভাবে ইন-অ্যাপ ডাউনলোড বড় ফাইলগুলিকে পরিচালনা করে, আপনার জন্য এগুলোকে বিভাজন করে।</string>
-  <string name="help_15">আপনি যদি অন্য ডিভাইসে ডাউনলোড করে থাকেন, তাহলে নিম্নলিখিত সফটওয়্যার ব্যবহার করে আপনাকে ZIM ফাইলটি বিভক্ত করতে হবে:</string>
-  <string name="help_16">\u2022 মাইক্রোসফট উইন্ডোজে: HJ-Split</string>
-  <string name="help_17">\ u2022 অ্যাপল ম্যাক ওএসএক্স: বিভক্ত এবং কনক্যাট</string>
-  <string name="help_19">দ্রষ্টব্য: আপনার পছন্দের ফাইলগুলি my_big_file.jimaa, my_big_file.jimab ইত্যাদি নামে হতে হবে।</string>
   <string name="pref_storage">সংগ্রহস্থল</string>
   <string name="pref_current_folder">বর্তমান ফোল্ডার</string>
   <string name="path_not_writable">পূর্বনির্ধারিত ব্যবহার করে, প্রয়োজনীয় ডিরেক্টরিতে প্রবেশ করতে পারবেন না। এটি ঠিক করার জন্য অ্যাপ্লিকেশন সেটিংসের মধ্যে পছন্দসই ডিরেক্টরি পুনঃনির্বাচন করুন।</string>
@@ -141,7 +134,6 @@
   <string name="do_not_ask_anymore">আর জিজ্ঞাসা করবেন না</string>
   <string name="your_languages">নির্বাচিত ভাষা</string>
   <string name="other_languages">অন্যান্য ভাষাসমূহ:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -153,14 +145,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-br/strings.xml
+++ b/core/src/main/res/values-br/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Kaout endalc\'had</string>
   <string name="menu_help">Skoazell</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Endalc\'hadoù all evel Wikileaks pe Wikisource a a c\'haller kaout ivez.</string>
   <string name="help_10">Gallout a reot pe pellgargañ ho restroù ZIM dibabet en arload, pe dibab, gant aked, ar re ho peus c\'hoant da bellgargañ diwar hoc\'h urhiataer burev a-raok treuzkas ar restroù ZIM war ho kartenn SD.</string>
   <string name="help_11">Ar restroù ZIM pellgarget en arload zo er c\'havlec\'h skokañ diavaez en ur c\'havlec\'h anvet Kiwix.</string>
-  <string name="help_12">Penaos implijout ar restroù bras ZIM ?</string>
-  <string name="help_13">Ma vez brasoc\'h ho restr ZIM eget 4Go e c\'hallfec\'h chom hep gallout stokañ anezhi war ho kartenn SIM, abalamour da vevennoù ar reizhiad restroù.</string>
-  <string name="help_14">Pa vez pellgarget diwar an arload e vez meret ent emgefre ar restroù brasoc\'h ha e vezont rannet en ho lec\'h.</string>
-  <string name="help_15">Ma pellgargit diwar un drobarzhell all, koulskoude, e rankit troc\'hañ ar restr ZIM en ur implijout ar meziant-mañ :</string>
-  <string name="help_16">\u2022 War Microsoft Windows : HJ-Split</string>
-  <string name="help_17">\u2022 War Apple Mac OSX : Split and Concat</string>
-  <string name="help_19">Notenn : ar restroù o tisoc\'hañ a rank bezañ anvet ma_restr_vras.zimaa, ma_restr_vras.zimab, ha kement zo…</string>
   <string name="pref_storage">Stokañ</string>
   <string name="pref_current_folder">Renkell red</string>
   <string name="path_not_writable">Ne c\'haller diraez ar c\'havlec\'h spisaet, impljout ar c\'havlec\'h dre ziouer. Evit reizhañ an dra-se, dibab ar c\'havlec\'h nevez ho peus c\'hoant en arventennoù an arload.</string>
@@ -142,7 +135,6 @@
   <string name="do_not_ask_anymore">Chom hep goulenn ken</string>
   <string name="your_languages">Yezhoù diuzet</string>
   <string name="other_languages">Yezhoù all :</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -154,14 +146,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ca/strings.xml
+++ b/core/src/main/res/values-ca/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obtenir contingut</string>
   <string name="menu_help">Ajuda</string>
@@ -72,13 +72,6 @@
   <string name="help_9">\u2022 Altres continguts com Wikileaks o Wikisource també estan disponibles</string>
   <string name="help_10">Pots descarregar els arxius ZIM triats a l\'aplicació, o bé seleccionar acuradament els que vulguis, descarregar-los des d\'un ordinador i transferir-los a la targeta SD.</string>
   <string name="help_11">Els fitxers ZIM descarregats en l\'aplicació es troben al directori d\'emmagatzematge extern, en una carpeta anomenada Kiwix.</string>
-  <string name="help_12">Com utilitzar fitxers ZIM grans?</string>
-  <string name="help_13">Si el teu fitxer ZIM és més gran de 4GB, pot ser que no puguis emmagatzemar-lo en la teva targeta SD per limitacions en el sistema de fitxers.</string>
-  <string name="help_14">La descàrrega en l\'aplicació gestiona els fitxers grans automàticament, i els parteix per a tu.</string>
-  <string name="help_15">No obstant això, si estàs descarregant-lo en un altre dispositiu, pot ser que necessitis dividir el fitxer ZIM amb el següent programari:</string>
-  <string name="help_16">\u2022 En Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 En Apple Mac OSX: Split i Concat</string>
-  <string name="help_19">Nota: cal que els fitxers resultants siguin anomenats fitxer_gran.zimaa, fitxer_gran.zimab, etc.</string>
   <string name="path_not_writable">No s\'ha pogut accedir al directori desitjat, s\'usa el predeterminat. Per solucionar això, torna a seleccionar el directori desitjat en les preferències de l\'aplicació.</string>
   <string name="delete_zim_failed">No podem eliminar aquest fitxer. Hauries de provar amb un administrador de fitxers.</string>
   <string name="internal_storage">Intern</string>
@@ -94,7 +87,6 @@
   <string name="do_not_ask_anymore">No tornar a preguntar</string>
   <string name="your_languages">Idiomes seleccionats:</string>
   <string name="other_languages">Altres idiomes:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -106,14 +98,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Získat obsah</string>
   <string name="menu_help">Nápověda</string>
@@ -70,8 +70,6 @@
   <string name="no_files_here">Zde nejsou žádné soubory</string>
   <string name="download_no_space">Nedostatečný prostor ke stažení tohoto souboru.</string>
   <string name="zim_simple">Jednoduché</string>
-  <string name="help_12">Jak použít velké ZIM soubory?</string>
-  <string name="help_16">\u2022 v Microsoft Windows: HJ-Split</string>
   <string name="pref_storage">Úložiště</string>
   <string name="tts_pause">Pozastavit</string>
   <string name="tts_resume">Obnovit</string>
@@ -88,7 +86,6 @@
   <string name="do_not_ask_anymore">Neptat se příště</string>
   <string name="your_languages">Vybrané jazyky:</string>
   <string name="other_languages">Jiné jazyky:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -100,14 +97,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-cv/strings.xml
+++ b/core/src/main/res/values-cv/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Пулăшу</string>
   <string name="menu_home">Тĕпел</string>
@@ -16,7 +16,6 @@
   <string name="pref_language_title">Чĕлхе</string>
   <string name="menu_bookmarks_list">Картсем</string>
   <string name="zim_manager">Вулавăш</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -28,14 +27,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-cy/strings.xml
+++ b/core/src/main/res/values-cy/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Cymorth</string>
   <string name="menu_home">Hafan</string>
@@ -34,7 +34,6 @@
   <string name="pref_language_chooser">Dewis iaith</string>
   <string name="menu_bookmarks_list">Llyfrnodau</string>
   <string name="zim_manager">Llyfrgell</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -46,14 +45,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-da/strings.xml
+++ b/core/src/main/res/values-da/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Hent indhold</string>
   <string name="menu_help">Hjælp</string>
@@ -98,13 +98,6 @@
   <string name="help_9">\u2022 Andet indhold såsom Wikileaks eller Wikisource er også tilgængeligt</string>
   <string name="help_10">Den kan enten hente dine valgte ZIM-filer fra programmet eller omhyggeligt vælge dem du ønsker og hente dem fra en skrivebordscomputer før ZIM-filerne overføres til dit SD-kort.</string>
   <string name="help_11">ZIM-filer hentet inden i programmet placeres i det ekstern lager i mappen Kiwix.</string>
-  <string name="help_12">Sådan anvender man store ZIM-filer?</string>
-  <string name="help_13">Hvis din ZIM-fil er større end 4 GB, så kan du måske ikke gemme den på dit SD-kort på grund af begrænsninger i filsystemet.</string>
-  <string name="help_14">Overførsel inden i programmet håndterer automatisk større filer, idet de opdeles for dig.</string>
-  <string name="help_15">Hvis du henter på en anden enhed, så skal du måske opdele ZIM-filen med det følgende program:</string>
-  <string name="help_16">\u2022 På Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 På Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Bemærk: Dine filer skal navngives min_store_fil.zimmaa, min_store_fil.zimab etc.</string>
   <string name="pref_storage">Lagring</string>
   <string name="pref_current_folder">Nuværende mappe</string>
   <string name="path_not_writable">Kan ikke tilgå ønsket mappe, bruger standarden. For at rette dette så vælg på ny den ønskede mappe under indstillinger.</string>
@@ -136,7 +129,6 @@
   <string name="do_not_ask_anymore">Spørg ikke igen</string>
   <string name="your_languages">Valgte sprog:</string>
   <string name="other_languages">Andre sprog:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -148,14 +140,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Inhalt abrufen</string>
   <string name="menu_help">Hilfe</string>
@@ -99,13 +99,6 @@
   <string name="help_9">\u2022 Andere Inhalte wie Wikileaks oder Wikisource sind ebenfalls verfügbar</string>
   <string name="help_10">Sie können entweder Ihre ausgewählten ZIM-Dateien in der App herunterladen oder die gewünschten Datei(en) sorgsam auf einem Desktopcomputer auswählen und herunterladen, bevor Sie die ZIM-Dateien auf Ihre SD-Karte übertragen.</string>
   <string name="help_11">Heruntergeladene ZIM-Dateien in der App befinden sich im Verzeichnis des externen Speichers in einem Ordner namens Kiwix.</string>
-  <string name="help_12">Wie verwendet man große ZIM-Dateien?</string>
-  <string name="help_13">Falls Ihre ZIM-Datei größer als 4 GB ist, werden Sie aufgrund von Dateisystembeschränkungen nicht in der Lage sein, sie auf Ihrer SD-Karte zu speichern.</string>
-  <string name="help_14">Das Herunterladen in der App verwaltet automatisch größere Dateien und teilt sie für Sie auf.</string>
-  <string name="help_15">Falls Sie jedoch den Download auf einem anderen Gerät durchführen, müssen Sie die ZIM-Datei mithilfe der folgenden Software aufteilen:</string>
-  <string name="help_16">\u2022 Auf Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Auf Apple Mac OSX: Split &amp; Concat</string>
-  <string name="help_19">Hinweis: Ihre Dateien müssen meine_große_datei.zimaa, meine_große_datei.zimab etc. heißen.</string>
   <string name="pref_storage">Speicher</string>
   <string name="pref_current_folder">Aktueller Ordner</string>
   <string name="path_not_writable">Auf das gewünschte Verzeichnis kann nicht zugegriffen werden. Es wird das Standardverzeichnis verwendet. Um dieses Problem zu beheben, wählen Sie das gewünschte Verzeichnis in den App-Einstellungen erneut aus.</string>
@@ -141,7 +134,6 @@
   <string name="do_not_ask_anymore">Nicht mehr fragen</string>
   <string name="your_languages">Ausgewählte Sprachen:</string>
   <string name="other_languages">Weitere Sprachen:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -153,14 +145,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-el/strings.xml
+++ b/core/src/main/res/values-el/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Λάβετε περιεχόμενο</string>
   <string name="menu_help">Βοήθεια</string>
@@ -91,9 +91,6 @@
   <string name="help_7">Είναι διαθέσιμα ως αρχεία ZIM. Υπάρχουν πολλά από αυτά:</string>
   <string name="help_8">\u2022 Η Βικιπαίδεια είναι διαθέσιμη ξεχωριστά για κάθε γλώσσα</string>
   <string name="help_9">\u2022 Άλλα περιεχόμενα όπως το Wikileaks ή η Βικιθήκη είναι επίσης διαθέσιμα</string>
-  <string name="help_12">Πώς να χρησιμοποιήσετε μεγάλα αρχεία ZIM;</string>
-  <string name="help_16">\u2022 Στο Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Στο Apple Mac OSX: Split και Concat</string>
   <string name="pref_storage">Αποθηκευτικός χώρος</string>
   <string name="pref_current_folder">Τρέχων φάκελος</string>
   <string name="delete_zim_failed">Λυπούμαστε, δεν μπορέσαμε να διαγράψουμε αυτό το αρχείο. Αντί γι\'αυτού θα έπρεπε να χρησιμοποιήσετε ένα διαχειριστή αρχείων.</string>
@@ -126,7 +123,6 @@
   <string name="do_not_ask_anymore">Μη με ρωτήσεις άλλο</string>
   <string name="your_languages">Επιλεγμένες γλώσσες:</string>
   <string name="other_languages">Άλλες γλώσσες:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -138,14 +134,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-eo/strings.xml
+++ b/core/src/main/res/values-eo/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Akiri Enhavon</string>
   <string name="menu_help">Helpo</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Alia enhavo, kiel Wikileaks aŭ Vikifontaro, estas havebla</string>
   <string name="help_10">Vi povas aŭ elŝuti vian elektitajn ZIM-dosierojn per ĉi tiu aplikaĵo, aŭ zorge elekti tiu(j)n kiu(j) vi deziras kaj elŝuti ilin per surtabla komputilo, antaŭ transigi la ZIM-dosierojn per SD-karto.</string>
   <string name="help_11">ZIM-dosieroj elŝutitaj per ĉi tiu aplikaĵo estas en la dosierujo nomita Kiwix en ekstera konservejo.</string>
-  <string name="help_12">Kiel uzi grandan ZIM-dosieron?</string>
-  <string name="help_13">Se via ZIM-dosiero estas pli granda ol 4 GB, vi eble ne povas konservi ĝin en via SD-karto pro dosiersistemaj limoj.</string>
-  <string name="help_14">Elŝutado per la aplikaĵo aŭtomate traktas grandajn dosierojn por vi per disfendado.</string>
-  <string name="help_15">Se, tamen, vi elŝutas per alia aparato, vi eble devas disfendi la ZIM-dosieron per unu el la jenaj programaroj:</string>
-  <string name="help_16">\2022 Je Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Je Apple macOS: Split kaj Concat</string>
-  <string name="help_19">Noto: viaj rezultaj dosieroj nomiĝu mia_dosierego.zimaa, mia_dosierego.zimab, ktp.</string>
   <string name="pref_storage">Konservejo</string>
   <string name="pref_current_folder">Aktuala Dosierujo</string>
   <string name="path_not_writable">Ne povas atingi deziratan dosierujon; uzante la implicitan. Por korekti tion, reelektu la deziratan dosierujon en la aplikaĵaj agordoj.</string>
@@ -142,7 +135,6 @@
   <string name="do_not_ask_anymore">Ne demandu plu</string>
   <string name="your_languages">Elektitaj lingvoj:</string>
   <string name="other_languages">Aliaj Lingvoj:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -154,14 +146,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obtener contenido</string>
   <string name="menu_help">Ayuda</string>
@@ -101,13 +101,6 @@
   <string name="help_9">\u2022 Otros contenidos, como Wikileaks o Wikisource también están disponibles</string>
   <string name="help_10">Puedes descargar los archivos ZIM elegidos en la aplicación, o bien seleccionar cuidadosamente los que quieras, descargarlos desde una computadora y transferirlos a tu tarjeta SD.</string>
   <string name="help_11">Los archivos ZIM descargados en la aplicación se encuentran en el directorio de almacenamiento externo, en una carpeta llamada Kiwix.</string>
-  <string name="help_12">¿Cómo utilizar archivos ZIM grandes?</string>
-  <string name="help_13">Si tu archivo ZIM es mayor a 4GB, puede que no puedas almacenarlo en tu tarjeta SD debido a limitaciones en el sistema de archivos.</string>
-  <string name="help_14">La descarga en la aplicación gestiona archivos grandes automáticamente, partiéndolos para ti.</string>
-  <string name="help_15">Sin embargo, si estás descargandolo en otro dispositivo, puede que necesites dividir el archivo ZIM utilizando el siguiente software:</string>
-  <string name="help_16">\u2022 En Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 En Apple Mac OSX: Split y Concat</string>
-  <string name="help_19">Nota: los archivos resultantes deben llamarse mi_gran_archivo.zimaa, mi_gran_archivo.zimab, etc.</string>
   <string name="pref_storage">Almacenamiento</string>
   <string name="pref_current_folder">Carpeta actual</string>
   <string name="path_not_writable">No se pudo acceder al directorio deseado; se usa el predeterminado. Para solucionar esto, vuelve a seleccionar el directorio deseado en las preferencias de la aplicación.</string>
@@ -139,7 +132,6 @@
   <string name="do_not_ask_anymore">No preguntar de nuevo</string>
   <string name="your_languages">Idiomas seleccionados:</string>
   <string name="other_languages">Otros idiomas:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -151,14 +143,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-et/strings.xml
+++ b/core/src/main/res/values-et/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Abi</string>
   <string name="menu_home">Koduleht</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_chooser">Vali keel</string>
   <string name="menu_bookmarks_list">Järjehoidjad</string>
   <string name="zim_manager">Raamatukogu</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-eu/strings.xml
+++ b/core/src/main/res/values-eu/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Edukia Lortu</string>
   <string name="menu_help">Laguntza</string>
@@ -102,12 +102,6 @@
   <string name="help_9">\u2022 Beste edukiak Wikileaks edo Wikisource gisa baliogarriak dira ere.</string>
   <string name="help_10">ZIM artxiboak in-app-aren bidez jaitsi ditzakezu edo aukeratu deskargatu nahi dituzunak eta ordengailuan egin, ZIM artxiboak SD-ra aldatu baino lehen.</string>
   <string name="help_11">In-app-eko jaitsitako ZIM artxiboak kanpoko memorian daude, Kiwix deritzon karpeta batean.</string>
-  <string name="help_12">Nola erabili ZIM artxibo handiak?</string>
-  <string name="help_13">Zure ZIM artxiboa 4GB baino handiagoa bada, agian ezin izango duzu zure memorian gorde sistemaren mugaketengatik.</string>
-  <string name="help_14">Automatikoki artxibo handiagoak deskargatzen ditu aplikazioan, hauek zuretzat banatzen ditu.</string>
-  <string name="help_15">Beste gailuren batean jaisten bazabiltza, ZIM artxiboa banatu beharko duzu hurrengo softwarea erabiltzen:</string>
-  <string name="help_17">\u2022 Apple Macen OSX: Banatu eta Kontaktua</string>
-  <string name="help_19">Oharra: zure artxiboen izena my_big_file.zimaa, my_big_file.zimab… izan behar dute.</string>
   <string name="pref_storage">Biltegia</string>
   <string name="pref_current_folder">Oraingo Artxiboa</string>
   <string name="path_not_writable">Ezin da nahi den direktoriora sartu, erabilitako bolereekin. Hau konpontzeko hautatu nahi den direktorioa app-eko doikuntza atalean.</string>
@@ -141,7 +135,6 @@
   <string name="do_not_ask_anymore">Ez galdetu berriz</string>
   <string name="your_languages">Hautatutako hizkuntzak:</string>
   <string name="other_languages">Beste hizkuntzak:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -153,14 +146,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-fa/strings.xml
+++ b/core/src/main/res/values-fa/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">راهنما</string>
   <string name="menu_home">آغازه</string>
@@ -95,7 +95,6 @@
   <string name="do_not_ask_anymore">لطفاً دیگر درخواست نکنید</string>
   <string name="your_languages">زبان‌های انتخاب‌شده:</string>
   <string name="other_languages">زبان‌های دیگر:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -107,14 +106,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-fi/strings.xml
+++ b/core/src/main/res/values-fi/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Hanki sisältöä</string>
   <string name="menu_help">Ohje</string>
@@ -91,9 +91,6 @@
   <string name="help_6">Sisältöämme ylläpidetään Kiwixin verkkosivulla.</string>
   <string name="help_8">\u2022 Wikipedia on saatavilla erikseen kullekin kielelle</string>
   <string name="help_9">\u2022 Muut sisällöt kuten Wikileaks tai Wikiaineisto ovat myös käytettävissä</string>
-  <string name="help_12">Kuinka käyttää suuria ZIM-tiedostoja?</string>
-  <string name="help_16">\u2022 Microsoft Windowsissa: HJ-Split</string>
-  <string name="help_17">\u2022 Apple Mac OSX:ssä: Split and Concat</string>
   <string name="pref_storage">Tallennuslaite</string>
   <string name="pref_current_folder">Nykyinen kansio</string>
   <string name="delete_zim_failed">Emme pystyneet poistamaan tätä tiedostoa. Sinun pitäisi kokeilla käyttää tiedostonhallintaa sen sijaan.</string>
@@ -121,7 +118,6 @@
   <string name="do_not_ask_anymore">Älä kysy enää</string>
   <string name="your_languages">Valitut kielet:</string>
   <string name="other_languages">Muut kielet:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -133,14 +129,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-fo/strings.xml
+++ b/core/src/main/res/values-fo/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Hjálp</string>
   <string name="menu_home">Heim</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_chooser">Vel eitt mál</string>
   <string name="menu_bookmarks_list">Bókamerki</string>
   <string name="zim_manager">Bókasavn</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obtenir du contenu</string>
   <string name="menu_help">Aide</string>
@@ -96,13 +96,6 @@
   <string name="help_9">\u2022 D’autres contenus comme Wikileaks ou Wikisource sont aussi disponibles</string>
   <string name="help_10">Vous pouvez soit télécharger vos fichiers ZIM sélectionnés dans l’application, ou sélectionner soigneusement ceux que vous voulez télécharger depuis un ordinateur de bureau avant de transférer les fichiers ZIM sur votre carte SD.</string>
   <string name="help_11">Les fichiers ZIM téléchargés dans l’application sont situés dans le répertoire de stockage externe dans un répertoire appelé Kiwix.</string>
-  <string name="help_12">Comment utiliser de gros fichiers ZIM ?</string>
-  <string name="help_13">Si votre fichier ZIM est plus gros que 4Go, vous pourriez ne pas pouvoir le stocker sur votre carte SD, du fait des limitations du système de fichiers.</string>
-  <string name="help_14">Télécharger depuis l’application gère automatiquement les plus gros fichiers, en les fractionnant à votre place.</string>
-  <string name="help_15">Si toutefois vous téléchargez depuis un autre appareil, vous devez couper le fichier ZIM en utilisant le logiciel suivant :</string>
-  <string name="help_16">\u2022 Sur Microsoft Windows : HJ-Split</string>
-  <string name="help_17">\u2022 Sur Apple Mac OSX : Split and Concat</string>
-  <string name="help_19">Note : les fichiers résultants doivent être nommés mon_gros_fichier.zimaa, mon_gros_fichier.zimab, etc.</string>
   <string name="pref_storage">Stockage</string>
   <string name="pref_current_folder">Dossier courant</string>
   <string name="path_not_writable">Impossible d’accéder au répertoire spécifié, utilisation de celui par défaut. Pour corriger cela, sélectionner de nouveau le répertoire voulu dans les paramètres de l’application.</string>
@@ -133,7 +126,6 @@
   <string name="do_not_ask_anymore">Ne plus demander</string>
   <string name="your_languages">Langues sélectionnées :</string>
   <string name="other_languages">Autres langues :</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -145,14 +137,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-gl/strings.xml
+++ b/core/src/main/res/values-gl/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obter contido</string>
   <string name="menu_help">Axuda</string>
@@ -100,13 +100,6 @@
   <string name="help_9">\u2022 Outros contidos, como Wikileaks ou Wikisource tamén están dispoñibles</string>
   <string name="help_10">Pode descargar os ficheiros ZIM elixidos na aplicación, ou ben seleccionar coidadosamente os que queira, descargalos dende un ordenador e transferilos á súa tarxeta SD.</string>
   <string name="help_11">Os ficheiros ZIM descargados na aplicación atópanse no directorio de almacenamento externo, nunha carpeta chamada Kiwix.</string>
-  <string name="help_12">Como utilizar ficheiros ZIM grandes?</string>
-  <string name="help_13">Se o seu ficheiro ZIM é maior de 4GB, pode que non poida almacenalo na súa tarxeta SD debido a limitacións no sistema de ficheiros.</string>
-  <string name="help_14">A descarga na aplicación xestiona ficheiros grandes automaticamente, partíndoos para vostede.</string>
-  <string name="help_15">Porén, se está descargando noutro dispositivo, pode que necesite dividir o ficheiro ZIM utilizando o seguinte software:</string>
-  <string name="help_16">\u2022 En Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 En Apple Mac OSX: Split e Concat</string>
-  <string name="help_19">Nota: os ficheiros resultantes deben nomearse meu_gran_ficheiro.zimaa, meu_gran_ficheiro.zimab, etc.</string>
   <string name="pref_storage">Almacenamento</string>
   <string name="pref_current_folder">Carpeta actual</string>
   <string name="path_not_writable">Non se puido acceder ó directorio desexado; úsase o predeterminado. Para solucionar isto, volva a seleccionar o directorio desexado nas preferencias da aplicación.</string>
@@ -139,7 +132,6 @@
   <string name="do_not_ask_anymore">Non preguntar máis</string>
   <string name="your_languages">Linguas escollidas:</string>
   <string name="other_languages">Outras linguas:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -151,14 +143,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-gu/strings.xml
+++ b/core/src/main/res/values-gu/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">મદદ</string>
   <string name="menu_home">ઘર</string>
@@ -26,7 +26,6 @@
   <string name="pref_language_chooser">ભાષા પસંદ કરો</string>
   <string name="menu_bookmarks_list">બુકમાર્કો</string>
   <string name="zim_manager">લાઇબ્રેરી</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -38,14 +37,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-hi/strings.xml
+++ b/core/src/main/res/values-hi/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">सामग्री पायें</string>
   <string name="menu_help">सहायता</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\U2022 विकिलीक्स या विकीसोर्स जैसी अन्य सामग्री भी उपलब्ध हैं</string>
   <string name="help_10">आप या तो अपने चुने हुए ZIM फ़ाइलों को इन-ऐप में डाउनलोड कर सकते हैं या सावधानीपूर्वक जिन्हें आप चाहते हैं उन्हे चुन सकते हैं और अपने SD कार्ड पर ZIM फ़ाइलों को ट्रांसफर करने से पहले डेस्कटॉप कंप्यूटर से डाउनलोड कर सकते हैं।</string>
   <string name="help_11">ZIM फाइलें जो इन-ऐप में डाउनलोड हैं, एक बाहरी फ़ोल्डर में स्थित हैं, जिसमें किवीक्स नामक एक फ़ोल्डर है।</string>
-  <string name="help_12">बड़ी ZIM फ़ाइलों का उपयोग कैसे करें?</string>
-  <string name="help_13">अगर आपकी ZIM फ़ाइल 4 जीबी से अधिक है, तो आप इसे अपने सिस्टम पर फाइल सिस्टम सीमाओं के कारण SD कार्ड पर स्टोर करने में सक्षम नहीं हो सकते हैं।</string>
-  <string name="help_14">डाउनलोडिंग इन-ऐप बड़ी फ़ाइलों को स्वचालित रूप से संभालता है, उन्हें आपके लिए अलग कर रहा।</string>
-  <string name="help_15">यदि आप किसी अन्य यंत्र पर डाउनलोड कर रहे हैं, तो आपको निम्न सॉफ्टवेयर का उपयोग करके ZIM फ़ाइल को विभाजित करने की आवश्यकता हो सकती है:</string>
-  <string name="help_16">\U2022 माइक्रोसॉफ्ट विंडोज पर: HJ-Split</string>
-  <string name="help_17">\U2022 एप्पल मैक ओएसएक्स पर: स्प्लिट और कंसैट</string>
-  <string name="help_19">नोट: आपकी परिणामी फ़ाइलों का नाम my_big_file.zimaa, my_big_file.zimab, आदि होना चाहिए।</string>
   <string name="pref_storage">संचयन</string>
   <string name="pref_current_folder">वर्तमान फोल्डर</string>
   <string name="path_not_writable">डिफ़ॉल्ट का उपयोग करते हुए, इच्छित निर्देशिका तक नहीं पहुंच सकते। इसे ठीक करने के लिए ऐप सेटिंग्स में वांछित निर्देशिका को फिर से खोजें।</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">आगे और ना पूछें</string>
   <string name="your_languages">चयनित भाषाएं</string>
   <string name="other_languages">अन्य भाषाएँ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-hr/strings.xml
+++ b/core/src/main/res/values-hr/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pomoć</string>
   <string name="menu_home">Početna stranica</string>
@@ -18,7 +18,6 @@
   <string name="pref_language_chooser">Odaberite jezik</string>
   <string name="menu_bookmarks_list">Bilješke</string>
   <string name="zim_manager">Knjižnica</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -30,14 +29,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-hu/strings.xml
+++ b/core/src/main/res/values-hu/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Tartalom lekérése</string>
   <string name="menu_help">Súgó</string>
@@ -101,13 +101,6 @@
   <string name="help_9">\u2022 Más tartalmak, mint a Wikileaks vagy a Wikisource úgyszint elérhetőek</string>
   <string name="help_10">Letöltheted a kiválasztott ZIM fájljaidat alkalmazáson belül vagy kiválaszthatod és letöltheted ezeket egy asztali számítógépről mielőtt átküldenéd a ZIM fájlokat az SD-kártyádra.</string>
   <string name="help_11">Az alkalmazáson belül letöltött ZIM fájlok a külső tároló könyvtár Kiwix nevű mappájában vannak elhelyezve.</string>
-  <string name="help_12">Hogyan használnak nagy ZIM fájlokat?</string>
-  <string name="help_13">Ha a ZIM fájlod nagyobb, mint 4GB, lehet, hogy nem leszel képes tárolni az SD-kártyádon a fájlrendszer korlátozásai miatt.</string>
-  <string name="help_14">Az alkalmazáson belüli letöltések automatikusan kezelik a nagyobb fájlokat, felosztva ezt neked.</string>
-  <string name="help_15">Azonban ha másik eszközön töltöd le, fel kell oszd a ZIM fájlt, használva a következő szoftvert:</string>
-  <string name="help_16">\u2022 Microsoft Windows-on: HJ-Split</string>
-  <string name="help_17">\u2022 Apple Mac OSX-en: Split and Concat</string>
-  <string name="help_19">Megjegyzés: a kapott fájljaidat a következőképpen kell nevezni: my_big_file.zimaa, my_big_file.zimab, stb.</string>
   <string name="pref_storage">Tárhely</string>
   <string name="pref_current_folder">Aktuális folder</string>
   <string name="path_not_writable">Nem érhető el a kívánt könyvtár, ehelyett az alapértelmezett lesz használva. Ahhoz, hogy ezt helyrehozd, válaszd ki újra a kívánt könyvtárat az alkalmazás beállításainál.</string>
@@ -143,7 +136,6 @@
   <string name="do_not_ask_anymore">Ne kérdezz többször</string>
   <string name="your_languages">Nyelvek kiválasztása:</string>
   <string name="other_languages">További nyelvek:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -155,14 +147,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ia/strings.xml
+++ b/core/src/main/res/values-ia/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Adjuta</string>
   <string name="menu_home">Initio</string>
@@ -35,7 +35,6 @@
   <string name="zim_manager">Bibliotheca</string>
   <string name="do_not_ask_anymore">Non demandar plus</string>
   <string name="your_languages">Linguas eligite:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -47,14 +46,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ie/strings.xml
+++ b/core/src/main/res/values-ie/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Auxilie</string>
   <string name="menu_home">Principal</string>
@@ -15,7 +15,6 @@
   <string name="pref_back_to_top_summary">Monstra un taste in li fin del págine por saltar a supra.</string>
   <string name="pref_language_title">Lingue</string>
   <string name="menu_bookmarks_list">Marcatores</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -27,14 +26,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-in/strings.xml
+++ b/core/src/main/res/values-in/strings.xml
@@ -1,8 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="wifi_only_msg">If you choose “Yes” you won\'t be warned in future. However, you can always change this in Settings</string>
   <string name="human_kind_knowledge">Human kind\'s knowledge, on your phone.</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -14,15 +13,6 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
   <string name="ext_storage_write_permission_denied_add_note">Notes can\'t be used without access to storage</string>
   <string name="note_share_error_file_missing">Note file doesn\'t exist</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Aiuto</string>
   <string name="menu_home">Pagina principale</string>
@@ -72,8 +72,6 @@
   <string name="space_available">Spazio disponibile:</string>
   <string name="help_10">Puoi sia scaricare i tuoi file ZIM in-app selezionati o selezionare attentamente quello/i che desideri e scaricarli attraverso il Desktop di un computer prima di trasferire i file ZIM sulla tua memoria SD.</string>
   <string name="help_11">I file ZIM scaricati nell\'applicazione sono localizzati nella directory di archiviazione esterna in una cartella chiamata Kiwix.</string>
-  <string name="help_12">Come utilizzare file ZIM di grandi dimensioni?</string>
-  <string name="help_13">Se il tuo file ZIM è superiore a 4GB potresti non essere in grado di archiviarlo nella tua scheda SD a causa di limitazioni nel sistema.</string>
   <string name="pref_current_folder">Cartella attuale</string>
   <string name="delete_zim_failed">Non siamo stati in grado di eliminare questo file. Dovresti provare ad usare un file amministratore.</string>
   <string name="tts_pause">pausa</string>
@@ -90,7 +88,6 @@
   <string name="pref_auto_night_mode">Modalità notte automatica</string>
   <string name="your_languages">Lingue selezionate:</string>
   <string name="other_languages">Altre lingue:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -102,14 +99,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -1,8 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="wifi_only_msg">If you choose “Yes” you won\'t be warned in future. However, you can always change this in Settings</string>
   <string name="human_kind_knowledge">Human kind\'s knowledge, on your phone.</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -14,15 +13,6 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
   <string name="ext_storage_write_permission_denied_add_note">Notes can\'t be used without access to storage</string>
   <string name="note_share_error_file_missing">Note file doesn\'t exist</string>

--- a/core/src/main/res/values-ja/strings.xml
+++ b/core/src/main/res/values-ja/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">ヘルプ</string>
   <string name="menu_home">ホーム</string>
@@ -32,7 +32,6 @@
   <string name="zim_manager">ライブラリ</string>
   <string name="do_not_ask_anymore">これ以上聞かないでください</string>
   <string name="other_languages">その他の言語:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -44,14 +43,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ji/strings.xml
+++ b/core/src/main/res/values-ji/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">הילף</string>
   <string name="menu_home">היים</string>
@@ -37,7 +37,6 @@
   <string name="download_stop">אויפֿהערן</string>
   <string name="no_files_here">קיין טעקעס דא</string>
   <string name="yes">יא</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -49,14 +48,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-jv/strings.xml
+++ b/core/src/main/res/values-jv/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pitulung</string>
   <string name="menu_home">Latar</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_chooser">Pilih basa</string>
   <string name="menu_bookmarks_list">Tenger wacan</string>
   <string name="zim_manager">Perpustakan</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ka/strings.xml
+++ b/core/src/main/res/values-ka/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">დახმარება</string>
   <string name="menu_home">მთავარი</string>
@@ -41,7 +41,6 @@
   <string name="rate_dialog_negative">არა, გმადლობთ</string>
   <string name="rate_dialog_neutral">მოგვიანებით</string>
   <string name="zim_manager">ბიბლიოთეკა</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -53,14 +52,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-km/strings.xml
+++ b/core/src/main/res/values-km/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">ជំនួយ</string>
   <string name="menu_home">ទំព័រដើម</string>
@@ -26,7 +26,6 @@
   <string name="pref_language_title">ភាសា​</string>
   <string name="menu_bookmarks_list">ការកត់ចំណាំ</string>
   <string name="zim_manager">បណ្ណាល័យ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -38,14 +37,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-kn/strings.xml
+++ b/core/src/main/res/values-kn/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">ಸಹಾಯ</string>
   <string name="menu_home">ಮುಖ್ಯಪುಟ</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_chooser">ಭಾಷೆ ಆಯ್ದುಕೊಳ್ಳಿ</string>
   <string name="menu_bookmarks_list">ಓದುಗುರುತುಗಳು</string>
   <string name="zim_manager">ಗ್ರಂಥಾಲಯ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">내용 가져오기</string>
   <string name="menu_help">도움말</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 위키리스크나 위키문헌과 같은 다른 콘텐츠도 사용이 가능합니다</string>
   <string name="help_10">앱 안에서 선택한 ZIM 파일을 다운로드하거나 원하는 항목을 주의하여 선택한 다음 ZIM 파일을 SD 카드로 전송하기 전에 데스크톱 컴퓨터로부터 다운로드할 수 있습니다.</string>
   <string name="help_11">앱 안에서 다운로드되는 ZIM 파일들은 Kiwix라는 이름의 폴더의 외부 저장 디렉터리에 위치합니다.</string>
-  <string name="help_12">크기가 큰 ZIM 파일을 사용하는 방법?</string>
-  <string name="help_13">ZIM 파일이 4GB를 초과하면 파일 시스템 제한으로 인해 SD 카드에 저장하지 못할 수 있습니다.</string>
-  <string name="help_14">앱 안에서 다운로드하면 자동으로 큰 파일들을 관리하여 분할해 줍니다.</string>
-  <string name="help_15">그러나 다른 장치에서 다운로드하는 경우 다음의 소프트웨어를 사용하여 ZIM 파일을 여러 개로 나누어야 할 수 있습니다:</string>
-  <string name="help_16">\u2022 마이크로소프트 윈도우: HJ-Split</string>
-  <string name="help_17">\u2022 애플 맥 OSX: Split, Concat</string>
-  <string name="help_19">참고: 결과 파일의 이름은 my_big_file.zimaa, my_big_file.zimab 등으로 되어야 합니다.</string>
   <string name="pref_storage">기억 장치</string>
   <string name="pref_current_folder">현재 폴더</string>
   <string name="path_not_writable">기본값을 사용하여 원하는 디렉터리에 접근할 수 없습니다. 이 문제를 해결하려면 앱 설정에서 원하는 디렉터리를 다시 선택하십시오.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">더 이상 묻지 않습니다</string>
   <string name="your_languages">선택한 언어:</string>
   <string name="other_languages">다른 언어:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ky/strings.xml
+++ b/core/src/main/res/values-ky/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Жардам</string>
   <string name="menu_home">Башкы</string>
@@ -23,7 +23,6 @@
   <string name="pref_language_chooser">Тилин тандаңыз</string>
   <string name="menu_bookmarks_list">Чөп каттар</string>
   <string name="zim_manager">Китепкана</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -35,14 +34,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-lb/strings.xml
+++ b/core/src/main/res/values-lb/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Inhalt ofruffen</string>
   <string name="menu_help">Hëllef</string>
@@ -87,7 +87,6 @@
   <string name="do_not_ask_anymore">Net méi froen</string>
   <string name="your_languages">Erausgesicht Sproochen:</string>
   <string name="other_languages">Aner Sproochen:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -99,14 +98,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-li/strings.xml
+++ b/core/src/main/res/values-li/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Haol inhawd op</string>
   <string name="menu_help">Hölp</string>
@@ -74,10 +74,6 @@
   <string name="help_7">ZIM-bestenj zint te kriege. Väöl daovan bestaon:</string>
   <string name="help_8">\u2022 Wikipedia is apaart besjikbaar veur eder spraok</string>
   <string name="help_9">\u2022 Angeren inhawd wie Wikileaks or Wikisource is ouch besjikbaar</string>
-  <string name="help_12">Wie mós se groeate ZIM-bestenj gebroeke?</string>
-  <string name="help_16">\u2022 Op Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Op Apple Mac OSX: Split en Concat</string>
-  <string name="help_19">Opmirking: dien rizzelterende bestenj mótte \'t volgende heite: my_big_file.zimaa, my_big_file.zimab, etc.</string>
   <string name="pref_storage">Opslaag</string>
   <string name="pref_current_folder">Hujige Map</string>
   <string name="path_not_writable">Kan de gewunsjde map neet äöpene mitte standerdinstèlling. Veur dit op te losse mós se de gewunsjde map oppernuuj aanvinke inne toepassingsinstèllinge.</string>
@@ -102,7 +98,6 @@
   <string name="external_link_popup_dialog_message">Doe bös \'nen externe link in \'nt tikke. Det kan leie toet extra köste veur \'t euverbringe van gegaeves of wirk neet wen se offline bös. Wils se doorgaon?</string>
   <string name="do_not_ask_anymore">Vraog nimmieë</string>
   <string name="other_languages">Anger spraoke:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -114,14 +109,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-lt/strings.xml
+++ b/core/src/main/res/values-lt/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pagalba</string>
   <string name="menu_home">Pradžia</string>
@@ -43,7 +43,6 @@
   <string name="rate_dialog_neutral">Vėliau</string>
   <string name="pref_newtab_background_title">Atidaryti naujame skirtuke</string>
   <string name="zim_manager">Biblioteka</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -55,14 +54,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-lv/strings.xml
+++ b/core/src/main/res/values-lv/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Iegūt saturu</string>
   <string name="menu_help">Palīdzība</string>
@@ -31,7 +31,6 @@
   <string name="delete_specific_zim_toast">Fails dzēsts</string>
   <string name="tts_resume">turpināt</string>
   <string name="no">Nē</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -43,14 +42,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-mg/strings.xml
+++ b/core/src/main/res/values-mg/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Fanoroana</string>
   <string name="menu_home">Fandraisana</string>
@@ -49,7 +49,6 @@
   <string name="pref_newtab_background_title">Hanokatra vakizoro any aoriana</string>
   <string name="pref_newtab_background_summary">Rehefa manokatra vakizoro dia hosokafany any aoriana</string>
   <string name="zim_manager">Tahirim-boky</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -61,14 +60,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Дај содржини</string>
   <string name="menu_help">Помош</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Достапни се и други содржини Викиликс и Викиизвор</string>
   <string name="help_10">Можете да ги преземете избраните ZIM-податотеки во прилогот, или пак внимателно да ги изберете посакуваните и да ги преземете од столен сметач, а потоа да ги префрлите ZIM-податотеките на SD-картичка.</string>
   <string name="help_11">Преземањето на ZIM-податотеките во прилогот се сместени во надворешниот склад во папка наречена Kiwix.</string>
-  <string name="help_12">Како се користат големи ZIM-податотеки?</string>
-  <string name="help_13">Доколку вашата ZIM-податотека е поголема 4 ГБ, можеби нема да можете да ја ставите на SD-картичка поради ограничувањата во податотечниот систем.</string>
-  <string name="help_14">Преземањето во прилогот се справува сам со поголеми податотеки, делејќи ги по потреба.</string>
-  <string name="help_15">Но, доколку преземате на друг уред, може да треба да ја поделите ZIM-податотеката користејќи ја следнава програмска опрема:</string>
-  <string name="help_16">\u2022 На Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 На Apple Mac OSX: Split и Concat</string>
-  <string name="help_19">Напомена: исходните податотеки мораат да бидат наречени my_big_file.zimaa, my_big_file.zimab и тн.</string>
   <string name="pref_storage">Склад</string>
   <string name="pref_current_folder">Тековна папка</string>
   <string name="path_not_writable">Не можам да дојдам до саканата папка. Ќе ја користам основната. За да го поправите ова, преизберете папка во поставките на прилогот.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">Повеќе не прашувај</string>
   <string name="your_languages">Избрани јазици:</string>
   <string name="other_languages">Други јазици:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ml/strings.xml
+++ b/core/src/main/res/values-ml/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">സഹായം</string>
   <string name="menu_home">പ്രധാനം</string>
@@ -34,7 +34,6 @@
   <string name="rate_dialog_negative">വേണ്ട, നന്ദി</string>
   <string name="rate_dialog_neutral">പിന്നീട്</string>
   <string name="zim_manager">ഗ്രന്ഥപ്പുര</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -46,14 +45,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-mn/strings.xml
+++ b/core/src/main/res/values-mn/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Тусламж</string>
   <string name="menu_home">Нүүр</string>
@@ -29,7 +29,6 @@
   <string name="pref_language_chooser">Хэлээ сонгоно уу</string>
   <string name="menu_bookmarks_list">Тэмдэглэсэн хуудсууд</string>
   <string name="zim_manager">Сан</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -41,14 +40,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ms/strings.xml
+++ b/core/src/main/res/values-ms/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Bantuan</string>
   <string name="menu_home">Laman utama</string>
@@ -40,7 +40,6 @@
   <string name="no_section_info">Tiada judul kandungan ditemui</string>
   <string name="request_storage">Untuk mencapai fail ZIM kami memerlukan akses kepada storan anda</string>
   <string name="zim_manager">Perpustakaan</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -52,14 +51,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-mt/strings.xml
+++ b/core/src/main/res/values-mt/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Għajnuna</string>
   <string name="menu_home">Daħla</string>
@@ -18,7 +18,6 @@
   <string name="pref_language_chooser">Agħżel lingwa</string>
   <string name="menu_bookmarks_list">Werrejja</string>
   <string name="zim_manager">Librerija</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -30,14 +29,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-my/strings.xml
+++ b/core/src/main/res/values-my/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">အ​ကူ​အ​ညီ​</string>
   <string name="menu_home">ပင်မ</string>
@@ -88,7 +88,6 @@
   <string name="do_not_ask_anymore">နောက်ထပ် မမေးတော့</string>
   <string name="your_languages">ရွေးချယ်ထားသော ဘာသာစကားများ -</string>
   <string name="other_languages">အခြားဘာသာစကားများ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -100,14 +99,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-nb/strings.xml
+++ b/core/src/main/res/values-nb/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Hjelp</string>
   <string name="menu_home">Hjem</string>
@@ -49,7 +49,6 @@
   <string name="pref_newtab_background_title">Åpne ny fane i bakgrunnen</string>
   <string name="pref_newtab_background_summary">Når en ny fane åpnes vil den åpnes i bakgrunnen</string>
   <string name="zim_manager">Bibliotek</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -61,14 +60,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ne/strings.xml
+++ b/core/src/main/res/values-ne/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">सामग्रीहरू प्राप्त गर्नुहोस्</string>
   <string name="menu_help">सहायता</string>
@@ -98,7 +98,6 @@
   <string name="do_not_ask_anymore">फेरि नसोध्नुहोस्</string>
   <string name="your_languages">छानिएको भाष:</string>
   <string name="other_languages">अन्य भाषाहरू:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -110,14 +109,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Hulp</string>
   <string name="menu_home">Startpagina</string>
@@ -52,7 +52,6 @@
   <string name="help_6">Onze inhoud is ondergebracht op de Kiwix website</string>
   <string name="pref_auto_night_mode_summary">Automatisch veranderen tussen de dag- en nachtmodus</string>
   <string name="pref_auto_night_mode">Geautomatiseerde nachtmodus</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -64,14 +63,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-nn/strings.xml
+++ b/core/src/main/res/values-nn/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Hjelp</string>
   <string name="menu_home">Heim</string>
@@ -13,7 +13,6 @@
   <string name="pref_info_title">Informasjon</string>
   <string name="pref_language_title">Språk</string>
   <string name="menu_bookmarks_list">Bokmerke</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -25,14 +24,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-oc/strings.xml
+++ b/core/src/main/res/values-oc/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obténer de contengut</string>
   <string name="menu_help">Ajuda</string>
@@ -94,7 +94,6 @@
   <string name="previous">Precedent</string>
   <string name="time_day">jorn</string>
   <string name="time_left">esquèrra</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -106,14 +105,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-or/strings.xml
+++ b/core/src/main/res/values-or/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">ସହଯୋଗ</string>
   <string name="menu_home">ମୂଳ ଜାଗା</string>
@@ -34,7 +34,6 @@
   <string name="pref_language_chooser">ଭାଷା ଚୟନ କରନ୍ତୁ</string>
   <string name="menu_bookmarks_list">ବୁକମାର୍କ</string>
   <string name="zim_manager">ପାଠାଗାର</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -46,14 +45,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-pl/strings.xml
+++ b/core/src/main/res/values-pl/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pomoc</string>
   <string name="menu_home">Start</string>
@@ -90,8 +90,6 @@
   <string name="help_3">Kiwix to czytnik zawartości offline. Zachowuje się jak przeglądarka, jednak zamiast stron internetowych, czyta zawartość z pliku w formacie ZIM.</string>
   <string name="help_5">Gdzie jest zawartość?</string>
   <string name="help_11">Pliki ZIM pobrane rzez aplikacje znajdują się w zewnętrznym katalogu dysku w folderze o nazwie Kiwix.</string>
-  <string name="help_12">Jak korzystać z dużych plików ZIM?</string>
-  <string name="help_13">Jeśli twój plik ZIM ma rozmiar przekraczający 4GB, możliwe, że nie będziesz miał możliwości przechowywania go na twojej karcie SD z uwagi na limity pliku systemowego.</string>
   <string name="pref_storage">Magazyn</string>
   <string name="pref_current_folder">Bieżący folder</string>
   <string name="delete_zim_failed">Niestety nie udało się usunąć tego pliku. Zamiast tego powinieneś spróbować użyć menedżera plików.</string>
@@ -113,7 +111,6 @@
   <string name="do_not_ask_anymore">Nie pytaj więcej</string>
   <string name="your_languages">Wybierz język</string>
   <string name="other_languages">Inne języki:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -125,14 +122,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ps/strings.xml
+++ b/core/src/main/res/values-ps/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">مرسته</string>
   <string name="menu_home">کور</string>
@@ -72,7 +72,6 @@
   <string name="time_minute">مين</string>
   <string name="time_second">س</string>
   <string name="time_left">کيڼ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -84,14 +83,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Obter conteúdo</string>
   <string name="menu_help">Ajuda</string>
@@ -102,13 +102,6 @@
   <string name="help_9">\u2022 Também estão disponíveis outros conteúdos, tais como Wikileaks ou Wikisource</string>
   <string name="help_10">Pode descarregar os ficheiros ZIM que selecionou dentro da aplicação ou selecionar cuidadosamente os que deseja e fazer o download a partir de um computador de secretária antes de transferi-los para o seu cartão SD.</string>
   <string name="help_11">Os ficheiros ZIM descarregados dentro da aplicação estão localizados no diretório de armazenamento externo numa pasta intitulada Kiwix.</string>
-  <string name="help_12">Como usar ficheiros ZIM grandes?</string>
-  <string name="help_13">Se o seu ficheiro ZIM for maior do que 4 GB, talvez não consiga armazená-lo no seu cartão SD devido às limitações do sistema de ficheiros.</string>
-  <string name="help_14">Fazer o download dentro da aplicação trata automaticamente dos ficheiros grandes, dividindo-os por si.</string>
-  <string name="help_15">Se, no entanto, estiver a descarregar noutro dispositivo, talvez seja necessário dividir o ficheiro ZIM usando o seguinte software:</string>
-  <string name="help_16">\u2022 No Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 No Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Nota: os ficheiros resultantes têm de ter os nomes o_meu_ficheiro.zimaa, o_meu_ficheiro.zimab, etc.</string>
   <string name="pref_storage">Armazenamento</string>
   <string name="pref_current_folder">Pasta atual</string>
   <string name="path_not_writable">Não foi possível aceder o diretório desejado, utilizando o valor predefinido. Para corrigir isto, selecione novamente o diretório desejado nas configurações da aplicação.</string>
@@ -141,7 +134,6 @@
   <string name="do_not_ask_anymore">Não perguntar mais</string>
   <string name="your_languages">Línguas selecionadas:</string>
   <string name="other_languages">Outras línguas:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -153,14 +145,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-qu/strings.xml
+++ b/core/src/main/res/values-qu/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Yanapa</string>
   <string name="menu_home">Qallarina</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_title">Rimay</string>
   <string name="menu_bookmarks_list">Yuyana unanchakuna</string>
   <string name="zim_manager">Qillqakunantin</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-rm/strings.xml
+++ b/core/src/main/res/values-rm/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Agid</string>
   <string name="menu_home">Pagina da partenza</string>
@@ -28,7 +28,6 @@
   <string name="pref_language_title">Lingua</string>
   <string name="menu_bookmarks_list">Segnapaginas</string>
   <string name="zim_manager">Biblioteca</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -40,14 +39,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ro/strings.xml
+++ b/core/src/main/res/values-ro/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Preia conținut</string>
   <string name="menu_help">Ajutor</string>
@@ -100,12 +100,6 @@
   <string name="help_9">\u2022 Alt conținut ca Wikileaks sa Wikisursă este de asemenea disponibil</string>
   <string name="help_10">Fișiere ZIM pe cardul SD.</string>
   <string name="help_11">Fișierele ZIM descărcate în aplicație sunt localizate în directorul extern de stocare într-un folder denumit Kiwix.</string>
-  <string name="help_12">Cum să folosești fișiere ZIM?</string>
-  <string name="help_13">Dacă fișierul ZIM este mai mare de 4GB este posibil să nu poți să îl descarci în cardul SD din cauza limitărilor de sistem.</string>
-  <string name="help_14">Descărcând în aplicație în mod automat se pot utiliza fișiere mai mari împărțindu-le pentru tine.</string>
-  <string name="help_15">Dacă oricum descărcați pe alt dispozitiv, este posibil să trebuie să împărțiți fișierul ZIM folosind următorul software:</string>
-  <string name="help_16">\u2022 Pe Microsoft Windows: HJ-Split</string>
-  <string name="help_19">Notă: fișierele rezultate trebuie să fie numite my_big_file.zimaa, my_big_file.zimab, etc.</string>
   <string name="pref_storage">Stocare</string>
   <string name="pref_current_folder">Folder curent</string>
   <string name="path_not_writable">Nu putem accesa directorul dorit folosind implicit. Pentru a rezolva asta reselectează directorul dorit în setările aplicației.</string>
@@ -137,7 +131,6 @@
   <string name="do_not_ask_anymore">Nu mă mai întreba</string>
   <string name="your_languages">Limbi selectate:</string>
   <string name="other_languages">Alte limbi:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -149,14 +142,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Получить Контент</string>
   <string name="menu_help">Помощь</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Такое содержимое, как Wikleaks или Wikisource, также доступно</string>
   <string name="help_10">Вы можете или загрузить выбранные ZIM файлы через приложение, или тщательно выбрать те, которые вам нужны, и загрузить их с настольного компьютера, прежде чем передавать ZIM файлы на вашу SD-карту.</string>
   <string name="help_11">Загрузка ZIM файлов в приложении находится на внешнем накопителе в папке под названием Kiwix.</string>
-  <string name="help_12">Как использовать большие ZIM файлы?</string>
-  <string name="help_13">Если ваш ZIM файл больше 4GB, вы не сможете хранить его на SD-карте из-за ограничений файловой системы.</string>
-  <string name="help_14">Загрузка в приложении автоматически обрабатывает файлы больших размеров, разделяя их для вас.</string>
-  <string name="help_15">Однако, если вы загружаете на другое устройство, вам может потребоваться разделить ZIM файл, используя следующее ПО:</string>
-  <string name="help_16">• На Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 На Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Примечание: ваши готовые файлы должны быть названы my_big_file.zimaa, my_big_file.zimab и т.д.</string>
   <string name="pref_storage">Хранилище</string>
   <string name="pref_current_folder">Текущая Папка</string>
   <string name="path_not_writable">Нет доступа к желаемой директории, используя значение по умолчанию. Чтобы исправить это, выберите желаемую директорию заново в настройках приложения.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">Больше не спрашивай</string>
   <string name="your_languages">Выбранные языки:</string>
   <string name="other_languages">Другие языки:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sa/strings.xml
+++ b/core/src/main/res/values-sa/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">साहाय्यम्</string>
   <string name="menu_home">गृहम्</string>
@@ -44,7 +44,6 @@
   <string name="pref_newtab_background_title">पृष्ठे नवीनं प्लवनम् उद्घाट्यताम्</string>
   <string name="pref_newtab_background_summary">यदा नवीनप्लवनम् आरप्स्यते, तदा पृष्ठभागे एव भविष्यति</string>
   <string name="zim_manager">ग्रन्थालयः</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -56,14 +55,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sc/strings.xml
+++ b/core/src/main/res/values-sc/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Iscàrriga cuntenutos</string>
   <string name="menu_help">Agiudu</string>
@@ -102,13 +102,6 @@
   <string name="help_9">\u2022 Fintzas àteros cuntenutos comente a Wikileaks o Wikisource sunt disponìbiles</string>
   <string name="help_10">Podes iscarrigare sos documentos ZIM isseberados dae intro a s\'aplicatzione o isseberare cun atentzione sos chi cheres e los iscarrigare dae un\'elaboradore de iscrivania in antis de los tramudare in s\'ischeda SD tua.</string>
   <string name="help_11">Sos documentos ZIM iscarrigados dae intro de s\'aplicatzione sunt sarvados in sa memòria esterna in una cartella mutida “Kiwix”.</string>
-  <string name="help_12">Comente impreare documentos ZIM mannos?</string>
-  <string name="help_13">Si su documentu ZIM tuo est prus mannu de 4GB, dias pòdere non èssere in gradu de lu sarvare in s\'ischeda SD tua pro more de lìmites in su sistema de sos documentos.</string>
-  <string name="help_14">Iscarrighende in s\'aplicatzione sos documentos prus mannos ant a èssere manigiados automaticamente, segados in prus cantos pro tie.</string>
-  <string name="help_15">Ma, si ses iscarrighende in un\'àteru dispositivu, dias pòdere tènnere bisòngiu de truncare su documentu ZIM impreende custu programma:</string>
-  <string name="help_16">\u2022 In Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 In Apple Mac OSX: Split e Concat</string>
-  <string name="help_19">Nota: su documentu risultante tuo depet tènnere su nùmene documentu_mannu_meu.zimaa, documentu_mannu_meu.zimab, etz.</string>
   <string name="pref_storage">Memòria</string>
   <string name="pref_current_folder">Cartella atuale</string>
   <string name="path_not_writable">Impossìbile abèrrere sa cartella isseberada, impreende sas impostatziones predefinidas. Pro isòrvere su problema torra a ischertare sa cartella in sos inditos de s\'aplicatzione.</string>
@@ -142,7 +135,6 @@
   <string name="do_not_ask_anymore">Non mi lu preguntes prus</string>
   <string name="your_languages">Limbas ischertadas:</string>
   <string name="other_languages">Àteras limbas:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -154,14 +146,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sh/strings.xml
+++ b/core/src/main/res/values-sh/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pomoć</string>
   <string name="menu_home">Početna</string>
@@ -14,7 +14,6 @@
   <string name="pref_info_version">Verzija</string>
   <string name="pref_language_title">Jezik</string>
   <string name="menu_bookmarks_list">Oznake</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -26,14 +25,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-si/strings.xml
+++ b/core/src/main/res/values-si/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">උදව්</string>
   <string name="menu_home">මුල් පිටුව</string>
@@ -34,7 +34,6 @@
   <string name="pref_language_chooser">භාෂාවක් තෝරාගන්න</string>
   <string name="menu_bookmarks_list">පොත්යොමු</string>
   <string name="zim_manager">පුස්තකාලය</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -46,14 +45,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sk/strings.xml
+++ b/core/src/main/res/values-sk/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pomocník</string>
   <string name="menu_home">Domov</string>
@@ -49,7 +49,6 @@
   <string name="pref_newtab_background_title">Otvoriť novú kartu na pozadí</string>
   <string name="pref_newtab_background_summary">Pri otvorení novej karty bude karta otvorená na pozadí</string>
   <string name="zim_manager">Knižnica</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -61,14 +60,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sl/strings.xml
+++ b/core/src/main/res/values-sl/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pomoč</string>
   <string name="menu_home">Domov</string>
@@ -82,7 +82,6 @@
   <string name="time_day">dan</string>
   <string name="time_left">levo</string>
   <string name="your_languages">Izbrani jeziki:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -94,14 +93,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-so/strings.xml
+++ b/core/src/main/res/values-so/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Caawinaad</string>
   <string name="menu_home">Bogga Hore</string>
@@ -34,7 +34,6 @@
   <string name="pref_language_chooser">Dooro luqad</string>
   <string name="menu_bookmarks_list">Calaamadaha aqriska</string>
   <string name="zim_manager">Maktabad</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -46,14 +45,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sq/strings.xml
+++ b/core/src/main/res/values-sq/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Merrni Lëndë</string>
   <string name="menu_help">Ndihmë</string>
@@ -101,13 +101,6 @@
   <string name="help_9">\u2022 Ka të gatshme lëndë tjetër, të tillë si Wikileaks ose Wikisource</string>
   <string name="help_10">Mundeni ose t\’i shkarkoni brenda aplikacionit kartelat ZIM që keni zgjedhur, ose të përzgjidhni me kujdes atë(ato) që doni dhe ta(t\’i) shkarkoni nga një kompjuter desktop përpara se të shpërngulni kartelat ZIM te kujtesa juaj SD card.</string>
   <string name="help_11">Kartelat ZIM të shkarkuara brenda aplikacionit gjenden te drejtoria e depozitimit të jashtëm, në një dosje të quajtu Kiwix.</string>
-  <string name="help_12">Si të përdoren kartela ZIM të mëdha?</string>
-  <string name="help_13">Nëse kartela juaj ZIM është më e madhe se 4GB, mund të mos jeni në gjendje ta depozitoni te kujtesa juaj SD për shkak kufizimesh nga sistemi i kartelave.</string>
-  <string name="help_14">Shkarkimi brenda aplikacionit i trajton automatikisht kartelat e mëdha, duke i ndarë në copa për ju.</string>
-  <string name="help_15">Por nëse po shkarkoni në një tjetër pajisje, mund të donit ta ndanit kartelën ZIM në copa duke përdorur programin vijues:</string>
-  <string name="help_16">\u2022 Në Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Në Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Shënim: kartelat e prodhuara për ju duhet të emërtohen si emri_i_kartelës_time_të_madhe.zimaa, emri_i_kartelës_time_të_madhe.zimab, etj.</string>
   <string name="pref_storage">Depozitim</string>
   <string name="pref_current_folder">Dosja e Tanishme</string>
   <string name="path_not_writable">S\’hyhet dot te drejtori e dëshiruar, po përdoret parazgjedhja. Që të ndreqet kjo, ripërzgjidhni drejtorinë e dëshiruar te rregullimet e aplikacionit.</string>
@@ -141,7 +134,6 @@
   <string name="do_not_ask_anymore">Mos pyet më</string>
   <string name="your_languages">Gjuhë të përzgjedhura:</string>
   <string name="other_languages">Gjuhë të tjera:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -153,14 +145,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-su/strings.xml
+++ b/core/src/main/res/values-su/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Pitulung</string>
   <string name="menu_home">Tepas</string>
@@ -38,7 +38,6 @@
   <string name="no">Teu</string>
   <string name="confirm_stop_download_title">Eureunkeun undeuran?</string>
   <string name="download_change_storage">Pamilih parangkat panyimpenan</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -50,14 +49,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Hämta innehåll</string>
   <string name="menu_help">Hjälp</string>
@@ -101,13 +101,6 @@
   <string name="help_9">\u2022 Annat innehåll som Wikileaks eller Wikisource finns också tillgängligt</string>
   <string name="help_10">Du kan antingen ladda ned dina valda ZIM-filer i appen eller försiktigt välja ut de som du vill ladda ned från en dator innan du överför ZIM-filerna till ditt SD-kort.</string>
   <string name="help_11">ZIM-filer som laddas ned i appen placeras i den externa lagringskatalogen i en mapp som heter Kiwix.</string>
-  <string name="help_12">Hur använder man stora ZIM-filer?</string>
-  <string name="help_13">Om din ZIM-fil är större än 4GB kan du inte lagra den på ditt SD-kort p.g.a. begränsningar i filsystemet.</string>
-  <string name="help_14">Nedladdningarna i appen hanterar automatiskt större filer och delar upp dem åt dig.</string>
-  <string name="help_15">Om du laddar ned på en annan enhet måste du dela upp ZIM-filen med följande programvara:</string>
-  <string name="help_16">\u2022 På Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 På Apple Mac OSX: Split och Concat</string>
-  <string name="help_19">OBS: Resultatfilerna måste heta min_stora_fil.zimaa, min_stora_fil.zimab, etc.</string>
   <string name="pref_storage">Lagring</string>
   <string name="pref_current_folder">Nuvarande mapp</string>
   <string name="path_not_writable">Kan inte komma åt önskad katalog, använder standardplatsen. För att åtgärda detta, välj önskad katalog i appens inställningar igen.</string>
@@ -140,7 +133,6 @@
   <string name="do_not_ask_anymore">Fråga inte igen</string>
   <string name="your_languages">Valda språk:</string>
   <string name="other_languages">Andra språk:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -152,14 +144,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-sw/strings.xml
+++ b/core/src/main/res/values-sw/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Msaada</string>
   <string name="menu_home">Mwanzo</string>
@@ -50,7 +50,6 @@
   <string name="no">Hapana</string>
   <string name="next">Ijayo</string>
   <string name="other_languages">Lugha zingine:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -62,14 +61,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ta/strings.xml
+++ b/core/src/main/res/values-ta/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">உதவி</string>
   <string name="menu_home">முகப்பு</string>
@@ -32,7 +32,6 @@
   <string name="pref_language_chooser">மொழியைத் தேர்ந்தெடு</string>
   <string name="menu_bookmarks_list">புத்தகக்குறிகள்</string>
   <string name="zim_manager">நூலகம்</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -44,14 +43,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-te/strings.xml
+++ b/core/src/main/res/values-te/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">సహాయం</string>
   <string name="menu_home">ముంగిలి</string>
@@ -49,7 +49,6 @@
   <string name="pref_newtab_background_title">కొత్త ట్యబ్ ను వెనుకస్థలంలో తెరవండి</string>
   <string name="pref_newtab_background_summary">ఎప్పుడైతే కొత్త ట్యాబ్ ను తెరుస్తారో అప్పుడు అది వెనుకస్థలంలో తెరుచుకుంటుంది.</string>
   <string name="zim_manager">గ్రంథాలయము</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -61,14 +60,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-th/strings.xml
+++ b/core/src/main/res/values-th/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">วิธีใช้</string>
   <string name="menu_home">หน้าแรก</string>
@@ -42,7 +42,6 @@
   <string name="download_no_space">พื้นที่ไม่เพียงพอในการดาวน์โหลดไฟล์นี้</string>
   <string name="help_10">คุณสามารถดาวน์โหลดไฟล์ ZIM ที่คุณเลือกในแอพหรือเลือกไฟล์ที่คุณต้องการและดาวน์โหลดจากคอมพิวเตอร์เดสก์ท็อปอย่างระมัดระวังก่อนที่จะถ่ายโอนไฟล์ ZIM ไปยังเอสดีการ์ดของคุณ</string>
   <string name="help_11">การดาวน์โหลดไฟล์ ZIM ในแอพจะอยู่ในไดเรกทอรีจัดเก็บข้อมูลภายนอกในโฟลเดอร์ชื่อ Kiwix</string>
-  <string name="help_12">จะใช้ไฟล์ ZIM ขนาดใหญ่ได้อย่างไร ?</string>
   <string name="delete_zim_failed">ขออภัยเราไม่สามารถลบไฟล์นี้ คุณควรลองใช้โปรแกรมจัดการไฟล์แทน</string>
   <string name="external_storage">ภายนอก</string>
   <string name="confirm_stop_download_title">หยุดดาวน์โหลดหรือไม่?</string>
@@ -51,7 +50,6 @@
   <string name="external_link_popup_dialog_title">กำลังเข้าสู่ลิงค์ภายนอก</string>
   <string name="external_link_popup_dialog_message">คุณกำลังป้อนลิงก์ภายนอก ซึ่งอาจทำให้มีค่าใช้จ่ายเพิ่มเติมสำหรับการถ่ายโอนข้อมูลหรือจะไม่ทำงานเมื่อคุณออฟไลน์ คุณต้องการดำเนินการต่อหรือไม่?</string>
   <string name="do_not_ask_anymore">อย่าถามอีก</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -63,14 +61,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-tl/strings.xml
+++ b/core/src/main/res/values-tl/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Tulong</string>
   <string name="menu_home">Tahanan</string>
@@ -19,7 +19,6 @@
   <string name="pref_language_chooser">Pumili ng wika</string>
   <string name="menu_bookmarks_list">Mga pananda</string>
   <string name="zim_manager">Aklatan</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -31,14 +30,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">İçerik al</string>
   <string name="menu_help">Yardım</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Wikileaks veya Vikikaynak gibi diğer kaynaklarımız da kullanılabilir durumdadır</string>
   <string name="help_10">Seçtiğiniz ZIM dosyalarını uygulama içerisinden indirebilir veya istediklerinizi seçerek SD kartınıza aktarmadan önce bir Masaüstü bilgisayarından indirebilirsiniz.</string>
   <string name="help_11">Uygulama içinden indirilen ZIM dosyaları harici depolama aygıtındaki Kiwix başlıklı bir klasördedir.</string>
-  <string name="help_12">Büyük ZIM dosyaları nasıl kullanılır?</string>
-  <string name="help_13">Eğer ZIM dosyanız 4GB\'tan büyükse, dosya sistemi kısıtlamalarından dolayı SD kartınıza depolayamayabilirsiniz.</string>
-  <string name="help_14">Uygulama içinde indirme yapmak büyük dosyaları sizin için otomatik olarak bölmeyi sağlar.</string>
-  <string name="help_15">Yine de başka bir cihaza indirme yapıyorsanız, ZIM dosyasını bölmek için aşağıdaki yazılımı kullanmanız gerekebilir:</string>
-  <string name="help_16">\u2022 Microsoft Windows için : HJ-Split</string>
-  <string name="help_17">\u2022 Apple Mac OSX için: Split and Concat</string>
-  <string name="help_19">Not: çıkış dosyalarınız my_big_file.zimaa, my_big_file.zimab, vs. gibi isimlendirilmiş olmalı.</string>
   <string name="pref_storage">Depolama</string>
   <string name="pref_current_folder">Mevcut Klasör</string>
   <string name="path_not_writable">Varsayılan kullanılarak istenen dizine erişilemiyor. Bu durumu çözmek için uygulama ayarlarından istenen dizini yeniden seçin.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">Artık sorma</string>
   <string name="your_languages">Seçilen diller:</string>
   <string name="other_languages">Diğer diller:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Отримати контент</string>
   <string name="menu_help">Довідка</string>
@@ -103,13 +103,6 @@
   <string name="help_9">\u2022 Доступний також інший контент, такий як Вікілікс чи Вікіджерела</string>
   <string name="help_10">Ви можете або завантажити свої обрані ZIM-файли в межах застосунка, або обережно вибрати ті, які Ви хочете, й завантажити їх зі стаціонарного комп\'ютера, перед тим як переносити ZIM-файли на свою SD-карту.</string>
   <string name="help_11">ZIM-файли, завантажені із застосунка, розташовані в каталозі зовнішнього зберігання даних у папці під назвою Kiwix.</string>
-  <string name="help_12">Як використовувати великі ZIM-файли?</string>
-  <string name="help_13">Якщо Ваші ZIM-файли більші ніж 4 ГБ, можливо, Ви не зможете зберегти їх на свою SD-карту через обмеження файлової системи.</string>
-  <string name="help_14">Завантаження в межах застосунка автоматично опрацьовує більші файли, розбиваючи їх на частини замість Вас.</string>
-  <string name="help_15">Якщо, однак, Ви завантажуєте на іншому пристрої, можливо, Вам треба буде розділити ZIM-файл за допомогою такого програмного забезпечення:</string>
-  <string name="help_16">\u2022 На Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 На Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Примітка: файли, отримані Вами в результаті, повинні мати назви my_big_file.zimaa, my_big_file.zimab тощо.</string>
   <string name="pref_storage">Зберігання даних</string>
   <string name="pref_current_folder">Поточна папка</string>
   <string name="path_not_writable">Не вдалося отримати доступ до бажаного каталогу, використовується стандартне налаштування. Щоб виправити це, виберіть бажану категорію в налаштуваннях програми повторно.</string>
@@ -145,7 +138,6 @@
   <string name="do_not_ask_anymore">Більш не питати</string>
   <string name="your_languages">Вибір мови:</string>
   <string name="other_languages">Інші мови:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -157,14 +149,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-ur/strings.xml
+++ b/core/src/main/res/values-ur/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">معاونت</string>
   <string name="menu_home">صفحہ اول</string>
@@ -17,7 +17,6 @@
   <string name="pref_language_chooser">ایک زبان کا انتخاب کریں</string>
   <string name="menu_bookmarks_list">نشانزدہ</string>
   <string name="zim_manager">مکتبہ</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -29,14 +28,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-uz/strings.xml
+++ b/core/src/main/res/values-uz/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Yordam</string>
   <string name="menu_home">Boshiga</string>
@@ -16,7 +16,6 @@
   <string name="pref_language_title">Til</string>
   <string name="menu_bookmarks_list">Xatchoʻplar</string>
   <string name="zim_manager">Kutubxona</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -28,14 +27,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-vi/strings.xml
+++ b/core/src/main/res/values-vi/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_zim_manager">Lấy Nội dung</string>
   <string name="menu_help">Trợ giúp</string>
@@ -102,13 +102,6 @@
   <string name="help_9">\u2022 Các nội dung khác như Wikileaks hay Wikisource cũng có sẵn</string>
   <string name="help_10">Bạn có thể chọn tập tin ZIM muốn tải về từ ứng dụng hoặc cẩn thận chọn tập tin ZIM bạn muốn và tải về từ máy tính trước khi chuyển tập tin đó sang thẻ SD.</string>
   <string name="help_11">Các tập tin ZIM được tải về bằng ứng dụng sẽ được lưu trữ ở bộ nhớ ngoài, trong thư mục có tên Kiwix.</string>
-  <string name="help_12">Làm thế nào để dùng các tập tin ZIM kích cỡ lớn?</string>
-  <string name="help_13">Nếu tập tin ZIM của bạn lớn hơn 4GB thì bạn có thể không lưu trữ được tập tin đó trên thẻ SD vì giới hạn của filesystem.</string>
-  <string name="help_14">Nếu bạn tải về bằng ứng dụng thì ứng dụng sẽ tự động cắt tập tin ra cho bạn.</string>
-  <string name="help_15">Tuy nhiên, nếu bạn tải về bằng thiết bị khác thì bạn có thể cần dùng các phần mềm sau để cắt tập tin ZIM ra:</string>
-  <string name="help_16">\u2022 Đối với Microsoft Windows: HJ-Split</string>
-  <string name="help_17">\u2022 Đối với Apple Mac OSX: Split and Concat</string>
-  <string name="help_19">Lưu ý: các tập tin kết quả phải được đặt theo dạng my_big_file.zimaa, my_big_file.zimab,…</string>
   <string name="pref_storage">Lưu trữ</string>
   <string name="pref_current_folder">Thư mục Hiện tại</string>
   <string name="delete_zim_failed">Rất tiếc, chúng tôi không thể xoá tập tin này. Bạn hãy dùng một trình duyệt tập tin để làm việc đó.</string>
@@ -142,7 +135,6 @@
   <string name="do_not_ask_anymore">Đừng hỏi lại</string>
   <string name="your_languages">Ngôn ngữ được chọn:</string>
   <string name="other_languages">Ngôn ngữ khác:</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -154,14 +146,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-yo/strings.xml
+++ b/core/src/main/res/values-yo/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">Ìrànwọ́</string>
   <string name="menu_home">Ibùdó</string>
@@ -16,7 +16,6 @@
   <string name="pref_language_title">Èdè</string>
   <string name="menu_bookmarks_list">Àwọn ojúewé àdápamọ́</string>
   <string name="zim_manager">Ibiàmúlò</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -28,14 +27,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string name="menu_help">帮助</string>
   <string name="menu_home">主页</string>
@@ -13,7 +13,6 @@
   <string name="pref_info_title">信息</string>
   <string name="pref_language_title">语言</string>
   <string name="menu_bookmarks_list">书签</string>
-
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>
@@ -25,14 +24,5 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
   <string name="kiwi">Kiwi</string>
   <string name="menu_zim_manager">Library</string>
@@ -132,14 +132,6 @@
   <string name="help_9">• Other contents like Wikileaks or Wikisource are also available</string>
   <string name="help_10">You can either download your chosen ZIM files in-app or carefuly select the one(s) you want and download from a Desktop computer before transferring the ZIM files to your SD card.</string>
   <string name="help_11">ZIM files download in-app are located in the external storage directory in a folder entitled Kiwix.</string>
-  <string name="help_12">How to use large ZIM files?</string>
-  <string name="help_13">If your ZIM file is larger than 4GB, you might not be able to store it on your SD card due to filesystem limitations.</string>
-  <string name="help_14">Downloading in-app automatically handles larger files, splitting them up for you.</string>
-  <string name="help_15">If however you are downloading on another device, you may need to split the ZIM file up using the following software:</string>
-  <string name="help_16">• On Microsoft Windows: HJ-Split</string>
-  <string name="help_17">• On Apple Mac OSX: Split and Concat</string>
-  <string name="help_18" tools:ignore="TypographyDashes">• On GNU/Linux and with the console: split --bytes=4000M my_big_file.zim</string>
-  <string name="help_19">Note: your resulting files must be named my_big_file.zimaa, my_big_file.zimab, etc.</string>
   <string name="pref_storage">Storage</string>
   <string name="pref_current_folder">Current Folder</string>
   <string name="path_not_writable">Can not access desired directory, using default. To fix this reselect the desired directory in app settings.</string>
@@ -225,15 +217,6 @@
     <item>@string/help_9</item>
     <item>@string/help_10</item>
     <item>@string/help_11</item>
-  </string-array>
-  <string-array name="description_help_12">
-    <item>@string/help_13</item>
-    <item>@string/help_14</item>
-    <item>@string/help_15</item>
-    <item>@string/help_16</item>
-    <item>@string/help_17</item>
-    <item>@string/help_18</item>
-    <item>@string/help_19</item>
   </string-array>
   <string name="bookmarks_from_current_book">Bookmarks from current book</string>
   <string name="search_bookmarks">Search bookmarks</string>


### PR DESCRIPTION
Splitting ZIM files that way is not recommended any more.