### PR TITLE
#1668 Crash Report 3.1.2 Custom Apps Parameter specified as non-null …

### DIFF
--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -52,10 +52,10 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
   private fun zimFiles() =
     scanDirs(ContextCompat.getExternalFilesDirs(context, null), "zim")
 
-  private fun scanDirs(dirs: Array<out File>, extensionToMatch: String): List<File> =
-    dirs.fold(listOf()) { acc, dir ->
+  private fun scanDirs(dirs: Array<out File?>?, extensionToMatch: String): List<File> =
+    dirs?.filterNotNull()?.fold(listOf()) { acc, dir ->
       acc + dir.walk().filter { it.extension.startsWith(extensionToMatch) }.toList()
-    }
+    } ?: emptyList()
 }
 
 sealed class ValidationState {


### PR DESCRIPTION
…is null - use nullable types to express the possible return types

