### PR TITLE
Fix nightly CI failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: run instrumentation tests
         uses: ReactiveCircus/android-emulator-runner@v2.19.1
         with:


### PR DESCRIPTION

Fixes #2898 

It was failing due to environment Java 11 was missing.

