### PR TITLE
Travis-ci builds only on master branch branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ if: type != push OR tag IS present
 # Build only on master branch
 branches:
   only:
-  - master
+  - master 
 
 install:
   - pip install --user 'requests[security]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ env:
 
 if: type != push OR tag IS present
 
+# Build only on master branch
+branches:
+  only:
+  - master
+
 install:
   - pip install --user 'requests[security]'
   - wget -r -nH -nd -np -R index.html* robots.txt* http://download.kiwix.org/dev/android/api/licenses/ -e robots=off -P $ANDROID_HOME/licenses || true


### PR DESCRIPTION
This is to allow automatic publishing without having each commit to `develop` or any other feature branch triggering a build request to Travis-ci (on the top of the Pull Request)