### PR TITLE
Fixed: Undo Option in TabSwitcher view

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -849,10 +849,12 @@ public abstract class CoreMainActivity extends BaseActivity
     webViewList.remove(index);
     tabsAdapter.notifyItemRemoved(index);
     tabsAdapter.notifyDataSetChanged();
-    Snackbar.make(snackbarRoot, R.string.tab_closed, Snackbar.LENGTH_LONG)
+    Snackbar.make(tabSwitcherRoot, R.string.tab_closed, Snackbar.LENGTH_LONG)
       .setAction(R.string.undo, v -> {
         webViewList.add(index, tempForUndo);
         tabsAdapter.notifyItemInserted(index);
+        tabsAdapter.notifyDataSetChanged();
+        Snackbar.make(snackbarRoot,"Tab restored",Snackbar.LENGTH_SHORT).show();
         setUpWebViewWithTextToSpeech();
       })
       .show();


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1872  #1873 

<!-- Add here what changes were made in this issue and if possible provide links. -->
### Changes
Added `tabsAdapter.notifyDataSetChanged();`
And another snack bar saying **Tab Restored** to notify the user.
Passed tabSwitcherRoot in  Snackbar View.

<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
[Video Link](https://imgur.com/OfpI03u)