### PR TITLE
Fix #1918 Show only a snackbar when space is insufficient

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
@@ -42,7 +42,6 @@ import org.kiwix.kiwixmobile.core.downloader.Downloader
 import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity.Book
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.snack
-import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.DialogShower
@@ -194,14 +193,11 @@ class LibraryFragment : BaseFragment() {
   private fun onBookItemClick(item: BookItem) {
     when {
       notEnoughSpaceAvailable(item) -> {
-        context.toast(
+        libraryList.snack(
           getString(R.string.download_no_space) +
             "\n" + getString(R.string.space_available) + " " +
-            storageCalculator.calculateAvailableSpace(File(sharedPreferenceUtil.prefStorage))
-        )
-        libraryList.snack(
+            storageCalculator.calculateAvailableSpace(File(sharedPreferenceUtil.prefStorage)),
           R.string.download_change_storage,
-          R.string.open,
           ::showStorageSelectDialog
         )
         return

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -20,8 +20,10 @@ package org.kiwix.kiwixmobile.core.extensions
 
 import android.graphics.Color
 import android.view.View
+import android.widget.TextView
 import androidx.annotation.ColorInt
 import com.google.android.material.snackbar.Snackbar
+import org.kiwix.kiwixmobile.core.R
 
 fun View.snack(
   stringId: Int,
@@ -35,6 +37,23 @@ fun View.snack(
     actionStringId?.let { setAction(it) { actionClick?.invoke() } }
     setActionTextColor(actionTextColor)
   }.show()
+}
+
+fun View.snack(
+  string: String,
+  actionStringId: Int? = null,
+  actionClick: (() -> Unit)? = null,
+  @ColorInt actionTextColor: Int = Color.WHITE
+) {
+  val snackbar: Snackbar = Snackbar.make(this, string, Snackbar.LENGTH_LONG)
+  val snackbarView = snackbar.view
+  val tv = snackbarView.findViewById<TextView>(R.id.snackbar_text)
+  tv.setSingleLine(false)
+  snackbar.apply {
+    actionStringId?.let { setAction(it) { actionClick?.invoke() } }
+    setActionTextColor(actionTextColor)
+  }
+  snackbar.show()
 }
 
 fun View.snack(stringId: Int) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -38,13 +38,13 @@ fun View.snack(
 }
 
 fun View.snack(
-  string: String,
+  message: String,
   actionStringId: Int? = null,
   actionClick: (() -> Unit)? = null,
   @ColorInt actionTextColor: Int = Color.WHITE
 ) {
   Snackbar.make(
-    this, string, Snackbar.LENGTH_LONG
+    this, message, Snackbar.LENGTH_LONG
   ).apply {
     actionStringId?.let { setAction(it) { actionClick?.invoke() } }
     setActionTextColor(actionTextColor)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -20,10 +20,8 @@ package org.kiwix.kiwixmobile.core.extensions
 
 import android.graphics.Color
 import android.view.View
-import android.widget.TextView
 import androidx.annotation.ColorInt
 import com.google.android.material.snackbar.Snackbar
-import org.kiwix.kiwixmobile.core.R
 
 fun View.snack(
   stringId: Int,
@@ -45,15 +43,12 @@ fun View.snack(
   actionClick: (() -> Unit)? = null,
   @ColorInt actionTextColor: Int = Color.WHITE
 ) {
-  val snackbar: Snackbar = Snackbar.make(this, string, Snackbar.LENGTH_LONG)
-  val snackbarView = snackbar.view
-  val tv = snackbarView.findViewById<TextView>(R.id.snackbar_text)
-  tv.setSingleLine(false)
-  snackbar.apply {
+  Snackbar.make(
+    this, string, Snackbar.LENGTH_LONG
+  ).apply {
     actionStringId?.let { setAction(it) { actionClick?.invoke() } }
     setActionTextColor(actionTextColor)
-  }
-  snackbar.show()
+  }.show()
 }
 
 fun View.snack(stringId: Int) {

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -12,7 +12,6 @@
   <dimen name="webview_search_edit_text_margin_right">10dip</dimen>
   <dimen name="progressbar_layout_margin_top">300dp</dimen>
   <dimen name="fullscreen_control_button_margin">7dp</dimen>
-  <dimen name="snackbar_action_inline_max_width">128dp</dimen>
 
   <dimen name="kiwix_search_widget_margin">1dp</dimen>
   <dimen name="progress_view_height">3dp</dimen>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -12,6 +12,7 @@
   <dimen name="webview_search_edit_text_margin_right">10dip</dimen>
   <dimen name="progressbar_layout_margin_top">300dp</dimen>
   <dimen name="fullscreen_control_button_margin">7dp</dimen>
+  <dimen name="snackbar_action_inline_max_width">128dp</dimen>
 
   <dimen name="kiwix_search_widget_margin">1dp</dimen>
   <dimen name="progress_view_height">3dp</dimen>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
   <string name="delete_zim_body">Delete %s?</string>
   <string name="delete_specific_zim_toast" tools:keep="@string/delete_specific_zim_toast">File deleted</string>
   <string name="no_files_here" tools:keep="@string/no_files_here">No files here</string>
-  <string name="download_no_space" tools:keep="@string/download_no_space">Insufficient space to download this file.</string>
+  <string name="download_no_space" tools:keep="@string/download_no_space">Insufficient space to download.</string>
   <string name="space_available" tools:keep="@string/space_available">Space Available:</string>
   <string name="zim_simple">Simple</string>
   <string name="zim_no_pic">No Pictures</string>

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -17,7 +17,7 @@
     <item name="colorSecondaryVariant">?colorPrimary</item>
 
     <!--Material snackbar attributes-->
-    <item name="maxActionInlineWidth" tools:ignore="PrivateResource">@dimen/design_snackbar_action_inline_max_width</item>
+    <item name="maxActionInlineWidth">@dimen/snackbar_action_inline_max_width</item>
 
     <!--colorBackground appears behind scrollable content and is used for the default window-->
     <!--background. colorSurface is mapped to the surface of components such as cards, sheets-->

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -16,6 +16,9 @@
     <item name="colorSecondary">?colorPrimary</item>
     <item name="colorSecondaryVariant">?colorPrimary</item>
 
+    <!--Material snackbar attributes-->
+    <item name="maxActionInlineWidth" tools:ignore="PrivateResource">@dimen/design_snackbar_action_inline_max_width</item>
+
     <!--colorBackground appears behind scrollable content and is used for the default window-->
     <!--background. colorSurface is mapped to the surface of components such as cards, sheets-->
     <!--and menus. colorError is used to indicate an error state for components such as-->

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -17,7 +17,7 @@
     <item name="colorSecondaryVariant">?colorPrimary</item>
 
     <!--Material snackbar attributes-->
-    <item name="maxActionInlineWidth">@dimen/snackbar_action_inline_max_width</item>
+    <item name="maxActionInlineWidth">128dp</item>
 
     <!--colorBackground appears behind scrollable content and is used for the default window-->
     <!--background. colorSurface is mapped to the surface of components such as cards, sheets-->


### PR DESCRIPTION
Fixes #1918 

Now just a snackbar is shown with the appropriate message when storage is insufficient for downloading a zim instead of showing a toast and a snackbar both. 

**Screenshots** 

![screencap](https://user-images.githubusercontent.com/41234408/77101130-cf7ed800-6a3c-11ea-8a54-ff1261d35a03.png)
