### PR TITLE
Fix Nightly build are actually running on default API but showing as its running on google_apis

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         api-level: [21, 22, 23, 24, 25, 27, 28, 30]
-        target: [google_apis]
+        target: [default]
       fail-fast: false
     runs-on: macos-11
     steps:
@@ -40,6 +40,7 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2.23.0
         with:
           api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_2
           ndk: 21.4.7075529


### PR DESCRIPTION
Fixes #3095 