### PR TITLE
bug/gouri-panda/2534 WikiMedia AR app doesn't start interface very well

### DIFF
--- a/custom/src/main/res/drawable-night-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-night-v23/launch_screen.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/custom/src/main/res/drawable-night-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-night-v23/launch_screen.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Kiwix Android
   ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
   ~ This program is free software: you can redistribute it and/or modify

--- a/custom/src/main/res/drawable-night-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-night-v23/launch_screen.xml
@@ -17,6 +17,15 @@
   ~
   -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+  android:opacity="opaque">
+  <!-- The background color, preferably the same as your normal theme -->
+  <item android:drawable="@color/alabaster_white" />
+  <item
+    android:bottom="24dp"
+    android:drawable="@mipmap/ic_launcher"
+    android:gravity="center"
+    android:left="24dp"
+    android:right="24dp"
+    android:top="24dp" />
+</layer-list>

--- a/custom/src/main/res/drawable-night/launch_screen.xml
+++ b/custom/src/main/res/drawable-night/launch_screen.xml
@@ -21,11 +21,8 @@
   android:opacity="opaque">
   <!-- The background color, preferably the same as your normal theme -->
   <item android:drawable="@color/mine_shaft_gray900" />
-  <item
-    android:bottom="24dp"
-    android:drawable="@mipmap/ic_launcher"
-    android:gravity="center"
-    android:left="24dp"
-    android:right="24dp"
-    android:top="24dp" />
+  <item>
+    <bitmap android:src="@mipmap/ic_launcher"
+      android:gravity="center"/>
+  </item>
 </layer-list>

--- a/custom/src/main/res/drawable-night/launch_screen.xml
+++ b/custom/src/main/res/drawable-night/launch_screen.xml
@@ -6,7 +6,7 @@
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
   ~ (at your option) any later version.
-  ~
+
   ~ This program is distributed in the hope that it will be useful,
   ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
   ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/custom/src/main/res/drawable-night/launch_screen.xml
+++ b/custom/src/main/res/drawable-night/launch_screen.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Kiwix Android
   ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
   ~ This program is free software: you can redistribute it and/or modify
@@ -22,7 +21,8 @@
   <!-- The background color, preferably the same as your normal theme -->
   <item android:drawable="@color/mine_shaft_gray900" />
   <item>
-    <bitmap android:src="@mipmap/ic_launcher"
-      android:gravity="center"/>
+    <bitmap
+      android:gravity="center"
+      android:src="@mipmap/ic_launcher" />
   </item>
 </layer-list>

--- a/custom/src/main/res/drawable-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-v23/launch_screen.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+</selector>

--- a/custom/src/main/res/drawable-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-v23/launch_screen.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Kiwix Android
   ~ Copyright (c) 2020 Kiwix <android.kiwix.org>
   ~ This program is free software: you can redistribute it and/or modify

--- a/custom/src/main/res/drawable-v23/launch_screen.xml
+++ b/custom/src/main/res/drawable-v23/launch_screen.xml
@@ -17,6 +17,15 @@
   ~
   -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-</selector>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+  android:opacity="opaque">
+  <!-- The background color, preferably the same as your normal theme -->
+  <item android:drawable="@color/alabaster_white" />
+  <item
+    android:bottom="24dp"
+    android:drawable="@mipmap/ic_launcher"
+    android:gravity="center"
+    android:left="24dp"
+    android:right="24dp"
+    android:top="24dp" />
+</layer-list>

--- a/custom/src/main/res/drawable/launch_screen.xml
+++ b/custom/src/main/res/drawable/launch_screen.xml
@@ -22,7 +22,8 @@
   <!-- The background color, preferably the same as your normal theme -->
   <item android:drawable="@color/alabaster_white" />
   <item>
-    <bitmap android:src="@mipmap/ic_launcher"
-      android:gravity="center"/>
+    <bitmap
+      android:gravity="center"
+      android:src="@mipmap/ic_launcher" />
   </item>
 </layer-list>

--- a/custom/src/main/res/drawable/launch_screen.xml
+++ b/custom/src/main/res/drawable/launch_screen.xml
@@ -21,11 +21,8 @@
   android:opacity="opaque">
   <!-- The background color, preferably the same as your normal theme -->
   <item android:drawable="@color/alabaster_white" />
-  <item
-    android:bottom="24dp"
-    android:drawable="@mipmap/ic_launcher"
-    android:gravity="center"
-    android:left="24dp"
-    android:right="24dp"
-    android:top="24dp" />
+  <item>
+    <bitmap android:src="@mipmap/ic_launcher"
+      android:gravity="center"/>
+  </item>
 </layer-list>


### PR DESCRIPTION
Fixes #2534 
Note: The only problem is that it shows perfectly on the device that stretched before but it doesn’t show(i.e splash screen) at all on not stretched before

