### PR TITLE
Fix #1908 Put condition to check for cancelling search to prevent incorrect toast

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -1450,6 +1450,8 @@ public abstract class CoreMainActivity extends BaseActivity
           } else {
             searchForTitle(title);
           }
+        } else if (resultCode == RESULT_CANCELED) {
+          Log.w(TAG_KIWIX, "Search cancelled or exited");
         } else {
           Log.w(TAG_KIWIX, "Unhandled search failure");
           Toast.makeText(this, R.string.search_error, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
Fixes #1908 

Added a condition to check if the search is just being canceled by the user to prevent the error toast from showing up. 