### PR TITLE
Fix crash-causing memory leak

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -25,6 +25,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import kotlinx.android.synthetic.main.fragment_destination_library.go_to_downloads_button_no_files
 import org.kiwix.kiwixmobile.R
@@ -57,6 +58,11 @@ class LocalLibraryFragment : ZimFileSelectFragment() {
 
   override fun inject(baseActivity: BaseActivity) {
     baseActivity.kiwixActivityComponent.inject(this)
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    (activity as AppCompatActivity).setSupportActionBar(null)
   }
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -57,6 +57,11 @@ class OnlineLibraryFragment : LibraryFragment(), BaseFragmentActivityExtensions 
     zimManageViewModel.requestFiltering.onNext("")
   }
 
+  override fun onDestroyView() {
+    super.onDestroyView()
+    (activity as AppCompatActivity).setSupportActionBar(null)
+  }
+
   override fun onBackPressed(activity: AppCompatActivity): BaseFragmentActivityExtensions.Super {
     getActivity()?.finish()
     return BaseFragmentActivityExtensions.Super.ShouldNotCall

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderFragment.kt
@@ -238,6 +238,11 @@ class ReaderFragment : CoreReaderFragment() {
     )
   }
 
+  override fun onDestroyView() {
+    super.onDestroyView()
+    (activity as AppCompatActivity).setSupportActionBar(null)
+  }
+
   override fun openFullScreen() {
     super.openFullScreen()
     requireActivity().bottom_nav_view.visibility = GONE

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/fileselect_view/ZimFileSelectFragment.kt
@@ -84,6 +84,11 @@ open class ZimFileSelectFragment : BaseFragment() {
     baseActivity.kiwixActivityComponent.inject(this)
   }
 
+  override fun onDestroyView() {
+    super.onDestroyView()
+    actionMode = null
+  }
+
   override fun onCreateView(
     inflater: LayoutInflater,
     container: ViewGroup?,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TableDrawerAdapter.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TableDrawerAdapter.java
@@ -72,7 +72,8 @@ public class TableDrawerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
         vh.title.setText(title);
       } else {
         String empty = context.getString(R.string.no_section_info);
-        if (context instanceof WebViewProvider) {
+        if (context instanceof WebViewProvider
+          && ((WebViewProvider) context).getCurrentWebView() != null) {
           empty = ((WebViewProvider) context).getCurrentWebView().getTitle();
         }
         vh.title.setText(empty);


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2242

<!-- Add here what changes were made in this issue and if possible provide links. -->
Because the main activities toolbar is set for each fragment and is not disposed of, the fragment reference is probably kept and the garbage collector can't collect the fragments. Setting the support action bar to null before switching fragment allows the reference to be collected and fixes the memory leak that causes tab switching to be slow and crashing. 

<!-- If possible, please add relevant screenshots / GIFs -->

