### PR TITLE
#1949 full screen now opens after a page is loaded if it is enabled.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -847,7 +847,7 @@ public abstract class CoreMainActivity extends BaseActivity
   private void closeTab(int index) {
     tempForUndo = webViewList.get(index);
     webViewList.remove(index);
-    if(index <= currentWebViewIndex && currentWebViewIndex > 0){
+    if (index <= currentWebViewIndex && currentWebViewIndex > 0) {
       currentWebViewIndex--;
     }
     tabsAdapter.notifyItemRemoved(index);
@@ -1278,6 +1278,12 @@ public abstract class CoreMainActivity extends BaseActivity
     updateNightMode();
   }
 
+  private void openFullScreenIfEnabled() {
+    if (isInFullScreenMode()) {
+      openFullScreen();
+    }
+  }
+
   private void updateBottomToolbarVisibility() {
     if (checkNull(bottomToolbar)) {
       if (!urlIsInvalid()
@@ -1543,9 +1549,7 @@ public abstract class CoreMainActivity extends BaseActivity
       backToTopButton.hide();
     }
 
-    if (isInFullScreenMode()) {
-      openFullScreen();
-    }
+    openFullScreenIfEnabled();
     updateNightMode();
   }
 
@@ -1620,6 +1624,7 @@ public abstract class CoreMainActivity extends BaseActivity
       presenter.saveHistory(history);
     }
     updateBottomToolbarVisibility();
+    openFullScreenIfEnabled();
     updateNightMode();
   }
 


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1949

<!-- Add here what changes were made in this issue and if possible provide links. -->

`webViewUrlFinishedLoading()` did not update to full screen mode, and since it is called after onResume 
it overwrites any visibility changes to the toolbars on its `updateBottomToolbarVisibility()` call. To solve this I added `updateBottomToolbarVisibility()` after this call. 

<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
![untitled](https://user-images.githubusercontent.com/22193232/77421624-73b1a780-6dcc-11ea-9530-28a427352504.gif)