### PR TITLE
Fixes of files which are too big to be downloaded in the local storage should be greyed

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -55,7 +55,6 @@ import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.downloader.Downloader
-import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
@@ -100,7 +99,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   @Inject lateinit var alertDialogShower: AlertDialogShower
   private var fragmentDestinationDownloadBinding: FragmentDestinationDownloadBinding? = null
 
-  private var downloadBookItem: LibraryNetworkEntity.Book? = null
+  private var downloadBookItem: LibraryListItem.BookItem? = null
   private val zimManageViewModel by lazy {
     requireActivity().viewModel<ZimManageViewModel>(viewModelFactory)
   }
@@ -329,7 +328,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   }
 
   private fun downloadFile() {
-    downloadBookItem?.let {
+    downloadBookItem?.book?.let {
       downloader.download(it)
       downloadBookItem = null
     }
@@ -344,7 +343,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         sharedPreferenceUtil.getPublicDirectoryPath(storageDevice.name)
       )
       sharedPreferenceUtil.putStoragePosition(INTERNAL_SELECT_POSITION)
-      downloadFile()
+      clickOnBookItem()
     } else {
       if (sharedPreferenceUtil.isPlayStoreBuild) {
         setExternalStoragePath(storageDevice)
@@ -364,7 +363,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private fun setExternalStoragePath(storageDevice: StorageDevice) {
     sharedPreferenceUtil.putPrefStorage(storageDevice.name)
     sharedPreferenceUtil.putStoragePosition(EXTERNAL_SELECT_POSITION)
-    downloadFile()
+    clickOnBookItem()
   }
 
   private fun selectFolder() {
@@ -388,7 +387,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       data?.let {
         getPathFromUri(requireActivity(), data)?.let(sharedPreferenceUtil::putPrefStorage)
         sharedPreferenceUtil.putStoragePosition(EXTERNAL_SELECT_POSITION)
-        downloadFile()
+        clickOnBookItem()
       } ?: run {
         activity.toast(
           resources
@@ -465,7 +464,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   private fun onBookItemClick(item: LibraryListItem.BookItem) {
     if (checkExternalStorageWritePermission()) {
-      downloadBookItem = item.book
+      downloadBookItem = item
       when {
         isNotConnected -> {
           noInternetSnackbar()
@@ -474,7 +473,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         noWifiWithWifiOnlyPreferenceSet -> {
           dialogShower.show(WifiOnly, {
             sharedPreferenceUtil.putPrefWifiOnly(false)
-            downloadFile()
+            clickOnBookItem()
           })
           return
         }
@@ -515,8 +514,12 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       },
       {
         sharedPreferenceUtil.showStorageOption = false
-        downloadFile()
+        clickOnBookItem()
       }
     )
+  }
+
+  private fun clickOnBookItem() {
+    downloadBookItem?.let(::onBookItemClick)
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -107,7 +107,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   private val libraryAdapter: LibraryAdapter by lazy {
     LibraryAdapter(
-      LibraryDelegate.BookDelegate(bookUtils, ::onBookItemClick),
+      LibraryDelegate.BookDelegate(bookUtils, ::onBookItemClick, availableSpaceCalculator),
       LibraryDelegate.DownloadDelegate {
         if (it.currentDownloadState == Status.FAILED) {
           if (isNotConnected) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
@@ -26,8 +26,8 @@ import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CanWrite4GbFile
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CannotWrite4GbFile
+import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.DetectingFileSystem
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.NotEnoughSpaceFor4GbFile
-import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.Unknown
 import org.kiwix.kiwixmobile.zimManager.FileSystemCapability.CANNOT_WRITE_4GB
 import org.kiwix.kiwixmobile.zimManager.FileSystemCapability.CAN_WRITE_4GB
 import org.kiwix.kiwixmobile.zimManager.FileSystemCapability.INCONCLUSIVE
@@ -46,7 +46,7 @@ class Fat32Checker constructor(
     Flowable.combineLatest(
       sharedPreferenceUtil.prefStorages
         .distinctUntilChanged()
-        .doOnNext { fileSystemStates.offer(Unknown) },
+        .doOnNext { fileSystemStates.offer(DetectingFileSystem) },
       requestCheckSystemFileType,
       BiFunction { storage: String, _: Unit -> storage }
     )
@@ -100,6 +100,6 @@ class Fat32Checker constructor(
     object NotEnoughSpaceFor4GbFile : FileSystemState()
     object CanWrite4GbFile : FileSystemState()
     object CannotWrite4GbFile : FileSystemState()
-    object Unknown : FileSystemState()
+    object DetectingFileSystem : FileSystemState()
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/AvailableSpaceCalculator.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/AvailableSpaceCalculator.kt
@@ -25,6 +25,7 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadModel
+import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity.Book
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem
 import javax.inject.Inject
@@ -52,6 +53,9 @@ class AvailableSpaceCalculator @Inject constructor(
         }
       }
   }
+
+  fun hasAvailableSpaceForBook(book: Book) =
+    book.size.toLong() * Kb < storageCalculator.availableBytes()
 
   fun dispose() {
     availableSpaceCalculatorDisposable?.dispose()

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryDelegate.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryDelegate.kt
@@ -24,6 +24,7 @@ import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.databinding.ItemDownloadBinding
 import org.kiwix.kiwixmobile.databinding.ItemLibraryBinding
 import org.kiwix.kiwixmobile.databinding.LibraryDividerBinding
+import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.BookItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.DividerItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.LibraryDownloadItem
@@ -36,7 +37,8 @@ sealed class LibraryDelegate<I : LibraryListItem, out VH : LibraryViewHolder<I>>
 
   class BookDelegate(
     private val bookUtils: BookUtils,
-    private val clickAction: (BookItem) -> Unit
+    private val clickAction: (BookItem) -> Unit,
+    private val availableSpaceCalculator: AvailableSpaceCalculator
   ) : LibraryDelegate<BookItem, LibraryBookViewHolder>() {
     override val itemClass = BookItem::class.java
 
@@ -44,7 +46,8 @@ sealed class LibraryDelegate<I : LibraryListItem, out VH : LibraryViewHolder<I>>
       LibraryBookViewHolder(
         parent.viewBinding(ItemLibraryBinding::inflate, false),
         bookUtils,
-        clickAction
+        clickAction,
+        availableSpaceCalculator
       )
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItem.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItem.kt
@@ -31,7 +31,7 @@ import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CanWrite4GbFile
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CannotWrite4GbFile
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.NotEnoughSpaceFor4GbFile
-import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.Unknown
+import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.DetectingFileSystem
 
 sealed class LibraryListItem {
   abstract val id: Long
@@ -49,7 +49,7 @@ sealed class LibraryListItem {
   ) : LibraryListItem() {
 
     val canBeDownloaded: Boolean = when (fileSystemState) {
-      Unknown, CannotWrite4GbFile -> book.isLessThan4GB()
+      DetectingFileSystem, CannotWrite4GbFile -> book.isLessThan4GB()
       NotEnoughSpaceFor4GbFile, CanWrite4GbFile -> true
     }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -36,7 +36,7 @@ import org.kiwix.kiwixmobile.databinding.ItemDownloadBinding
 import org.kiwix.kiwixmobile.databinding.ItemLibraryBinding
 import org.kiwix.kiwixmobile.databinding.LibraryDividerBinding
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CannotWrite4GbFile
-import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.Unknown
+import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.DetectingFileSystem
 import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.BookItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.DividerItem
@@ -77,7 +77,7 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       itemLibraryBinding.unableToDownload.setOnLongClickListener {
         when (item.fileSystemState) {
           CannotWrite4GbFile -> it.centreToast(R.string.file_system_does_not_support_4gb)
-          Unknown -> it.centreToast(R.string.detecting_file_system)
+          DetectingFileSystem -> it.centreToast(R.string.detecting_file_system)
           else -> {
             if (item.canBeDownloaded && !hasAvailableSpaceInStorage) {
               clickAction.invoke(item)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItemTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItemTest.kt
@@ -30,7 +30,7 @@ import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CanWrite4GbFile
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.CannotWrite4GbFile
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.NotEnoughSpaceFor4GbFile
-import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.Unknown
+import org.kiwix.kiwixmobile.zimManager.Fat32Checker.FileSystemState.DetectingFileSystem
 import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem.BookItem
 
 internal class LibraryListItemTest {
@@ -47,19 +47,19 @@ internal class LibraryListItemTest {
 
   @Test
   internal fun `Unknown file system state files under 4GB can be downloaded`() {
-    assertThat(canBeDownloaded(book, Unknown)).isTrue
+    assertThat(canBeDownloaded(book, DetectingFileSystem)).isTrue
   }
 
   @Test
   internal fun `Unknown file system state greater than 4GB can't be downloaded`() {
     every { book.size } returns (Fat32Checker.FOUR_GIGABYTES_IN_KILOBYTES + 1).toString()
-    assertThat(canBeDownloaded(book, Unknown)).isFalse
+    assertThat(canBeDownloaded(book, DetectingFileSystem)).isFalse
   }
 
   @Test
   internal fun `Unknown file system state empty size can be downloaded`() {
     every { book.size } returns ""
-    assertThat(canBeDownloaded(book, Unknown)).isTrue
+    assertThat(canBeDownloaded(book, DetectingFileSystem)).isTrue
   }
 
   @Test


### PR DESCRIPTION
Fixes #2639 

* I have added a condition for both internal and external storage. if file system is OK but device has not enough space then ZIM file will showing as grey.
* I have added a new condition on grey view. If ZIM file showing as grey(this means device has not enough space in storage (But ZIM file can be download) which might be internal or external). Then user can long click on grey zim file, it shows a storage selection dialog (like previously showing when we clicking on zim file).

**For Internal Storage**


https://user-images.githubusercontent.com/34593983/217218341-ae428202-a8b2-45a3-bf0d-fb71d8443b7f.mp4


**For External Storage**


https://user-images.githubusercontent.com/34593983/217218892-af801fcd-6de3-4cdc-b520-ba15f5911fef.mp4


* Fixed downloading start after clicking on storage selection dialog if device has not enough storage.
