### PR TITLE
#1868 Fix app crash on tab navigation after closing tab.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -845,9 +845,11 @@ public abstract class CoreMainActivity extends BaseActivity
   }
 
   private void closeTab(int index) {
-    currentWebViewIndex = 0;
     tempForUndo = webViewList.get(index);
     webViewList.remove(index);
+    if(currentWebViewIndex >= webViewList.size()){
+      currentWebViewIndex = webViewList.size() - 1;
+    }
     tabsAdapter.notifyItemRemoved(index);
     tabsAdapter.notifyDataSetChanged();
     Snackbar.make(tabSwitcherRoot, R.string.tab_closed, Snackbar.LENGTH_LONG)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -845,6 +845,7 @@ public abstract class CoreMainActivity extends BaseActivity
   }
 
   private void closeTab(int index) {
+    currentWebViewIndex = 0;
     tempForUndo = webViewList.get(index);
     webViewList.remove(index);
     tabsAdapter.notifyItemRemoved(index);

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -847,7 +847,7 @@ public abstract class CoreMainActivity extends BaseActivity
   private void closeTab(int index) {
     tempForUndo = webViewList.get(index);
     webViewList.remove(index);
-    if(index <= currentWebViewIndex){
+    if(index <= currentWebViewIndex && currentWebViewIndex > 0){
       currentWebViewIndex--;
     }
     tabsAdapter.notifyItemRemoved(index);

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -847,8 +847,8 @@ public abstract class CoreMainActivity extends BaseActivity
   private void closeTab(int index) {
     tempForUndo = webViewList.get(index);
     webViewList.remove(index);
-    if(currentWebViewIndex >= webViewList.size()){
-      currentWebViewIndex = webViewList.size() - 1;
+    if(index <= currentWebViewIndex){
+      currentWebViewIndex--;
     }
     tabsAdapter.notifyItemRemoved(index);
     tabsAdapter.notifyDataSetChanged();


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1868

<!-- Add here what changes were made in this issue and if possible provide links. -->
The bug occurs when the `currentWebViewIndex` is the last index of the `webViewList` and a tab is closed. After any tab is closed, the `webViewList` length is reduced by one. When we then try to open any tab: `hideTabSwitcher()` is called, which in turn calls `selectTab(currentWebViewIndex)`. Since `currentWebViewIndex` is the previous last index of the `webViewList` we get an index out of bounds exception. 

To solve this I added `currentWebViewIndex = 0;` to the `closeTab()` method. This seems to fix the issue. A more robust solution might be to calculate the new index when a tab is closed but just setting it  to zero seems to work as well. 
