### PR TITLE
Fix #1963 Close keyboard when dialog is dismissed

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.java
@@ -136,8 +136,8 @@ public class AddNoteDialog extends DialogFragment
     toolbar.setTitle(R.string.note);
     toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);
     toolbar.setNavigationOnClickListener(v -> {
-      closeKeyboard();
       exitAddNoteDialog();
+      closeKeyboard();
     });
 
     toolbar.setOnMenuItemClickListener(item -> {


### PR DESCRIPTION
Fixes #1963 

Keyboard is now closed when the add notes dialog is closed using the close button on the top left corner. 