### PR TITLE
Removed `publishReleaseApk` to `assembleRelease` in download.kiwix.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           UNIVERSAL_RELEASE_APK: app/build/outputs/apk/release/*universal*.apk
         run: |
-          ./gradlew publishReleaseApk
+          ./gradlew assembleRelease
           cp $UNIVERSAL_RELEASE_APK kiwix-${TAG}.apk
           scp -vrp -i ssh_key -o StrictHostKeyChecking=no kiwix-${TAG}.apk ci@download.kiwix.org:/data/download/release/kiwix-android/
 


### PR DESCRIPTION
Due to version duplicates, we can't publish APK and bundle twice.