### PR TITLE
For #1739 Pictures are not saved in an easy accessible place

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.java
@@ -191,6 +191,7 @@ public class KiwixWebView extends VideoEnabledWebView {
       return fileName.substring(fileName.indexOf("%3A") + 1);
     }
 
+    @SuppressLint("StringFormatInvalid")
     @Override
     public void handleMessage(Message msg) {
       String url = (String) msg.getData().get("url");


### PR DESCRIPTION
For #1739 

For Android 10 we no longer have access by default to arbitrary locations on external storage or removable storage. This includes `Environment.getExternalStorageDirectory()` and other methods on `Environment` (e.g: `getExternalStoragePublicDirectory()`).
Reference [here](https://developer.android.com/reference/android/os/Environment#getExternalStorageDirectory())

In our case the target/compile sdk being less than 29 we are still able to use these deprecated methods.

So making a easily accessible media directory on the Storage (outside the package folder) is still possible, but is not suggested. As it won't work on upcoming Android versions as well, so this is will be a short-term fix.

For sdk >= 29 [this](https://developer.android.com/reference/android/provider/MediaStore.MediaColumns) should be implemented.

This is a PR which removes error for _`save_media_saved`_ being not a valid format string.

