### PR TITLE
Upgraded android Gradle version to 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: create unit coverage
         if: ${{ matrix.api-level==21 }}
-        run: ./gradlew jacocoTestDebugUnitTestReport jacocoTestCustomExampleDebugUnitTestReport
+        run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.api-level==21 }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,9 +11,9 @@ repositories {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:7.3.1")
+  implementation("com.android.tools.build:gradle:7.4.2")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
-  implementation("com.dicedmelon.gradle:jacoco-android:0.1.5")
+  implementation("org.jacoco:org.jacoco.core:0.8.8")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev129-1.25.0")
   implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.20.0")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -46,7 +46,7 @@ object Versions {
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
-  const val com_android_tools_build_gradle: String = "7.3.1"
+  const val com_android_tools_build_gradle: String = "7.4.2"
 
   const val de_fayard_buildsrcversions_gradle_plugin: String = "0.7.0"
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -36,7 +36,7 @@ class AllProjectConfigurer {
     target.plugins.apply("kotlin-android")
     target.plugins.apply("kotlin-kapt")
     target.plugins.apply("kotlin-parcelize")
-    target.plugins.apply("com.dicedmelon.gradle.jacoco-android")
+    target.plugins.apply("jacoco")
     target.plugins.apply("org.jlleitschuh.gradle.ktlint")
     target.plugins.apply("io.gitlab.arturbosch.detekt")
     target.plugins.apply("androidx.navigation.safeargs")
@@ -141,7 +141,7 @@ class AllProjectConfigurer {
       resolutionStrategy {
         eachDependency {
           if ("org.jacoco" == this.requested.group) {
-            useVersion("0.8.7")
+            useVersion("0.8.8")
           }
         }
       }
@@ -150,7 +150,7 @@ class AllProjectConfigurer {
 
   fun configurePlugins(target: Project) {
     target.run {
-      configureExtension<JacocoPluginExtension> { toolVersion = "0.8.7" }
+      configureExtension<JacocoPluginExtension> { toolVersion = "0.8.8" }
       configureExtension<KtlintExtension> { android.set(true) }
       configureExtension<DetektExtension> {
         buildUponDefaultConfig = true

--- a/custom/src/customexample/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/custom/src/customexample/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background" />
   <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+  <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/custom/src/customexample/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/custom/src/customexample/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background" />
   <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+  <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 19 16:13:45 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -19,7 +19,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-  toolVersion = "0.8.7"
+  toolVersion = "0.8.8"
 }
 
 tasks.withType(Test) {

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -34,7 +34,7 @@
   <issue id="InvalidPackage">
     <ignore path="**simple-xml-2.7.1.jar" />
     <ignore path="**javapoet-1.8.0.jar" />
-    <ignore path="**/org.jacoco.agent-0.8.7-runtime.jar" />
+    <ignore path="**/org.jacoco.agent-0.8.8-runtime.jar" />
     <ignore regexp="kotlinx.coroutines.debug.AgentPremain" />
   </issue>
   <issue id="IconLocation">


### PR DESCRIPTION
Fixes #3266 

* We have upgraded android Gradle version to ```8.0``` .
* In this PR we have replaced ```com.dicedmelon.gradle:jacoco-android:0.1.5``` with ```org.jacoco:org.jacoco.core:0.8.8``` . Because this library contains the deprecated code which is not compatible with gradle ```8.0```.
* WE have upgraded ```com.android.tools.build:gradle``` from ```7.3.1``` to ```7.4.2``` .
* Gradle ```8.0``` comes with updated lint rules. Currently in this PR two lint errors are present 
     * ```NotificationPermission``` for this lint error we have ticket open https://github.com/kiwix/kiwix-android/issues/3268
     * ```Monochrome icon is not defined```  in Custom application , It needs a small fix so i have placed in this PR.