### PR TITLE
Adding escape character in pref_text_zoom_summary

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -261,7 +261,7 @@
   <string name="pref_clear_all_notes_summary">Clears all notes on all articles</string>
   <string name="pref_clear_all_notes_title">Clear all notes</string>
   <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read and write ZIM files on SD card</string>
-  <string name="pref_text_zoom_summary">Change text size with 25% increments.</string>
+  <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
   <string name="tag_pic">Pic</string>
   <string name="tag_vid">Vid</string>
   <string name="tag_text_only">Text Only</string>


### PR DESCRIPTION
Fixes #3180 

I'm introducing escape character in English string.xml which will be sufficient for string count issue but translate wiki update will be required after this merge. 