### PR TITLE
Fix #1894 Cursor position fixed in notes

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
@@ -376,7 +376,7 @@ public class AddNoteDialog extends DialogFragment
       }
 
       addNoteEditText.setText(contents.toString()); // Display the note content
-
+      addNoteEditText.setSelection(addNoteEditText.getText().length() - 1);
       enableShareNoteMenuItem(); // As note content exists which can be shared
     }
 


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1894 

<!-- Add here what changes were made in this issue and if possible provide links. -->

## Changes
Brought cursor to the end of saved notes


## Screenshot

[Link](https://imgur.com/Ut7g4Cg)