### PR TITLE
#2282 Samsung exfat driver "sdfat" forbids to write big files

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/zim_manager/MountPointProducer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/zim_manager/MountPointProducer.kt
@@ -44,8 +44,8 @@ data class MountInfo(val device: String, val mountPoint: String, val fileSystem:
   val doesNotSupport4GBFiles = DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS.contains(fileSystem)
 
   companion object {
-    private val VIRTUAL_FILE_SYSTEMS = listOf("fuse", "sdcardfs")
+    private val VIRTUAL_FILE_SYSTEMS = listOf("fuse", "sdcardfs", "sdfat")
     private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat")
-    private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat", "sdfat")
+    private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat")
   }
 }


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2282 

<!-- Add here what changes were made in this issue and if possible provide links. -->
 - mark sdfat as virtual


