### PR TITLE
#2194 Crash Report 3.3.3: ArrayIndexOutOfBoundsException: CoreReaderFragment.getCurrentWebView (CoreReaderFragment.java:932)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -928,7 +928,7 @@ public abstract class CoreReaderFragment extends BaseFragment
 
   @NotNull @Override public KiwixWebView getCurrentWebView() {
     if (webViewList.size() == 0) return newMainPageTab();
-    if (currentWebViewIndex < webViewList.size()) {
+    if (currentWebViewIndex < webViewList.size() && currentWebViewIndex > 0) {
       return webViewList.get(currentWebViewIndex);
     } else {
       return webViewList.get(0);


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2194 

<!-- Add here what changes were made in this issue and if possible provide links. -->
 - guard against negative values

<!-- If possible, please add relevant screenshots / GIFs -->
