### PR TITLE
Fixes Search Kiwix is just redirecting to kiwix

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.java
@@ -1219,9 +1219,7 @@ public abstract class CoreReaderFragment extends BaseFragment
   private void handleIntentActions(Intent intent) {
     Log.d(TAG_KIWIX, "action" + getActivity().getIntent().getAction());
     if (intent.getAction() != null) {
-      if (zimReaderContainer.getId() != null) {
-        startIntentBasedOnAction(intent);
-      }
+      startIntentBasedOnAction(intent);
     }
   }
 


### PR DESCRIPTION
Fixes #2398 

Note: In order to successfully create the bug you have to completely kill the `kiwix-android` app, and start searching from another app as in the issue mentioned.