### PR TITLE
#1784 Multiple instances of MainActivity created when opening a book …

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/effects/OpenFile.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/effects/OpenFile.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.zim_manager.fileselect_view.effects
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import org.kiwix.kiwixmobile.core.R
@@ -37,6 +38,7 @@ data class OpenFile(private val bookOnDisk: BookOnDisk) :
       activity.finish()
       activity.start<KiwixMainActivity> {
         data = file.toUri()
+        flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
       }
     }
   }


### PR DESCRIPTION
…- clear top

Fixes #1784 

<!-- Add here what changes were made in this issue and if possible provide links. -->
Use CLEAR_TOP flag to bring existing activity to forefront

