### PR TITLE
Small translation correction

### DIFF
--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -125,7 +125,7 @@
   <string name="time_hour">h</string>
   <string name="time_minute">min</string>
   <string name="time_second">s</string>
-  <string name="time_left">esquerda</string>
+  <string name="time_left">restante</string>
   <string name="pref_external_link_popup_title">Avisar quando introduzir hiperligações externas</string>
   <string name="pref_external_link_popup_summary">Mostrar os cartões flutuantes para avisar sobre os custos adicionais ou quando não funcionar nas hiperligações quando desligadas.</string>
   <string name="external_link_popup_dialog_title" fuzzy="true">Hiperligação externa de entrada</string>


### PR DESCRIPTION
Ex: "1 min esquerda"

Should be "1 min restante".