### PR TITLE
Fixes of remove custom LayoutInflatorFactory for custom fonts

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -116,7 +116,7 @@ class LocalLibraryFragment : BaseFragment() {
     savedInstanceState: Bundle?
   ): View? {
     LanguageUtils(requireActivity())
-      .changeFont(requireActivity().layoutInflater, sharedPreferenceUtil)
+      .changeFont(requireActivity(), sharedPreferenceUtil)
     fragmentDestinationLibraryBinding = FragmentDestinationLibraryBinding.inflate(
       inflater,
       container,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -792,7 +792,7 @@ abstract class CoreReaderFragment :
   private fun handleLocaleCheck() {
     sharedPreferenceUtil?.let {
       handleLocaleChange(requireActivity(), it)
-      LanguageUtils(requireActivity()).changeFont(layoutInflater, it)
+      LanguageUtils(requireActivity()).changeFont(requireActivity(), it)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -93,7 +93,7 @@ abstract class CorePrefsFragment :
     setupZoom()
     sharedPreferenceUtil?.let {
       LanguageUtils(requireActivity()).changeFont(
-        requireActivity().layoutInflater,
+        requireActivity(),
         it
       )
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
@@ -24,12 +24,8 @@ import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Typeface
 import android.os.Handler
-import android.util.AttributeSet
-import android.util.Log
 import android.util.TypedValue
-import android.view.InflateException
-import android.view.LayoutInflater
-import android.view.View
+import android.view.ViewGroup
 import android.widget.TextView
 import org.kiwix.kiwixmobile.core.extensions.locale
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
@@ -83,8 +79,8 @@ class LanguageUtils(private val context: Context) {
   // which also sets a Factory on the LayoutInflator, we have to access the private field of the
   // LayoutInflater, that handles this restriction via Java's reflection API
   // and make it accessible set it to false again.
-  @SuppressLint("SoonBlockedPrivateApi") fun changeFont(
-    layoutInflater: LayoutInflater,
+  fun changeFont(
+    activity: Activity,
     sharedPreferenceUtil: SharedPreferenceUtil
   ) {
 
@@ -92,69 +88,34 @@ class LanguageUtils(private val context: Context) {
       return
     }
 
-    try {
-      val field = LayoutInflater::class.java.getDeclaredField("mFactorySet")
-      field.isAccessible = true
-      field.setBoolean(layoutInflater, false)
-      layoutInflater.factory = LayoutInflaterFactory(
-        context,
-        layoutInflater
-      )
-    } catch (e: NoSuchFieldException) {
-      Log.w(
-        TAG_KIWIX,
-        "Font Change Failed: Could not access private field of the LayoutInflater",
-        e
-      )
-    } catch (e: IllegalAccessException) {
-      Log.w(
-        TAG_KIWIX,
-        "Font Change Failed: Could not access private field of the LayoutInflater",
-        e
-      )
-    } catch (e: IllegalArgumentException) {
-      Log.w(
-        TAG_KIWIX,
-        "Font Change Failed: Could not access private field of the LayoutInflater",
-        e
-      )
+    setTypeFace(activity.window.decorView as ViewGroup, activity)
+  }
+
+  private fun setTypeFace(viewGroup: ViewGroup, activity: Activity) {
+    for (i in 0 until viewGroup.childCount) {
+      val child = viewGroup.getChildAt(i)
+      if (child is ViewGroup) {
+        setTypeFace(child, activity)
+        continue
+      }
+      if (child is TextView) {
+        setTyfaceToTextView(child, activity)
+      }
     }
   }
 
-  // That's the Factory, that will handle the manipulation of all our TextView's and its subcalsses
-  // while the content is being parsed
-  class LayoutInflaterFactory(
-    private val mContext: Context,
-    private val mLayoutInflater: LayoutInflater
-  ) : LayoutInflater.Factory {
-
-    @SuppressWarnings("ImplicitSamInstance")
-    override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
-
-      // Apply the custom font, if the xml equals "TextView", "EditText" or "AutoCompleteTextView"
-      if (name.equals("TextView", ignoreCase = true) ||
-        name.equals("EditText", ignoreCase = true) ||
-        name.equals("AutoCompleteTextView", ignoreCase = true)
-      ) {
-        try {
-          val view = mLayoutInflater.createView(name, null, attrs)
-          Handler().post {
-            (view as TextView).apply {
-              typeface = Typeface.createFromAsset(
-                mContext.assets,
-                getTypeface(Locale.getDefault().language)
-              )
-              setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize - 2f)
-            }
-          }
-          return view
-        } catch (e: InflateException) {
-          Log.w(TAG_KIWIX, "Could not apply the custom font to $name", e)
-        } catch (e: ClassNotFoundException) {
-          Log.w(TAG_KIWIX, "Could not apply the custom font to $name", e)
-        }
+  private fun setTyfaceToTextView(child: TextView, activity: Activity) {
+    Handler().post {
+      child.apply {
+        setTypeface(
+          Typeface.createFromAsset(
+            activity.assets,
+            getTypeface(Locale.getDefault().language)
+          ),
+          Typeface.NORMAL
+        )
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize - 2f)
       }
-      return null
     }
   }
 


### PR DESCRIPTION
Fixes #37 

**What is the issue**

* ```Custom LayoutInflatorFactory``` code is outdated now.
* This code is not working on above android 12 (Now we are targeting android 13) I have tested with redmi note 9 **Android 12**.
   
![Screenshot from 2023-02-08 17-41-16](https://user-images.githubusercontent.com/34593983/217533432-279efc24-53e1-42dd-864d-b14209312c84.png)

**How i solve this problem**

* I have removed ```Custom LayoutInflatorFactory``` code (so now it's not giving error on android 12 and above).
* I have use ```window.decorView``` for getting text views from window and set custom fonts to those ```textviews``` .

| First Header  | Second Header | Second Header |
| ------------- | ------------- | ------------- |
| ![first](https://user-images.githubusercontent.com/34593983/217535981-edf0aa51-8ce8-4c77-b6a4-b0c8fe05582a.jpg)  | ![second](https://user-images.githubusercontent.com/34593983/217535976-5f1e1c5a-2f8c-414a-b0f2-863349f74192.jpg)  | ![third](https://user-images.githubusercontent.com/34593983/217535970-498efe9c-1e96-419a-8897-bee4778563c6.jpg)  |




