### PR TITLE
Add voice data checks for Read Aloud

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -39,6 +39,7 @@ import org.kiwix.kiwixmobile.core.CoreApp;
 import org.kiwix.kiwixmobile.core.R;
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils;
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer;
+import org.kiwix.kiwixmobile.core.extensions.ContextExtensionsKt;
 
 import static org.kiwix.kiwixmobile.core.utils.Constants.TAG_KIWIX;
 
@@ -131,23 +132,14 @@ public class KiwixTextToSpeech {
           context.getResources().getString(R.string.tts_lang_not_supported),
           Toast.LENGTH_LONG).show();
       } else {
-        // check if voice needs to be installed for API below 21
-        if(VERSION.SDK_INT < VERSION_CODES.LOLLIPOP
-          && tts.getFeatures(locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
-          Toast.makeText(context,
-            context.getResources().getString(R.string.tts_lang_not_supported),
-            Toast.LENGTH_LONG).show();
-          return;
-        }
-
         tts.setLanguage(locale);
 
-        // check if voice needs to be installed for API 21 or higher
-        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP
-          && tts.getVoice().getFeatures().contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
-          Toast.makeText(context,
-            context.getResources().getString(R.string.tts_lang_not_supported),
-            Toast.LENGTH_LONG).show();
+        if ((VERSION.SDK_INT < VERSION_CODES.LOLLIPOP // check if voice needs to be installed for API below 21
+          && tts.getFeatures(locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED))
+          // check if voice needs to be installed for API 21 or higher
+          ||(VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP
+          && tts.getVoice().getFeatures().contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED))){
+          ContextExtensionsKt.toast(this.context,R.string.tts_lang_not_supported,Toast.LENGTH_LONG);
           return;
         }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -146,11 +146,9 @@ public class KiwixTextToSpeech {
       }
     }
   }
+  @SuppressLint("NewApi")
   private Set<String> getFeatures(TextToSpeech tts, Locale locale){
-    if(VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)
-      return tts.getFeatures(locale);
-    else
-      return tts.getVoice().getFeatures();
+    return ((VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)?tts.getFeatures(locale):tts.getVoice().getFeatures());
   }
   private void loadURL(WebView webView) {
     // We use JavaScript to get the content of the page conveniently, earlier making some

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.kiwix.kiwixmobile.core.CoreApp;
 import org.kiwix.kiwixmobile.core.R;
@@ -134,11 +135,7 @@ public class KiwixTextToSpeech {
       } else {
         tts.setLanguage(locale);
 
-        if ((VERSION.SDK_INT < VERSION_CODES.LOLLIPOP // check if voice needs to be installed for API below 21
-          && tts.getFeatures(locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED))
-          // check if voice needs to be installed for API 21 or higher
-          ||(VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP
-          && tts.getVoice().getFeatures().contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED))){
+        if (getFeatures(tts,locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
           ContextExtensionsKt.toast(this.context,R.string.tts_lang_not_supported,Toast.LENGTH_LONG);
           return;
         }
@@ -149,7 +146,9 @@ public class KiwixTextToSpeech {
       }
     }
   }
-
+  private Set<String> getFeatures(TextToSpeech tts, Locale locale){
+    return (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)? tts.getFeatures(locale) : tts.getVoice().getFeatures();
+  }
   private void loadURL(WebView webView) {
     // We use JavaScript to get the content of the page conveniently, earlier making some
     // changes in the page

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -135,8 +135,9 @@ public class KiwixTextToSpeech {
       } else {
         tts.setLanguage(locale);
 
-        if (getFeatures(tts,locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
-          ContextExtensionsKt.toast(this.context,R.string.tts_lang_not_supported,Toast.LENGTH_LONG);
+        if (getFeatures(tts, locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)) {
+          ContextExtensionsKt.toast(context, R.string.tts_lang_not_supported,
+            Toast.LENGTH_LONG);
           return;
         }
 
@@ -146,10 +147,13 @@ public class KiwixTextToSpeech {
       }
     }
   }
+
   @SuppressLint("NewApi")
-  private Set<String> getFeatures(TextToSpeech tts, Locale locale){
-    return ((VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)?tts.getFeatures(locale):tts.getVoice().getFeatures());
+  private Set<String> getFeatures(TextToSpeech tts, Locale locale) {
+    return VERSION.SDK_INT < VERSION_CODES.LOLLIPOP ? tts.getFeatures(locale)
+      : tts.getVoice().getFeatures();
   }
+
   private void loadURL(WebView webView) {
     // We use JavaScript to get the content of the page conveniently, earlier making some
     // changes in the page

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -131,7 +131,25 @@ public class KiwixTextToSpeech {
           context.getResources().getString(R.string.tts_lang_not_supported),
           Toast.LENGTH_LONG).show();
       } else {
+        // check if voice needs to be installed for API below 21
+        if(VERSION.SDK_INT < VERSION_CODES.LOLLIPOP
+          && tts.getFeatures(locale).contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
+          Toast.makeText(context,
+            context.getResources().getString(R.string.tts_lang_not_supported),
+            Toast.LENGTH_LONG).show();
+          return;
+        }
+
         tts.setLanguage(locale);
+
+        // check if voice needs to be installed for API 21 or higher
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP
+          && tts.getVoice().getFeatures().contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)){
+          Toast.makeText(context,
+            context.getResources().getString(R.string.tts_lang_not_supported),
+            Toast.LENGTH_LONG).show();
+          return;
+        }
 
         if (requestAudioFocus()) {
           loadURL(webView);

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.java
@@ -147,7 +147,10 @@ public class KiwixTextToSpeech {
     }
   }
   private Set<String> getFeatures(TextToSpeech tts, Locale locale){
-    return (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)? tts.getFeatures(locale) : tts.getVoice().getFeatures();
+    if(VERSION.SDK_INT < VERSION_CODES.LOLLIPOP)
+      return tts.getFeatures(locale);
+    else
+      return tts.getVoice().getFeatures();
   }
   private void loadURL(WebView webView) {
     // We use JavaScript to get the content of the page conveniently, earlier making some


### PR DESCRIPTION
<!--

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Linked issue #1510

<!-- Add here what changes were made in this issue and if possible provide links. -->
I added checks to see if the voice that is going to be used is available on the device or needs downloading.
if it is not available a toast informing the user that the voice needs downloading appears. if Google TTS engine is used it will automatically download the voice whenever Wifi is available.
There is a scenario where tts object adds a language `tts.setLanguage(locale);` but tts is not used again. Should I do something about this ?
