### PR TITLE
Issue#3255/delete note snackbar

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -41,6 +41,7 @@ import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.databinding.DialogAddNoteBinding
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
+import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
@@ -359,14 +360,23 @@ class AddNoteDialog : DialogFragment() {
     val noteFile =
       File(notesFolder.absolutePath, "$articleNoteFileName.txt")
     val noteDeleted = noteFile.delete()
+    val noteText = dialogNoteAddNoteBinding?.addNoteEditText?.text.toString()
     if (noteDeleted) {
       dialogNoteAddNoteBinding?.addNoteEditText?.text?.clear()
       mainRepositoryActions.deleteNote(articleNoteFileName)
       disableMenuItems()
-      context.toast(R.string.note_delete_successful, Toast.LENGTH_LONG)
+      view?.snack(
+        R.string.note_delete_successful,
+        R.string.undo,
+        actionClick = { onUndoCLicked(noteText) }
+      )
     } else {
       context.toast(R.string.note_delete_unsuccessful, Toast.LENGTH_LONG)
     }
+  }
+
+  private fun onUndoCLicked(text: String) {
+    dialogNoteAddNoteBinding?.addNoteEditText?.setText(text)
   }
 
   /* String content of the note text file given at:

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -368,14 +368,14 @@ class AddNoteDialog : DialogFragment() {
       view?.snack(
         R.string.note_delete_successful,
         R.string.undo,
-        actionClick = { onUndoCLicked(noteText) }
+        actionClick = { restoreDeletedNote(noteText) }
       )
     } else {
       context.toast(R.string.note_delete_unsuccessful, Toast.LENGTH_LONG)
     }
   }
 
-  private fun onUndoCLicked(text: String) {
+  private fun restoreDeletedNote(text: String) {
     dialogNoteAddNoteBinding?.addNoteEditText?.setText(text)
   }
 

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -5,6 +5,14 @@
   android:layout_height="match_parent"
   android:background="@android:color/transparent">
 
+  <org.kiwix.kiwixmobile.core.utils.NestedCoordinatorLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
   <include layout="@layout/layout_standard_app_bar" />
 
   <ScrollView

--- a/core/src/main/res/layout/dialog_add_note.xml
+++ b/core/src/main/res/layout/dialog_add_note.xml
@@ -5,14 +5,6 @@
   android:layout_height="match_parent"
   android:background="@android:color/transparent">
 
-  <org.kiwix.kiwixmobile.core.utils.NestedCoordinatorLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
-
   <include layout="@layout/layout_standard_app_bar" />
 
   <ScrollView


### PR DESCRIPTION

Fixes #3255

<!-- Add here what changes were made in this issue and if possible provide links. -->
1) Previously if user clicked on deleteNote button accidentally it used to delete the whole text and show a toast. There was no functionality to retrieve the deleted text.

2) Now on clicking on deleteNote Button it displays a snack-bar with an undo button embedded in it from which the user can restore their previously deleted text in the note.  


<!-- If possible, please add relevant screenshots / GIFs -->

!<img src="https://user-images.githubusercontent.com/61341524/222450355-3828f946-2368-468d-8b90-3e97231b2682.gif" width=30% height=30%>

**Screenshots** 

!<img src="https://user-images.githubusercontent.com/61341524/222449123-1ecb8400-aa07-487c-8a3d-c2e48524c9d2.jpeg" width=30% height=30%>
