### PR TITLE
CI: Upload Reports to GH Actions even on check failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Upload Coverage to GH-Actions
         uses: actions/upload-artifact@v2.2.0
+        if: ${{ always()  }}
         with:
           name: Tests Coverage Report
           path: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Upload Static Analysis Report
         uses: actions/upload-artifact@v2.2.0
+        if: ${{ always() }}
         with:
           name: Static Analysis Report
           path: |


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2504 

<!-- Add here what changes were made in this issue and if possible provide links. -->

Added the `always` condition for upload steps/jobs.
<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
NA