### PR TITLE
#1272 Lint Issue: MissingTranslation - make MissingTranslation a warning

### DIFF
--- a/.idea/inspectionProfiles/kiwixAndroidInspections.xml
+++ b/.idea/inspectionProfiles/kiwixAndroidInspections.xml
@@ -111,7 +111,7 @@
     <inspection_tool class="AndroidLintMissingBackupPin" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AndroidLintMissingFirebaseInstanceTokenRefresh" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AndroidLintMissingId" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintMissingTranslation" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintMissingTranslation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AndroidLintMissingVersion" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AndroidLintNegativeMargin" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AndroidLintNestedScrolling" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -101,6 +101,7 @@ class AllProjectConfigurer {
         warning(
           "UnknownNullness",
           "SelectableText",
+          "MissingTranslation",
           "IconDensities",
           "ContentDescription",
           "IconDipSize"

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -92,7 +92,6 @@ class AllProjectConfigurer {
         ignore(
           "SyntheticAccessor",
           //TODO stop ignoring below this
-          "MissingTranslation",
           "CheckResult",
           "LabelFor",
           "DuplicateStrings",


### PR DESCRIPTION
Fixes #1272

Managing or fixing MissingTranslations on our side is not feasible. As such it is marked a warning and can be listed by running lint/inspections should the list ever need to be created

