### PR TITLE
Fix #1852 Change layout when the server is stopped via notification

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
@@ -177,6 +177,8 @@ class ZimHostActivity : BaseActivity(), ZimHostCallbacks, ZimHostContract.View {
     if (ServerUtils.isServerStarted) {
       ip = ServerUtils.getSocketAddress()
       layoutServerStarted()
+    } else {
+      layoutServerStopped()
     }
   }
 


### PR DESCRIPTION
Fixes #1852 

The layout is changed back to the start server layout even when the server is stopped using the stop button in the notification. 

