### PR TITLE
Fixed read aloud feature on the wiki med offline app

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -117,7 +117,7 @@ class KiwixTextToSpeech internal constructor(
       } else {
         tts.language = locale
         if (getFeatures(tts).contains(Engine.KEY_FEATURE_NOT_INSTALLED)) {
-          context.toast(R.string.tts_lang_not_supported, Toast.LENGTH_LONG)
+          (context as CoreMainActivity).externalLinkOpener.showTTSLanguageDownloadDialog()
         } else if (requestAudioFocus()) {
           loadURL(webView)
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -117,7 +117,8 @@ class KiwixTextToSpeech internal constructor(
       } else {
         tts.language = locale
         if (getFeatures(tts).contains(Engine.KEY_FEATURE_NOT_INSTALLED)) {
-          (context as CoreMainActivity).externalLinkOpener.showTTSLanguageDownloadDialog()
+          val activity = context as CoreMainActivity?
+          activity?.externalLinkOpener?.showTTSLanguageDownloadDialog()
         } else if (requestAudioFocus()) {
           loadURL(webView)
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
@@ -20,7 +20,7 @@ package org.kiwix.kiwixmobile.core.utils
 
 import android.app.Activity
 import android.content.Intent
-import android.speech.tts.TextToSpeech
+import android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -69,7 +69,7 @@ class ExternalLinkOpener @Inject constructor(
       {
         activity.startActivity(
           Intent().apply {
-            action = TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
+            action = ACTION_INSTALL_TTS_DATA
           }
         )
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.utils
 
 import android.app.Activity
 import android.content.Intent
+import android.speech.tts.TextToSpeech
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -58,6 +59,19 @@ class ExternalLinkOpener @Inject constructor(
       {
         sharedPreferenceUtil.putPrefExternalLinkPopup(false)
         openLink(intent)
+      }
+    )
+  }
+
+  fun showTTSLanguageDownloadDialog() {
+    alertDialogShower.show(
+      KiwixDialog.DownloadTTSLanguage,
+      {
+        activity.startActivity(
+          Intent().apply {
+            action = TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
+          }
+        )
       }
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -221,6 +221,13 @@ sealed class KiwixDialog(
     android.R.string.cancel
   )
 
+  object DownloadTTSLanguage : KiwixDialog(
+    R.string.download_tts_language_title,
+    R.string.download_tts_language_message,
+    R.string.download,
+    android.R.string.cancel
+  )
+
   open class YesNoDialog(
     title: Int?,
     message: Int

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -323,4 +323,6 @@
   <string name="open_article">Open Article</string>
   <string name="delete_note_dialog_message">Note: Notes are not deleted from your storage</string>
   <string name="delete_selected_notes">Delete Selected Notes?</string>
+  <string name="download_tts_language_title">Download this language for read aloud feature</string>
+  <string name="download_tts_language_message">Please click download button it will automatically download the required language.</string>
 </resources>


### PR DESCRIPTION
Fixes #2065 

**What is the problem**

* In TTS (Text to speech) has not that language which user were using in read aloud feature.
* We are previously showing wrong message to user.
https://github.com/kiwix/kiwix-android/blob/30773dad42bd90b8d108bd292e47ab474a9df032/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt#L120

**What i did to fix this problem**

* I have added a dialog. If TTS has not that language then this dialog popup to the user (After clicking on read aloud).
* After clicking on download button it automatically download the required language in TTS (through intent with action ```TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA``` . It will go into phone settings and automatically installed the TTS language without user interaction).