### PR TITLE
Fix #1792 Change color of arrow to be grey 

### DIFF
--- a/core/src/main/res/layout/item_help.xml
+++ b/core/src/main/res/layout/item_help.xml
@@ -21,7 +21,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:contentDescription="@string/expand"
-    android:tint="@color/icons"
+    android:tint="?colorOnSurface"
     app:layout_constraintBottom_toBottomOf="@id/item_help_title"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="@id/item_help_title"

--- a/core/src/main/res/layout/item_help.xml
+++ b/core/src/main/res/layout/item_help.xml
@@ -10,7 +10,7 @@
     android:id="@+id/item_help_title"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:textAppearance="@style/TextAppearance.KiwixTheme.Headline6"
     app:layout_constraintEnd_toStartOf="@id/item_help_toggle_expand"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"

--- a/core/src/main/res/layout/item_help.xml
+++ b/core/src/main/res/layout/item_help.xml
@@ -10,7 +10,7 @@
     android:id="@+id/item_help_title"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:textAppearance="@style/TextAppearance.KiwixTheme.Headline6"
+    android:textAppearance="?textAppearanceHeadline6"
     app:layout_constraintEnd_toStartOf="@id/item_help_toggle_expand"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -3,7 +3,6 @@
   <color name="black">#000000</color>
 
   <color name="accent">#2196F3</color>
-  <color name="icons">#212121</color>
   <color name="white">#fafafa</color>
   <color name="black_regular_mat_design">#212121</color>
   <color name="grey">#5a5a5a</color>


### PR DESCRIPTION
Fixes #1792 

Changed the color of the arrow next to help questions to grey so that it is visible in the light as well as dark mode. 

**Screenshots** 

![screencap](https://user-images.githubusercontent.com/41234408/75090431-ca874f80-5588-11ea-9d52-9b335d4e38e8.png)

![screencap](https://user-images.githubusercontent.com/41234408/75090454-fa365780-5588-11ea-9b06-6787732c2166.png)