### PR TITLE
only portrait mode for Intro activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,9 @@
         android:name="android.app.shortcuts"
         android:resource="@xml/shortcuts" />
     </activity>
-    <activity android:name=".intro.IntroActivity" />
+    <activity
+      android:name=".intro.IntroActivity"
+      android:screenOrientation="portrait" />
     <activity
       android:name=".main.KiwixMainActivity"
       android:configChanges="orientation|keyboardHidden|screenSize"


### PR DESCRIPTION

Fixes #1842 

**Explanation** 
Allow only portrait mode in UI Intro screen
