### PR TITLE
Fixed Sometimes CI failed due to Broken pipe (32) error in android 33 

### DIFF
--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 adb logcat -c
-adb logcat *:E -v color &
+adb logcat ./*:E -v color &
 retry=0
 while [ $retry -le 3 ]
 do
@@ -12,6 +12,7 @@ do
     adb kill-server
     adb start-server
     adb logcat -c
+    adb logcat ./*:E -v color &
     ./gradlew clean
     retry=$(( $retry + 1 ))
     if [ $retry == 3 ]; then

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -2,9 +2,21 @@
 
 adb logcat -c
 adb logcat *:E -v color &
-if ./gradlew jacocoInstrumentationTestReport; then
-  echo "jacocoInstrumentationTestReport succeeded" >&2
-else
-  adb exec-out screencap -p >screencap.png
-  exit 1
-fi
+retry=0
+while [ $retry -le 3 ]
+do
+  if ./gradlew jacocoInstrumentationTestReport; then
+    echo "jacocoInstrumentationTestReport succeeded" >&2
+    break
+  else
+    adb kill-server
+    adb start-server
+    adb logcat -c
+    ./gradlew clean
+    retry=$(( $retry + 1 ))
+    if [ $retry == 3 ]; then
+      adb exec-out screencap -p >screencap.png
+      exit 1
+    fi
+  fi
+done


### PR DESCRIPTION
Fixes #3202 

I have added retry count in bash script if emulator freeze then it will kill the adb and start again.