### PR TITLE
#2193 Crash Report 3.3.3: IllegalArgumentException LanguageUtils.getCurrentLocale 

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -1657,28 +1657,30 @@ public abstract class CoreReaderFragment extends BaseFragment
 
   @Override
   public void webViewUrlFinishedLoading() {
-    updateTableOfContents();
-    tabsAdapter.notifyDataSetChanged();
-    updateUrlProcessor();
-    updateBottomToolbarArrowsAlpha();
-    String url = getCurrentWebView().getUrl();
-    final ZimFileReader zimFileReader = zimReaderContainer.getZimFileReader();
-    if (hasValidFileAndUrl(url, zimFileReader)) {
-      final long timeStamp = System.currentTimeMillis();
-      SimpleDateFormat sdf =
-        new SimpleDateFormat("d MMM yyyy", LanguageUtils.getCurrentLocale(getActivity()));
-      HistoryItem history = new HistoryItem(
-        getCurrentWebView().getUrl(),
-        getCurrentWebView().getTitle(),
-        sdf.format(new Date(timeStamp)),
-        timeStamp,
-        zimFileReader
-      );
-      presenter.saveHistory(history);
+    if(isAdded()) {
+      updateTableOfContents();
+      tabsAdapter.notifyDataSetChanged();
+      updateUrlProcessor();
+      updateBottomToolbarArrowsAlpha();
+      String url = getCurrentWebView().getUrl();
+      final ZimFileReader zimFileReader = zimReaderContainer.getZimFileReader();
+      if (hasValidFileAndUrl(url, zimFileReader)) {
+        final long timeStamp = System.currentTimeMillis();
+        SimpleDateFormat sdf =
+          new SimpleDateFormat("d MMM yyyy", LanguageUtils.getCurrentLocale(getActivity()));
+        HistoryItem history = new HistoryItem(
+          getCurrentWebView().getUrl(),
+          getCurrentWebView().getTitle(),
+          sdf.format(new Date(timeStamp)),
+          timeStamp,
+          zimFileReader
+        );
+        presenter.saveHistory(history);
+      }
+      updateBottomToolbarVisibility();
+      openFullScreenIfEnabled();
+      updateNightMode();
     }
-    updateBottomToolbarVisibility();
-    openFullScreenIfEnabled();
-    updateNightMode();
   }
 
   protected boolean hasValidFileAndUrl(String url, ZimFileReader zimFileReader) {


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2193 

<!-- Add here what changes were made in this issue and if possible provide links. -->
- stop performing updates if fragment is not attached

<!-- If possible, please add relevant screenshots / GIFs -->


