### PR TITLE
#2287 set OS's bottom navigationBar color to black

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -37,15 +37,6 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -37,6 +37,15 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/core/src/main/res/values-night/themes.xml
+++ b/core/src/main/res/values-night/themes.xml
@@ -17,5 +17,6 @@
     <item name="textSecondary">@color/mine_shaft_gray350</item>
     <item name="textTertiary">@color/mine_shaft_gray500</item>
     <item name="cardViewBackground">@color/mine_shaft_gray850</item>
+
   </style>
 </resources>

--- a/core/src/main/res/values-night/themes.xml
+++ b/core/src/main/res/values-night/themes.xml
@@ -17,6 +17,5 @@
     <item name="textSecondary">@color/mine_shaft_gray350</item>
     <item name="textTertiary">@color/mine_shaft_gray500</item>
     <item name="cardViewBackground">@color/mine_shaft_gray850</item>
-
   </style>
 </resources>

--- a/core/src/main/res/values-v21/themes.xml
+++ b/core/src/main/res/values-v21/themes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+  <style name="Base.MaterialThemeBuilder" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+
+    <item name="android:statusBarColor" tools:ignore="NewApi">@color/black</item>
+    <item name="actionModeBackground">@color/cornflower_blue</item>
+    <item name="windowActionModeOverlay">true</item>
+
+    <!--Remap legacy AppCompat attributes to MaterialComponent attributes-->
+    <item name="colorPrimaryDark">?colorPrimaryVariant</item>
+    <item name="colorAccent">?colorSecondary</item>
+
+    <!-- NavigationBar color for android OS -->
+    <item name="android:navigationBarColor">@color/black</item>
+  </style>
+</resources>

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -22,6 +22,8 @@
     <item name="textSecondary">@color/mine_shaft_gray850</item>
     <item name="textTertiary">@color/mine_shaft_gray600</item>
     <item name="cardViewBackground">@color/alabaster_white</item>
+
+
   </style>
 
   <!--Base custom theme which will be shared between both light and dark theme variants-->


### PR DESCRIPTION
<!--
#2287 - Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2287 

<!-- Add here what changes were made in this issue and if possible provide links. -->
An item for navigationBar color was added in the base theme of the app

<!-- If possible, please add relevant screenshots / GIFs -->

