### PR TITLE
Fixed Bottom Navigation disappear after saving language

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.language.viewmodel
 import android.annotation.SuppressLint
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.Flowable
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
@@ -34,6 +35,7 @@ data class SaveLanguagesAndFinish(
   override fun invokeWith(activity: AppCompatActivity) {
     Flowable.fromCallable { languageDao.insert(languages) }
       .subscribeOn(Schedulers.io())
+      .observeOn(AndroidSchedulers.mainThread())
       .subscribe({
         activity.onBackPressed()
       }, Throwable::printStackTrace)


### PR DESCRIPTION
Fixes #3208 

**What is the issue**
The main culprit is ```activity.onBackPressed()``` in ```SaveLanguagesAndFinish.kt``` for this bug beacuse it's not called from ```main thread```. That's the reason our activity did not recognised this is ```OnlineFragment``` after saving language.

```
Flowable.fromCallable { languageDao.insert(languages) }
      .subscribeOn(Schedulers.io())
      .subscribe({
        activity.onBackPressed()
      }, Throwable::printStackTrace)
```

**What i do for fixing this issue**

* I have tested with ```AndroidSchedulers.mainThread()``` and it's works as expected (Bottom Navigation is visible after saving language).
