### PR TITLE
Fixed sometimes ```DownloadTest``` failing in CI

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -52,18 +52,36 @@ class DownloadRobot : BaseRobot() {
     clickOn(ViewId(R.id.downloadsFragment))
   }
 
+  private fun longClickOnZimFile() {
+    longClickOn(Text(zimFileTitle))
+  }
+
+  private fun clickOnFileDeleteIcon() {
+    clickOn(ViewId(R.id.zim_file_delete_item))
+  }
+
+  private fun assertDeleteDialogDisplayed() {
+    onView(withText("DELETE")).check(matches(isDisplayed()))
+  }
+
+  private fun clickOnDeleteZimFile() {
+    onView(withText("DELETE")).perform(click())
+  }
+
   fun deleteZimIfExists(shouldDeleteZimFile: Boolean) {
     try {
-      longClickOn(Text(zimFileTitle))
-      clickOn(ViewId(R.id.zim_file_delete_item))
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      onView(withText("DELETE")).check(matches(isDisplayed()))
-      onView(withText("DELETE")).perform(click())
+      longClickOnZimFile()
+      clickOnFileDeleteIcon()
+      assertDeleteDialogDisplayed()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      clickOnDeleteZimFile()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
     } catch (e: Exception) {
       if (shouldDeleteZimFile) {
         throw Exception(
           "$zimFileTitle downloaded successfully. " +
-            "But failed to delete $zimFileTitle file"
+            "But failed to delete $zimFileTitle file " +
+            "Actual exception ${e.localizedMessage}"
         )
       }
       Log.i(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -57,13 +57,30 @@ class InitialDownloadRobot : BaseRobot() {
     isVisible(ViewId(R.id.libraryList))
   }
 
+  private fun longClickOnZimFile() {
+    longClickOn(Text(zimFileTitle))
+  }
+
+  private fun clickOnFileDeleteIcon() {
+    clickOn(ViewId(R.id.zim_file_delete_item))
+  }
+
+  private fun assertDeleteDialogDisplayed() {
+    onView(withText("DELETE")).check(matches(isDisplayed()))
+  }
+
+  private fun clickOnDeleteZimFile() {
+    onView(withText("DELETE")).perform(click())
+  }
+
   fun deleteZimIfExists() {
     try {
-      longClickOn(Text(zimFileTitle))
-      clickOn(ViewId(R.id.zim_file_delete_item))
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      onView(withText("DELETE")).check(matches(isDisplayed()))
-      onView(withText("DELETE")).perform(click())
+      longClickOnZimFile()
+      clickOnFileDeleteIcon()
+      assertDeleteDialogDisplayed()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      clickOnDeleteZimFile()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -48,6 +48,7 @@ object TestUtils {
   private const val TAG = "TESTUTILS"
   @JvmField var TEST_PAUSE_MS = 250
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
+  var TEST_PAUSE_MS_FOR_ESPRESSO = 3000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
   const val RETRY_COUNT_FOR_FLAKY_TEST = 3
 


### PR DESCRIPTION
Fixes #3190

**How i fix this problem**
* I have improved test cases for better emulator performance.
* I have increase some wait for it in ```DownloadTest``` , ```InitialDownloadTest``` to visible ```Delete dialog``` properly. So ```Espresso``` can easily find it.
