### PR TITLE
2566 re-anchor diagnostic activity buttons

### DIFF
--- a/core/src/main/res/layout/activity_kiwix_error.xml
+++ b/core/src/main/res/layout/activity_kiwix_error.xml
@@ -33,7 +33,7 @@
     android:background="@color/alabaster_white"
     android:text="@string/crash_button_confirm"
     app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintEnd_toStartOf="@+id/restartButton"
     app:layout_constraintHorizontal_bias="0.173"
     app:layout_constraintStart_toStartOf="parent" />
 
@@ -41,14 +41,13 @@
     android:id="@+id/restartButton"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginStart="8dp"
     android:layout_marginEnd="8dp"
     android:layout_marginBottom="32dp"
     android:text="@string/no_thanks"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="0.769"
-    app:layout_constraintStart_toStartOf="parent" />
+    app:layout_constraintStart_toEndOf="@+id/reportButton" />
 
   <TextView
     android:id="@+id/textView2"


### PR DESCRIPTION
Fixes #2566

Hello, the buttons are anchored to each other and the outside of the parent, so they should be visible now and not overlap.  The other issue in the checkbox list of details does scroll, but the window is small since the text is maximized.  Just touch and drag and you'll see it move.

