### PR TITLE
Fixes play store language issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,7 +63,13 @@ android {
       }
     }
   }
-
+  bundle {
+    language {
+      // This is disabled so that the App Bundle does NOT split the APK for each language.
+      // We're gonna use the same APK for all languages.
+      enableSplit = false
+    }
+  }
   sourceSets {
     getByName("androidTest") {
       java.srcDirs("$rootDir/core/src/sharedTestFunctions/java")


### PR DESCRIPTION
Fixes #2704 
  The language is disabled so that the App Bundle does NOT split the APK for each language. We're gonna use the same APK for all languages.
