### PR TITLE
bump kiwixlib version 9.4.0"

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -83,7 +83,7 @@ object Versions {
 
   const val core_ktx: String = "1.3.1"
 
-  const val kiwixlib: String = "9.3.1"
+  const val kiwixlib: String = "9.4.0"
 
   const val material: String = "1.2.0"
 


### PR DESCRIPTION
This uses the latest libzim 6.2.0 which integrates a cache system a lot better than before. Worth make it available in 3.4.