### PR TITLE
Fixed Allow download content via mobile network message still not proper

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -176,7 +176,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     zimManageViewModel.shouldShowWifiOnlyDialog.observe(
       viewLifecycleOwner
     ) {
-      if (it) {
+      if (it && !NetworkUtils.isWiFi(requireContext())) {
         showInternetAccessViaMobileNetworkDialog()
       }
     }


### PR DESCRIPTION
Fixes #3224 

**What is the issue**
* We have a condition if we click on no button in ```allow download content via mobile network dialog``` . then it save a boolean value in ```sharedprefrence``` and when we back to online fragment from another. It checked that value is true or not, if that value is true it shows the dialog. there is no other condition in that code block (if WIFI is active or not).

**How i fixed this problem**

* I have placed a condition in that code block, If allow content dialog is true and wifi is active then ```allow download content via mobile network dialog``` will not show.