### PR TITLE
Fix #1899 Finish action mode when shifting fragments

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
@@ -24,7 +24,6 @@ import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
-import androidx.viewpager.widget.ViewPager
 import kotlinx.android.synthetic.main.zim_manager.manageViewPager
 import kotlinx.android.synthetic.main.zim_manager.tabs
 import org.kiwix.kiwixmobile.R
@@ -38,7 +37,6 @@ import org.kiwix.kiwixmobile.core.utils.SimpleTextListener
 import org.kiwix.kiwixmobile.kiwixActivityComponent
 import org.kiwix.kiwixmobile.language.LanguageActivity
 import org.kiwix.kiwixmobile.local_file_transfer.LocalFileTransferActivity
-import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment
 import javax.inject.Inject
 
 class ZimManageActivity : BaseActivity() {
@@ -71,36 +69,13 @@ class ZimManageActivity : BaseActivity() {
       offscreenPageLimit = sectionsPagerAdapter.count - 1
       tabs.setupWithViewPager(this)
       addOnPageChangeListener(SimplePageChangeListener(::updateMenu))
-      addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
-
-        override fun onPageScrollStateChanged(state: Int) {
-          // empty method
-        }
-
-        override fun onPageScrolled(
-          position: Int,
-          positionOffset: Float,
-          positionOffsetPixels: Int
-        ) {
-          if (position == 1) {
-            val page =
-              supportFragmentManager.findFragmentByTag(
-                "android:switcher:" +
-                  R.id.manageViewPager + ":" +
-                  0
-              )
-            if (page != null) {
-              (page as ZimFileSelectFragment).finishActionMode()
-            }
-          }
-        }
-
-        override fun onPageSelected(position: Int) {
-          // empty method
-        }
-      })
+      addOnPageChangeListener(SimplePageChangeListener(::updatePage))
     }
     setViewPagerPositionFromIntent(intent)
+  }
+
+  private fun updatePage(position: Int) {
+    zimManageViewModel.currentTabIndex(position)
   }
 
   override fun onNewIntent(intent: Intent?) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
@@ -23,8 +23,8 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.viewpager.widget.ViewPager
 import kotlinx.android.synthetic.main.zim_manager.manageViewPager
 import kotlinx.android.synthetic.main.zim_manager.tabs
 import org.kiwix.kiwixmobile.R
@@ -71,6 +71,34 @@ class ZimManageActivity : BaseActivity() {
       offscreenPageLimit = sectionsPagerAdapter.count - 1
       tabs.setupWithViewPager(this)
       addOnPageChangeListener(SimplePageChangeListener(::updateMenu))
+      addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
+
+        override fun onPageScrollStateChanged(state: Int) {
+          // empty method
+        }
+
+        override fun onPageScrolled(
+          position: Int,
+          positionOffset: Float,
+          positionOffsetPixels: Int
+        ) {
+          if (position == 1) {
+            val page =
+              supportFragmentManager.findFragmentByTag(
+                "android:switcher:" +
+                  R.id.manageViewPager + ":" +
+                  0
+              )
+            if (page != null) {
+              (page as ZimFileSelectFragment).finishActionMode()
+            }
+          }
+        }
+
+        override fun onPageSelected(position: Int) {
+          // empty method
+        }
+      })
     }
     setViewPagerPositionFromIntent(intent)
   }
@@ -90,11 +118,6 @@ class ZimManageActivity : BaseActivity() {
     searchItem?.isVisible = position == 1
     languageItem?.isVisible = position == 1
     getZimItem?.isVisible = position == 0
-    if (position == 1) {
-      val fragment: Fragment?
-      fragment = ZimFileSelectFragment()
-      fragment.finishActionMode()
-    }
   }
 
   private fun setUpToolbar() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
@@ -23,6 +23,7 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import kotlinx.android.synthetic.main.zim_manager.manageViewPager
 import kotlinx.android.synthetic.main.zim_manager.tabs
@@ -37,6 +38,7 @@ import org.kiwix.kiwixmobile.core.utils.SimpleTextListener
 import org.kiwix.kiwixmobile.kiwixActivityComponent
 import org.kiwix.kiwixmobile.language.LanguageActivity
 import org.kiwix.kiwixmobile.local_file_transfer.LocalFileTransferActivity
+import org.kiwix.kiwixmobile.zim_manager.fileselect_view.ZimFileSelectFragment
 import javax.inject.Inject
 
 class ZimManageActivity : BaseActivity() {
@@ -88,6 +90,11 @@ class ZimManageActivity : BaseActivity() {
     searchItem?.isVisible = position == 1
     languageItem?.isVisible = position == 1
     getZimItem?.isVisible = position == 0
+    if (position == 1) {
+      val fragment: Fragment?
+      fragment = ZimFileSelectFragment()
+      fragment.finishActionMode()
+    }
   }
 
   private fun setUpToolbar() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageActivity.kt
@@ -75,7 +75,7 @@ class ZimManageActivity : BaseActivity() {
   }
 
   private fun updatePage(position: Int) {
-    zimManageViewModel.currentTabIndex(position)
+    zimManageViewModel.currentPage.offer(position)
   }
 
   override fun onNewIntent(intent: Intent?) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -110,7 +110,7 @@ class ZimManageViewModel @Inject constructor(
   val requestFiltering = BehaviorProcessor.createDefault<String>("")
   val currentPage = PublishProcessor.create<Int>()
 
-  val libraryFragmentIsVisible = currentPage.filter { it == 1 }
+  val libraryTabIsVisible = currentPage.filter { it == 1 }
 
   private val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -110,7 +110,7 @@ class ZimManageViewModel @Inject constructor(
   val requestFiltering = BehaviorProcessor.createDefault<String>("")
   val currentPage = PublishProcessor.create<Int>()
 
-  val libraryTabIsVisible = currentPage.filter { it == 1 }
+  val libraryTabIsVisible = currentPage.map { it == 1 }.filter { it }
 
   private val compositeDisposable = CompositeDisposable()
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -103,6 +103,7 @@ class ZimManageViewModel @Inject constructor(
   val deviceListIsRefreshing = MutableLiveData<Boolean>()
   val libraryListIsRefreshing = MutableLiveData<Boolean>()
   val networkStates = MutableLiveData<NetworkState>()
+  val currentPage = MutableLiveData<Int>()
 
   val requestFileSystemCheck = PublishProcessor.create<Unit>()
   val fileSelectActions = PublishProcessor.create<FileSelectActions>()
@@ -156,6 +157,10 @@ class ZimManageViewModel @Inject constructor(
       }
     )
   }, Throwable::printStackTrace)
+
+  fun currentTabIndex(position: Int) {
+    currentPage.value = position
+  }
 
   private fun startMultiSelectionAndSelectBook(
     bookOnDisk: BookOnDisk

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -19,9 +19,7 @@
 package org.kiwix.kiwixmobile.zim_manager
 
 import android.app.Application
-import android.content.Context
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.view.ActionMode
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.Flowable
@@ -112,6 +110,8 @@ class ZimManageViewModel @Inject constructor(
   val requestFiltering = BehaviorProcessor.createDefault<String>("")
   val currentPage = PublishProcessor.create<Int>()
 
+  val libraryFragmentIsVisible = currentPage.filter { it == 1 }
+
   private val compositeDisposable = CompositeDisposable()
 
   init {
@@ -144,12 +144,6 @@ class ZimManageViewModel @Inject constructor(
       requestsAndConnectivtyChangesToLibraryRequests(networkLibrary),
       fileSelectActions()
     )
-  }
-
-  fun actionMode(actionMode: ActionMode?) {
-    currentPage.filter { it == 1 }.subscribe {
-      actionMode?.finish()
-    }
   }
 
   private fun fileSelectActions() = fileSelectActions.subscribe({

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -19,7 +19,9 @@
 package org.kiwix.kiwixmobile.zim_manager
 
 import android.app.Application
+import android.content.Context
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.view.ActionMode
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.reactivex.Flowable
@@ -142,6 +144,12 @@ class ZimManageViewModel @Inject constructor(
       requestsAndConnectivtyChangesToLibraryRequests(networkLibrary),
       fileSelectActions()
     )
+  }
+
+  fun actionMode(actionMode: ActionMode?) {
+    currentPage.filter { it == 1 }.subscribe {
+      actionMode?.finish()
+    }
   }
 
   private fun fileSelectActions() = fileSelectActions.subscribe({

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModel.kt
@@ -103,12 +103,12 @@ class ZimManageViewModel @Inject constructor(
   val deviceListIsRefreshing = MutableLiveData<Boolean>()
   val libraryListIsRefreshing = MutableLiveData<Boolean>()
   val networkStates = MutableLiveData<NetworkState>()
-  val currentPage = MutableLiveData<Int>()
 
   val requestFileSystemCheck = PublishProcessor.create<Unit>()
   val fileSelectActions = PublishProcessor.create<FileSelectActions>()
   val requestDownloadLibrary = BehaviorProcessor.createDefault<Unit>(Unit)
   val requestFiltering = BehaviorProcessor.createDefault<String>("")
+  val currentPage = PublishProcessor.create<Int>()
 
   private val compositeDisposable = CompositeDisposable()
 
@@ -157,10 +157,6 @@ class ZimManageViewModel @Inject constructor(
       }
     )
   }, Throwable::printStackTrace)
-
-  fun currentTabIndex(position: Int) {
-    currentPage.value = position
-  }
 
   private fun startMultiSelectionAndSelectBook(
     bookOnDisk: BookOnDisk

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -112,9 +112,7 @@ class ZimFileSelectFragment : BaseFragment() {
       zimManageViewModel.fileSelectActions.offer(FileSelectActions.RestartActionMode)
     }
 
-    zimManageViewModel.currentPage.subscribe {
-      zimManageViewModel.actionMode(actionMode)
-    }
+    disposable.add(zimManageViewModel.libraryFragmentIsVisible.subscribe { actionMode?.finish() })
   }
 
   private fun sideEffects() = zimManageViewModel.sideEffects.subscribe(

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -112,11 +112,9 @@ class ZimFileSelectFragment : BaseFragment() {
       zimManageViewModel.fileSelectActions.offer(FileSelectActions.RestartActionMode)
     }
 
-    zimManageViewModel.currentPage.map { it == 1 }.subscribe { if (it) finishActionMode() }
-  }
-
-  private fun finishActionMode() {
-    actionMode?.finish()
+    zimManageViewModel.currentPage.subscribe {
+      zimManageViewModel.actionMode(actionMode)
+    }
   }
 
   private fun sideEffects() = zimManageViewModel.sideEffects.subscribe(

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -111,9 +111,15 @@ class ZimFileSelectFragment : BaseFragment() {
     if (savedInstanceState != null && savedInstanceState.getBoolean(WAS_IN_ACTION_MODE)) {
       zimManageViewModel.fileSelectActions.offer(FileSelectActions.RestartActionMode)
     }
+
+    zimManageViewModel.currentPage.observe(viewLifecycleOwner, Observer<Int> { currentPage ->
+      if (currentPage == 1) {
+        finishActionMode()
+      }
+    })
   }
 
-  fun finishActionMode() {
+  private fun finishActionMode() {
     actionMode?.finish()
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -112,11 +112,7 @@ class ZimFileSelectFragment : BaseFragment() {
       zimManageViewModel.fileSelectActions.offer(FileSelectActions.RestartActionMode)
     }
 
-    zimManageViewModel.currentPage.observe(viewLifecycleOwner, Observer<Int> { currentPage ->
-      if (currentPage == 1) {
-        finishActionMode()
-      }
-    })
+    zimManageViewModel.currentPage.map { it == 1 }.subscribe { if (it) finishActionMode() }
   }
 
   private fun finishActionMode() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -112,7 +112,11 @@ class ZimFileSelectFragment : BaseFragment() {
       zimManageViewModel.fileSelectActions.offer(FileSelectActions.RestartActionMode)
     }
 
-    disposable.add(zimManageViewModel.libraryFragmentIsVisible.subscribe { actionMode?.finish() })
+    disposable.add(zimManageViewModel.libraryTabIsVisible.subscribe { finishActionMode() })
+  }
+
+  fun finishActionMode() {
+    actionMode?.finish()
   }
 
   private fun sideEffects() = zimManageViewModel.sideEffects.subscribe(

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -113,6 +113,15 @@ class ZimFileSelectFragment : BaseFragment() {
     }
   }
 
+  override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+    super.setUserVisibleHint(isVisibleToUser)
+    if (this.isVisible) {
+      if (!isVisibleToUser) {
+        actionMode?.finish()
+      }
+    }
+  }
+
   private fun sideEffects() = zimManageViewModel.sideEffects.subscribe(
     {
       val effectResult = it.invokeWith(activity!! as AppCompatActivity)

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -115,7 +115,7 @@ class ZimFileSelectFragment : BaseFragment() {
     disposable.add(zimManageViewModel.libraryTabIsVisible.subscribe { finishActionMode() })
   }
 
-  fun finishActionMode() {
+  private fun finishActionMode() {
     actionMode?.finish()
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -113,15 +113,6 @@ class ZimFileSelectFragment : BaseFragment() {
     }
   }
 
-  /*override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-    super.setUserVisibleHint(isVisibleToUser)
-    if (this.isVisible) {
-      if (!isVisibleToUser) {
-        actionMode?.finish()
-      }
-    }
-  }*/
-
   fun finishActionMode() {
     actionMode?.finish()
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -113,13 +113,17 @@ class ZimFileSelectFragment : BaseFragment() {
     }
   }
 
-  override fun setUserVisibleHint(isVisibleToUser: Boolean) {
+  /*override fun setUserVisibleHint(isVisibleToUser: Boolean) {
     super.setUserVisibleHint(isVisibleToUser)
     if (this.isVisible) {
       if (!isVisibleToUser) {
         actionMode?.finish()
       }
     }
+  }*/
+
+  fun finishActionMode() {
+    actionMode?.finish()
   }
 
   private fun sideEffects() = zimManageViewModel.sideEffects.subscribe(

--- a/app/src/test/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModelTest.kt
@@ -519,14 +519,14 @@ class ZimManageViewModelTest {
   }
 
   @Test
-  fun `finish actionMode on tab change to online section`() {
+  fun `libraryTabIsVisible emits when currentPage is 1`() {
     viewModel.libraryTabIsVisible.test()
       .also { viewModel.currentPage.offer(1) }
-      .assertValue(1)
+      .assertValue(true)
   }
 
   @Test
-  fun `no change in actionMode`() {
+  fun `libraryTabIsVisible does not emit when currentPage is 0`() {
     viewModel.libraryTabIsVisible.test()
       .also { viewModel.currentPage.offer(0) }
       .assertEmpty()

--- a/app/src/test/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zim_manager/ZimManageViewModelTest.kt
@@ -517,4 +517,18 @@ class ZimManageViewModelTest {
         .assertValues(StartMultiSelection(viewModel.fileSelectActions))
     }
   }
+
+  @Test
+  fun `finish actionMode on tab change to online section`() {
+    viewModel.libraryTabIsVisible.test()
+      .also { viewModel.currentPage.offer(1) }
+      .assertValue(1)
+  }
+
+  @Test
+  fun `no change in actionMode`() {
+    viewModel.libraryTabIsVisible.test()
+      .also { viewModel.currentPage.offer(0) }
+      .assertEmpty()
+  }
 }


### PR DESCRIPTION
Fixes #1899 

The action mode is now finished when a user shifts from the library to the online fragment. 

**Screenshots** 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/41234408/76701134-5e5dbe80-66e4-11ea-88af-89707abc365c.gif)
