### PR TITLE
Small translation correction

### DIFF
--- a/core/src/main/res/values-gl/strings.xml
+++ b/core/src/main/res/values-gl/strings.xml
@@ -113,7 +113,7 @@
   <string name="time_hour">h</string>
   <string name="time_minute">min</string>
   <string name="time_second">s</string>
-  <string name="time_left">esquerda</string>
+  <string name="time_left">restante</string>
   <string name="pref_external_link_popup_title">Avisar cando introducir ligazóns externas</string>
   <string name="pref_external_link_popup_summary">Mostra as previsualizacións de páxinas para avisar sobre os custos adicionais ou cando non funciona en ligazóns desconectadas.</string>
   <string name="external_link_popup_dialog_title" fuzzy="true">Introducindo ligazón externa</string>


### PR DESCRIPTION
Ex: "1 min esquerda"

Should be "1 min restante".