### PR TITLE
Feature/frans lukas/2338 fix memory leaks

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -28,6 +28,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import kotlinx.android.synthetic.main.activity_library.libraryList
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -67,6 +68,11 @@ class OnlineLibraryFragment : LibraryFragment(), FragmentActivityExtensions {
       R.id.select_language -> activity?.start<LanguageActivity>()
     }
     return super.onOptionsItemSelected(item)
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    libraryList.adapter = null
   }
 
   override fun onCreateView(

--- a/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zim_manager/library_view/LibraryFragment.kt
@@ -43,11 +43,11 @@ import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity.Book
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.utils.BookUtils
+import org.kiwix.kiwixmobile.core.utils.NetworkUtils
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.YesNoDialog.StopDownload
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.YesNoDialog.WifiOnly
-import org.kiwix.kiwixmobile.core.utils.NetworkUtils
-import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.kiwixActivityComponent
 import org.kiwix.kiwixmobile.zim_manager.NetworkState
 import org.kiwix.kiwixmobile.zim_manager.NetworkState.CONNECTED

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -730,6 +730,8 @@ public abstract class CoreReaderFragment extends BaseFragment
     hideBackToTopTimer = null;
     webViewList.clear();
     actionBar = null;
+    mainMenu = null;
+    tabRecyclerView.setAdapter(null);
     tableDrawerAdapter.setTableClickListener(null);
     tableDrawerAdapter = null;
     unbinder.unbind();

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -112,13 +112,13 @@ import org.kiwix.kiwixmobile.core.reader.ZimFileReader;
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer;
 import org.kiwix.kiwixmobile.core.search.SearchActivity;
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchInPreviousScreen;
-import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower;
 import org.kiwix.kiwixmobile.core.utils.ExternalLinkOpener;
-import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog;
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils;
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil;
 import org.kiwix.kiwixmobile.core.utils.StyleUtils;
 import org.kiwix.kiwixmobile.core.utils.UpdateUtils;
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower;
+import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog;
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils;
 
 import static android.app.Activity.RESULT_CANCELED;
@@ -728,6 +728,8 @@ public abstract class CoreReaderFragment extends BaseFragment
     tabCallback = null;
     hideBackToTopTimer.cancel();
     hideBackToTopTimer = null;
+    webViewList.clear();
+    actionBar = null;
     tableDrawerAdapter.setTableClickListener(null);
     tableDrawerAdapter = null;
     unbinder.unbind();
@@ -1655,7 +1657,8 @@ public abstract class CoreReaderFragment extends BaseFragment
         }
       }
       selectTab(currentTab);
-      webViewList.get(currentTab).loadUrl(UpdateUtils.reformatProviderUrl(urls.getString(currentTab)));
+      webViewList.get(currentTab)
+        .loadUrl(UpdateUtils.reformatProviderUrl(urls.getString(currentTab)));
       getCurrentWebView().setScrollY(positions.getInt(currentTab));
     } catch (JSONException e) {
       Log.w(TAG_KIWIX, "Kiwix shared preferences corrupted", e);


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2338

Memory leaks present in ReaderFragment and OnlineLibraryFragment were fixed. 


One leak is reproducible by the following steps: 

1. Open app.
2. Open book and go to reader.
3. Go to history.
4. Go to OS home screen. That is, minimize Kiwix. 

This leaks either the `webViewList`, or the `actionBar` in CoreReaderFragment. 

Fixed by adding:

```
    webViewList.clear();
    actionBar = null;
```
to `onDestroyView()` in CoreReader.


Another memory leak from the `OnlineLibraryFragment`.

Reproduced by:
1. Open online library fragment.
2. Go to history.
3. Minimize kiwix.

libraryAdapter seems to be the villain here. 

Edit: Fixed by setting the `libraryList` `adapter` to null in `onDestroyView`.
