### PR TITLE
Rephrase pref_allow_to_read_or_write_zim_files_on_sd_card

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
   <string name="status" tools:keep="@string/status">Status</string>
   <string name="pref_clear_all_notes_summary">Clears all notes on all articles</string>
   <string name="pref_clear_all_notes_title">Clear all notes</string>
-  <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read/write ZIM file\'s on SD card</string>
+  <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read and write ZIM files on SD card</string>
   <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
   <string name="tag_pic">Pic</string>
   <string name="tag_vid">Vid</string>


### PR DESCRIPTION
1. Remove unnecessary apostrophe.
2. Replace a slash with "and", which is more natural to read.