### PR TITLE
#2308 duplicate page fragments will no longer occur.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -125,8 +125,6 @@ import static org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions.Super.S
 import static org.kiwix.kiwixmobile.core.downloader.fetch.FetchDownloadNotificationManagerKt.DOWNLOAD_NOTIFICATION_TITLE;
 import static org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem;
 import static org.kiwix.kiwixmobile.core.utils.AnimationUtils.rotate;
-import static org.kiwix.kiwixmobile.core.utils.ConstantsKt.EXTRA_CHOSE_X_TITLE;
-import static org.kiwix.kiwixmobile.core.utils.ConstantsKt.EXTRA_CHOSE_X_URL;
 import static org.kiwix.kiwixmobile.core.utils.ConstantsKt.REQUEST_STORAGE_PERMISSION;
 import static org.kiwix.kiwixmobile.core.utils.ConstantsKt.REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE;
 import static org.kiwix.kiwixmobile.core.utils.ConstantsKt.TAG_CURRENT_ARTICLES;
@@ -408,14 +406,6 @@ public abstract class CoreReaderFragment extends BaseFragment
       searchForTitle(intent.getStringExtra(TAG_FILE_SEARCHED),
         openInNewTab);
       selectTab(webViewList.size() - 1);
-    }
-    if (intent.hasExtra(EXTRA_CHOSE_X_URL)) {
-      newMainPageTab();
-      loadUrlWithCurrentWebview(intent.getStringExtra(EXTRA_CHOSE_X_URL));
-    }
-    if (intent.hasExtra(EXTRA_CHOSE_X_TITLE)) {
-      newMainPageTab();
-      loadUrlWithCurrentWebview(intent.getStringExtra(EXTRA_CHOSE_X_TITLE));
     }
     handleNotificationIntent(intent);
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/OpenPage.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/OpenPage.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
@@ -30,6 +31,7 @@ data class OpenPage(
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     activity as CoreMainActivity
+    activity.popNavigationBackstack()
     if (page.zimFilePath != zimReaderContainer.zimCanonicalPath) {
       activity.openPage(page.url, page.zimFilePath!!)
     } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
@@ -23,14 +23,6 @@ const val CONTACT_EMAIL_ADDRESS = "android@kiwix.org"
 // Request stuff
 const val REQUEST_STORAGE_PERMISSION = 1
 const val REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE = 3
-const val REQUEST_HISTORY_ITEM_CHOSEN = 99
-const val REQUEST_FILE_SELECT = 1234
-const val REQUEST_PREFERENCES = 1235
-const val BOOKMARK_CHOSEN_REQUEST = 1
-
-// Result stuff
-const val RESULT_RESTART = 1236
-const val RESULT_HISTORY_CLEARED = 1239
 
 // Tags
 const val TAG_FILE_SEARCHED = "searchedarticle"
@@ -42,12 +34,6 @@ const val TAG_CURRENT_TAB = "currenttab"
 const val TAG_FROM_TAB_SWITCHER = "fromtabswitcher"
 
 // Extras
-const val EXTRA_ZIM_FILE = "zimFile"
-const val EXTRA_CHOSE_X_URL = "choseXURL"
-const val EXTRA_CHOSE_X_TITLE = "choseXTitle"
-const val EXTRA_CHOSE_X_FILE = "choseXFile"
-const val EXTRA_SEARCH = "search"
 const val EXTRA_IS_WIDGET_VOICE = "isWidgetVoice"
 const val HOTSPOT_SERVICE_CHANNEL_ID = "hotspotService"
-const val EXTRA_WEBVIEWS_LIST = "webviewsList"
 const val OLD_PROVIDER_DOMAIN = "org.kiwix.zim.base"

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/OpenPageTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/OpenPageTest.kt
@@ -18,28 +18,23 @@
 
 package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
-import android.content.Intent
-import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.page.PageImpl
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
-import org.kiwix.kiwixmobile.core.utils.EXTRA_CHOSE_X_FILE
-import org.kiwix.kiwixmobile.core.utils.EXTRA_CHOSE_X_URL
 
 internal class OpenPageTest {
-  val page = PageImpl()
+  private val page = PageImpl()
   private val zimReaderContainer: ZimReaderContainer = mockk()
-  val activity: CoreMainActivity = mockk(relaxed = true)
-  val intent: Intent = mockk()
+  val activity: CoreMainActivity = mockk()
 
-  init {
-    mockkConstructor(Intent::class)
-    every { anyConstructed<Intent>().putExtra(EXTRA_CHOSE_X_URL, page.url) } returns intent
+  @BeforeEach
+  internal fun setUp() {
+    every { activity.navController.popBackStack() } returns true
   }
 
   @Test
@@ -49,13 +44,11 @@ internal class OpenPageTest {
     verify {
       activity.openPage(page.url)
     }
-    confirmVerified(intent)
   }
 
   @Test
   fun `invokeWith navigates to page with historyUrl and zimFilePath`() {
     every { zimReaderContainer.zimCanonicalPath } returns "notZimFilePath"
-    every { intent.putExtra(EXTRA_CHOSE_X_FILE, page.zimFilePath) } returns intent
     OpenPage(page, zimReaderContainer).invokeWith(activity)
     verify {
       activity.openPage(page.url, page.zimFilePath!!)


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2308

<!-- Add here what changes were made in this issue and if possible provide links. -->

The page fragment was not popped from the fragment backstack when a page was opened. This is now fixed, which fixes the back button in the top action bar from requiring double taps if two page fragments are active. 
<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
