### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
 
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -71,7 +71,7 @@ jobs:
           script: bash contrib/instrumentation.sh
 
       - name: Upload screenshot result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{ matrix.api-level }}
@@ -83,10 +83,10 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.api-level==21 }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 
       - name: Upload Coverage to GH-Actions
-        uses: actions/upload-artifact@v2.2.0
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.api-level==21 }}
         with:
           name: Tests Coverage Report

--- a/.github/workflows/fdroid_nightly.yml
+++ b/.github/workflows/fdroid_nightly.yml
@@ -12,11 +12,12 @@ jobs:
     environment: nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
       - name: Build
         run: |
           # use timestamp as Version Code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,14 +12,15 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
 
       - name: build debug
         run: ./gradlew assembleNightly

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,16 +13,17 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -36,7 +37,7 @@ jobs:
 
       - name: Upload ktlint Reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
          name: ktlint-report
          path: '**/build/reports/ktlint'
@@ -49,16 +50,18 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
+
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -70,7 +73,7 @@ jobs:
       - name: Static Analysis
         run: ./gradlew detekt
       - name: Upload Lint Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: detekt-report
@@ -85,17 +88,18 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
             java-version: 11
+	    distribution: temurin
 
       - name: Restore Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -107,7 +111,7 @@ jobs:
         run: ./gradlew app:lintDebug custom:lintCustomexampleDebug
 
       - name: Upload Lint Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
             name: lint-report
@@ -122,20 +126,21 @@ jobs:
     continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
 
       - name: Build all configurations
         run: ./gradlew assemble
 
       - name: Upload APK as Artifacts
-        uses: actions/upload-artifact@v2.2.0
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
             name: kiwix-android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,13 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+	  distribution: temurin
 
       - name: Decrypt files
         env:


### PR DESCRIPTION
To stop having the CI display warnings because these actions (old versions) were relying on deprecated Node.js 12.