### PR TITLE
#2161 moved isChecked to above where the onCheckedListener is set for…

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarksActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarksActivity.kt
@@ -83,10 +83,10 @@ class BookmarksActivity : OnItemClickListener, BaseActivity() {
     recycler_view.adapter = bookmarksAdapter
     recycler_view.layoutManager = LinearLayoutManager(this, RecyclerView.VERTICAL, false)
 
+    bookmarks_switch.isChecked = sharedPreferenceUtil.showBookmarksAllBooks
     bookmarks_switch.setOnCheckedChangeListener { _, isChecked ->
       bookmarkViewModel.actions.offer(Action.UserClickedShowAllToggle(isChecked))
     }
-    bookmarks_switch.isChecked = sharedPreferenceUtil.showBookmarksAllBooks
 
     compositeDisposable.add(bookmarkViewModel.effects.subscribe { it.invokeWith(this) })
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryActivity.kt
@@ -88,10 +88,10 @@ class HistoryActivity : OnItemClickListener, BaseActivity() {
     recycler_view.adapter = historyAdapter
 
     compositeDisposable.add(historyViewModel.effects.subscribe { it.invokeWith(this) })
+    history_switch.isChecked = sharedPreferenceUtil.showHistoryAllBooks
     history_switch.setOnCheckedChangeListener { _, isChecked ->
       historyViewModel.actions.offer(Action.UserClickedShowAllToggle(isChecked))
     }
-    history_switch.isChecked = sharedPreferenceUtil.showHistoryAllBooks
   }
 
   override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
… bookmarks and history activity.

<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2161 

<!-- Add here what changes were made in this issue and if possible provide links. -->
Moved `*_switch.isChecked = sharedPreferenceUtil.showHistoryAllBooks` to before `*_switch.setOnCheckedChangeListener` for History and Bookmarks activity. 