### PR TITLE
Target uploads to new dropbox address

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,5 +69,5 @@ jobs:
         run: |
           mkdir $DATE
           cp $UNIVERSAL_DEBUG_APK $DATE
-          scp -vrp -i ssh_key -o StrictHostKeyChecking=no $DATE ci@download.kiwix.org:/data/download/nightly/
+          scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no $DATE ci@master.download.kiwix.org:/data/download/nightly/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           ./gradlew assembleRelease
           cp $UNIVERSAL_RELEASE_APK kiwix-${TAG}.apk
-          scp -vrp -i ssh_key -o StrictHostKeyChecking=no kiwix-${TAG}.apk ci@download.kiwix.org:/data/download/release/kiwix-android/
+          scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no kiwix-${TAG}.apk ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
       - name: Publish to github releases
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
SSH server which was used to receive file uploads (CI, nightly and release) has been
migrated to a new one on a different address.
Username, Key and paths are unchanged.
Most notable changes are the use of master.download.kiwix.org as the target in
replacement of mirror.download.kiwix.org (although it would still work) and the
Port to which SSH is listening on (30022 instead of 22)
