### PR TITLE
Stop uploading F-Droid auto-publish VERSION_INFO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,10 +47,9 @@ jobs:
           cp $UNIVERSAL_RELEASE_APK kiwix-${TAG}.apk
           scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no kiwix-${TAG}.apk ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
-      - name: Publish  versionInfo to download.kiwix.org
+      - name: Build VERSION_INFO for F-Droid auto-publishing
         run: |
           ./gradlew generateVersionCodeAndName
-          scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no VERSION_INFO ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
       - name: Publish to github releases
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Following @licaon-kter comment at https://github.com/kiwix/kiwix-android/issues/1682#issuecomment-1217860757, it seems this is not necessary anymore to upload `VERSION_INFO` to download.kiwix.org. The version on the git repository is good enough.