### PR TITLE
#2104 CrashReport 3.3.1: java.lang.NullPointerException FileUtils.contentQuery

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -144,6 +144,8 @@ object FileUtils {
         }
     } catch (ignore: SecurityException) {
       null
+    } catch (ignore: NullPointerException) {
+      null
     }
   }
 


### PR DESCRIPTION


<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2104 

<!-- Add here what changes were made in this issue and if possible provide links. -->
 - catch NPE

<!-- If possible, please add relevant screenshots / GIFs -->

