### PR TITLE
#1799 Update README with slack details

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pieces in Java).
 [![CodeFactor](https://www.codefactor.io/repository/github/kiwix/kiwix-android/badge)](https://www.codefactor.io/repository/github/kiwix/kiwix-android)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Public Chat](https://img.shields.io/badge/public-chat-green)](https://chat.kiwix.org)
+[![Slack](https://img.shields.io/badge/Slack-chat-E01E5A)](https://kiwixoffline.slack.com)
 
 ## Build Instructions
 
@@ -77,7 +78,7 @@ Available communication channels:
 * [Web Public Chat channel](https://chat.kiwix.org)
 * [Email](mailto:contact+android@kiwix.org)
 * [Mailing list](mailto:kiwix-developer@lists.sourceforge.net)
-* [Slack](https://kiwixoffline.slack.com): #android channel
+* [Slack](https://join.slack.com/t/kiwixoffline/shared_invite/enQtOTUyMTg4NzMxMTM4LTU0MzYyZDliYjdmMDYzYWMzNDA0MDc4MWE5OGM0ODFhYjAxNWIxMjVjZTU4MTkyODJlZWFkMmQ2YTZkYTUzZDY): #android channel (get an invite)
 * IRC: #kiwix on irc.freenode.net
 
 For more information, please refer to


### PR DESCRIPTION
Fixes #1799 

Updated README with Slack badge and Slack invite details.