### PR TITLE
#2545 New Tabs & recreation is loading home page on other tabs 

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -251,7 +251,9 @@ class KiwixReaderFragment : CoreReaderFragment() {
     val zimFile = settings.getString(TAG_CURRENT_FILE, null)
 
     if (zimFile != null) {
-      openZimFile(File(zimFile))
+      if (zimReaderContainer.zimFile == null) {
+        openZimFile(File(zimFile))
+      }
     } else {
       getCurrentWebView().snack(R.string.zim_not_opened)
     }


### PR DESCRIPTION

<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Partial #2545 

<!-- Add here what changes were made in this issue and if possible provide links. -->
- simplify tab restoration

This does not address the images of tabs being blank post restoration, however selecting one tab will restore the others

<!-- If possible, please add relevant screenshots / GIFs -->