### PR TITLE
#2348 out of bounds error fixed on ip formatting.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
@@ -53,7 +53,7 @@ object ServerUtils {
   private fun formatIpForAndroidPie(ip: String): String {
     var result: String = ip
     for (i in 15..17) {
-      if (ip[i] == '.') {
+      if (i < ip.length && ip[i] == '.') {
         result = ip.substring(0, i - 2)
         break
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
@@ -36,9 +36,7 @@ object ServerUtils {
           ip += formatLocalAddress(inetAddress)
       }
       // To remove extra characters from IP for Android Pie
-      if (ip.length > 14) {
-        ip = formatIpForAndroidPie(ip)
-      }
+      ip = formatIpForAndroidPie(ip)
     } catch (e: SocketException) {
       e.printStackTrace()
       ip += "Something Wrong! $e\n"
@@ -52,10 +50,12 @@ object ServerUtils {
   @Suppress("MagicNumber")
   private fun formatIpForAndroidPie(ip: String): String {
     var result: String = ip
-    for (i in 15..17) {
-      if (i < ip.length && ip[i] == '.') {
-        result = ip.substring(0, i - 2)
-        break
+    if (ip.length > 14) {
+      for (i in 14 until ip.length) {
+        if (ip[i] == '.') {
+          result = ip.substring(0, i - 2)
+          break
+        }
       }
     }
     return result

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ServerUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ServerUtilsTest.kt
@@ -44,14 +44,8 @@ internal class ServerUtilsTest {
   @Test
   internal fun `formatIpForAndroidPie should return full ip on given ip`() {
     assertThat(
-      ServerUtils.formatIpForAndroidPie(
-        """
-      192.168.232.2
-    """.trimIndent()
-      )
-    ).isEqualTo(
-      "192.168.232.2"
-    )
+      ServerUtils.formatIpForAndroidPie("192.168.232.2")
+    ).isEqualTo("192.168.232.2")
   }
 
   @Test(expected = IllegalArgumentException::class)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ServerUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ServerUtilsTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2020 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+internal class ServerUtilsTest {
+
+  @Test
+  internal fun `formatIpForAndroidPie should return first ip occurrence of pie address`() {
+    assertThat(
+      ServerUtils.formatIpForAndroidPie(
+        """
+      fec0::15:b2ff:fe00:0
+      fec0::15d6:ece1:61fb:5b55
+      192.168.232.2
+      fec0::d8d1:9ff:fe42:160c
+      fec0::8d6e:2327:6d9f:ce75
+      192.168.200.2
+    """.trimIndent()
+      )
+    ).isEqualTo(
+      "192.168.232.2"
+    )
+  }
+
+  @Test
+  internal fun `formatIpForAndroidPie should return full ip on given ip`() {
+    assertThat(
+      ServerUtils.formatIpForAndroidPie(
+        """
+      192.168.232.2
+    """.trimIndent()
+      )
+    ).isEqualTo(
+      "192.168.232.2"
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  internal fun `formatIpForAndroidPie should throw invalid argument exception on invalid ip`() {
+    ServerUtils.formatIpForAndroidPie("invalid ip")
+  }
+}


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2348

<!-- Add here what changes were made in this issue and if possible provide links. -->
Made the `formatIpForAndroidPie` function not iterate out of bounds. What is the purpose of this function? Given the input `"192.168.10.141.1"` it returns `"192.168.10.1"` which seems might broken, not that it would ever get `"192.168.10.141.1"`. 

