### PR TITLE
Fix #1902 Make note title completely visible

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
@@ -29,6 +29,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -155,6 +156,7 @@ public class AddNoteDialog extends DialogFragment
     disableMenuItems();
 
     addNoteTextView.setText(articleTitle);
+    addNoteTextView.setMovementMethod(new ScrollingMovementMethod());
 
     // Show the previously saved note if it exists
     displayNote();

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
@@ -29,7 +29,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -156,7 +155,6 @@ public class AddNoteDialog extends DialogFragment
     disableMenuItems();
 
     addNoteTextView.setText(articleTitle);
-    addNoteTextView.setMovementMethod(new ScrollingMovementMethod());
 
     // Show the previously saved note if it exists
     displayNote();

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -30,7 +30,7 @@
         android:paddingStart="20dp"
         android:paddingTop="10dp"
         android:paddingEnd="20dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
+        android:textAppearance="?textAppearanceSubtitle1" />
 
       <View
         android:layout_width="match_parent"

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -20,18 +20,25 @@
       android:layout_height="match_parent"
       android:orientation="vertical">
 
+      <HorizontalScrollView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:scrollbars="none">
+
       <TextView
         android:id="@+id/add_note_text_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
         android:hint="@string/wiki_article_title"
-        android:maxLines="1"
+        android:singleLine="true"
         android:paddingStart="20dp"
         android:paddingTop="10dp"
-        android:scrollbars = "vertical"
+        android:scrollHorizontally="true"
         android:paddingEnd="20dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
+
+      </HorizontalScrollView>
 
       <View
         android:layout_width="match_parent"

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -20,25 +20,17 @@
       android:layout_height="match_parent"
       android:orientation="vertical">
 
-      <HorizontalScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:scrollbars="none">
-
       <TextView
         android:id="@+id/add_note_text_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
         android:hint="@string/wiki_article_title"
-        android:singleLine="true"
+        android:maxLines="3"
         android:paddingStart="20dp"
         android:paddingTop="10dp"
-        android:scrollHorizontally="true"
         android:paddingEnd="20dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
-
-      </HorizontalScrollView>
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1" />
 
       <View
         android:layout_width="match_parent"

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -29,15 +29,14 @@
         android:maxLines="1"
         android:paddingStart="20dp"
         android:paddingTop="10dp"
+        android:scrollbars = "vertical"
         android:paddingEnd="20dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5" />
 
       <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginStart="15dp"
         android:layout_marginTop="5dp"
-        android:layout_marginEnd="15dp"
         android:layout_marginBottom="5dp"
         android:background="#000000" />
 

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -27,7 +27,7 @@
 
       <TextView
         android:id="@+id/add_note_text_view"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@android:color/transparent"
         android:hint="@string/wiki_article_title"


### PR DESCRIPTION
Fixes #1902 

The note's title can be completely visible now even if it's too long. Users can view the entire title by scrolling it. 

**Screenshot**

![screencap](https://user-images.githubusercontent.com/41234408/76881870-cc9ab080-689f-11ea-8e3d-33ff3e786979.png)