### PR TITLE
created and implemented disableSaveNoteMenuItem function

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -211,6 +211,15 @@ class AddNoteDialog : DialogFragment() {
     }
   }
 
+  private fun disableSaveNoteMenuItem() {
+    if (toolbar?.menu != null) {
+      saveItem?.isEnabled = false
+      saveItem?.icon?.alpha = DISABLE_ICON_ITEM_ALPHA
+    } else {
+      Log.d(TAG, "Toolbar without inflated menu")
+    }
+  }
+
   private fun enableSaveNoteMenuItem() {
     if (toolbar?.menu != null) {
       saveItem?.isEnabled = true
@@ -321,6 +330,7 @@ class AddNoteDialog : DialogFragment() {
           enableDeleteNoteMenuItem()
           // adding only if saving file is success
           addNoteToDao(noteFile.canonicalPath, "${zimFileTitle.orEmpty()}: $articleTitle")
+          disableSaveNoteMenuItem()
         } catch (e: IOException) {
           e.printStackTrace()
             .also { context.toast(R.string.note_save_unsuccessful, Toast.LENGTH_LONG) }


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #3269 

<!-- Add here what changes were made in this issue and if possible provide links. -->
1) Previously if the user saved a note after writing a text the save button would still be enabled and clicked on it would repeatedly show the toast of "Note Successful".


2) Now after saving a note the save note button is disabled until the user makes some changes to the note.



<!-- If possible, please add relevant screenshots / GIFs -->
https://user-images.githubusercontent.com/61341524/225615351-2f53bf7c-84f1-44b9-853d-47d5ff6f61dd.mp4


**Screenshots** 

!<img src="https://user-images.githubusercontent.com/61341524/225616359-ab9da20b-f553-4e62-ad87-651b9f324197.jpeg" width=30% height=30%> !<img src="https://user-images.githubusercontent.com/61341524/225616756-399a4459-6c97-4f4b-a2d6-3a20ba0c70ab.jpeg" width=30% height=30%>
