### PR TITLE
CI job for detecting kotlin Version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Install NDK
         run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;22.0.7026061" --sdk_root=${ANDROID_SDK_ROOT}
 
+      - name: Building Kotlin Report
+        run: bash contrib/kotlin-validator.sh
+
+
       - name: Build all configurations
         run: ./gradlew assemble
 

--- a/contrib/kotlin-validator.sh
+++ b/contrib/kotlin-validator.sh
@@ -40,8 +40,9 @@
    version=$(cat app/build/kotlinToolingMetadata/kotlin-tooling-metadata.json | tr { '\n' | tr , '\n' | tr } '\n' | grep "buildPluginVersion" | awk  -F'"' '{print $4}')
    if [ $version == "1.7.0" ];
    then
-    echo "Build System is using kotlin version 1.7.0"
+    echo "Build System is using kotlin Version 1.7.0"
    else
+    echo "Build Failure : Due to kotlin Version 1.7.0 is missing"
      exit 1
    fi
  else

--- a/contrib/kotlin-validator.sh
+++ b/contrib/kotlin-validator.sh
@@ -1,24 +1,4 @@
-#
-# Kiwix Android
-# Copyright (c) 2022 Kiwix <android.kiwix.org>
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#
-
- #!/usr/bin/env bash
-
- #
+#!/usr/bin/env bash
  # Kiwix Android
  # Copyright (c) 2022 Kiwix <android.kiwix.org>
  # This program is free software: you can redistribute it and/or modify
@@ -42,7 +22,7 @@
    then
     echo "Build System is using kotlin Version 1.7.0"
    else
-    echo "Build Failure : Due to kotlin Version 1.7.0 is missing"
+     echo "Build Failure : Due to kotlin Version 1.7.0 is missing"
      exit 1
    fi
  else

--- a/contrib/kotlin-validator.sh
+++ b/contrib/kotlin-validator.sh
@@ -17,7 +17,7 @@
  #
 
  if ./gradlew buildKotlinToolingMetadata; then
-   version=$(cat app/build/kotlinToolingMetadata/kotlin-tooling-metadata.json | tr { '\n' | tr , '\n' | tr } '\n' | grep "buildPluginVersion" | awk  -F'"' '{print $4}')
+   version=$(< app/build/kotlinToolingMetadata/kotlin-tooling-metadata.json  tr { '\n' | tr , '\n' | tr } '\n' | grep "buildPluginVersion" | awk  -F'"' '{print $4}')
    if [ $version == "1.7.0" ];
    then
     echo "Build System is using kotlin Version 1.7.0"

--- a/contrib/kotlin-validator.sh
+++ b/contrib/kotlin-validator.sh
@@ -1,0 +1,49 @@
+#
+# Kiwix Android
+# Copyright (c) 2022 Kiwix <android.kiwix.org>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+ #!/usr/bin/env bash
+
+ #
+ # Kiwix Android
+ # Copyright (c) 2022 Kiwix <android.kiwix.org>
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program. If not, see <http://www.gnu.org/licenses/>.
+ #
+ #
+
+ if ./gradlew buildKotlinToolingMetadata; then
+   version=$(cat app/build/kotlinToolingMetadata/kotlin-tooling-metadata.json | tr { '\n' | tr , '\n' | tr } '\n' | grep "buildPluginVersion" | awk  -F'"' '{print $4}')
+   if [ $version == "1.7.0" ];
+   then
+    echo "Build System is using kotlin version 1.7.0"
+   else
+     exit 1
+   fi
+ else
+   exit 1
+ fi


### PR DESCRIPTION
Fixes #2892 

a) In this PR we are generating Kotlin report by buildKotlinToolingMetadata gradle task then we check the Kotlin version used in project if its 1.7.0 then CI will work otherwise leads to failure.