### PR TITLE
Move exact match to top of search results

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchResultGenerator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchResultGenerator.kt
@@ -40,15 +40,16 @@ class ZimSearchResultGenerator @Inject constructor(
     if (sharedPreferenceUtil.prefFullTextSearch)
       zimReaderContainer.search(it, 200).run { fullTextResults() }
     else
-      zimReaderContainer.searchSuggestions(it, 200).run { suggestionResults() }
+      zimReaderContainer.searchSuggestions(it, 200).run { suggestionResults(it) }
 
   private fun fullTextResults() = generateSequence {
     zimReaderContainer.getNextResult()?.title?.let(::ZimSearchResultListItem)
   }.filter { it.value.isNotBlank() }
     .toList()
 
-  private fun suggestionResults() = generateSequence {
+  private fun suggestionResults(searchTerm: String) = generateSequence {
     zimReaderContainer.getNextSuggestion()?.let { ZimSearchResultListItem(it.title) }
   }.distinct()
+    .sortedByDescending { it.value == searchTerm }
     .toList()
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
@@ -86,4 +86,44 @@ internal class ZimSearchResultGeneratorTest {
       .isEqualTo(listOf(ZimSearchResultListItem(validTitle)))
     verify { zimReaderContainer.searchSuggestions(searchTerm, 200) }
   }
+
+  @Test
+  internal fun `search term is moved to top of search results`() {
+    val searchTerm = "a"
+    every { sharedPreferenceUtil.prefFullTextSearch } returns false
+    every { zimReaderContainer.getNextSuggestion() } returnsMany listOf(
+      mockk<SearchSuggestion>().also { every { it.title } returns "android" },
+      mockk<SearchSuggestion>().also { every { it.title } returns "a" },
+      mockk<SearchSuggestion>().also { every { it.title } returns "abc" },
+      null
+    )
+    assertThat(zimSearchResultGenerator.generateSearchResults(searchTerm))
+      .isEqualTo(
+        listOf(
+          ZimSearchResultListItem("a"),
+          ZimSearchResultListItem("android"),
+          ZimSearchResultListItem("abc")
+        )
+      )
+    verify { zimReaderContainer.searchSuggestions(searchTerm, 200) }
+  }
+
+  @Test
+  internal fun `invalid search term does not appear in results`() {
+    val searchTerm = "invalid"
+    every { sharedPreferenceUtil.prefFullTextSearch } returns false
+    every { zimReaderContainer.getNextSuggestion() } returnsMany listOf(
+      mockk<SearchSuggestion>().also { every { it.title } returns "invalid phrase" },
+      mockk<SearchSuggestion>().also { every { it.title } returns "invalid proverb" },
+      null
+    )
+    assertThat(zimSearchResultGenerator.generateSearchResults(searchTerm))
+      .isEqualTo(
+        listOf(
+          ZimSearchResultListItem("invalid phrase"),
+          ZimSearchResultListItem("invalid proverb")
+        )
+      )
+    verify { zimReaderContainer.searchSuggestions(searchTerm, 200) }
+  }
 }


### PR DESCRIPTION
Workaround / partial solution for #2033

The search result matching the search query exactly will be moved to the top.

**Screenshots**

![Screenshot_20200427-073637](https://user-images.githubusercontent.com/25646384/80367918-e265a300-8859-11ea-84e3-0ed7ace7c0e9.jpg)