### PR TITLE
Adds disable_external_links to build options

### DIFF
--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -34,7 +34,8 @@ data class CustomApp(
   val versionName: String,
   val disableSideBar: Boolean = false,
   val disableTabs: Boolean = false,
-  val disableReadAloud: Boolean = false
+  val disableReadAloud: Boolean = false,
+  val disableExternalLinks: Boolean = false
 ) {
   constructor(name: String, parsedJson: JSONObject) : this(
     name,
@@ -44,7 +45,8 @@ data class CustomApp(
     readVersionOrInfer(parsedJson),
     parsedJson.getAndCast("disable_sidebar") ?: false,
     parsedJson.getAndCast("disable_tabs") ?: false,
-    parsedJson.getAndCast("disable_read_aloud") ?: false
+    parsedJson.getAndCast("disable_read_aloud") ?: false,
+    parsedJson.getAndCast("disable_external_links") ?: false
   )
 
   val versionCode: Int = formatCurrentDate("YYDDD0").toInt()

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -49,6 +49,7 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       buildConfigField("Boolean", "DISABLE_SIDEBAR", "${customApp.disableSideBar}")
       buildConfigField("Boolean", "DISABLE_TABS", "${customApp.disableTabs}")
       buildConfigField("Boolean", "DISABLE_READ_ALOUD", "${customApp.disableReadAloud}")
+      buildConfigField("Boolean", "DISABLE_EXTERNAL_LINKS", "${customApp.disableExternalLinks}")
       configureStrings(customApp.displayName)
     }
   }

--- a/custom/src/customexample/info.json
+++ b/custom/src/customexample/info.json
@@ -4,6 +4,7 @@
   "enforced_lang": "en",
   "disable_sidebar": false,
   "disable_tabs": false,
-  "disable_read_aloud": false
+  "disable_read_aloud": false,
+  "disable_external_links": false
 }
 

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -240,4 +240,10 @@ class CustomReaderFragment : CoreReaderFragment() {
   override fun createNewTab() {
     newMainPageTab()
   }
+
+  override fun openExternalUrl(intent: Intent?) {
+    if (!BuildConfig.DISABLE_EXTERNAL_LINKS) {
+      super.openExternalUrl(intent)
+    }
+  }
 }


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #2023 

<!-- Add here what changes were made in this issue and if possible provide links. -->

This pull request adds the option to entirely disable the ability to open external links in custom apps. 

<!-- If possible, please add relevant screenshots / GIFs -->

