### PR TITLE
 io.objectbox:objectbox: updating to maven repo with version 2.9.1 

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -34,7 +34,7 @@ object Versions {
 
   const val androidx_test: String = "1.3.0"
 
-  const val io_objectbox: String = "2.8.1"
+  const val io_objectbox: String = "2.9.1"
 
   const val org_jacoco: String = "0.8.7"
 


### PR DESCRIPTION
Fixes #2828 

 updating to maven repo with version 2.9.1