### PR TITLE
#1656 Crash Report 3.1.2: NPE CoreMainActivity.hideTabSwitcher mainMenu

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -504,7 +504,9 @@ public abstract class CoreMainActivity extends BaseActivity
       tabSwitcherRoot.setVisibility(View.GONE);
       progressBar.setVisibility(View.VISIBLE);
       contentFrame.setVisibility(View.VISIBLE);
-      mainMenu.showWebViewOptions(!urlIsInvalid());
+      if (mainMenu != null) {
+        mainMenu.showWebViewOptions(!urlIsInvalid());
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1656 

