### PR TITLE
#2732 Refactored all files access permission code to the  app module

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+    tools:ignore="ScopedStorage" />
 
   <queries>
     <intent>

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -33,6 +33,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -51,9 +52,12 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.REQUEST_STORAGE_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BookOnDiskDelegate
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskAdapter
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem
@@ -64,12 +68,6 @@ import org.kiwix.kiwixmobile.zim_manager.ZimManageViewModel.FileSelectActions.Re
 import org.kiwix.kiwixmobile.zim_manager.ZimManageViewModel.FileSelectActions.RequestSelect
 import org.kiwix.kiwixmobile.zim_manager.fileselect_view.FileSelectListState
 import javax.inject.Inject
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
-import androidx.annotation.RequiresApi
-import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
-import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 
 private const val WAS_IN_ACTION_MODE = "WAS_IN_ACTION_MODE"
 
@@ -223,7 +221,9 @@ class LocalLibraryFragment : BaseFragment() {
             // Show Dialog and  Go to settings to give permission
             dialogShower.show(
               KiwixDialog.ManageExternalFilesPermissionDialog,
-              ::navigateToSettings
+              {
+                this.activity?.let(FragmentActivity::navigateToSettings)
+              }
             )
           }
         }
@@ -243,14 +243,5 @@ class LocalLibraryFragment : BaseFragment() {
 
   private fun navigateToLocalFileTransferFragment() {
     requireActivity().navigate(R.id.localFileTransferFragment)
-  }
-
-  @RequiresApi(Build.VERSION_CODES.R)
-  private fun navigateToSettings() {
-    val intent = Intent().apply {
-      action = Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
-      data = Uri.fromParts("package", requireActivity().packageName, null)
-    }
-    startActivity(intent)
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
@@ -77,6 +77,6 @@ class KiwixPrefsFragment : CorePrefsFragment() {
 
   companion object {
     const val PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION =
-      "pref_manage_external_storage";
+      "pref_manage_external_storage"
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
@@ -18,10 +18,15 @@
 
 package org.kiwix.kiwixmobile.settings
 
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
 import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.settings.CorePrefsFragment
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil.Companion.PREF_STORAGE
@@ -31,6 +36,7 @@ class KiwixPrefsFragment : CorePrefsFragment() {
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
     super.onCreatePreferences(savedInstanceState, rootKey)
     setUpLanguageChooser(SharedPreferenceUtil.PREF_LANG)
+    setMangeExternalStoragePermission()
   }
 
   override fun setStorage() {
@@ -43,4 +49,34 @@ class KiwixPrefsFragment : CorePrefsFragment() {
 
   private fun internalStorage(): String? =
     ContextCompat.getExternalFilesDirs(requireContext(), null).firstOrNull()?.path
+
+  private fun setMangeExternalStoragePermission() {
+    val permissionPref = findPreference<Preference>(PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      showPermissionPreference()
+      val externalStorageManager = Environment.isExternalStorageManager()
+      if (externalStorageManager) {
+        permissionPref!!.setSummary(org.kiwix.kiwixmobile.core.R.string.allowed)
+      } else {
+        permissionPref!!.setSummary(org.kiwix.kiwixmobile.core.R.string.not_allowed)
+      }
+      permissionPref.onPreferenceClickListener =
+        Preference.OnPreferenceClickListener {
+          activity?.let(FragmentActivity::navigateToSettings)
+          true
+        }
+    }
+  }
+
+  private fun showPermissionPreference() {
+    val preferenceCategory = findPreference<PreferenceCategory>(
+      PREF_PERMISSION
+    )
+    preferenceCategory!!.isVisible = true
+  }
+
+  companion object {
+    const val PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION =
+      "pref_manage_external_storage";
+  }
 }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -8,8 +8,6 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-    tools:ignore="ScopedStorage" />
 
   <!-- Device with versions >= Pie need this permission -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
@@ -37,4 +37,3 @@ fun Activity.navigateToSettings() {
   }
   startActivity(intent)
 }
-

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
@@ -20,8 +20,21 @@ package org.kiwix.kiwixmobile.core
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.annotation.RequiresApi
 
 object Intents {
   @JvmStatic fun <T : Activity> internal(clazz: Class<T>): Intent =
     Intent(clazz.canonicalName).setPackage(CoreApp.instance.packageName)
 }
+@RequiresApi(Build.VERSION_CODES.R)
+fun Activity.navigateToSettings() {
+  val intent = Intent().apply {
+    action = Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION
+    data = Uri.fromParts("package", packageName, null)
+  }
+  startActivity(intent)
+}
+

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.java
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.java
@@ -20,23 +20,16 @@ package org.kiwix.kiwixmobile.core.settings;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
-import android.provider.Settings;
 import android.view.LayoutInflater;
 import android.webkit.WebView;
-import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.navigation.NavController;
 import androidx.preference.EditTextPreference;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
-import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import com.google.android.material.snackbar.Snackbar;
 import eu.mhutti1.utils.storage.StorageDevice;
@@ -69,8 +62,6 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
   public static final String PREF_CLEAR_ALL_HISTORY = "pref_clear_all_history";
   public static final String PREF_CLEAR_ALL_NOTES = "pref_clear_all_notes";
   public static final String PREF_CREDITS = "pref_credits";
-  public static final String PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION =
-    "pref_manage_external_storage";
   public static final String PREF_PERMISSION = "pref_permissions";
   private static final int ZOOM_OFFSET = 2;
   private static final int ZOOM_SCALE = 25;
@@ -97,7 +88,6 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
     setStorage();
     setUpSettings();
     setupZoom();
-    setMangeExternalStoragePermission();
     new LanguageUtils(getActivity()).changeFont(getActivity().getLayoutInflater(),
       sharedPreferenceUtil);
   }
@@ -185,27 +175,8 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
     versionPref.setSummary(getVersionName() + " Build: " + getVersionCode());
   }
 
-  private void setMangeExternalStoragePermission() {
-    Preference permissionPref = findPreference(PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION);
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-      showPermissionPreference();
-      boolean externalStorageManager = Environment.isExternalStorageManager();
-      if (externalStorageManager) {
-        permissionPref.setSummary(R.string.allowed);
-      } else {
-        permissionPref.setSummary(R.string.not_allowed);
-      }
-      permissionPref.setOnPreferenceClickListener(
-        preference -> {
-            navigateToSettings();
-            return true;
-        });
-    }
-  }
-  private void showPermissionPreference() {
-    PreferenceCategory preferenceCategory = findPreference(PREF_PERMISSION);
-    preferenceCategory.setVisible(true);
-  }
+
+
 
   private int getVersionCode() {
     try {
@@ -316,13 +287,4 @@ public abstract class CorePrefsFragment extends PreferenceFragmentCompat impleme
     return Unit.INSTANCE;
   }
 
-  // TODO: 28/10/21 Refactor the code. We are using it twice.
-  @RequiresApi(Build.VERSION_CODES.R)
-  private void navigateToSettings() {
-    Intent intent = new Intent();
-    intent.setAction(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
-    Uri uri = Uri.fromParts("package", getActivity().getPackageName(), null);
-    intent.setData(uri);
-    startActivity(intent);
-  }
 }


### PR DESCRIPTION
Fixes #2732 
 * Refactored all the manage files permission code of external sd card functionality to the app module. Currently, we have code in the core module. Which makes no sense at all. We don't need permission at all in our custom apps.
 * Fixes unnecessary permission showing on our Custom apps.