### PR TITLE
FIxed Translate wiki PR failed to compile application due to tarask string file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,3 +111,19 @@ task("generateVersionCodeAndName") {
     )
   }
 }
+
+task("renameTarakFile") {
+  val taraskFile = File("core/src/main/res/values-b+be+tarask/strings.xml")
+  if (taraskFile.exists()) {
+    val taraskOldFile = File("core/src/main/res/values-b+be+tarask+old/strings.xml")
+    if (!taraskOldFile.exists()) taraskOldFile.createNewFile()
+    taraskOldFile.printWriter().use {
+      it.print(taraskFile.readText())
+    }
+    taraskFile.delete()
+  }
+}
+
+tasks.build {
+  dependsOn("renameTarakFile")
+}


### PR DESCRIPTION
Fixes #3176 

I have created a gradle task and it run before gradlew build. It will copy all strings from tarask file and add into tarask+old file after that it will delete the tarask file. so there is no compilation error and also we get latest changes from translate wiki if any change comes in tarask file.