### PR TITLE
Added country name in front of ZIM file language

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/BookUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/BookUtils.kt
@@ -31,8 +31,20 @@ class BookUtils {
     return when {
       languageCode == null -> ""
       languageCode.length == 2 -> LanguageContainer(languageCode).languageName
-      languageCode.length == 3 -> localeMap[languageCode]?.displayLanguage.orEmpty()
+      languageCode.length == 3 -> localeMap[languageCode]?.displayLanguage.orEmpty() +
+        getCountryFromLanguageCode(
+          languageCode
+        )
       else -> ""
+    }
+  }
+
+  private fun getCountryFromLanguageCode(languageCode: String): String {
+    val local = LanguageUtils.iSO3ToLocale(languageCode)
+    return if (local?.displayCountry?.isNotEmpty() == true) {
+      " (${local.displayCountry})"
+    } else {
+      ""
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageContainer.kt
@@ -24,12 +24,21 @@ class LanguageContainer private constructor(val languageCode: String, val langua
   constructor(languageCode: String) : this(languageCode, chooseLanguageName(languageCode))
 
   companion object {
+
     private fun chooseLanguageName(languageCode: String): String {
       val displayLanguage = Locale(languageCode).displayLanguage
+      val displayCountry =
+        Locale(languageCode).displayCountry
       return if (displayLanguage.length == 2 || displayLanguage.isEmpty())
-        Locale.ENGLISH.displayLanguage
+        Locale.ENGLISH.displayLanguage + " (${Locale.ENGLISH.displayCountry})"
       else
-        displayLanguage
+        "${displayLanguage}${getCountry(displayCountry)}"
+    }
+
+    private fun getCountry(displayCountry: String) = if (displayCountry.isNotEmpty()) {
+      " ($displayCountry)"
+    } else {
+      ""
     }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/BookUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/BookUtilsTest.kt
@@ -34,12 +34,16 @@ class BookUtilsTest {
     assertEquals("code length more than 3", "", t.getLanguage("english"))
 
     // testing the hashmap created inside the BookUtils class
-    assertEquals("code length equals 3 (English)", "English", t.getLanguage("eng"))
-    assertEquals("code length equals 3 (Hindi)", "Hindi", t.getLanguage("hin"))
-    assertEquals("code length equals 3 (French)", "French", t.getLanguage("fra"))
-    assertEquals("code length equals 3 (Akan)", "Akan", t.getLanguage("aka"))
-    assertEquals("code length equals 3 (Burmese)", "Burmese", t.getLanguage("mya"))
-    assertEquals("code length equals 3 (Catalan)", "Catalan", t.getLanguage("cat"))
+    assertEquals("code length equals 3 (English)", "English (India)", t.getLanguage("eng"))
+    assertEquals("code length equals 3 (Hindi)", "Hindi (India)", t.getLanguage("hin"))
+    assertEquals("code length equals 3 (French)", "French (Rwanda)", t.getLanguage("fra"))
+    assertEquals("code length equals 3 (Akan)", "Akan (Ghana)", t.getLanguage("aka"))
+    assertEquals(
+      "code length equals 3 (Burmese)",
+      "Burmese (Myanmar (Burma))",
+      t.getLanguage("mya")
+    )
+    assertEquals("code length equals 3 (Catalan)", "Catalan (Spain)", t.getLanguage("cat"))
 
     // this case uses the result from the container nested class inside LanguageUtils. It will be tested in LanguageUtilsTest
     assertEquals("code length equals 2 (dummy)", "English", t.getLanguage("en"))


### PR DESCRIPTION
Fixes #3215 

* Added country name in front of ZIM file language.
* We have a method (```iSO3ToLocale```) to get ```Local``` from ```iSO3``` , I have use that for getting country name from ```ISO 639-2 language code``` , most of ZIM files are using ```ISO 639-2``` for ZIM language and some file are using ```ISO 639-1``` language.
* For getting country name from ```ISO 639-1 language code``` i have used ```Locale(languageCode).displayCountry``` method of ```Local``` class.

**Screenshots** 

| Screenshot  | Screenshot | Screenshot |
| ------------- | ------------- | ------------- |
| ![Screenshot_2023-02-24-17-40-59-894_org kiwix kiwixmobile](https://user-images.githubusercontent.com/34593983/221181492-e90b2a4a-0fd1-412d-9774-a542c79a0fc0.jpg) |  ![Screenshot_2023-02-24-17-41-06-893_org kiwix kiwixmobile](https://user-images.githubusercontent.com/34593983/221181526-cd466009-662d-48ba-89e6-0d9e1f61d29e.jpg) | ![Screenshot_2023-02-24-17-41-12-653_org kiwix kiwixmobile](https://user-images.githubusercontent.com/34593983/221181625-4b16c6f3-3b0f-4fac-834a-c0b9c3108bc4.jpg) |