### PR TITLE
Fixed Endless media access permission request

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/Intents.kt
@@ -29,6 +29,7 @@ object Intents {
   @JvmStatic fun <T : Activity> internal(clazz: Class<T>): Intent =
     Intent(clazz.canonicalName).setPackage(CoreApp.instance.packageName)
 }
+
 @RequiresApi(Build.VERSION_CODES.R)
 fun Activity.navigateToSettings() {
   val intent = Intent().apply {
@@ -36,4 +37,12 @@ fun Activity.navigateToSettings() {
     data = Uri.fromParts("package", packageName, null)
   }
   startActivity(intent)
+}
+
+fun Activity.navigateToAppSettings() {
+  startActivity(
+    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+      data = Uri.fromParts("package", packageName, null)
+    }
+  )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -95,7 +95,7 @@ sealed class KiwixDialog(
   object ReadPermissionRequired : KiwixDialog(
     R.string.storage_permission_denied,
     R.string.grant_read_storage_permission,
-    R.string.go_to_settings,
+    R.string.go_to_settings_label,
     null,
     cancelable = false
   )

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
   <string name="tag_text_only">Text Only</string>
   <string name="tag_short_text">Short Text</string>
   <string name="storage_permission_denied">Storage Permission Denied</string>
-  <string name="grant_read_storage_permission">This app requires the ability to read storage permission to function. Please grant the storage permission in your app setting</string>
+  <string name="grant_read_storage_permission">This app requires the ability to read storage to function. Please grant the permission in your settings</string>
   <string name="go_to_settings">Go to Hotspot Settings</string>
   <string name="no_results">No Results</string>
   <string name="no_bookmarks">No Bookmarks</string>
@@ -334,5 +334,5 @@
   <string name="forward_history">Forward history</string>
   <string name="clear_all_navigation_history_message">Clears all (backward, forward) navigation history</string>
   <string name="navigation_history_cleared">Navigation History Cleared</string>
-  <string name="go_to_settings_label">Go to Setting</string>
+  <string name="go_to_settings_label">Go to Settings</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -268,7 +268,7 @@
   <string name="tag_text_only">Text Only</string>
   <string name="tag_short_text">Short Text</string>
   <string name="storage_permission_denied">Storage Permission Denied</string>
-  <string name="grant_read_storage_permission">This app requires the ability to read storage to function. Please grant the permission in your settings</string>
+  <string name="grant_read_storage_permission">This app requires the ability to read storage permission to function. Please grant the storage permission in your app setting</string>
   <string name="go_to_settings">Go to Hotspot Settings</string>
   <string name="no_results">No Results</string>
   <string name="no_bookmarks">No Bookmarks</string>
@@ -334,4 +334,5 @@
   <string name="forward_history">Forward history</string>
   <string name="clear_all_navigation_history_message">Clears all (backward, forward) navigation history</string>
   <string name="navigation_history_cleared">Navigation History Cleared</string>
+  <string name="go_to_settings_label">Go to Setting</string>
 </resources>

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.custom.main
 import android.Manifest
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.annotation.TargetApi
+import android.app.Dialog
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_DENIED
 import android.os.Build
@@ -65,8 +66,10 @@ class CustomReaderFragment : CoreReaderFragment() {
   @Inject
   lateinit var customFileValidator: CustomFileValidator
 
+  @JvmField
   @Inject
-  lateinit var dialogShower: DialogShower
+  var dialogShower: DialogShower? = null
+  private var permissionRequiredDialog: Dialog? = null
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     if (enforcedLanguage()) {
@@ -179,10 +182,13 @@ class CustomReaderFragment : CoreReaderFragment() {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     if (permissions.isNotEmpty() && permissions[0] == Manifest.permission.READ_EXTERNAL_STORAGE) {
       if (readStorageHasBeenPermanentlyDenied(grantResults)) {
-        dialogShower.show(
-          KiwixDialog.ReadPermissionRequired,
-          requireActivity()::navigateToAppSettings
-        )
+        if (permissionRequiredDialog == null || permissionRequiredDialog?.isShowing == false) {
+          permissionRequiredDialog = dialogShower?.create(
+            KiwixDialog.ReadPermissionRequired,
+            requireActivity()::navigateToAppSettings
+          )
+          permissionRequiredDialog?.show()
+        }
       } else {
         openObbOrZim()
       }
@@ -249,5 +255,10 @@ class CustomReaderFragment : CoreReaderFragment() {
 
   override fun createNewTab() {
     newMainPageTab()
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    permissionRequiredDialog = null
   }
 }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -21,13 +21,10 @@ package org.kiwix.kiwixmobile.custom.main
 import android.Manifest
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.annotation.TargetApi
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_DENIED
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.provider.Settings
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
@@ -45,6 +42,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setupDrawerToggl
 import org.kiwix.kiwixmobile.core.main.CoreReaderFragment
 import org.kiwix.kiwixmobile.core.main.FIND_IN_PAGE_SEARCH_STRING
 import org.kiwix.kiwixmobile.core.main.MainMenu
+import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchItemToOpen
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.TAG_FILE_SEARCHED
@@ -181,19 +179,14 @@ class CustomReaderFragment : CoreReaderFragment() {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     if (permissions.isNotEmpty() && permissions[0] == Manifest.permission.READ_EXTERNAL_STORAGE) {
       if (readStorageHasBeenPermanentlyDenied(grantResults)) {
-        dialogShower.show(KiwixDialog.ReadPermissionRequired, ::goToSettings)
+        dialogShower.show(
+          KiwixDialog.ReadPermissionRequired,
+          requireActivity()::navigateToAppSettings
+        )
       } else {
         openObbOrZim()
       }
     }
-  }
-
-  private fun goToSettings() {
-    startActivity(
-      Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-        data = Uri.fromParts("package", activity?.packageName, null)
-      }
-    )
   }
 
   private fun readStorageHasBeenPermanentlyDenied(grantResults: IntArray) =

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -70,6 +70,7 @@ class CustomReaderFragment : CoreReaderFragment() {
   @Inject
   var dialogShower: DialogShower? = null
   private var permissionRequiredDialog: Dialog? = null
+  private var appSettingsLaunched = false
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     if (enforcedLanguage()) {
@@ -182,10 +183,13 @@ class CustomReaderFragment : CoreReaderFragment() {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     if (permissions.isNotEmpty() && permissions[0] == Manifest.permission.READ_EXTERNAL_STORAGE) {
       if (readStorageHasBeenPermanentlyDenied(grantResults)) {
-        if (permissionRequiredDialog == null || permissionRequiredDialog?.isShowing == false) {
+        if (permissionRequiredDialog?.isShowing != true) {
           permissionRequiredDialog = dialogShower?.create(
             KiwixDialog.ReadPermissionRequired,
-            requireActivity()::navigateToAppSettings
+            {
+              requireActivity().navigateToAppSettings()
+              appSettingsLaunched = true
+            }
           )
           permissionRequiredDialog?.show()
         }
@@ -262,5 +266,13 @@ class CustomReaderFragment : CoreReaderFragment() {
   override fun onDestroyView() {
     super.onDestroyView()
     permissionRequiredDialog = null
+  }
+
+  override fun onResume() {
+    super.onResume()
+    if (appSettingsLaunched) {
+      appSettingsLaunched = false
+      openObbOrZim()
+    }
   }
 }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -191,6 +191,8 @@ class CustomReaderFragment : CoreReaderFragment() {
         }
       } else {
         openObbOrZim()
+        permissionRequiredDialog?.dismiss()
+        permissionRequiredDialog = null
       }
     }
   }


### PR DESCRIPTION
Fixes #3229 

* I have corrected the message and button text in custom app(in dialog which is un-clear to user previously)

![Screenshot_2023-02-06-17-37-41-030_org kiwix kiwixcustomcustomexample](https://user-images.githubusercontent.com/34593983/216981819-74ed4c89-a485-4b28-98df-7929aff5a645.jpg)

* I have added a UI as mention on #3229 , if kiwix haven't storage permission.

![Screenshot_2023-02-06-18-15-33-748_org kiwix kiwixmobile](https://user-images.githubusercontent.com/34593983/216982059-aa7d3481-ce4a-4800-810d-098370b72d24.jpg)

* I have made a extension function to go into ```app setting``` for reusability in both (custom and kiwix ) app.