### PR TITLE
#1709 Change icon of history and bookmarks items on selection and unselection

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ImageViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ImageViewExtensions.kt
@@ -26,10 +26,7 @@ import org.kiwix.kiwixmobile.core.downloader.model.Base64String
 
 fun ImageView.setBitmap(base64String: Base64String) {
   base64String.toBitmap()
-    ?.let {
-      setImageBitmap(it)
-      tag = base64String
-    }
+    ?.let(::setImageBitmap)
 }
 
 // methods that accept inline classes as parameters are not allowed to be called from java

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ImageViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ImageViewExtensions.kt
@@ -25,13 +25,11 @@ import androidx.core.widget.ImageViewCompat
 import org.kiwix.kiwixmobile.core.downloader.model.Base64String
 
 fun ImageView.setBitmap(base64String: Base64String) {
-  if (tag != base64String) {
-    base64String.toBitmap()
-      ?.let {
-        setImageBitmap(it)
-        tag = base64String
-      }
-  }
+  base64String.toBitmap()
+    ?.let {
+      setImageBitmap(it)
+      tag = base64String
+    }
 }
 
 // methods that accept inline classes as parameters are not allowed to be called from java


### PR DESCRIPTION

<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1709 

<!-- Add here what changes were made in this issue and if possible provide links. -->
The tag condition while setting the icon has been removed for proper changing of icons. Now when an item is selected or unselected in the bookmarks or history activity, the icon is changed properly. 
