### PR TITLE
Changing FileReader usage to extension function readAssetAsText (file renamed to AssetUtils)

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/core/main/AssetUtilsKtTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/core/main/AssetUtilsKtTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2020 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.main
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AssetUtilsKtTest {
+
+  val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+  @Test
+  fun readAssetAsText_withValidFile_assertContentReturns() {
+    val fileContent = context.readAssetAsText("js/documentParser.js")
+    assertTrue(fileContent.isNotEmpty())
+  }
+
+  @Test
+  fun readAssetAsText_withFileNotFound_assertEmptyContentReturnsAndNoThrowException() {
+    val fileContent = context.readAssetAsText("js/someFileThatWontBeFound.js")
+    assertTrue(fileContent.isEmpty())
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AssetUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AssetUtils.kt
@@ -15,18 +15,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+@file:JvmName("AssetUtils")
+
 package org.kiwix.kiwixmobile.core.main
 
 import android.content.Context
 import java.io.BufferedReader
 import java.io.IOException
 
-class FileReader {
-  fun readFile(filePath: String?, context: Context): String = try {
-    context.assets.open(filePath)
-      .bufferedReader()
-      .use(BufferedReader::readText)
-  } catch (e: IOException) {
-    "".also { e.printStackTrace() }
-  }
+fun Context.readAssetAsText(assetPath: String): String = try {
+  assets.open(assetPath)
+    .bufferedReader()
+    .use(BufferedReader::readText)
+} catch (e: IOException) {
+  "".also { e.printStackTrace() }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -488,7 +488,7 @@ public abstract class CoreReaderFragment extends BaseFragment
   }
 
   private void addFileReader() {
-    documentParserJs = new FileReader().readFile("js/documentParser.js", getActivity());
+    documentParserJs = AssetUtils.readAssetAsText(requireActivity(), "js/documentParser.js");
     documentSections = new ArrayList<>();
   }
 


### PR DESCRIPTION
Fixes #2331

<!-- Add here what changes were made in this issue and if possible provide links. -->
`FileReader` class changed to a single extension function `readAssetAsText` as [suggested here](https://github.com/kiwix/kiwix-android/issues/2331#issuecomment-680761572).
I've created an instrumented test for it, and also renamed the file from `FileReader.kt` -> `AssetUtils.kt` to reflect better what is the type of file which can be read using this function.

**Screenshots** 

Not sure if the screenshot is relevant, but everything seems to be working fine 😅 

<img width="460" src="https://user-images.githubusercontent.com/841984/96154910-b3b1b680-0ee5-11eb-8155-0f3031522320.png"/>
