### PR TITLE
Fixed Action mode always visible after deleting zim file in ```LocalLibraryFragment```

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -283,6 +283,7 @@ class LocalLibraryFragment : BaseFragment() {
     booksOnDiskAdapter.items = items
     if (items.none(BooksOnDiskListItem::isSelected)) {
       actionMode?.finish()
+      actionMode = null
     }
     actionMode?.title = String.format("%d", state.selectedBooks.size)
     fragmentDestinationLibraryBinding?.apply {


### PR DESCRIPTION
Fixes #3197 

I have placed a fix for it. If no ```zim file``` were selected in ```local library fragment``` then ```action mode``` would be ```null``` .