### PR TITLE
#2139 KiwixSettingsActivity.testStorageDialog failing consistently on API 29 emulator 

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivityTest.java
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsActivityTest.java
@@ -18,10 +18,12 @@
 
 package org.kiwix.kiwixmobile.settings;
 
+import android.Manifest;
 import android.view.View;
 import androidx.annotation.StringRes;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
 import org.hamcrest.Matcher;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Rule;
@@ -42,6 +44,12 @@ public class KiwixSettingsActivityTest {
   @Rule
   public ActivityTestRule<KiwixSettingsActivity> activityTestRule =
     new ActivityTestRule<>(KiwixSettingsActivity.class);
+  @Rule
+  public GrantPermissionRule readPermissionRule =
+    GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
+  @Rule
+  public GrantPermissionRule writePermissionRule =
+    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
   @Test
   public void testToggle() {


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2139 

<!-- Add here what changes were made in this issue and if possible provide links. -->
 - ensure storage permissions granted

<!-- If possible, please add relevant screenshots / GIFs -->


