### PR TITLE
Added Update for Detekt Dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation("com.hiya:jacoco-android:0.2")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:9.2.1")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev129-1.25.0")
-  implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1")
+  implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.10.0")
 
   implementation(gradleApi())
   implementation(localGroovy())


### PR DESCRIPTION
## Description:

Updated the Detekt Dependency from version `1.9.1` to version `1.10.0` which was released on July 7th, 2020. Also tested and verified with various scenarios while running the app.