### PR TITLE
Added update for Jlleitschuh Gradle Ktlint dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,9 +14,9 @@ dependencies {
   implementation("com.android.tools.build:gradle:4.0.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
   implementation("com.hiya:jacoco-android:0.2")
-  implementation("org.jlleitschuh.gradle:ktlint-gradle:9.2.1")
+  implementation("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev129-1.25.0")
-  implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1")
+  implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.10.0")
 
   implementation(gradleApi())
   implementation(localGroovy())


### PR DESCRIPTION
## Description:

Added update for the Jlleitschuh Gradle Ktlint dependency from version `9.2.1` to version `9.4.0` which was released on October 7th, 2020. Also tested and verified in various scenarios while running the app.