### PR TITLE
CI sometimes failing on target 33

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -3,7 +3,11 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.kiwix.kiwixmobile">
 
+  <!-- support for androidx.test.orchestrator clearPackageData for android 33
+       see more information here https://github.com/kiwix/kiwix-android/issues/3172
+  -->
   <application
+    android:forceQueryable="true"
     android:usesCleartextTraffic="true"/>
   <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 </manifest>


### PR DESCRIPTION
Fixes #3172

I have added ```android:forceQueryable="true"``` in android test manifest (for sometimes apk not installing in android 33 with error ```FAILED TO INSTALL APK Error: UNKNOWN```) using ```forceQueryable``` basically lets other apps (like the orchestrator app) communicate with the test package. [More infomation here](https://developer.android.com/training/package-visibility)
