### PR TITLE
#2108 Crash Report 3.3.1: java.lang.ArrayIndexOutOfBoundsException CoreMainActivity.selectTab

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.java
@@ -868,8 +868,7 @@ public abstract class CoreMainActivity extends BaseActivity
   protected void selectTab(int position) {
     currentWebViewIndex = position;
     contentFrame.removeAllViews();
-
-    KiwixWebView webView = webViewList.get(position);
+    KiwixWebView webView = safelyGetWebView(position);
     if (webView.getParent() != null) {
       ((ViewGroup) webView.getParent()).removeView(webView);
     }
@@ -884,6 +883,16 @@ public abstract class CoreMainActivity extends BaseActivity
     if (!isHideToolbar && webView instanceof ToolbarScrollingKiwixWebView) {
       ((ToolbarScrollingKiwixWebView) webView).ensureToolbarDisplayed();
     }
+  }
+
+  private KiwixWebView safelyGetWebView(int position) {
+    return webViewList.size() == 0 ? newMainPageTab() : webViewList.get(safePosition(position));
+  }
+
+  private int safePosition(int position) {
+    return position < 0 ? 0
+      : position >= webViewList.size() ? webViewList.size() - 1
+        : position;
   }
 
   protected KiwixWebView getCurrentWebView() {


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2108 
Fixes #2103  

<!-- Add here what changes were made in this issue and if possible provide links. -->
 - constrain position to be within bounds

