### PR TITLE
ci: Bump RC version to accept API-29 SDK license

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 1
 
       - name: run instrumentation tests
-        uses: ReactiveCircus/android-emulator-runner@v2.14.3
+        uses: ReactiveCircus/android-emulator-runner@v2.19.1
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #

<!-- Add here what changes were made in this issue and if possible provide links. -->

**Problem fixed:**
Again nightly builds were failing for a long time. Turned out, there were some changes made in API27+ SDK's installation from CLI which required user to _manually_ accept the license, which wasn't the case earlier.
Find failing builds here: [actions/nightly](https://github.com/kiwix/kiwix-android/actions/workflows/nightly.yml)
<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
NA