### PR TITLE
Improve problems with low contrast text  in dark mode

### DIFF
--- a/core/src/main/res/values-night/color.xml
+++ b/core/src/main/res/values-night/color.xml
@@ -5,10 +5,10 @@
   <!--The same color values are defined for dark theme, but with values more appropriate for -->
   <!--low-luminance UIs. These colors will be used by night/themes.xml.-->
 
-  <color name="color_primary">#42a5f5</color> <!--blue400-->
+  <color name="color_primary">@color/blue400</color>
 
-  <color name="color_surface">#212121</color> <!--grey900-->
-  <color name="color_error">#f06292</color> <!--pink300-->
+  <color name="color_surface">@color/grey900</color>
+  <color name="color_error">@color/pink300</color>
 
   <color name="color_on_primary">@color/white</color>
   <color name="color_on_surface">@color/white</color>

--- a/core/src/main/res/values-night/color.xml
+++ b/core/src/main/res/values-night/color.xml
@@ -5,10 +5,10 @@
   <!--The same color values are defined for dark theme, but with values more appropriate for -->
   <!--low-luminance UIs. These colors will be used by night/themes.xml.-->
 
-  <color name="color_primary">@color/blue800</color>
+  <color name="color_primary">#42a5f5</color> <!--blue400-->
 
-  <color name="color_surface">#121212</color>
-  <color name="color_error">#cf6679</color>
+  <color name="color_surface">#212121</color> <!--grey900-->
+  <color name="color_error">#f06292</color> <!--#f06292-->
 
   <color name="color_on_primary">@color/white</color>
   <color name="color_on_surface">@color/white</color>

--- a/core/src/main/res/values-night/color.xml
+++ b/core/src/main/res/values-night/color.xml
@@ -8,7 +8,7 @@
   <color name="color_primary">#42a5f5</color> <!--blue400-->
 
   <color name="color_surface">#212121</color> <!--grey900-->
-  <color name="color_error">#f06292</color> <!--#f06292-->
+  <color name="color_error">#f06292</color> <!--pink300-->
 
   <color name="color_on_primary">@color/white</color>
   <color name="color_on_surface">@color/white</color>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -7,10 +7,13 @@
   <color name="white">#fafafa</color>
   <color name="black_regular_mat_design">#212121</color>
   <color name="grey">#5a5a5a</color>
+  <color name="grey900">#212121</color>
   <color name="pure_grey">#808080</color>
   <color name="blue_grey">#ECEFF1</color>
+  <color name="blue400">#42a5f5</color>
   <color name="blue800">#1565c0</color>
   <color name="blueTransparent">#962e7ac4</color>
+  <color name="pink300">#f06292</color>
   <color name="actionModeBackground">#4285F4</color>
   <color name="greenTick">#4CAF50</color>
   <color name="stopServer">#E53935</color>


### PR DESCRIPTION
Fixes #1748 

In low brightness the text are now readable.
Material colors have been used under the WCAG AA/AAA guidelines.
* changed `blue800` for dark theme to `blue400` (improved contrast ratio 6.08:1 )
* changed color_surface to `grey900` from` #121212`(hexcode) 
* changed color_error to `pink300` from `#cf669`(hexcode) (contrast ratio 5.26:1 )


<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
![Webp net-resizeimage (1)](https://user-images.githubusercontent.com/53831987/73775011-137a8e00-47ab-11ea-89a1-de29891ff4f1.png) ![Webp net-resizeimage](https://user-images.githubusercontent.com/53831987/73775036-1e352300-47ab-11ea-98b8-b3145c7d884f.png)

Real images(sorry for bad quality) 
![rsz_whatsapp_image_2020-02-05_at_121040_am_1](https://user-images.githubusercontent.com/53831987/73776097-28f0b780-47ad-11ea-993c-5483138e0a52.jpg) ![rsz_11whatsapp_image_2020-02-05_at_121039_am](https://user-images.githubusercontent.com/53831987/73776336-913f9900-47ad-11ea-8b71-501d16b7e203.jpg)

