### PR TITLE
Fixed remove deprecated ActivityTestRule from test cases. Upgrade test dependencies to latest stable version.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -19,11 +19,10 @@
 package org.kiwix.kiwixmobile
 
 import android.Manifest.permission
-import android.app.Activity
 import android.content.Context
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -34,7 +33,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 @RunWith(AndroidJUnit4::class)
 abstract class BaseActivityTest {
   @get:Rule
-  open var activityRule = ActivityTestRule(KiwixMainActivity::class.java)
+  open var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)
 
   @get:Rule
   var readPermissionRule: GrantPermissionRule =
@@ -47,16 +46,6 @@ abstract class BaseActivityTest {
   val context: Context by lazy {
     getInstrumentation().targetContext.applicationContext
   }
-
-  protected inline fun <reified T : Activity> activityTestRule(
-    noinline beforeActivityAction: (() -> Unit)? = null
-  ) =
-    object : ActivityTestRule<T>(T::class.java) {
-      override fun beforeActivityLaunched() {
-        super.beforeActivityLaunched()
-        beforeActivityAction?.invoke()
-      }
-    }
 
   protected fun testComponent(): TestComponent = DaggerTestComponent.builder()
     .context(context)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -18,7 +18,6 @@
 package org.kiwix.kiwixmobile.help
 
 import android.os.Build
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
@@ -43,7 +42,9 @@ class HelpFragmentTest : BaseActivityTest() {
   @Test
   fun verifyHelpActivity() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      runOnUiThread { activityRule.activity.navigate(R.id.helpFragment) }
+      activityScenarioRule.scenario.onActivity {
+        it.navigate(R.id.helpFragment)
+      }
       help {
         clickOnWhatDoesKiwixDo()
         assertWhatDoesKiwixDoIsExpanded()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -25,7 +25,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import leakcanary.LeakAssertions
@@ -43,15 +42,6 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class InitialDownloadTest : BaseActivityTest() {
-  override var activityRule: ActivityTestRule<KiwixMainActivity> = activityTestRule {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
-      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, true)
-      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-    }
-  }
 
   @Rule
   @JvmField
@@ -60,6 +50,13 @@ class InitialDownloadTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, true)
+      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.intro
 import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -41,7 +41,9 @@ class IntroFragmentTest : BaseActivityTest() {
   @Test
   fun viewIsSwipeableAndNavigatesToMain() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      runOnUiThread { activityRule.activity.navigate(R.id.introFragment) }
+      activityScenarioRule.scenario.onActivity {
+        it.navigate(R.id.introFragment)
+      }
       intro(IntroRobot::swipeLeft) clickGetStarted {}
       LeakAssertions.assertNoLeaks()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.mimetype
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
 import org.junit.Assert
 import org.junit.Before
@@ -31,23 +30,19 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
 
 class MimeTypeTest : BaseActivityTest() {
 
-  override var activityRule: ActivityTestRule<KiwixMainActivity> = activityTestRule {
+  @Before
+  override fun waitForIdle() {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
     }
-  }
-
-  @Before
-  override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.note
 
 import android.os.Build
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
@@ -44,7 +43,9 @@ class NoteFragmentTest : BaseActivityTest() {
   @Test
   fun verifyNoteFragment() {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      UiThreadStatement.runOnUiThread { activityRule.activity.navigate(R.id.notesFragment) }
+      activityScenarioRule.scenario.onActivity {
+        it.navigate(R.id.notesFragment)
+      }
       note {
         assertToolbarExist()
         assertNoteRecyclerViewExist()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.search
 
+import android.os.Build
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
@@ -59,48 +60,50 @@ class SearchFragmentTest : BaseActivityTest() {
 
   @Test
   fun searchFragmentSimple() {
-    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
-      kiwixMainActivity = it
-      kiwixMainActivity.navigate(R.id.libraryFragment)
-    }
-    val loadFileStream =
-      SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+        kiwixMainActivity = it
+        kiwixMainActivity.navigate(R.id.libraryFragment)
+      }
+      val loadFileStream =
+        SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+      val zimFile = File(context.cacheDir, "testzim.zim")
+      if (zimFile.exists()) zimFile.delete()
+      zimFile.createNewFile()
+      loadFileStream.use { inputStream ->
+        val outputStream: OutputStream = FileOutputStream(zimFile)
+        outputStream.use { it ->
+          val buffer = ByteArray(inputStream.available())
+          var length: Int
+          while (inputStream.read(buffer).also { length = it } > 0) {
+            it.write(buffer, 0, length)
+          }
         }
       }
-    }
-    UiThreadStatement.runOnUiThread {
-      kiwixMainActivity.navigate(
-        actionNavigationLibraryToNavigationReader()
-          .apply { zimFileUri = zimFile.toUri().toString() }
-      )
-    }
-    search { checkZimFileSearchSuccessful(R.id.readerFragment) }
-    UiThreadStatement.runOnUiThread {
-      if (zimFile.canRead()) {
-        kiwixMainActivity.openSearch(searchString = "Android")
-      } else {
-        throw RuntimeException(
-          "File $zimFile is not readable." +
-            " Original File $zimFile is readable = ${zimFile.canRead()}" +
-            " Size ${zimFile.length()}"
+      UiThreadStatement.runOnUiThread {
+        kiwixMainActivity.navigate(
+          actionNavigationLibraryToNavigationReader()
+            .apply { zimFileUri = zimFile.toUri().toString() }
         )
       }
+      search { checkZimFileSearchSuccessful(R.id.readerFragment) }
+      UiThreadStatement.runOnUiThread {
+        if (zimFile.canRead()) {
+          kiwixMainActivity.openSearch(searchString = "Android")
+        } else {
+          throw RuntimeException(
+            "File $zimFile is not readable." +
+              " Original File $zimFile is readable = ${zimFile.canRead()}" +
+              " Size ${zimFile.length()}"
+          )
+        }
+      }
+      search {
+        clickOnSearchItemInSearchList()
+        checkZimFileSearchSuccessful(R.id.readerFragment)
+      }
+      LeakAssertions.assertNoLeaks()
     }
-    search {
-      clickOnSearchItemInSearchList()
-      checkZimFileSearchSuccessful(R.id.readerFragment)
-    }
-    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -197,7 +197,7 @@ object Libs {
   /**
    * https://developer.android.com/testing
    */
-  const val androidx_test_rules: String = "androidx.test:rules:" + Versions.androidx_test
+  const val androidx_test_rules: String = "androidx.test:rules:" + Versions.androidx_test_core
 
   /**
    * https://developer.android.com/testing

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
 
   const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.4.1"
 
-  const val androidx_test_espresso: String = "3.4.0"
+  const val androidx_test_espresso: String = "3.5.0"
 
   const val androidx_test_espresso_contrib: String = "3.3.0"
 
@@ -36,9 +36,9 @@ object Versions {
 
   const val com_jakewharton: String = "10.2.3"
 
-  const val androidx_test: String = "1.4.0"
+  const val androidx_test: String = "1.5.1"
 
-  const val androidx_test_core: String = "1.5.0-alpha02"
+  const val androidx_test_core: String = "1.5.0"
 
   const val androidx_test_orchestrator: String = "1.4.1"
 
@@ -66,7 +66,7 @@ object Versions {
 
   const val preference_ktx: String = "1.1.1"
 
-  const val junit_jupiter: String = "5.7.0"
+  const val junit_jupiter: String = "5.9.1"
 
   const val assertj_core: String = "3.18.1"
 
@@ -112,7 +112,7 @@ object Versions {
 
   const val aapt2: String = "4.1.1-6503028"
 
-  const val junit: String = "1.1.2"
+  const val junit: String = "1.1.4"
 
   /**
    * Current version: "6.2"


### PR DESCRIPTION
Fixes #3204 

* I have removed deprecated ```ActivityTestRule``` from test cases.
* Upgraded test dependencies to latest stable versions to better test performance.

| Dependency | From | To |
| :---         |     :---:      |     :---:      |
|  androidx.test:rules  |   1.4.0   | 1.5.0  |
|  androidx.test:runner  |   1.4.0   | 1.5.1  |
|  androidx.test:core  |   1.5.0-alpha02   | 1.5.0  |
|  androidx.test:rules  |   1.5.0-alpha02   | 1.5.0  |
|  androidx.test.espresso:espresso-web  |   3.4.0   | 3.5.0  |
|  androidx.test.espresso:espresso-intents  |   3.4.0   | 3.5.0  |
|  androidx.test.espresso:espresso-core  |   3.4.0   | 3.5.0  |
|  androidx.test.espresso:espresso-contrib  |   3.4.0   | 3.5.0  |
|  org.junit.jupiter:junit-jupiter  |   5.7.0   | 5.9.1  |
|  androidx.test.ext:junit  |   1.1.2   | 1.1.4  |
