### PR TITLE
#1825: Fix search history to show Unique searches

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewRecentSearchDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewRecentSearchDao.kt
@@ -40,6 +40,7 @@ class NewRecentSearchDao @Inject constructor(
   }
 
   fun saveSearch(title: String, id: String) {
+    deleteSearchString(title)
     box.put(RecentSearchEntity(searchTerm = title, zimId = id))
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewRecentSearchDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewRecentSearchDao.kt
@@ -34,13 +34,12 @@ class NewRecentSearchDao @Inject constructor(
       orderDesc(RecentSearchEntity_.id)
     }
   ).map { searchEntities ->
-    searchEntities.distinct()
+    searchEntities.distinctBy(RecentSearchEntity::searchTerm)
       .take(NUM_RECENT_RESULTS)
       .map { searchEntity -> RecentSearchListItem(searchEntity.searchTerm) }
   }
 
   fun saveSearch(title: String, id: String) {
-    deleteSearchString(title)
     box.put(RecentSearchEntity(searchTerm = title, zimId = id))
   }
 


### PR DESCRIPTION
Fixes #1825 

### Context
- User's recent searches to be unique

### Approach
- Before saving a recent search, delete duplicates of that search title in the database.
