### PR TITLE
Improved wifi detection

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -50,12 +50,19 @@ class DownloadRobot : BaseRobot() {
     clickOn(ViewId(R.id.downloadsFragment))
   }
 
-  fun deleteZimIfExists() {
+  fun deleteZimIfExists(shouldDeleteZimFile: Boolean) {
     try {
       longClickOn(Text(zimFileTitle))
       clickOn(ViewId(R.id.zim_file_delete_item))
+      isVisible(Text("DELETE"))
       onView(withText("DELETE")).perform(click())
-    } catch (e: RuntimeException) {
+    } catch (e: Exception) {
+      if (shouldDeleteZimFile) {
+        throw Exception(
+          "$zimFileTitle downloaded successfully. " +
+            "But failed to delete $zimFileTitle file"
+        )
+      }
       Log.i(
         "TEST_DELETE_ZIM",
         "Failed to delete ZIM file with title [" + zimFileTitle + "]... " +

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -22,6 +22,8 @@ import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
@@ -54,7 +56,8 @@ class DownloadRobot : BaseRobot() {
     try {
       longClickOn(Text(zimFileTitle))
       clickOn(ViewId(R.id.zim_file_delete_item))
-      isVisible(Text("DELETE"))
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      onView(withText("DELETE")).check(matches(isDisplayed()))
       onView(withText("DELETE")).perform(click())
     } catch (e: Exception) {
       if (shouldDeleteZimFile) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -30,6 +30,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
+import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -43,7 +44,6 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
-import leakcanary.LeakAssertions
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -71,7 +71,7 @@ class DownloadTest : BaseActivityTest() {
       try {
         downloadRobot {
           clickLibraryOnBottomNav()
-          deleteZimIfExists()
+          deleteZimIfExists(false)
           clickDownloadOnBottomNav()
           waitForDataToLoad()
           downloadZimFile()
@@ -79,15 +79,11 @@ class DownloadTest : BaseActivityTest() {
           waitUntilDownloadComplete()
           clickLibraryOnBottomNav()
           checkIfZimFileDownloaded()
-          deleteZimIfExists()
+          deleteZimIfExists(true)
         }
       } catch (e: Exception) {
         Assert.fail(
-          """
-        Couldn't find downloaded file 'Off the Grid'
-        Original Exception:
-        ${e.localizedMessage}
-          """.trimIndent()
+          "Couldn't find downloaded file ' Off the Grid ' Original Exception: ${e.message}"
         )
       }
       try {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -35,12 +35,14 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
@@ -48,6 +50,10 @@ import java.util.concurrent.TimeUnit
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class DownloadTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Before
   override fun waitForIdle() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -23,9 +23,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.RetryRule
 
 class HelpFragmentTest : BaseActivityTest() {
 
@@ -33,6 +35,10 @@ class HelpFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
   }
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Test
   fun verifyHelpActivity() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -40,6 +40,10 @@ class InitialDownloadRobot : BaseRobot() {
 
   private var retryCountForCheckDownloadStart = 5
 
+  fun clickDownloadOnBottomNav() {
+    clickOn(ViewId(R.id.downloadsFragment))
+  }
+
   fun assertLibraryListDisplayed() {
     isVisible(ViewId(R.id.libraryList))
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -63,6 +63,9 @@ class InitialDownloadTest : BaseActivityTest() {
   fun initialDownloadTest() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
       initialDownload {
+        clickLibraryOnBottomNav()
+        // This is for if download test fails for some reason after downloading the zim file
+        deleteZimIfExists()
         clickDownloadOnBottomNav()
         assertLibraryListDisplayed()
         refreshList()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -29,11 +29,13 @@ import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -47,6 +49,10 @@ class InitialDownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
     }
   }
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Before
   override fun waitForIdle() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -23,7 +23,6 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
@@ -33,7 +32,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 
@@ -58,8 +56,8 @@ class InitialDownloadTest : BaseActivityTest() {
   @Test
   fun initialDownloadTest() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      UiThreadStatement.runOnUiThread { activityRule.activity.navigate(R.id.downloadsFragment) }
       initialDownload {
+        clickDownloadOnBottomNav()
         assertLibraryListDisplayed()
         refreshList()
         waitForDataToLoad()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -25,12 +25,18 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.testutils.RetryRule
 
 class IntroFragmentTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Test
   fun viewIsSwipeableAndNavigatesToMain() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -18,6 +18,8 @@
 package org.kiwix.kiwixmobile.intro
 
 import android.os.Build
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -26,6 +28,7 @@ import org.junit.Before
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
 class IntroFragmentTest : BaseActivityTest() {
 
@@ -41,5 +44,8 @@ class IntroFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
+    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -35,10 +35,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class LanguageFragmentTest {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @get:Rule
   var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -26,15 +26,21 @@ import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.nav.destination.library.OnlineLibraryRobot
 import org.kiwix.kiwixmobile.settings.SettingsRobot
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.webserver.ZimHostRobot
 
 class TopLevelDestinationTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Before
   override fun waitForIdle() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -24,11 +24,17 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.RetryRule
 
 class NoteFragmentTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @Before
   override fun waitForIdle() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -28,17 +28,24 @@ import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
 
 class SearchFragmentTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
   override var activityRule: ActivityTestRule<KiwixMainActivity> = activityTestRule {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -32,9 +32,14 @@ import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.intro.IntroRobot
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.utils.StandardActions
 
 class KiwixSettingsFragmentTest {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   @get:Rule
   var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -42,11 +42,16 @@ import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class KiwixSplashActivityTest {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   private val activityScenario: ActivityScenario<KiwixMainActivity> =
     ActivityScenario.launch(KiwixMainActivity::class.java)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/RetryRule.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/RetryRule.kt
@@ -1,0 +1,53 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2022 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.testutils
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.kiwix.kiwixmobile.testutils.TestUtils.RETRY_COUNT_FOR_FLAKY_TEST
+import java.util.Objects
+
+class RetryRule : TestRule {
+
+  override fun apply(base: Statement, description: Description): Statement =
+    statement(base, description)
+
+  private fun statement(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      @Throws(Throwable::class) override fun evaluate() {
+        var caughtThrowable: Throwable? = null
+        for (i in 0 until RETRY_COUNT_FOR_FLAKY_TEST) {
+          try {
+            base.evaluate()
+            return
+          } catch (t: Throwable) {
+            caughtThrowable = t
+            System.err.println(description.displayName + ": run " + (i + 1) + " failed.")
+          }
+        }
+        System.err.println(
+          description.displayName + ": Giving up after " +
+            RETRY_COUNT_FOR_FLAKY_TEST + " failures."
+        )
+        throw Objects.requireNonNull(caughtThrowable!!)
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -49,6 +49,7 @@ object TestUtils {
   @JvmField var TEST_PAUSE_MS = 250
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
+  const val RETRY_COUNT_FOR_FLAKY_TEST = 3
 
   /*
     TEST_PAUSE_MS is used as such:

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroFragment.kt
@@ -69,7 +69,7 @@ class IntroFragment : BaseFragment(), IntroContract.View, FragmentActivityExtens
     )
     view_pager.run {
       adapter = IntroPagerAdapter(views)
-      addOnPageChangeListener(SimplePageChangeListener(::updateView, ::handleDraggingState))
+      simplePageChangeListener?.let(::addOnPageChangeListener)
     }
     tab_indicator.setViewPager(view_pager)
     timer?.schedule(
@@ -104,6 +104,7 @@ class IntroFragment : BaseFragment(), IntroContract.View, FragmentActivityExtens
       it.setOnClickListener(null)
     }
     views = emptyArray()
+    simplePageChangeListener = null
   }
 
   private fun navigateToLibrary() {
@@ -135,4 +136,7 @@ class IntroFragment : BaseFragment(), IntroContract.View, FragmentActivityExtens
     handler.removeCallbacksAndMessages(null)
     timer?.cancel()
   }
+
+  private var simplePageChangeListener: SimplePageChangeListener? =
+    SimplePageChangeListener(::updateView, ::handleDraggingState)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ConnectivityReporter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ConnectivityReporter.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.utils
 
+import android.net.wifi.SupplicantState.COMPLETED
 import android.net.wifi.WifiManager
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
@@ -25,7 +26,8 @@ import javax.inject.Inject
 
 class ConnectivityReporter @Inject constructor(private val wifiManager: WifiManager) {
 
-  fun checkWifi(): Boolean = wifiManager.isWifiEnabled && wifiManager.connectionInfo.networkId != -1
+  fun checkWifi(): Boolean =
+    wifiManager.isWifiEnabled && wifiManager.connectionInfo.supplicantState == COMPLETED
 
   fun checkTethering(): Boolean = try {
     val method: Method = wifiManager.javaClass.getDeclaredMethod("isWifiApEnabled")


### PR DESCRIPTION
Fixes #2678 

**Changes:** solved Wifi local hosting server not working as wifi was not getting detected 

**possible error**:  ``getConnectionInfo()`` was deprecated in Api level 31. ``WifiInfo`` available in ConnectivityManager. [more info](https://developer.android.com/reference/android/net/wifi/WifiManager#getConnectionInfo())
