### PR TITLE
SearchActivity: disable animation when updating results list

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchActivity.kt
@@ -90,6 +90,7 @@ class SearchActivity : BaseActivity() {
       adapter = searchAdapter
       layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
       setHasFixedSize(true)
+      itemAnimator = null
     }
     compositeDisposable.add(searchViewModel.effects.subscribe { it.invokeWith(this) })
   }


### PR DESCRIPTION
Kiwix 3.2's new Search activity (#1696) added a fade effect to the list of
search results.

The effect is somewhat distracting and doesn't match the look and feel
of other Android applications.

I compared the search bars in Chrome, Google Play, Google Maps, YouTube,
and the Android Settings app: none of them animate when displaying results.

This patch disables the fade animation from the search screen.

----

If you prefer the animation, I can add an option to enable/disable it.

Video: [before and after](https://drive.google.com/file/d/1xqZLSJQqNxS4BmCYx6Co1I8eUro1LVnG/view?usp=sharing)
