### PR TITLE
#2038 Crash Report 3.3.0: ZimFileReader.mimeTypeFromReader (ZimFileReader.java:132) 

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -126,19 +126,20 @@ class ZimFileReader constructor(
   }
 
   fun readMimeType(uri: String) = uri.removeArguments().let {
-    it.mimeType?.takeIf(String::isNotEmpty) ?: mimeTypeFromReader(it)
+    it.mimeType?.takeIf(String::isNotEmpty) ?: mimeTypeFromReader(it) ?: DEFAULT_MIME_TYPE
   }.also { Log.d(TAG, "getting mimetype for $uri = $it") }
 
+  @Suppress("TooGenericExceptionCaught")
   private fun mimeTypeFromReader(it: String) =
     try {
       jniKiwixReader.getMimeType(it.filePath)
-    } catch (illegalStateException: IllegalStateException) {
-      DEFAULT_MIME_TYPE.also {
-        Log.e(TAG, "error reading mime type", illegalStateException)
+    } catch (exception: Exception) {
+      null.also {
+        Log.e(TAG, "error reading mime type", exception)
       }
     }
       // Truncate mime-type (everything after the first space
-      .replace("^([^ ]+).*$", "$1")
+      ?.replace("^([^ ]+).*$", "$1")
 
   fun getRedirect(url: String) = "${toRedirect(url)}"
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -129,17 +129,9 @@ class ZimFileReader constructor(
     it.mimeType?.takeIf(String::isNotEmpty) ?: mimeTypeFromReader(it) ?: DEFAULT_MIME_TYPE
   }.also { Log.d(TAG, "getting mimetype for $uri = $it") }
 
-  @Suppress("TooGenericExceptionCaught")
   private fun mimeTypeFromReader(it: String) =
-    try {
-      jniKiwixReader.getMimeType(it.filePath)
-    } catch (exception: Exception) {
-      null.also {
-        Log.e(TAG, "error reading mime type", exception)
-      }
-    }
-      // Truncate mime-type (everything after the first space
-      ?.replace("^([^ ]+).*$", "$1")
+    // Truncate mime-type (everything after the first space
+    jniKiwixReader.getMimeType(it.filePath)?.replace("^([^ ]+).*$", "$1")
 
   fun getRedirect(url: String) = "${toRedirect(url)}"
 


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2038 

<!-- Add here what changes were made in this issue and if possible provide links. -->
- prevent IllegalStateException

After checking our email crash reports it seems the IllegalStateException was what kotlin thought was nonNullable returning null 
<!-- If possible, please add relevant screenshots / GIFs -->

