### PR TITLE
Fix #1794 Improve README instructions about project import

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ pieces in Java).
 Production releases of the app are built on travis and released automatically
 
 To build this repository alone for development purposes you can simply
-import the project into Android Studio and the hard work will be done
-for you. If you prefer to build without Android Studio you must first
+**import** the project into Android Studio and the hard work will be done
+for you. Note here that instead of *opening* the project, you have to *import* it. If you prefer to build without Android Studio you must first
 set up the Android SDK and then run the command: `./gradlew build `
 from the root directory of the project.
 


### PR DESCRIPTION
Fixes #1794 

Highlighted a portion in the readme to make it clear that the project has to imported and built instead of opening it the regular way.