### PR TITLE
Fixes of When we scroll up, then white space showing in ```LocalLibraryFragment```

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -62,6 +62,9 @@ import org.kiwix.kiwixmobile.core.utils.FILE_SELECT_CODE
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.REQUEST_STORAGE_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener
+import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener.Companion.SCROLL_DOWN
+import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener.Companion.SCROLL_UP
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
@@ -152,10 +155,8 @@ class LocalLibraryFragment : BaseFragment() {
         coreMainActivity.navHostContainer
           .setBottomMarginToFragmentContainerView(0)
 
-        val bottomNavigationView =
-          requireActivity().findViewById<BottomNavigationView>(R.id.bottom_nav_view)
-        bottomNavigationView?.let {
-          setBottomMarginToSwipeRefreshLayout(bottomNavigationView.measuredHeight)
+        getBottomNavigationView()?.let {
+          setBottomMarginToSwipeRefreshLayout(it.measuredHeight)
         }
       }
     disposable.add(sideEffects())
@@ -170,7 +171,25 @@ class LocalLibraryFragment : BaseFragment() {
       offerAction(FileSelectActions.UserClickedDownloadBooksButton)
     }
     hideFilePickerButton()
+
+    fragmentDestinationLibraryBinding?.zimfilelist?.addOnScrollListener(
+      SimpleRecyclerViewScrollListener { _, newState ->
+        when (newState) {
+          SCROLL_DOWN -> {
+            setBottomMarginToSwipeRefreshLayout(0)
+          }
+          SCROLL_UP -> {
+            getBottomNavigationView()?.let {
+              setBottomMarginToSwipeRefreshLayout(it.measuredHeight)
+            }
+          }
+        }
+      }
+    )
   }
+
+  private fun getBottomNavigationView() =
+    requireActivity().findViewById<BottomNavigationView>(R.id.bottom_nav_view)
 
   private fun setBottomMarginToSwipeRefreshLayout(marginBottom: Int) {
     fragmentDestinationLibraryBinding?.zimSwiperefresh?.apply {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SimpleRecyclerViewScrollListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SimpleRecyclerViewScrollListener.kt
@@ -31,4 +31,30 @@ class SimpleRecyclerViewScrollListener(
       newState
     )
   }
+
+  override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+    super.onScrolled(recyclerView, dx, dy)
+    val currentScrollPosition = recyclerView.computeVerticalScrollOffset()
+
+    if (currentScrollPosition > previousScrollPosition) {
+      onLayoutScrollListener(
+        recyclerView,
+        SCROLL_DOWN
+      )
+    } else if (currentScrollPosition < previousScrollPosition) {
+      onLayoutScrollListener(
+        recyclerView,
+        SCROLL_UP
+      )
+    }
+
+    previousScrollPosition = currentScrollPosition
+  }
+
+  private var previousScrollPosition = 0
+
+  companion object {
+    const val SCROLL_DOWN = 2000
+    const val SCROLL_UP = 2001
+  }
 }


### PR DESCRIPTION
Fixes #3240 

**What is the problem**
We have implemented a fix for issue #3210. In this fix, we have set the bottom margin to ```SwipeRefreshLayout```. Our ```SwipeRefreshLayout``` has a scrolling behaviour, so when we scroll up, it shows white space.

**Fix**
* When we scroll up, I have set the bottom margin to 0 (so no more white space is showing). When we scroll down, I have set the bottom margin to the height of the bottom navigation, just as we did previously(for fix of #3210). 

**Video**

https://user-images.githubusercontent.com/34593983/221561321-d0da66e1-f5d3-4096-880e-c0d76fe3b4cf.mp4


