### PR TITLE
Fixed bad visual artefact around network authorisation

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -202,6 +202,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         onRefreshStateChange(true)
         fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.GONE
         fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.GONE
+        fragmentDestinationDownloadBinding?.libraryList?.visibility = View.VISIBLE
         sharedPreferenceUtil.putPrefWifiOnly(false)
         zimManageViewModel.shouldShowWifiOnlyDialog.value = false
       },
@@ -216,6 +217,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         )
         fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
         fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.VISIBLE
+        fragmentDestinationDownloadBinding?.libraryList?.visibility = View.GONE
       }
     )
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -189,10 +189,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         }
       }
     )
-
-    fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.setOnClickListener {
-      showInternetPermissionDialog()
-    }
   }
 
   private fun showInternetPermissionDialog() {
@@ -201,7 +197,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       {
         onRefreshStateChange(true)
         fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.GONE
-        fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.GONE
         fragmentDestinationDownloadBinding?.libraryList?.visibility = View.VISIBLE
         sharedPreferenceUtil.putPrefWifiOnly(false)
         zimManageViewModel.shouldShowWifiOnlyDialog.value = false
@@ -213,10 +208,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           Toast.LENGTH_SHORT
         )
         fragmentDestinationDownloadBinding?.libraryErrorText?.setText(
-          R.string.allow_internet_permission_message
+          R.string.swipe_down_for_library
         )
         fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
-        fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.VISIBLE
         fragmentDestinationDownloadBinding?.libraryList?.visibility = View.GONE
       }
     )
@@ -274,7 +268,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           )
           fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
         }
-        fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.GONE
         fragmentDestinationDownloadBinding?.librarySwipeRefresh?.isRefreshing = false
       }
       else -> {}
@@ -304,7 +297,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     } else {
       fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.GONE
     }
-    fragmentDestinationDownloadBinding?.allowInternetPermissionButton?.visibility = View.GONE
   }
 
   private fun refreshFragment() {
@@ -313,6 +305,8 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     } else {
       zimManageViewModel.requestDownloadLibrary.onNext(Unit)
     }
+    fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.GONE
+    fragmentDestinationDownloadBinding?.libraryList?.visibility = View.VISIBLE
   }
 
   private fun downloadFile() {

--- a/app/src/main/res/layout/fragment_destination_download.xml
+++ b/app/src/main/res/layout/fragment_destination_download.xml
@@ -65,16 +65,4 @@
     app:layout_constraintVertical_bias="0.45"
     tools:ignore="RequiredSize" />
 
-  <Button
-    android:id="@+id/allowInternetPermissionButton"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="8dp"
-    android:text="@string/allow"
-    android:visibility="gone"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/libraryErrorText" />
-
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -303,7 +303,6 @@
   <string name="select_folder">الرجاء تحديد مجلد للتخزين الخارجي.</string>
   <string name="system_unable_to_grant_permission_message">النظام غير قادر على منح الإذن!</string>
   <string name="allow">السماح</string>
-  <string name="allow_internet_permission_message">يرجى السماح بإذن الإنترنت لتنزيل المحتوى</string>
   <string name="no_notes">لا توجد ملاحظات</string>
   <string name="notes_from_all_books">عرض الملاحظات من جميع الكتب</string>
   <string name="search_notes">ملاحظات البحث</string>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -304,7 +304,6 @@
   <string name="select_folder">Vyberte složku pro externí úložiště.</string>
   <string name="system_unable_to_grant_permission_message">Systém nemůže udělit oprávnění!</string>
   <string name="allow">Povolit</string>
-  <string name="allow_internet_permission_message">Povolte prosím internetové povolení ke stahování obsahu</string>
   <string name="no_notes">Žádné poznámky</string>
   <string name="notes_from_all_books">Zobrazit poznámky ze všech knih</string>
   <string name="search_notes">Hledat poznámky</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -309,5 +309,4 @@
   <string name="select_folder">Bitte einen Ordner für externe Speicherung auswählen.</string>
   <string name="system_unable_to_grant_permission_message">System kann keine Berechtigung erteilen!</string>
   <string name="allow">Erlauben</string>
-  <string name="allow_internet_permission_message">Bitte erteile die Internet-Erlaubnis, um Inhalte herunterzuladen</string>
 </resources>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -309,7 +309,6 @@
   <string name="select_folder">Veuillez sélectionner un dossier pour le stockage externe.</string>
   <string name="system_unable_to_grant_permission_message">Le système n’a pas pu accorder le droit d’accès !</string>
   <string name="allow">Autoriser</string>
-  <string name="allow_internet_permission_message">Veuillez autoriser le droit sur Internet de télécharger le contenu.</string>
   <string name="no_notes">Aucune note</string>
   <string name="notes_from_all_books">Afficher les notes de tous les livres</string>
   <string name="search_notes">Rechercher des notes</string>

--- a/core/src/main/res/values-hi/strings.xml
+++ b/core/src/main/res/values-hi/strings.xml
@@ -132,5 +132,4 @@
   <string name="on">चालू</string>
   <string name="off">बंद</string>
   <string name="allow">अनुमति दें</string>
-  <string name="allow_internet_permission_message">कृपया कंटैट डाउनलोड करने के लिए इंटरनेट की अनुमति दें</string>
 </resources>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -304,7 +304,6 @@
   <string name="select_folder">Seleziona una cartella per l\'archiviazione esterna.</string>
   <string name="system_unable_to_grant_permission_message">Il sistema non è in grado di concedere l\'autorizzazione!</string>
   <string name="allow">Consenti</string>
-  <string name="allow_internet_permission_message">Si prega di consentire l\'autorizzazione a Internet per scaricare i contenuti</string>
   <string name="no_notes">Nessuna nota</string>
   <string name="notes_from_all_books">Visualizza le note di tutti i libri</string>
   <string name="search_notes">Cerca note</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -301,7 +301,6 @@
   <string name="select_folder">נא לבחור תיקייה לאחסון חיצוני.</string>
   <string name="system_unable_to_grant_permission_message">המערכת אינה יכולה לתת הרשאה!</string>
   <string name="allow">לאפשר</string>
-  <string name="allow_internet_permission_message">נא לאפשר הרשאת אינטרנט כדי להוריד תוכן</string>
   <string name="no_notes">אין הערות</string>
   <string name="notes_from_all_books">הצגת הערות מכל הספרים</string>
   <string name="search_notes">חיפוש בהערות</string>

--- a/core/src/main/res/values-ku/strings.xml
+++ b/core/src/main/res/values-ku/strings.xml
@@ -297,7 +297,6 @@
   <string name="select_folder">Ji kerema xwe peldankekê bibijêre ji bo depokirina xaricî.</string>
   <string name="system_unable_to_grant_permission_message">Sîstem nikare destûrê werbigire!</string>
   <string name="allow">Destûr bide</string>
-  <string name="allow_internet_permission_message">Ji kerema xwe destûra înternetê bide da ku karibe naverokê daxîne</string>
   <string name="no_notes">Not tine</string>
   <string name="notes_from_all_books">Notan Bibîne Ji Hemû Kitêban</string>
   <string name="search_notes">Li notan bigere</string>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -293,7 +293,6 @@
   <string name="select_folder">Изберете ја папката за надворешно складирање.</string>
   <string name="system_unable_to_grant_permission_message">Системот не може да ја даде дозволата!</string>
   <string name="allow">Дозволи</string>
-  <string name="allow_internet_permission_message">Дајте дозвола за семрежен пристап за преземање на содржините</string>
   <string name="no_notes">Нема белешки</string>
   <string name="notes_from_all_books">Погл. белешки од сите книги</string>
   <string name="search_notes">Пребарај белешки</string>

--- a/core/src/main/res/values-nqo/strings.xml
+++ b/core/src/main/res/values-nqo/strings.xml
@@ -295,7 +295,6 @@
   <string name="select_folder">ߞߎ߲ߓߍ߲ ߘߏ߫ ߛߎߥߊ߲ߘߌ߫ ߖߊ߰ߣߌ߲߫ ߞߣߐߘߐ ߟߊ߬ߡߙߊ߬ߦߙߐ߬ ߞߏ ߘߐ߫.</string>
   <string name="system_unable_to_grant_permission_message">ߘߌ߬ߢߍ߬ ߞߍߣߍ߲߫ ߣߍ߫ ߞߊ߲ߞߋ ߢߍ߫ ߖߡߊ߬ߙߌ߬ߟߌ ߘߐ߫߹</string>
   <string name="allow">ߊ߬ ߟߊߘߌ߬ߢߍ߬</string>
-  <string name="allow_internet_permission_message">ߓߟߐߟߐ ߖߡߊ߬ߙߌ߬ߦߊ ߟߊߘߌ߬ߢߍ߫ ߖߊ߰ߣߌ߲߫ ߞߊ߬ ߛߋ߫ ߞߣߐߘߐ ߡߊߞߍ߫ ߟߴߌ ߞߎ߲߬</string>
   <string name="no_notes">ߦߟߌߣߐ߫ ߕߴߦߋ߲߬</string>
   <string name="notes_from_all_books">ߦߟߌߣߐ ߘߐߜߍ߫ ߞߊ߬ ߝߘߊ߫ ߞߊ߬ߝߊ ߟߎ߬ ߓߍ߯ ߟߊ߫</string>
   <string name="search_notes">ߞߐߕߐ߮ ߟߎ߬ ߢߌߣߌ߲߫</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -314,7 +314,6 @@
   <string name="select_folder">Выберите папку для внешнего хранилища.</string>
   <string name="system_unable_to_grant_permission_message">Система не может предоставить разрешение!</string>
   <string name="allow">Разрешить</string>
-  <string name="allow_internet_permission_message">Пожалуйста разрешите доступ в интернет для загрузки контента</string>
   <string name="no_notes">Нет заметок</string>
   <string name="notes_from_all_books">Просмотр заметок из всех книг</string>
   <string name="search_notes">Искать заметки</string>

--- a/core/src/main/res/values-sc/strings.xml
+++ b/core/src/main/res/values-sc/strings.xml
@@ -294,7 +294,6 @@
   <string name="select_folder">Pro praghere seletziona una cartella pro sa memòria esterna.</string>
   <string name="system_unable_to_grant_permission_message">Su sistema no est in gradu de frunire su permissu!</string>
   <string name="allow">Permite</string>
-  <string name="allow_internet_permission_message">Pro praghere fruni su permissu pro sa retze ìnternet pro iscarrigare cuntenutos</string>
   <string name="no_notes">Peruna nota</string>
   <string name="notes_from_all_books">Pòmpia sas notas de totu sos libros</string>
   <string name="search_notes">Chirca notas</string>

--- a/core/src/main/res/values-sk/strings.xml
+++ b/core/src/main/res/values-sk/strings.xml
@@ -293,7 +293,6 @@
   <string name="select_folder">Prosím vyberte priečinok pre externé úložisko.</string>
   <string name="system_unable_to_grant_permission_message">Systému sa nedarí udeliť povolenie!</string>
   <string name="allow">Povoliť</string>
-  <string name="allow_internet_permission_message">Povoľte internetové povolenie na sťahovanie obsahu</string>
   <string name="no_notes">Žiadne poznámky</string>
   <string name="notes_from_all_books">Zobraziť poznámky zo všetkých kníh</string>
   <string name="search_notes">Hľadať v poznámkach</string>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -298,7 +298,6 @@
   <string name="select_folder">Välj mapp för extern lagring.</string>
   <string name="system_unable_to_grant_permission_message">Systemet kunde inte ge tillstånd!</string>
   <string name="allow">Tillåt</string>
-  <string name="allow_internet_permission_message">Tillåt internetbehörigheter för att ladda ner innehåll</string>
   <string name="no_notes">Inga anteckningar</string>
   <string name="notes_from_all_books">Visa anteckningar från alla böcker</string>
   <string name="search_notes">Sök i anteckningar</string>

--- a/core/src/main/res/values-ta/strings.xml
+++ b/core/src/main/res/values-ta/strings.xml
@@ -296,7 +296,6 @@
   <string name="select_folder">வெளிப்புற சேமிப்பகத்திற்கான கோப்புறையைத் தேர்ந்தெடுக்கவும்.</string>
   <string name="system_unable_to_grant_permission_message">அமைப்பு அனுமதி வழங்க முடியவில்லை!</string>
   <string name="allow">அனுமதிக்கவும்</string>
-  <string name="allow_internet_permission_message">உள்ளடக்கத்தைப் பதிவிறக்க இணைய அனுமதியை அனுமதிக்கவும்</string>
   <string name="no_notes">குறிப்புகள் இல்லை</string>
   <string name="notes_from_all_books">எல்லா புத்தகங்களிலிருந்தும் குறிப்புகளைப் பார்க்கவும்</string>
   <string name="search_notes">குறிப்புகளைத் தேடு</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -307,7 +307,6 @@
   <string name="select_folder">Lütfen harici depolama için bir klasör seçin.</string>
   <string name="system_unable_to_grant_permission_message">Sistem izin veremiyor!</string>
   <string name="allow">İzin ver</string>
-  <string name="allow_internet_permission_message">Lütfen içeriği indirmek için internet iznine izin verin</string>
   <string name="no_notes">Not Yok</string>
   <string name="notes_from_all_books">Tüm Kitaplardan Notları Görüntüle</string>
   <string name="search_notes">Notları Ara</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -299,7 +299,6 @@
   <string name="select_folder">請選取用於外部儲存的資料夾。</string>
   <string name="system_unable_to_grant_permission_message">系統無法授予權限！</string>
   <string name="allow">允許</string>
-  <string name="allow_internet_permission_message">請允許網路權限來下載內容</string>
   <string name="no_notes">沒有註釋</string>
   <string name="notes_from_all_books">檢視來自所有書籍的註釋</string>
   <string name="search_notes">搜尋註釋</string>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -311,7 +311,6 @@
   <string name="select_folder">请选择用于外部存储的文件夹。</string>
   <string name="system_unable_to_grant_permission_message">系统无法授予权限！</string>
   <string name="allow">允许</string>
-  <string name="allow_internet_permission_message">请允许联网权限来下载内容</string>
   <string name="no_notes">没有注释</string>
   <string name="notes_from_all_books">查看来自所有书籍的注释</string>
   <string name="search_notes">搜索注释</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -304,7 +304,7 @@
   <string name="select_folder">Please select a folder for external storage.</string>
   <string name="system_unable_to_grant_permission_message">System unable to grant permission!</string>
   <string name="allow">Allow</string>
-  <string name="allow_internet_permission_message">Please allow internet permission to download content</string>
+  <string name="swipe_down_for_library">Swipe Down for Library</string>
   <string-array name="pref_night_modes_entries">
     <item>@string/on</item>
     <item>@string/off</item>


### PR DESCRIPTION
Fixes #3211 

**What is the issue**

* If user click on no button in internet permission dialog then allow permission text and button appears on zim file.

**How i fix this problem**
* I have set ```visibility=GONE``` to recyclerview of zim files when allow permission text and button is visible. 
* I have changed message as mention on ticket.
* I have removed allow button from online fragment.
* I have improved library loading (previously it's showing blank screen after placing above fixes) when network state is changed (from mobile network to WIFI).
