### PR TITLE
#2230 fullscreen now works

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderFragment.kt
@@ -30,6 +30,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toFile
@@ -144,7 +145,7 @@ class ReaderFragment : CoreReaderFragment() {
   private fun setFragmentContainerBottomMarginToSizeOfNavBar() {
     val actionBarHeight = context?.getAttribute(android.R.attr.actionBarSize)
     if (actionBarHeight != null) {
-      setParentFragmentsBottomMargin(
+      setParentFragmentsBottomMarginTo(
         complexToDimensionPixelSize(
           actionBarHeight,
           resources.displayMetrics
@@ -153,9 +154,15 @@ class ReaderFragment : CoreReaderFragment() {
     }
   }
 
-  private fun setParentFragmentsBottomMargin(margin: Int) {
+  private fun setParentFragmentsBottomMarginTo(margin: Int) {
     val params = parentFragment?.view?.layoutParams as ViewGroup.MarginLayoutParams?
     params?.bottomMargin = margin
+    parentFragment?.view?.requestLayout()
+  }
+
+  private fun setParentFragmentsTopMarginTo(margin: Int) {
+    val params = parentFragment?.view?.layoutParams as ViewGroup.MarginLayoutParams?
+    params?.topMargin = margin
     parentFragment?.view?.requestLayout()
   }
 
@@ -163,7 +170,7 @@ class ReaderFragment : CoreReaderFragment() {
     super.onPause()
     // ScrollingViewWithBottomNavigationBehavior changes the margin to the size of the nav bar,
     // this resets the margin to zero, before fragment navigation.
-    setParentFragmentsBottomMargin(0)
+    setParentFragmentsBottomMarginTo(0)
   }
 
   override fun onCreateOptionsMenu(menu: Menu, menuInflater: MenuInflater) {
@@ -239,6 +246,19 @@ class ReaderFragment : CoreReaderFragment() {
       toolbarContainer, bottomToolbar, requireActivity().nav_view,
       sharedPreferenceUtil
     )
+  }
+
+  override fun openFullScreen() {
+    super.openFullScreen()
+    requireActivity().nav_view.visibility = GONE
+    setParentFragmentsBottomMarginTo(0)
+    getCurrentWebView().translationY = 0f
+  }
+
+  override fun closeFullScreen() {
+    super.closeFullScreen()
+    requireActivity().nav_view.visibility = VISIBLE
+    setFragmentContainerBottomMarginToSizeOfNavBar()
   }
 
   private fun getSharedPrefSettings() =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -1031,7 +1031,7 @@ public abstract class CoreReaderFragment extends BaseFragment
     return true;
   }
 
-  private void openFullScreen() {
+  protected void openFullScreen() {
     toolbarContainer.setVisibility(View.GONE);
     bottomToolbar.setVisibility(View.GONE);
     exitFullscreenButton.setVisibility(View.VISIBLE);
@@ -1045,7 +1045,7 @@ public abstract class CoreReaderFragment extends BaseFragment
   }
 
   @OnClick(R2.id.activity_main_fullscreen_button)
-  void closeFullScreen() {
+  protected void closeFullScreen() {
     toolbarContainer.setVisibility(View.VISIBLE);
     updateBottomToolbarVisibility();
     exitFullscreenButton.setVisibility(View.GONE);


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2230

<!-- Add here what changes were made in this issue and if possible provide links. -->
The webviews Y translation and the reader fragments bottom margin are set to 0 on openFullscreen. The bottom nav bar is also hidden on `openFullscreen` and shown on `closeFullScreen`.

The alpha does not work on the `activity_main_fullscreen_button` image button. Any ideas? It works if the background color is set with a hard coded alpha value (or if we create a new theme attribute) e.x. `#CC000000` Where CC is the alpha value. 

<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 

![untitled](https://user-images.githubusercontent.com/22193232/88525465-ea6ce480-cffa-11ea-9501-9c421f619265.gif)


