### PR TITLE
Fix #1824 Make night UI properly translated

### DIFF
--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -259,4 +259,7 @@
   <string name="device_default">الجهاز الافتراضي</string>
   <string name="delete_history">حذف التاريخ؟</string>
   <string name="delete_bookmarks">أزل العلامات المرجعية؟</string>
+  <string name="on">تشغيل</string>
+  <string name="off">تعطيل</string>
+  <string name="auto">تلقائي</string>
 </resources>

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -42,4 +42,7 @@
   <string name="search_history">TODO: Unclear, must be documented. See https://github.com/kiwix/overview/issues/31</string>
   <string name="save">{{Identical|Save}}</string>
   <string name="no_bookmarks">This means \"there are no bookmarks\"</string>
+  <string name="on">This is used in the settings screen to turn on the night mode.</string>
+  <string name="off">This is used in the settings screen to turn off the night mode.</string>
+  <string name="auto">This is used in the settings screen to turn the night mode on or off automatically depending upon the system settings of the phone.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -269,10 +269,13 @@
   <string name="device_default">Device Default</string>
   <string name="delete_history">Delete History?</string>
   <string name="delete_bookmarks">Delete Bookmarks?</string>
+  <string name="on">On</string>
+  <string name="off">Off</string>
+  <string name="auto">Auto</string>
   <string-array name="pref_night_modes_entries">
-    <item>On</item>
-    <item>Off</item>
-    <item>Auto</item>
+    <item>@string/on</item>
+    <item>@string/off</item>
+    <item>@string/auto</item>
   </string-array>
   <string-array name="pref_night_modes_values">
     <item>2</item>


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #1824

The strings for turning night mode on, off and automatic were earlier hardcoded. Now they are not and hence should be properly visible in all languages in which they are translated. 
