### PR TITLE
Small translation correction

### DIFF
--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -154,7 +154,7 @@
   <string name="time_hour">h</string>
   <string name="time_minute">min</string>
   <string name="time_second">s</string>
-  <string name="time_left">esquerda</string>
+  <string name="time_left">restante</string>
   <string name="time_today">Hoje</string>
   <string name="time_yesterday">Ontem</string>
   <string name="pref_external_link_popup_title">Avisar ao inserir links externos</string>


### PR DESCRIPTION
Ex: "1 min esquerda"

Should be "1 min restante".
