### PR TITLE
Added `MANAGE_EXTERNAL_STORAGE` permission for Android 11 and later

### DIFF
--- a/app/detekt_baseline.xml
+++ b/app/detekt_baseline.xml
@@ -11,7 +11,7 @@
     <ID>MagicNumber:ShareFiles.kt$ShareFiles$24</ID>
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$5</ID>
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$500</ID>
-    <ID>MagicNumber:ZimHostFragment.kt$ZimHostFragment$4</ID>
+    <ID>NestedBlockDepth:LocalLibraryFragment.kt$LocalLibraryFragment$checkPermissions</ID>
     <ID>NestedBlockDepth:PeerGroupHandshake.kt$PeerGroupHandshake$readHandshakeAndExchangeMetaData</ID>
     <ID>NestedBlockDepth:ReceiverHandShake.kt$ReceiverHandShake$exchangeFileTransferMetadata</ID>
     <ID>PackageNaming:AvailableSpaceCalculator.kt$package org.kiwix.kiwixmobile.zim_manager.library_view</ID>

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+    tools:ignore="ScopedStorage" />
 
   <!-- Device with versions >= Pie need this permission -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.java
@@ -36,6 +36,7 @@ import androidx.navigation.NavController;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
 import eu.mhutti1.utils.storage.StorageDevice;
@@ -70,6 +71,7 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
   public static final String PREF_CREDITS = "pref_credits";
   public static final String PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION =
     "pref_manage_external_storage";
+  public static final String PREF_PERMISSION = "pref_permissions";
   private static final int ZOOM_OFFSET = 2;
   private static final int ZOOM_SCALE = 25;
   private static final String INTERNAL_TEXT_ZOOM = "text_zoom";
@@ -186,6 +188,7 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
   private void setMangeExternalStoragePermission() {
     Preference permissionPref = findPreference(PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION);
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      showPermissionPreference();
       boolean externalStorageManager = Environment.isExternalStorageManager();
       if (externalStorageManager) {
         permissionPref.setSummary(R.string.allowed);
@@ -198,6 +201,10 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
             return true;
         });
     }
+  }
+  private void showPermissionPreference() {
+    PreferenceCategory preferenceCategory = findPreference(PREF_PERMISSION);
+    preferenceCategory.setVisible(true);
   }
 
   private int getVersionCode() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -140,6 +140,13 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun updateNightMode() = nightModes.offer(nightMode)
 
+  var manageExternalFilesPermissionDialog: Boolean
+    get() = sharedPreferences.getBoolean(PREF_MANAGE_EXTERNAL_FILES, true)
+    set(prefManageExternalFilesPermissionDialog) =
+      sharedPreferences.edit {
+        putBoolean(PREF_MANAGE_EXTERNAL_FILES, prefManageExternalFilesPermissionDialog)
+      }
+
   var hostedBooks: Set<String>
     get() = sharedPreferences.getStringSet(PREF_HOSTED_BOOKS, null)?.toHashSet() ?: HashSet()
     set(hostedBooks) {
@@ -172,5 +179,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_NIGHT_MODE = "pref_night_mode"
     private const val TEXT_ZOOM = "true_text_zoom"
     private const val DEFAULT_ZOOM = 100
+    private const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -84,6 +84,14 @@ sealed class KiwixDialog(
     cancelable = false
   )
 
+  object ManageExternalFilesPermissionDialog : KiwixDialog(
+    R.string.all_files_permission_needed,
+    R.string.all_files_permission_needed_message,
+    R.string.yes,
+    R.string.no,
+    cancelable = false
+  )
+
   data class ShowHotspotDetails(override val args: List<Any>) : KiwixDialog(
     R.string.hotspot_turned_on,
     R.string.hotspot_details_message,

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
   <string name="pref_clear_all_history_title">Clear history</string>
   <string name="pref_clear_all_history_summary">Clear recent searches and tabs history</string>
   <string name="pref_notes">Notes</string>
+  <string name="pref_permission">Permissions</string>
   <string name="all_history_cleared">All History Cleared</string>
   <string name="pref_clear_all_bookmarks_title">Clear bookmarks</string>
   <string name="clear_all_history_dialog_title">Clear All History?</string>
@@ -255,6 +256,7 @@
   <string name="status" tools:keep="@string/status">Status</string>
   <string name="pref_clear_all_notes_summary">Clears all notes on all articles</string>
   <string name="pref_clear_all_notes_title">Clear all notes</string>
+  <string name="pref_manage_external_storage_title">MANAGE_EXTERNAL_STORAGE</string>
   <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
   <string name="tag_pic">Pic</string>
   <string name="tag_vid">Vid</string>
@@ -291,6 +293,8 @@
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>
   <string name="all_files_permission_needed_message">In order to access all the zim files across device we need to have All Files Permission</string>
+  <string name="allowed">Allowed</string>
+  <string name="not_allowed">Not allowed</string>
   <string-array name="pref_night_modes_entries">
     <item>@string/on</item>
     <item>@string/off</item>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
   <string name="status" tools:keep="@string/status">Status</string>
   <string name="pref_clear_all_notes_summary">Clears all notes on all articles</string>
   <string name="pref_clear_all_notes_title">Clear all notes</string>
-  <string name="pref_manage_external_storage_title">MANAGE_EXTERNAL_STORAGE</string>
+  <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read/write ZIM file\'s on SD card</string>
   <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
   <string name="tag_pic">Pic</string>
   <string name="tag_vid">Vid</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -289,6 +289,8 @@
   <string name="close_drawer">Close Drawer</string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
+  <string name="all_files_permission_needed">All Files Permission Needed</string>
+  <string name="all_files_permission_needed_message">In order to access all the zim files across device we need to have All Files Permission</string>
   <string-array name="pref_night_modes_entries">
     <item>@string/on</item>
     <item>@string/off</item>

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -97,6 +97,17 @@
 
   </PreferenceCategory>
   <PreferenceCategory
+    android:key="pref_permissions"
+    android:title="@string/pref_permission"
+    app:iconSpaceReserved="false">
+
+    <Preference
+      android:key="pref_manage_external_storage"
+      android:title="@string/pref_manage_external_storage_title"
+      app:iconSpaceReserved="false" />
+
+  </PreferenceCategory>
+  <PreferenceCategory
     android:key="pref_language"
     android:title="@string/pref_language_title"
     app:iconSpaceReserved="false">

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -104,7 +104,7 @@
 
     <Preference
       android:key="pref_manage_external_storage"
-      android:title="@string/pref_manage_external_storage_title"
+      android:title="@string/pref_allow_to_read_or_write_zim_files_on_sd_card"
       app:iconSpaceReserved="false" />
 
   </PreferenceCategory>

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -99,6 +99,7 @@
   <PreferenceCategory
     android:key="pref_permissions"
     android:title="@string/pref_permission"
+    app:isPreferenceVisible="false"
     app:iconSpaceReserved="false">
 
     <Preference


### PR DESCRIPTION
Fixes #2694 
Fixes #2716

**Description**
Added `MANAGE_EXTERNAL_STORAGE` permission. For the first time android 11 and later we'll ask specifically to give us permission in order to access all the zim files in android. If the user clicks yes then we'll navigate to Our app's android settings screen, then the user will give access permission.

If the user currently doesn't want to give the permission, We implemented a preference in our app's preference screen. That will allow users to go to our app's navigate settings screen. 

NOTE:-
Currently, if the user first allows the permission and then disallows the permission then the app will show all external files too even though clicking the zim files will not open that. In order to open(read or delete the external)zim files that you have to give the app permission.
It shows on the custom app Which we don't need that permission. (We should really think how to move that)

**ScreenShot**
![Screen Shot 2021-10-28 at 18 26 12](https://user-images.githubusercontent.com/43576162/139259622-4c540323-2703-4ba2-83b3-7a367b90a0cf.png)
![Screen Shot 2021-10-28 at 18 15 39](https://user-images.githubusercontent.com/43576162/139257802-b87f96ce-5e0a-49ff-879c-3683541327f2.png)
![Screen Shot 2021-10-28 at 18 16 16](https://user-images.githubusercontent.com/43576162/139257878-f0f77fbf-be88-4039-b86b-f9b8523366e8.png)



