### PR TITLE
Dismiss loading icon if no internet connection detected

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
@@ -137,6 +137,7 @@ class LibraryFragment : BaseFragment() {
           libraryErrorText.setText(R.string.no_network_connection)
           libraryErrorText.visibility = VISIBLE
         }
+        librarySwipeRefresh.isRefreshing = false
       }
     }
   }


### PR DESCRIPTION
Fixes #1856

It removes the loading icon when LibraryFragment is created without internet connection being available.
