### PR TITLE
Adding desktop mode for wide view so that content like graph's can be visible due to misalign on phone view. 

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -276,6 +276,15 @@ class KiwixReaderFragment : CoreReaderFragment() {
     }
   }
 
+  override fun onDesktopModeMenuClicked(isEnable: Boolean) {
+    getCurrentWebView()?.settings?.apply {
+      useWideViewPort = isEnable
+    }.also {
+      sharedPreferenceUtil?.isDesktopModeEnable = isEnable
+      mainMenu?.setDesktopModeEnable(!isEnable)
+    }
+  }
+
   override fun openFullScreen() {
     super.openFullScreen()
     hideNavBar()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -827,7 +827,9 @@ abstract class CoreReaderFragment :
   }
 
   private fun loadUrl(url: String?, webview: KiwixWebView) {
-    if (url != null && !url.endsWith("null")) {
+    if (url?.endsWith("null") == false) {
+      webview.settings.useWideViewPort = sharedPreferenceUtil?.isDesktopModeEnable == true
+      mainMenu?.setDesktopModeEnable(sharedPreferenceUtil?.isDesktopModeEnable == false)
       webview.loadUrl(url)
     }
   }
@@ -1472,6 +1474,7 @@ abstract class CoreReaderFragment :
     super<BaseFragment>.onCreateOptionsMenu(menu, inflater)
     menu.clear()
     mainMenu = createMainMenu(menu)
+    mainMenu?.setDesktopModeEnable(sharedPreferenceUtil?.isDesktopModeEnable == false)
   }
 
   protected open fun createMainMenu(menu: Menu?): MainMenu? =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
@@ -57,6 +57,7 @@ class MainMenu(
     fun onRandomArticleMenuClicked()
     fun onReadAloudMenuClicked()
     fun onFullscreenMenuClicked()
+    fun onDesktopModeMenuClicked(isEnable: Boolean)
   }
 
   init {
@@ -71,6 +72,7 @@ class MainMenu(
   private val randomArticle = menu.findItem(R.id.menu_random_article)
   private val fullscreen = menu.findItem(R.id.menu_fullscreen)
   private var readAloud: MenuItem? = menu.findItem(R.id.menu_read_aloud)
+  private var desktopMode: MenuItem? = menu.findItem(R.id.menu_desktop_mode)
   private var isInTabSwitcher: Boolean = false
 
   init {
@@ -96,6 +98,7 @@ class MainMenu(
     randomArticle.menuItemClickListener { menuClickListener.onRandomArticleMenuClicked() }
     readAloud.menuItemClickListener { menuClickListener.onReadAloudMenuClicked() }
     fullscreen.menuItemClickListener { menuClickListener.onFullscreenMenuClicked() }
+    desktopMode.menuItemClickListener { menuClickListener.onDesktopModeMenuClicked(it.isChecked) }
 
     showWebViewOptions(urlIsValid)
     zimFileReader?.let {
@@ -114,27 +117,27 @@ class MainMenu(
     }
 
   fun onFileOpened(urlIsValid: Boolean) {
-    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, fullscreen)
+    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, fullscreen, desktopMode)
     search.setOnMenuItemClickListener { navigateToSearch() }
   }
 
   fun hideBookSpecificMenuItems() {
-    setVisibility(false, search, tabSwitcher, randomArticle, addNote)
+    setVisibility(false, search, tabSwitcher, randomArticle, addNote, desktopMode)
   }
 
   fun showBookSpecificMenuItems() {
-    setVisibility(true, search, tabSwitcher, randomArticle, addNote)
+    setVisibility(true, search, tabSwitcher, randomArticle, addNote, desktopMode)
   }
 
   fun showTabSwitcherOptions() {
     isInTabSwitcher = true
-    setVisibility(false, randomArticle, readAloud, addNote, fullscreen)
+    setVisibility(false, randomArticle, readAloud, addNote, fullscreen, desktopMode)
   }
 
   fun showWebViewOptions(urlIsValid: Boolean) {
     isInTabSwitcher = false
     fullscreen.isVisible = true
-    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote)
+    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, desktopMode)
   }
 
   fun updateTabIcon(tabs: Int) {
@@ -152,6 +155,10 @@ class MainMenu(
 
   fun onTextToSpeechStoppedTalking() {
     readAloud?.setTitle(R.string.menu_read_aloud)
+  }
+
+  fun setDesktopModeEnable(isEnable: Boolean) {
+    desktopMode?.isChecked = isEnable
   }
 
   private fun setVisibility(visibility: Boolean, vararg menuItems: MenuItem?) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -139,6 +139,12 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun setIntroShown() = sharedPreferences.edit { putBoolean(PREF_SHOW_INTRO, false) }
 
+  var isDesktopModeEnable: Boolean
+    get() = sharedPreferences.getBoolean(PREF_DESKTOP_MODE_ENABLE, true)
+    set(isEnable) {
+      sharedPreferences.edit { putBoolean(PREF_DESKTOP_MODE_ENABLE, isEnable) }
+    }
+
   var showHistoryAllBooks: Boolean
     get() = sharedPreferences.getBoolean(PREF_SHOW_HISTORY_ALL_BOOKS, true)
     set(prefShowHistoryAllBooks) {
@@ -213,6 +219,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_WIFI_ONLY = "pref_wifi_only"
     const val PREF_KIWIX_MOBILE = "kiwix-mobile"
     const val PREF_SHOW_INTRO = "showIntro"
+    const val PREF_DESKTOP_MODE_ENABLE = "desktop_mode_enable"
     private const val PREF_BACK_TO_TOP = "pref_backtotop"
     private const val PREF_FULLSCREEN = "pref_fullscreen"
     private const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"

--- a/core/src/main/res/menu/menu_main.xml
+++ b/core/src/main/res/menu/menu_main.xml
@@ -46,4 +46,12 @@
     app:showAsAction="never"
     tools:visible="true" />
 
+  <item
+    android:id="@+id/menu_desktop_mode"
+    android:title="@string/menu_desktop_mode"
+    android:visible="false"
+    android:checkable="true"
+    app:showAsAction="never"
+    tools:visible="true"/>
+
 </menu>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -323,4 +323,5 @@
   <string name="open_article">Open Article</string>
   <string name="delete_note_dialog_message">Note: Notes are not deleted from your storage</string>
   <string name="delete_selected_notes">Delete Selected Notes?</string>
+  <string name="menu_desktop_mode">Desktop Mode</string>
 </resources>

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -208,6 +208,15 @@ class CustomReaderFragment : CoreReaderFragment() {
     menu.findItem(R.id.menu_host_books)?.isVisible = false
   }
 
+  override fun onDesktopModeMenuClicked(isEnable: Boolean) {
+    getCurrentWebView()?.settings?.apply {
+      useWideViewPort = isEnable
+    }.also {
+      sharedPreferenceUtil?.isDesktopModeEnable = isEnable
+      mainMenu?.setDesktopModeEnable(!isEnable)
+    }
+  }
+
   private fun enforcedLanguage(): Boolean {
     val currentLocaleCode = Locale.getDefault().toString()
     if (BuildConfig.ENFORCED_LANG.isNotEmpty() && BuildConfig.ENFORCED_LANG != currentLocaleCode) {


### PR DESCRIPTION
Fixes #2714

I have added the new feature as Desktop mode view on which content which are misaligned on phone view can be easily readable via Desktop mode.

Desktop mode is being added to menu item so by default phone view will be active but if user needs desktop mode they can move to desktop mode similar as chrome.

| Phone View      | Desktop View |
| ----------- | ----------- |
|   ![Darkmode](https://user-images.githubusercontent.com/34593983/193824247-68e39655-e114-4752-8b7c-53220714db75.jpg)  | ![Desktopmode](https://user-images.githubusercontent.com/34593983/193824307-749cd86c-0389-4c25-8a38-0d412ccb425a.jpg)|
