### PR TITLE
#1775 Kiwix does not find the ZIM files on SD-Card since Jan. Update

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.java
@@ -179,7 +179,7 @@ public class ErrorActivity extends BaseActivity {
 
         body += "\nExternal Directories\n";
         for (File externalFilesDir : ContextCompat.getExternalFilesDirs(this, null)) {
-          body += externalFilesDir != null ? externalFilesDir.getPath() : "null";
+          body += (externalFilesDir != null ? externalFilesDir.getPath() : "null") + "\n";
         }
       }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/zim_manager/MountPointProducer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/zim_manager/MountPointProducer.kt
@@ -46,6 +46,6 @@ data class MountInfo(val device: String, val mountPoint: String, val fileSystem:
   companion object {
     private val VIRTUAL_FILE_SYSTEMS = listOf("fuse", "sdcardfs")
     private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat")
-    private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat")
+    private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat", "sdfat")
   }
 }


### PR DESCRIPTION

Fixes #1775 

<!-- Add here what changes were made in this issue and if possible provide links. -->
Add sdfat to list of filesystems that can't support 4GB
Fix error in diagnostic report where external dirs weren't getting newlines appended

