### PR TITLE
#1058 Revamp the menu of the History Activity

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/history/HistoryActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/history/HistoryActivity.java
@@ -26,7 +26,9 @@ import android.provider.Settings;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
+import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.ActionBar;
@@ -74,6 +76,8 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
   RecyclerView recyclerView;
   @BindView(R2.id.no_history)
   TextView noHistory;
+  @BindView(R2.id.history_switch)
+  Switch historySwitch;
   private boolean refreshAdapter = true;
   private HistoryAdapter historyAdapter;
   private LinearLayoutManager layoutManager;
@@ -148,6 +152,15 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
     recyclerView.setAdapter(historyAdapter);
     layoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
     recyclerView.setLayoutManager(layoutManager);
+
+    historySwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        sharedPreferenceUtil.setShowHistoryCurrentBook(!isChecked);
+        presenter.loadHistory(sharedPreferenceUtil.getShowHistoryCurrentBook());
+      }
+    });
+
+    historySwitch.setChecked(!sharedPreferenceUtil.getShowHistoryCurrentBook());
   }
 
   private void setupHistoryAdapter() {
@@ -186,30 +199,31 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
 
   @Override
   public boolean onCreateOptionsMenu(Menu menu) {
-    getMenuInflater().inflate(R.menu.menu_history, menu);
-    MenuItem toggle = menu.findItem(R.id.menu_history_toggle);
-    toggle.setChecked(sharedPreferenceUtil.getShowHistoryCurrentBook());
 
-    SearchView search = (SearchView) menu.findItem(R.id.menu_history_search).getActionView();
-    search.setQueryHint(getString(R.string.search_history));
-    search.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-      @Override
-      public boolean onQueryTextSubmit(String query) {
-        return false;
-      }
+    if (!historyList.isEmpty()) {
+      getMenuInflater().inflate(R.menu.menu_history, menu);
 
-      @Override
-      public boolean onQueryTextChange(String newText) {
-        historyList.clear();
-        historyList.addAll(fullHistory);
-        if ("".equals(newText)) {
-          historyAdapter.notifyDataSetChanged();
+      SearchView search = (SearchView) menu.findItem(R.id.menu_history_search).getActionView();
+      search.setQueryHint(getString(R.string.search_history));
+      search.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+        @Override
+        public boolean onQueryTextSubmit(String query) {
+          return false;
+        }
+
+        @Override
+        public boolean onQueryTextChange(String newText) {
+          historyList.clear();
+          historyList.addAll(fullHistory);
+          if ("".equals(newText)) {
+            historyAdapter.notifyDataSetChanged();
+            return true;
+          }
+          presenter.filterHistory(historyList, newText);
           return true;
         }
-        presenter.filterHistory(historyList, newText);
-        return true;
-      }
-    });
+      });
+    }
     return true;
   }
 
@@ -218,11 +232,6 @@ public class HistoryActivity extends BaseActivity implements HistoryContract.Vie
     int itemId = item.getItemId();
     if (itemId == android.R.id.home) {
       onBackPressed();
-      return true;
-    } else if (itemId == R.id.menu_history_toggle) {
-      item.setChecked(!item.isChecked());
-      sharedPreferenceUtil.setShowHistoryCurrentBook(item.isChecked());
-      presenter.loadHistory(sharedPreferenceUtil.getShowHistoryCurrentBook());
       return true;
     } else if (itemId == R.id.menu_history_clear) {
       presenter.deleteHistory(new ArrayList<>(fullHistory));

--- a/core/src/main/res/layout/activity_history.xml
+++ b/core/src/main/res/layout/activity_history.xml
@@ -24,6 +24,7 @@
       android:paddingBottom="@dimen/switch_padding_bottom"
       android:switchPadding="@dimen/switch_padding"
       android:text="@string/history_from_current_book"
+      android:textAppearance="@style/TextAppearance.KiwixTheme.Body2"
       app:theme="@style/ThemeOverlay.MaterialComponents.Dark" />
 
   </com.google.android.material.appbar.AppBarLayout>

--- a/core/src/main/res/layout/activity_history.xml
+++ b/core/src/main/res/layout/activity_history.xml
@@ -5,7 +5,23 @@
   android:layout_height="match_parent"
   android:fitsSystemWindows="true">
 
-  <include layout="@layout/layout_standard_app_bar" />
+  <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/app_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:showIn="@layout/activity_help">
+
+    <include layout="@layout/layout_toolbar" />
+
+    <Switch
+      android:id="@+id/history_switch"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/history_from_current_book"
+      android:switchPadding="@dimen/switch_padding"/>
+
+  </com.google.android.material.appbar.AppBarLayout>
 
   <TextView
     android:id="@+id/no_history"

--- a/core/src/main/res/layout/activity_history.xml
+++ b/core/src/main/res/layout/activity_history.xml
@@ -10,6 +10,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:layout_constraintTop_toTopOf="parent"
+    android:background="@color/black"
     tools:showIn="@layout/activity_help">
 
     <include layout="@layout/layout_toolbar" />
@@ -19,6 +20,8 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/history_from_current_book"
+      android:paddingStart="@dimen/switch_text_padding"
+      android:textColor="@android:color/white"
       android:switchPadding="@dimen/switch_padding"/>
 
   </com.google.android.material.appbar.AppBarLayout>

--- a/core/src/main/res/layout/activity_history.xml
+++ b/core/src/main/res/layout/activity_history.xml
@@ -18,12 +18,12 @@
 
     <Switch
       android:id="@+id/history_switch"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:paddingStart="@dimen/switch_text_padding"
+      android:layout_gravity="end"
       android:paddingBottom="@dimen/switch_padding_bottom"
+      android:switchPadding="@dimen/switch_padding"
       android:text="@string/history_from_current_book"
-      android:textColor="@android:color/white"
       app:theme="@style/ThemeOverlay.MaterialComponents.Dark" />
 
   </com.google.android.material.appbar.AppBarLayout>

--- a/core/src/main/res/layout/activity_history.xml
+++ b/core/src/main/res/layout/activity_history.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:fitsSystemWindows="true">
 
-  <com.google.android.material.appbar.AppBarLayout xmlns:tools="http://schemas.android.com/tools"
+  <com.google.android.material.appbar.AppBarLayout
     android:id="@+id/app_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -17,12 +18,13 @@
 
     <Switch
       android:id="@+id/history_switch"
-      android:layout_width="wrap_content"
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:text="@string/history_from_current_book"
       android:paddingStart="@dimen/switch_text_padding"
+      android:paddingBottom="@dimen/switch_padding_bottom"
+      android:text="@string/history_from_current_book"
       android:textColor="@android:color/white"
-      android:switchPadding="@dimen/switch_padding"/>
+      app:theme="@style/ThemeOverlay.MaterialComponents.Dark" />
 
   </com.google.android.material.appbar.AppBarLayout>
 

--- a/core/src/main/res/menu/menu_history.xml
+++ b/core/src/main/res/menu/menu_history.xml
@@ -13,12 +13,6 @@
     tools:ignore="AlwaysShowAction" />
 
   <item
-    android:id="@+id/menu_history_toggle"
-    android:checkable="true"
-    android:title="@string/history_from_current_book"
-    app:showAsAction="never" />
-
-  <item
     android:id="@+id/menu_history_clear"
     android:title="@string/pref_clear_all_history_title"
     app:showAsAction="never" />

--- a/core/src/main/res/menu/menu_history.xml
+++ b/core/src/main/res/menu/menu_history.xml
@@ -14,6 +14,7 @@
 
   <item
     android:id="@+id/menu_history_clear"
+    android:icon="@drawable/ic_delete_white_24dp"
     android:title="@string/pref_clear_all_history_title"
-    app:showAsAction="never" />
+    app:showAsAction="ifRoom" />
 </menu>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
   <dimen name="activity_vertical_margin">16dp</dimen>
   <dimen name="dimen_small_padding">4dp</dimen>
   <dimen name="dimen_medium_padding">8dp</dimen>
+  <dimen name="switch_padding_bottom">10dp</dimen>
   <dimen name="switch_padding">15dp</dimen>
   <dimen name="switch_text_padding">20dp</dimen>
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -5,7 +5,7 @@
   <dimen name="activity_vertical_margin">16dp</dimen>
   <dimen name="dimen_small_padding">4dp</dimen>
   <dimen name="dimen_medium_padding">8dp</dimen>
-  <dimen name="switch_padding_bottom">10dp</dimen>
+  <dimen name="switch_padding_bottom">6dp</dimen>
   <dimen name="switch_padding">15dp</dimen>
   <dimen name="switch_text_padding">20dp</dimen>
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
   <dimen name="activity_vertical_margin">16dp</dimen>
   <dimen name="dimen_small_padding">4dp</dimen>
   <dimen name="dimen_medium_padding">8dp</dimen>
+  <dimen name="switch_padding">15dp</dimen>
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>
   <dimen name="abc_dropdownitem_text_padding_right">8dip</dimen>
   <dimen name="kiwix_search_widget_layout_id_height">50dp</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -7,7 +7,6 @@
   <dimen name="dimen_medium_padding">8dp</dimen>
   <dimen name="switch_padding_bottom">6dp</dimen>
   <dimen name="switch_padding">15dp</dimen>
-  <dimen name="switch_text_padding">20dp</dimen>
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>
   <dimen name="abc_dropdownitem_text_padding_right">8dip</dimen>
   <dimen name="kiwix_search_widget_layout_id_height">50dp</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
   <dimen name="dimen_small_padding">4dp</dimen>
   <dimen name="dimen_medium_padding">8dp</dimen>
   <dimen name="switch_padding">15dp</dimen>
+  <dimen name="switch_text_padding">20dp</dimen>
   <dimen name="abc_dropdownitem_text_padding_left">8dip</dimen>
   <dimen name="abc_dropdownitem_text_padding_right">8dip</dimen>
   <dimen name="kiwix_search_widget_layout_id_height">50dp</dimen>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -202,7 +202,7 @@
   <string name="send_feedback">Send feedback</string>
   <string name="expand">Expand</string>
   <string name="history">History</string>
-  <string name="history_from_current_book">History from current book</string>
+  <string name="history_from_current_book">View History From All Books</string>
   <string name="search_history">Search history</string>
   <string name="selected_items">%1$d selected</string>
   <string-array name="description_help_2">


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1058 

<!-- Add here what changes were made in this issue and if possible provide links. -->
Made the following changes in the menu of the history section:
- Removed the menus
- Created an icon in the top bar to enable/disable the display of all (versus current) book/tab history
- Replace the 3 dots menu with a simple trash icon. The click on trash deletes what is displayed.

<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
![sc](https://user-images.githubusercontent.com/41234408/73358580-f46c8f80-42c4-11ea-94ff-f579a7d63c6f.png)
![sc1](https://user-images.githubusercontent.com/41234408/73358584-f6cee980-42c4-11ea-8b5c-e0dbb780451b.png)
![sc2](https://user-images.githubusercontent.com/41234408/73358586-f9314380-42c4-11ea-8d9b-c2f0a9817e7a.png)
![sc3](https://user-images.githubusercontent.com/41234408/73358589-fafb0700-42c4-11ea-8270-81fe63011758.png)