### PR TITLE
Fixes of Display Navigation History

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -1,0 +1,92 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.kiwix.kiwixmobile.page.history
+
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator
+import applyWithViewHierarchyPrinting
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.StringId.TextId
+import org.kiwix.kiwixmobile.Findable.ViewId
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.TestUtils
+
+fun navigationHistory(func: NavigationHistoryRobot.() -> Unit) =
+  NavigationHistoryRobot().applyWithViewHierarchyPrinting(func)
+
+class NavigationHistoryRobot : BaseRobot() {
+
+  fun checkZimFileLoadedSuccessful(readerFragment: Int) {
+    pauseForBetterTestPerformance()
+    isVisible(ViewId(readerFragment))
+  }
+
+  fun clickOnAndroidArticle() {
+    pauseForBetterTestPerformance()
+    onWebView()
+      .withElement(
+        findElement(
+          Locator.XPATH,
+          "//*[contains(text(), 'Android_(operating_system)')]"
+        )
+      )
+      .perform(webClick())
+  }
+
+  fun longClickOnBackwardButton() {
+    pauseForBetterTestPerformance()
+    longClickOn(ViewId(R.id.bottom_toolbar_arrow_back))
+  }
+
+  fun longClickOnForwardButton() {
+    pauseForBetterTestPerformance()
+    longClickOn(ViewId(R.id.bottom_toolbar_arrow_forward))
+  }
+
+  fun assertBackwardNavigationHistoryDialogDisplayed() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.backward_history))
+  }
+
+  fun clickOnBackwardButton() {
+    pauseForBetterTestPerformance()
+    clickOn(ViewId(R.id.bottom_toolbar_arrow_back))
+  }
+
+  fun assertForwardNavigationHistoryDialogDisplayed() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.forward_history))
+  }
+
+  fun clickOnDeleteHistory() {
+    pauseForBetterTestPerformance()
+    clickOn(ViewId(R.id.menu_pages_clear))
+  }
+
+  fun assertDeleteDialogDisplayed() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.clear_all_history_dialog_title))
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.page.history
+
+import android.os.Build
+import androidx.core.content.edit
+import androidx.core.net.toUri
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.internal.runner.junit4.statement.UiThreadStatement
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import leakcanary.LeakAssertions
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+class NavigationHistoryTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
+  private lateinit var kiwixMainActivity: KiwixMainActivity
+
+  @Before
+  override fun waitForIdle() {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+    }
+  }
+
+  @Test
+  fun navigationHistoryDialogTest() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+        kiwixMainActivity = it
+        kiwixMainActivity.navigate(R.id.libraryFragment)
+      }
+      val loadFileStream =
+        NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+      val zimFile = File(context.cacheDir, "testzim.zim")
+      if (zimFile.exists()) zimFile.delete()
+      zimFile.createNewFile()
+      loadFileStream.use { inputStream ->
+        val outputStream: OutputStream = FileOutputStream(zimFile)
+        outputStream.use { it ->
+          val buffer = ByteArray(inputStream.available())
+          var length: Int
+          while (inputStream.read(buffer).also { length = it } > 0) {
+            it.write(buffer, 0, length)
+          }
+        }
+      }
+      UiThreadStatement.runOnUiThread {
+        kiwixMainActivity.navigate(
+          LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
+            .apply { zimFileUri = zimFile.toUri().toString() }
+        )
+      }
+      navigationHistory {
+        checkZimFileLoadedSuccessful(R.id.readerFragment)
+        clickOnAndroidArticle()
+        longClickOnBackwardButton()
+        assertBackwardNavigationHistoryDialogDisplayed()
+        pressBack()
+        clickOnBackwardButton()
+        longClickOnForwardButton()
+        assertForwardNavigationHistoryDialogDisplayed()
+        clickOnDeleteHistory()
+        assertDeleteDialogDisplayed()
+        pressBack()
+        pressBack()
+      }
+      LeakAssertions.assertNoLeaks()
+    }
+  }
+
+  @After
+  fun setIsTestPreference() {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+    }
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreActivityComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreActivityComponent.kt
@@ -28,6 +28,7 @@ import org.kiwix.kiwixmobile.core.main.AddNoteDialog
 import org.kiwix.kiwixmobile.core.page.bookmark.BookmarksFragment
 import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects.ShowDeleteBookmarksDialog
 import org.kiwix.kiwixmobile.core.page.history.HistoryFragment
+import org.kiwix.kiwixmobile.core.page.history.NavigationHistoryDialog
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.ShowDeleteHistoryDialog
 import org.kiwix.kiwixmobile.core.page.notes.NotesFragment
 import org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects.ShowDeleteNotesDialog
@@ -51,6 +52,7 @@ interface CoreActivityComponent {
   fun inject(addNoteDialog: AddNoteDialog)
   fun inject(helpFragment: HelpFragment)
   fun inject(notesFragment: NotesFragment)
+  fun inject(navigationHistoryDialog: NavigationHistoryDialog)
 
   @Subcomponent.Builder
   interface Builder {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryClickListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryClickListener.kt
@@ -1,0 +1,26 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history
+
+import org.kiwix.kiwixmobile.core.page.history.adapter.NavigationHistoryListItem
+
+interface NavigationHistoryClickListener {
+  fun onItemClicked(navigationHistoryListItem: NavigationHistoryListItem)
+  fun clearHistory()
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
@@ -1,0 +1,158 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.DialogFragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import org.kiwix.kiwixmobile.core.CoreApp
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.databinding.DialogNavigationHistoryBinding
+import org.kiwix.kiwixmobile.core.main.DISABLE_ICON_ITEM_ALPHA
+import org.kiwix.kiwixmobile.core.main.ENABLE_ICON_ITEM_ALPHA
+import org.kiwix.kiwixmobile.core.page.history.adapter.NavigationHistoryAdapter
+import org.kiwix.kiwixmobile.core.page.history.adapter.NavigationHistoryDelegate.NavigationDelegate
+import org.kiwix.kiwixmobile.core.page.history.adapter.NavigationHistoryListItem
+import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
+import javax.inject.Inject
+
+class NavigationHistoryDialog(
+  private val toolbarTitle: String,
+  private val navigationHistoryList: MutableList<NavigationHistoryListItem>,
+  private val navigationHistoryClickListener: NavigationHistoryClickListener
+) : DialogFragment() {
+
+  private var dialogNavigationHistoryBinding: DialogNavigationHistoryBinding? = null
+  private var navigationHistoryAdapter: NavigationHistoryAdapter? = null
+
+  @Inject
+  lateinit var alertDialogShower: AlertDialogShower
+
+  private val toolbar by lazy {
+    dialogNavigationHistoryBinding?.root?.findViewById<Toolbar>(R.id.toolbar)
+  }
+  private val deleteItem by lazy { toolbar?.menu?.findItem(R.id.menu_pages_clear) }
+
+  override fun onStart() {
+    super.onStart()
+    dialog?.let {
+      it.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+    }
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    CoreApp.coreComponent
+      .activityComponentBuilder()
+      .activity(requireActivity())
+      .build()
+      .inject(this)
+  }
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    super.onCreateView(inflater, container, savedInstanceState)
+    dialogNavigationHistoryBinding =
+      DialogNavigationHistoryBinding.inflate(inflater, container, false)
+    return dialogNavigationHistoryBinding?.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    navigationHistoryAdapter = NavigationHistoryAdapter(NavigationDelegate(::onItemClick)).apply {
+      items = navigationHistoryList
+    }
+    toolbar?.apply {
+      title = toolbarTitle
+      setNavigationIcon(R.drawable.ic_close_white_24dp)
+      setNavigationOnClickListener { dismissNavigationHistoryDialog() }
+      inflateMenu(R.menu.menu_page)
+      this.menu?.findItem(R.id.menu_page_search)?.isVisible = false
+    }
+    dialogNavigationHistoryBinding?.apply {
+      if (navigationHistoryList.isEmpty()) {
+        deleteItem?.isEnabled = false
+        deleteItem?.icon?.alpha = DISABLE_ICON_ITEM_ALPHA
+        searchNoResults.visibility = View.VISIBLE
+        navigationHistoryRecyclerView.visibility = View.GONE
+      } else {
+        deleteItem?.isEnabled = true
+        deleteItem?.icon?.alpha = ENABLE_ICON_ITEM_ALPHA
+        searchNoResults.visibility = View.GONE
+        navigationHistoryRecyclerView.visibility = View.VISIBLE
+      }
+      navigationHistoryRecyclerView.run {
+        adapter = navigationHistoryAdapter
+        layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+        setHasFixedSize(true)
+      }
+    }
+    deleteItem?.setOnMenuItemClickListener {
+      showConfirmClearHistoryDialog()
+      true
+    }
+  }
+
+  private fun showConfirmClearHistoryDialog() {
+    alertDialogShower.show(KiwixDialog.ClearAllNavigationHistory, ::clearHistory)
+  }
+
+  private fun clearHistory() {
+    dismissNavigationHistoryDialog()
+    navigationHistoryClickListener.clearHistory()
+  }
+
+  // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    return object : Dialog(requireContext(), theme) {
+      override fun onBackPressed() {
+        dismissNavigationHistoryDialog()
+      }
+    }
+  }
+
+  private fun dismissNavigationHistoryDialog() {
+    dialog?.dismiss()
+  }
+
+  override fun onDestroyView() {
+    super.onDestroyView()
+    navigationHistoryAdapter = null
+    dialogNavigationHistoryBinding = null
+  }
+
+  private fun onItemClick(item: NavigationHistoryListItem) {
+    dismissNavigationHistoryDialog()
+    navigationHistoryClickListener.onItemClicked(item)
+  }
+
+  companion object {
+    const val TAG = "NavigationHistoryDialog"
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryAdapter.kt
@@ -1,0 +1,30 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history.adapter
+
+import org.kiwix.kiwixmobile.core.base.adapter.AdapterDelegate
+import org.kiwix.kiwixmobile.core.base.adapter.BaseDelegateAdapter
+
+class NavigationHistoryAdapter(
+  vararg delegates: AdapterDelegate<NavigationHistoryListItem>
+) : BaseDelegateAdapter<NavigationHistoryListItem>(
+  *delegates
+) {
+  override fun getIdFor(item: NavigationHistoryListItem) = item.title.hashCode().toLong()
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryDelegate.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryDelegate.kt
@@ -1,0 +1,41 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history.adapter
+
+import android.view.ViewGroup
+import org.kiwix.kiwixmobile.core.base.adapter.AbsDelegateAdapter
+import org.kiwix.kiwixmobile.core.databinding.ItemBookmarkHistoryBinding
+import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.viewBinding
+
+sealed class NavigationHistoryDelegate<I : NavigationHistoryListItem,
+  out VH : NavigationHistoryViewHolder<I>> :
+  AbsDelegateAdapter<I, NavigationHistoryListItem, VH> {
+
+  class NavigationDelegate(private val onClickListener: ((NavigationHistoryListItem) -> Unit)) :
+    NavigationHistoryDelegate<NavigationHistoryListItem,
+      NavigationHistoryViewHolder.HistoryViewHolder>() {
+    override val itemClass = NavigationHistoryListItem::class.java
+
+    override fun createViewHolder(parent: ViewGroup) =
+      NavigationHistoryViewHolder.HistoryViewHolder(
+        parent.viewBinding(ItemBookmarkHistoryBinding::inflate, false),
+        onClickListener
+      )
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryListItem.kt
@@ -1,0 +1,24 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history.adapter
+
+data class NavigationHistoryListItem(
+  val title: String,
+  val pageUrl: String
+)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryViewHolder.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/NavigationHistoryViewHolder.kt
@@ -1,0 +1,42 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.page.history.adapter
+
+import android.view.View
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
+import org.kiwix.kiwixmobile.core.databinding.ItemBookmarkHistoryBinding
+import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
+
+sealed class NavigationHistoryViewHolder<in T : NavigationHistoryListItem>(containerView: View) :
+  BaseViewHolder<T>(containerView) {
+
+  class HistoryViewHolder(
+    private val itemBookmarkHistoryBinding: ItemBookmarkHistoryBinding,
+    private val onClickListener: ((NavigationHistoryListItem) -> Unit)
+  ) : NavigationHistoryViewHolder<NavigationHistoryListItem>(itemBookmarkHistoryBinding.root) {
+    override fun bind(item: NavigationHistoryListItem) {
+      containerView.setOnClickListener { onClickListener(item) }
+      itemBookmarkHistoryBinding.apply {
+        title.text = item.title
+        favicon.setImageDrawableCompat(R.mipmap.ic_launcher_round)
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -191,6 +191,13 @@ sealed class KiwixDialog(
     negativeMessage = R.string.cancel
   )
 
+  object ClearAllNavigationHistory : KiwixDialog(
+    R.string.clear_all_history_dialog_title,
+    R.string.clear_all_navigation_history_message,
+    positiveMessage = R.string.delete,
+    negativeMessage = R.string.cancel
+  )
+
   object ClearAllNotes : KiwixDialog(
     R.string.delete_notes_confirmation_msg,
     message = null,

--- a/core/src/main/res/layout/dialog_navigation_history.xml
+++ b/core/src/main/res/layout/dialog_navigation_history.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2023 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:background="@android:color/transparent">
+
+  <include layout="@layout/layout_standard_app_bar" />
+
+  <androidx.recyclerview.widget.RecyclerView
+    android:id="@+id/navigationHistoryRecyclerView"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    tools:listitem="@layout/item_bookmark_history"
+    app:layout_constraintTop_toBottomOf="@+id/app_bar" />
+
+  <TextView
+    android:id="@+id/searchNoResults"
+    style="@style/no_content"
+    android:text="@string/no_history"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -330,4 +330,8 @@
   <string name="read_aloud_service_channel_name" tools:keep="@string/read_aloud_service_channel_name">Read Aloud Service Channel</string>
   <string name="read_aloud_channel_description" tools:keep="@string/read_aloud_channel_description">Text to speech controls.</string>
   <string name="read_aloud_running" tools:keep="@string/read_aloud_running">Running Read Aloud</string>
+  <string name="backward_history">Backward history</string>
+  <string name="forward_history">Forward history</string>
+  <string name="clear_all_navigation_history_message">Clears all (backward,forward) navigation history</string>
+  <string name="navigation_history_cleared">Navigation History Cleared</string>
 </resources>


### PR DESCRIPTION
Fixes #3042 

* I have use ```WebBackForwardList``` list of ```WebView``` class for showing navigation history(backward and forward).
* I have create a dialog to show ```NavigationHistory``` to user (this list is scrollable), when user long click on backward and forward button.

| Backward History  | Forward History |
| ------------- | ------------- |
| ![backwardhistory](https://user-images.githubusercontent.com/34593983/220615616-eb6d602e-176a-40ff-abf2-3dc848b48b46.jpg)  | ![forwardhistory](https://user-images.githubusercontent.com/34593983/220615649-95297e23-a942-4f66-a0d2-62e9acaed31f.jpg) |

* I have create automated test (```NavigationHistoryTest```) for testing this functionality.


> In the preference panel, an option should allow to clear the history.

<del> @kelson42 , since we are not saving history to database, we are using webview history for showing backward and forward list. In webview we have only one method ```clearHistory()``` to clear the history(but it will clear full history for currently opened book, so user can not go back and forward. so that's why i have not implemented this). </del>

* Added navigation history delete feature to delete all navigation history.


https://user-images.githubusercontent.com/34593983/221520814-b2cbbf8a-aa38-433a-ad0e-35b9bcdc9413.mp4

