### PR TITLE
Bump-up fetch to 3.1.6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install NDK
+        run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;22.0.7026061" --sdk_root=${ANDROID_SDK_ROOT}
+
       - name: Build all configurations
         run: ./gradlew assemble
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -59,7 +59,7 @@ object Versions {
 
   const val junit_jupiter: String = "5.7.0"
 
-  const val xfetch2okhttp: String = "3.1.5"
+  const val xfetch2okhttp: String = "3.1.6"
 
   const val assertj_core: String = "3.18.1"
 
@@ -93,7 +93,7 @@ object Versions {
 
   const val barista: String = "2.7.1" // available: "3.7.0"
 
-  const val xfetch2: String = "3.1.5"
+  const val xfetch2: String = "3.1.6"
 
   const val jsr305: String = "3.0.2"
 


### PR DESCRIPTION
Many users complain that downloads get stuck in the middle since latest release of Kiwix 3.4.3. Considering that we have updated to Fetch 3.1.5, this might be the cause of the regression. Updating to the latest version.