### PR TITLE
Feature/frans lukas/2378 fix search keyboard

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
@@ -18,6 +18,8 @@
 
 package org.kiwix.kiwixmobile.core.extensions
 
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
@@ -33,4 +35,13 @@ fun Fragment.toast(
   length: Int = Toast.LENGTH_LONG
 ) {
   requireActivity().toast(stringId, length)
+}
+
+fun Fragment.closeKeyboard() {
+  val inputMethodManager =
+    requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+  inputMethodManager.toggleSoftInput(
+    InputMethodManager.HIDE_IMPLICIT_ONLY,
+    0
+  )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
@@ -30,18 +30,12 @@ inline fun <reified T : ViewModel> Fragment.viewModel(
   viewModelFactory: ViewModelProvider.Factory
 ) = ViewModelProviders.of(this, viewModelFactory).get(T::class.java)
 
-fun Fragment.toast(
-  stringId: Int,
-  length: Int = Toast.LENGTH_LONG
-) {
+fun Fragment.toast(stringId: Int, length: Int = Toast.LENGTH_LONG) {
   requireActivity().toast(stringId, length)
 }
 
 fun Fragment.closeKeyboard() {
   val inputMethodManager =
     requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-  inputMethodManager.toggleSoftInput(
-    InputMethodManager.HIDE_IMPLICIT_ONLY,
-    0
-  )
+  inputMethodManager.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -42,6 +42,7 @@ import kotlinx.android.synthetic.main.layout_toolbar.toolbar
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -259,15 +260,6 @@ class AddNoteDialog : DialogFragment() {
     val inputMethodManager =
       requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
-  }
-
-  private fun closeKeyboard() {
-    val inputMethodManager =
-      requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    inputMethodManager.toggleSoftInput(
-      InputMethodManager.HIDE_IMPLICIT_ONLY,
-      0
-    )
   }
 
   private fun saveNote(noteText: String) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -38,6 +38,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
+import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.setDistinctDisplayedChild
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -118,9 +119,10 @@ class SearchFragment : BaseFragment() {
     }
   }
 
-  override fun onDestroy() {
+  override fun onDestroyView() {
+    super.onDestroyView()
     compositeDisposable.clear()
-    super.onDestroy()
+    closeKeyboard()
   }
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {


### PR DESCRIPTION
Fixes #2378 

<!-- Add here what changes were made in this issue and if possible provide links. -->
`closeKeyboard()` was moved to FragmentExtensions.
Keyboard now closes on fragment exit (from searchFragment).
