### PR TITLE
Fixed `DrawerLayout` memory leak

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -234,6 +234,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
           navController.previousBackStackEntry?.destination
             ?.id?.equals(searchFragmentResId) == false
         ) {
+          drawerToggle = null
           finish()
         } else {
           super.onBackPressed()


### PR DESCRIPTION

Fixes #2618
This PR fixed `DrawerLayout` leaking from the `CoreMainActivity`. We are now setting it to null when the activity finishes.
