### PR TITLE
Fix #2071 Update the start server dialog

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
@@ -226,9 +226,7 @@ class ZimHostActivity : BaseActivity(), ZimHostCallbacks, ZimHostContract.View {
 
     alertDialogShower.show(KiwixDialog.StartHotspotManually,
       ::launchTetheringSettingsScreen,
-      {
-        startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
-      },
+      { startActivity(Intent(Settings.ACTION_WIFI_SETTINGS)) },
       {
         progressDialog = ProgressDialog.show(
           this,

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostActivity.kt
@@ -25,6 +25,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
+import android.provider.Settings
 import android.util.Log
 import android.widget.Button
 import android.widget.TextView
@@ -225,7 +226,9 @@ class ZimHostActivity : BaseActivity(), ZimHostCallbacks, ZimHostContract.View {
 
     alertDialogShower.show(KiwixDialog.StartHotspotManually,
       ::launchTetheringSettingsScreen,
-      {},
+      {
+        startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
+      },
       {
         progressDialog = ProgressDialog.show(
           this,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/KiwixDialog.kt
@@ -91,7 +91,7 @@ sealed class KiwixDialog(
     R.string.hotspot_dialog_title,
     R.string.hotspot_dialog_message,
     R.string.go_to_settings,
-    null,
+    R.string.go_to_wifi_settings_label,
     neutralMessage = R.string.hotspot_dialog_neutral_button
   )
 

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -45,4 +45,8 @@
   <string name="on">This is used in the settings screen to turn on the night mode.</string>
   <string name="off">This is used in the settings screen to turn off the night mode.</string>
   <string name="auto">This is used in the settings screen to turn the night mode on or off automatically depending upon the system settings of the phone.</string>
+  <string name="hotspot_dialog_title">This the title displayed when a user clicks wants to start the server in the host books section</string>
+  <string name="hotspot_dialog_message">This is used in the dialog while starting a server to host books to tell the user how exactly to proceed</string>
+  <string name="go_to_settings">This is used in the start server dialog and leads the user to mobile hotspot settings when pressed</string>
+  <string name="hotspot_dialog_neutral_button">This is used in the start server dialog on pressing which the server starts if user has followed the prior guidelines</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -34,9 +34,9 @@
   <string name="hotspot_details_message">Following are the details of your local hotspot. \nSSID : %1$s \nPass : %2$s</string>
   <string name="server_textview_default_message" tools:keep="@string/server_textview_default_message">Select the files you wish to host on the server</string>
   <string name="progress_dialog_starting_server" tools:keep="@string/progress_dialog_starting_server">Starting server</string>
-  <string name="hotspot_dialog_title">Turn on your WIFI hotspot</string>
-  <string name="hotspot_dialog_message">In order for this feature to work you need to first turn on your WIFI hotspot manually.</string>
-  <string name="hotspot_dialog_neutral_button">YES, I’VE TURNED IT ON</string>
+  <string name="hotspot_dialog_title">Instructions for hosting books</string>
+  <string name="hotspot_dialog_message">In order for this feature to work you need to first turn on your WIFI hotspot manually or ensure that the host device and receiver device are on the same WiFi network</string>
+  <string name="hotspot_dialog_neutral_button">PROCEED</string>
   <string name="hotspot_channel_description" tools:keep="@string/hotspot_channel_description">Updates about the state of your hotspot/server.</string>
   <string name="hotspot_notification_content_title" tools:keep="@string/hotspot_notification_content_title">Kiwix Hotspot</string>
   <string name="start_server_label" tools:keep="@string/start_server_label">Start server</string>
@@ -259,7 +259,7 @@
   <string name="tag_short_text">Short Text</string>
   <string name="storage_permission_denied">Storage Permission Denied</string>
   <string name="grant_read_storage_permission">This app requires the ability to read storage to function. Please grant the permission in your settings</string>
-  <string name="go_to_settings">Go to Settings</string>
+  <string name="go_to_settings">Go to Hotspot Settings</string>
   <string name="no_results">No Results</string>
   <string name="no_bookmarks">No Bookmarks</string>
   <string name="no_history">No History</string>


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2071 

Update the start server dialog to give user information that books can also be hosted if the devices are on the same wifi network. 

<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 

![screencap](https://user-images.githubusercontent.com/41234408/81407730-85bb8f80-9159-11ea-9a7b-5947459e53a5.png)
