### PR TITLE
Fixed lint issue CheckResult

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.language.viewmodel
 
+import android.annotation.SuppressLint
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
@@ -24,6 +25,7 @@ import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
 import org.kiwix.kiwixmobile.core.zim_manager.Language
 
+@SuppressLint("CheckResult")
 data class SaveLanguagesAndFinish(
   val languages: List<Language>,
   val languageDao: NewLanguagesDao

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -245,6 +245,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   override fun onDestroyView() {
     super.onDestroyView()
+    availableSpaceCalculator.dispose()
     fragmentDestinationDownloadBinding?.libraryList?.adapter = null
     fragmentDestinationDownloadBinding = null
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.webserver
 import android.util.Log
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.Disposable
 import org.kiwix.kiwixmobile.core.utils.DEFAULT_PORT
 import org.kiwix.kiwixmobile.core.utils.ServerUtils
 import org.kiwix.kiwixmobile.core.utils.ServerUtils.INVALID_IP
@@ -40,6 +41,7 @@ class WebServerHelper @Inject constructor(
 ) {
   private var kiwixServer: KiwixServer? = null
   private var isServerStarted = false
+  private var validIpAddressDisposable: Disposable? = null
 
   fun startServerHelper(selectedBooksPath: ArrayList<String>): Boolean {
     val ip = getIpAddress()
@@ -79,7 +81,7 @@ class WebServerHelper @Inject constructor(
   // If no ip is found after 15 seconds, dismisses the progress dialog
   @Suppress("MagicNumber")
   fun pollForValidIpAddress() {
-    Flowable.interval(1, TimeUnit.SECONDS)
+    validIpAddressDisposable = Flowable.interval(1, TimeUnit.SECONDS)
       .map { getIp() }
       .filter { s: String? -> s != INVALID_IP }
       .timeout(15, TimeUnit.SECONDS)
@@ -94,6 +96,10 @@ class WebServerHelper @Inject constructor(
         Log.d(TAG, "Unable to turn on server", e)
         ipAddressCallbacks.onIpAddressInvalid()
       }
+  }
+
+  fun dispose() {
+    validIpAddressDisposable?.dispose()
   }
 
   companion object {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
@@ -64,6 +64,7 @@ class HotspotService :
   }
 
   override fun onDestroy() {
+    webServerHelper?.dispose()
     hotspotStateReceiver?.let(this@HotspotService::unregisterReceiver)
     super.onDestroy()
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.zimManager
 
+import android.annotation.SuppressLint
 import android.os.FileObserver
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
@@ -32,6 +33,7 @@ import org.kiwix.kiwixmobile.zimManager.FileSystemCapability.CAN_WRITE_4GB
 import org.kiwix.kiwixmobile.zimManager.FileSystemCapability.INCONCLUSIVE
 import java.io.File
 
+@SuppressLint("CheckResult")
 class Fat32Checker constructor(
   sharedPreferenceUtil: SharedPreferenceUtil,
   private val fileSystemCheckers: List<FileSystemChecker>

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -246,12 +246,14 @@ class ZimManageViewModel @Inject constructor(
       .observeOn(Schedulers.io())
       .subscribe(
         {
-          kiwixService.library
-            .retry(5)
-            .subscribe(library::onNext) {
-              it.printStackTrace()
-              library.onNext(LibraryNetworkEntity().apply { book = LinkedList() })
-            }
+          compositeDisposable?.add(
+            kiwixService.library
+              .retry(5)
+              .subscribe(library::onNext) {
+                it.printStackTrace()
+                library.onNext(LibraryNetworkEntity().apply { book = LinkedList() })
+              }
+          )
         },
         Throwable::printStackTrace
       )

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -100,7 +100,6 @@ class AllProjectConfigurer {
           "GoogleAppIndexingApiWarning",
           "LockedOrientationActivity",
           //TODO stop ignoring below this
-          "CheckResult",
           "LabelFor",
           "LogConditional",
           "ConvertToWebp",

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
@@ -30,6 +30,7 @@ import eu.mhutti1.utils.storage.adapter.StorageAdapter
 import eu.mhutti1.utils.storage.adapter.StorageDelegate
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.databinding.StorageSelectDialogBinding
@@ -44,6 +45,7 @@ class StorageSelectDialog : DialogFragment() {
   @Inject lateinit var sharedPreferenceUtil: SharedPreferenceUtil
   private var aTitle: String? = null
   private var storageSelectDialogViewBinding: StorageSelectDialogBinding? = null
+  private var storageDisposable: Disposable? = null
 
   private val storageAdapter: StorageAdapter by lazy {
     StorageAdapter(
@@ -73,13 +75,14 @@ class StorageSelectDialog : DialogFragment() {
       setHasFixedSize(true)
     }
 
-    Flowable.fromCallable { StorageDeviceUtils.getWritableStorage(requireActivity()) }
-      .subscribeOn(Schedulers.io())
-      .observeOn(AndroidSchedulers.mainThread())
-      .subscribe(
-        { storageAdapter.items = it },
-        Throwable::printStackTrace
-      )
+    storageDisposable =
+      Flowable.fromCallable { StorageDeviceUtils.getWritableStorage(requireActivity()) }
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(
+          { storageAdapter.items = it },
+          Throwable::printStackTrace
+        )
   }
 
   override fun show(fm: FragmentManager, text: String?) {
@@ -89,6 +92,7 @@ class StorageSelectDialog : DialogFragment() {
 
   override fun onDestroyView() {
     super.onDestroyView()
+    storageDisposable?.dispose()
     storageSelectDialogViewBinding = null
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/NightModeConfig.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/NightModeConfig.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.core
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
@@ -24,6 +25,7 @@ import org.kiwix.kiwixmobile.core.NightModeConfig.Mode.SYSTEM
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
 
+@SuppressLint("CheckResult")
 class NightModeConfig @Inject constructor(
   val sharedPreferenceUtil: SharedPreferenceUtil,
   val context: Context

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.downloader
 
+import android.annotation.SuppressLint
 import io.reactivex.Observable
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
@@ -31,6 +32,7 @@ class DownloaderImpl @Inject constructor(
   private val kiwixService: KiwixService
 ) : Downloader {
 
+  @SuppressLint("CheckResult")
   override fun download(book: LibraryNetworkEntity.Book) {
     urlProvider(book)
       .take(1)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadMonitor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadMonitor.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.core.downloader.fetch
 
+import android.annotation.SuppressLint
 import com.tonyodev.fetch2.Download
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Fetch
@@ -28,6 +29,7 @@ import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.downloader.DownloadMonitor
 import javax.inject.Inject
 
+@SuppressLint("CheckResult")
 class FetchDownloadMonitor @Inject constructor(fetch: Fetch, fetchDownloadDao: FetchDownloadDao) :
   DownloadMonitor {
   private val updater = PublishSubject.create<() -> Unit>()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -439,6 +439,7 @@ class AddNoteDialog : DialogFragment() {
 
   override fun onDestroyView() {
     super.onDestroyView()
+    mainRepositoryActions.dispose()
     dialogNoteAddNoteBinding = null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -802,6 +802,7 @@ abstract class CoreReaderFragment :
       val activity = requireActivity() as AppCompatActivity?
       activity?.setSupportActionBar(null)
     }
+    repositoryActions?.dispose()
     safeDispose()
     tabCallback = null
     hideBackToTopTimer?.cancel()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.main
 
 import android.util.Log
+import io.reactivex.disposables.Disposable
 import org.kiwix.kiwixmobile.core.data.DataSource
 import org.kiwix.kiwixmobile.core.di.ActivityScope
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.BookmarkItem
@@ -29,14 +30,18 @@ private const val TAG = "MainPresenter"
 
 @ActivityScope
 class MainRepositoryActions @Inject constructor(private val dataSource: DataSource) {
+  private var saveHistoryDisposable: Disposable? = null
+  private var saveBookmarkDisposable: Disposable? = null
+  private var saveNoteDisposable: Disposable? = null
+  private var deleteNoteDisposable: Disposable? = null
 
   fun saveHistory(history: HistoryItem) {
-    dataSource.saveHistory(history)
+    saveHistoryDisposable = dataSource.saveHistory(history)
       .subscribe({}, { e -> Log.e(TAG, "Unable to save history", e) })
   }
 
   fun saveBookmark(bookmark: BookmarkItem) {
-    dataSource.saveBookmark(bookmark)
+    saveBookmarkDisposable = dataSource.saveBookmark(bookmark)
       .subscribe({}, { e -> Log.e(TAG, "Unable to save bookmark", e) })
   }
 
@@ -47,12 +52,19 @@ class MainRepositoryActions @Inject constructor(private val dataSource: DataSour
   }
 
   fun saveNote(note: NoteListItem) {
-    dataSource.saveNote(note)
+    saveNoteDisposable = dataSource.saveNote(note)
       .subscribe({}, { e -> Log.e(TAG, "Unable to save note", e) })
   }
 
   fun deleteNote(noteUniqueKey: String) {
-    dataSource.deleteNote(noteUniqueKey)
+    deleteNoteDisposable = dataSource.deleteNote(noteUniqueKey)
       .subscribe({}, { e -> Log.e(TAG, "Unable to delete note", e) })
+  }
+
+  fun dispose() {
+    saveHistoryDisposable?.dispose()
+    saveBookmarkDisposable?.dispose()
+    saveNoteDisposable?.dispose()
+    deleteNoteDisposable?.dispose()
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.core.reader
 
+import android.annotation.SuppressLint
 import android.content.res.AssetFileDescriptor
 import android.net.Uri
 import android.os.ParcelFileDescriptor
@@ -173,6 +174,7 @@ class ZimFileReader constructor(
 
   private fun getContent(url: String) = getContentAndMimeType(url).let { (content, _) -> content }
 
+  @SuppressLint("CheckResult")
   private fun streamZimContentToPipe(uri: String, outputStream: OutputStream) {
     Completable.fromAction {
       try {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -127,6 +127,11 @@ abstract class CorePrefsFragment :
       .unregisterOnSharedPreferenceChangeListener(this)
   }
 
+  override fun onDestroyView() {
+    presenter?.dispose()
+    super.onDestroyView()
+  }
+
   private fun setUpSettings() {
     setAppVersionNumber()
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsPresenter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsPresenter.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.settings
 
 import android.util.Log
+import io.reactivex.disposables.Disposable
 import org.kiwix.kiwixmobile.core.base.BasePresenter
 import org.kiwix.kiwixmobile.core.data.DataSource
 import org.kiwix.kiwixmobile.core.settings.SettingsContract.Presenter
@@ -26,12 +27,17 @@ import javax.inject.Inject
 
 internal class SettingsPresenter @Inject constructor(private val dataSource: DataSource) :
   BasePresenter<View?>(), Presenter {
+  private var dataSourceDisposable: Disposable? = null
   override fun clearHistory() {
-    dataSource.clearHistory()
+    dataSourceDisposable = dataSource.clearHistory()
       .subscribe({
         // TODO
       }, { e ->
         Log.e("SettingsPresenter", e.message, e)
       })
+  }
+
+  fun dispose() {
+    dataSourceDisposable?.dispose()
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NewBookDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NewBookDaoTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.dao
 
+import android.annotation.SuppressLint
 import io.mockk.CapturingSlot
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -63,6 +64,7 @@ internal class NewBookDaoTest {
       newBookDao.books().test().assertValues(listOf(BookOnDisk(expectedEntity)))
     }
 
+    @SuppressLint("CheckResult")
     @Test
     fun `books deletes entities whose file does not exist`() {
       val (_, deletedEntity) = expectEmissionOfExistingAndNotExistingBook()


### PR DESCRIPTION
Fixes #1273 

**What's the isssue**
It's giving lint error ```CheckResult``` on ```subscribe``` because we are only defining the objects but not disposing them after there use.

**What i do for fix this problem**
* I have disposed rxjava objects after there use.
* On some rxjava objects we have no control like we don't know when to dispose them (They have no life cycle events). so for now i have suppress lint warning for them.

```
SaveLanguagesAndFinish.kt (invokeWith) method.
Fat32Checker.kt (init) method.
NightModeConfig.kt (init) method.
DownloaderImpl.kt (download) method.
FetchDownloadMonitor.kt (init) method.
ZimFileReader.kt (streamZimContentToPipe) method.
(books deletes entities whose file does not exist) test case.
```

**We can do 2 thing for these object**

* We can store this objects in a variable it will fix lint error ```CheckResult``` (but then that variable is unused not a good practice).
* We can ignore these object by suppressing lint error as i did in this PR.


If you have a better way for these objects please feel free tell us.