### PR TITLE
#1636 If the ZIM file tag (Vid,Pic) doesn't fit, additionally the tex…

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/TagsView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/TagsView.kt
@@ -62,5 +62,6 @@ class TagsView(context: Context, attrs: AttributeSet) : ChipGroup(context, attrs
   private fun Chip.selectBy(criteria: Boolean) {
     isChecked = criteria
     isEnabled = criteria
+    visibility = if (criteria) VISIBLE else GONE
   }
 }


### PR DESCRIPTION
…t should be stroke. - hide inactive tags

Fixes #1636