### PR TITLE
#2079 Crash Report 3.3.1: NPE MainMenu.isInTabSwitcher 

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -1450,7 +1450,7 @@ public abstract class CoreMainActivity extends BaseActivity
     switch (requestCode) {
       case MainMenuKt.REQUEST_FILE_SEARCH:
         if (resultCode == RESULT_OK) {
-          boolean wasFromTabSwitcher = mainMenu.isInTabSwitcher();
+          boolean wasFromTabSwitcher = mainMenu != null && mainMenu.isInTabSwitcher();
           hideTabSwitcher();
           String title =
             data.getStringExtra(TAG_FILE_SEARCHED).replace("<b>", "").replace("</b>", "");


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2079 

<!-- Add here what changes were made in this issue and if possible provide links. -->
- check mainMenu is not null

