### PR TITLE
Fix Misalignment of FloatingActionButton and BottomNavBar is Blank

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -57,6 +57,7 @@ import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
+import org.kiwix.kiwixmobile.core.extensions.setParentFragmentsBottomMarginTo
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.navigateToSettings
@@ -140,6 +141,9 @@ class LocalLibraryFragment : BaseFragment() {
       setHasFixedSize(true)
     }
     zimManageViewModel.fileSelectListStates.observe(viewLifecycleOwner, Observer(::render))
+      .also {
+        setParentFragmentsBottomMarginTo(0)
+      }
     disposable.add(sideEffects())
     zimManageViewModel.deviceListIsRefreshing.observe(viewLifecycleOwner) {
       zim_swiperefresh.isRefreshing = it!!

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -63,6 +63,7 @@ import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
+import org.kiwix.kiwixmobile.core.extensions.setParentFragmentsBottomMarginTo
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -160,6 +161,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       setHasFixedSize(true)
     }
     zimManageViewModel.libraryItems.observe(viewLifecycleOwner, Observer(::onLibraryItemsChange))
+      .also {
+        setParentFragmentsBottomMarginTo(0)
+      }
     zimManageViewModel.libraryListIsRefreshing.observe(
       viewLifecycleOwner, Observer(::onRefreshStateChange)
     )

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -47,6 +47,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigatio
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setupDrawerToggle
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
+import org.kiwix.kiwixmobile.core.extensions.setParentFragmentsBottomMarginTo
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -201,12 +202,6 @@ class KiwixReaderFragment : CoreReaderFragment() {
         )
       )
     }
-  }
-
-  private fun setParentFragmentsBottomMarginTo(margin: Int) {
-    val params = parentFragment?.view?.layoutParams as ViewGroup.MarginLayoutParams?
-    params?.bottomMargin = margin
-    parentFragment?.view?.requestLayout()
   }
 
   override fun onPause() {

--- a/app/src/main/res/layout/fragment_destination_library.xml
+++ b/app/src/main/res/layout/fragment_destination_library.xml
@@ -83,7 +83,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginEnd="10dp"
-    android:layout_marginBottom="60dp"
+    android:layout_marginBottom="66dp"
     android:contentDescription="@string/app_name"
     android:src="@drawable/ic_add_blue_24dp"
     app:backgroundTint="@color/black"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.extensions
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.fragment.app.Fragment
@@ -48,3 +49,9 @@ fun View.closeKeyboard() {
 }
 
 val Fragment.coreMainActivity get() = activity as CoreMainActivity
+
+fun Fragment.setParentFragmentsBottomMarginTo(margin: Int) {
+  val params = parentFragment?.view?.layoutParams as ViewGroup.MarginLayoutParams?
+  params?.bottomMargin = margin
+  parentFragment?.view?.requestLayout()
+}


### PR DESCRIPTION
Fixes #2984
Fixes #3069 

Fix Misalignment of FloatingActionButton and BottomNavBar is Blank.
### Whats the Issue
We Are Setting margin to parent fragment in KiwixReaderFragment
```
 private fun setFragmentContainerBottomMarginToSizeOfNavBar() {
    val actionBarHeight = context?.getAttribute(android.R.attr.actionBarSize)
    if (actionBarHeight != null) {
      setParentFragmentsBottomMarginTo(
        complexToDimensionPixelSize(
          actionBarHeight,
          resources.displayMetrics
        )
      )
    }
  }
```
on first run we take permission of storage and then we ask ``` MANAGE_EXTERNAL_PERMISSION ``` from user (in android 11 and above) so ```onPause``` method of ```KiwixReaderFragment``` not called where we set margin 0 to parent fragment that's why this blank space is visible on first run.

### Fix:
Removed the extra margin from parent fragment in ```LocalLibraryFragment``` and ```OnlineFragment``` and make Fragment extension function to reusability of ```setParentFragmentsBottomMarginTo``` method.