### PR TITLE
Supported external links in android 11 and higher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,14 @@
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
+  </queries>
+
   <application
     android:name=".KiwixApp"
     android:allowBackup="true"


### PR DESCRIPTION

Fixes #2693 

Starting with API level 30, if the application is targeting that version or higher, the app can't see, or directly interact with, most external packages without explicitly requesting allowance, either through a blanket QUERY_ALL_PACKAGES permission, or by including an appropriate <queries> element in your manifest. More info [here](https://developer.android.com/training/package-visibility)

Note:
Here I added all the browsable links. If we want to query appropriate links we can do that. IMO we should redirect all the links to the browser.
