### PR TITLE
Fixes Nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,16 +68,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Restore Cache
-        uses: actions/cache@v2
-        with:
-            path: |
-              ~/.gradle/caches
-              ~/.gradle/wrapper
-            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-            restore-keys: |
-              ${{ runner.os }}-gradle-
-
       - name: Install NDK
         run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;22.0.7026061" --sdk_root=${ANDROID_SDK_ROOT}
 


### PR DESCRIPTION
Fixes #2971 

Due to Gradle caches, NDK wasn't able to find some classes.


