### PR TITLE
Fixed library showing blank screen in android 13

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -18,16 +18,27 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
+import android.util.Log
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import applyWithViewHierarchyPrinting
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
 import org.kiwix.kiwixmobile.localFileTransfer.localFileTransfer
+import org.kiwix.kiwixmobile.testutils.TestUtils
 
 fun library(func: LibraryRobot.() -> Unit) = LibraryRobot().applyWithViewHierarchyPrinting(func)
 
 class LibraryRobot : BaseRobot() {
+
+  private val zimFileTitle = "Test_Zim"
 
   fun assertGetZimNearbyDeviceDisplayed() {
     isVisible(ViewId(R.id.get_zim_nearby_device))
@@ -36,5 +47,47 @@ class LibraryRobot : BaseRobot() {
   fun clickFileTransferIcon(func: LocalFileTransferRobot.() -> Unit) {
     clickOn(ViewId(R.id.get_zim_nearby_device))
     localFileTransfer(func)
+  }
+
+  fun assertLibraryListDisplayed() {
+    isVisible(ViewId(R.id.zimfilelist))
+  }
+
+  fun assertNoFilesTextDisplayed() {
+    isVisible(ViewId(R.id.file_management_no_files))
+  }
+
+  fun deleteZimIfExists() {
+    try {
+      longClickOnZimFile()
+      clickOnFileDeleteIcon()
+      assertDeleteDialogDisplayed()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      clickOnDeleteZimFile()
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+    } catch (e: Exception) {
+      Log.i(
+        "TEST_DELETE_ZIM",
+        "Failed to delete ZIM file with title [" + zimFileTitle + "]... " +
+          "Probably because it doesn't exist"
+      )
+    }
+  }
+
+  private fun clickOnFileDeleteIcon() {
+    clickOn(ViewId(R.id.zim_file_delete_item))
+  }
+
+  private fun assertDeleteDialogDisplayed() {
+    onView(withText("DELETE"))
+      .check(ViewAssertions.matches(isDisplayed()))
+  }
+
+  private fun longClickOnZimFile() {
+    longClickOn(Text(zimFileTitle))
+  }
+
+  private fun clickOnDeleteZimFile() {
+    onView(withText("DELETE")).perform(click())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.nav.destination.library
+
+import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.search.SearchFragmentTest
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+class LocalLibraryTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
+  override fun waitForIdle() {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    PreferenceManager.getDefaultSharedPreferences(
+      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    ).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      // set PREF_IS_TEST false for testing the real scenario
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+      // set PREF_MANAGE_EXTERNAL_FILES false for hiding
+      // manage external storage permission dialog on android 11 and above
+      putBoolean(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES, false)
+    }
+  }
+
+  @Test
+  fun testLocalLibrary() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+        it.navigate(R.id.libraryFragment)
+      }
+      library {
+        deleteZimIfExists()
+        assertNoFilesTextDisplayed()
+      }
+      // load a zim file to test, After downloading zim file library list is visible or not
+      val loadFileStream =
+        SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+      val zimFile =
+        File(
+          ContextCompat.getExternalFilesDirs(context, null)[0],
+          "testzim.zim"
+        )
+      if (zimFile.exists()) zimFile.delete()
+      zimFile.createNewFile()
+      loadFileStream.use { inputStream ->
+        val outputStream: OutputStream = FileOutputStream(zimFile)
+        outputStream.use { it ->
+          val buffer = ByteArray(inputStream.available())
+          var length: Int
+          while (inputStream.read(buffer).also { length = it } > 0) {
+            it.write(buffer, 0, length)
+          }
+        }
+      }
+      refresh(R.id.zim_swiperefresh)
+      library(LibraryRobot::assertLibraryListDisplayed)
+    }
+  }
+}

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -342,9 +342,11 @@ class LocalLibraryFragment : BaseFragment() {
 
         fileManagementNoFiles.visibility = View.VISIBLE
         goToDownloadsButtonNoFiles.visibility = View.VISIBLE
+        zimfilelist.visibility = View.GONE
       } else {
         fileManagementNoFiles.visibility = View.GONE
         goToDownloadsButtonNoFiles.visibility = View.GONE
+        zimfilelist.visibility = View.VISIBLE
       }
     }
   }
@@ -370,19 +372,16 @@ class LocalLibraryFragment : BaseFragment() {
           REQUEST_STORAGE_PERMISSION
         )
       } else {
-        fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
         requestFileSystemCheck()
       }
     } else {
       if (sharedPreferenceUtil.isPlayStoreBuild) {
-        fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
         requestFileSystemCheck()
       } else {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
           if (Environment.isExternalStorageManager()) {
             // We already have permission!!
             requestFileSystemCheck()
-            fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
           } else {
             if (sharedPreferenceUtil.manageExternalFilesPermissionDialog) {
               // We should only ask for first time, If the users wants to revoke settings
@@ -399,7 +398,6 @@ class LocalLibraryFragment : BaseFragment() {
           }
         } else {
           requestFileSystemCheck()
-          fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
         }
       }
     }
@@ -449,10 +447,7 @@ class LocalLibraryFragment : BaseFragment() {
           zimfilelist.visibility = GONE
         }
       } else if (!isPermissionDenied(grantResults)) {
-        fragmentDestinationLibraryBinding?.apply {
-          permissionDeniedLayoutShowing = false
-          requestFileSystemCheck()
-        }
+        permissionDeniedLayoutShowing = false
       }
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -301,7 +301,7 @@ class LocalLibraryFragment : BaseFragment() {
       !sharedPreferenceUtil.prefIsTest && !permissionDeniedLayoutShowing
     ) {
       checkPermissions()
-    } else if (sharedPreferenceUtil.prefIsTest) {
+    } else {
       fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
     }
   }
@@ -369,6 +369,9 @@ class LocalLibraryFragment : BaseFragment() {
           ),
           REQUEST_STORAGE_PERMISSION
         )
+      } else {
+        fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
+        requestFileSystemCheck()
       }
     } else {
       if (sharedPreferenceUtil.isPlayStoreBuild) {
@@ -448,9 +451,7 @@ class LocalLibraryFragment : BaseFragment() {
       } else if (!isPermissionDenied(grantResults)) {
         fragmentDestinationLibraryBinding?.apply {
           permissionDeniedLayoutShowing = false
-          fileManagementNoFiles.visibility = GONE
-          goToDownloadsButtonNoFiles.visibility = GONE
-          zimfilelist.visibility = VISIBLE
+          requestFileSystemCheck()
         }
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -241,7 +241,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_NIGHT_MODE = "pref_night_mode"
     private const val TEXT_ZOOM = "true_text_zoom"
     private const val DEFAULT_ZOOM = 100
-    private const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
+    const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
     const val IS_PLAY_STORE_BUILD = "is_play_store_build"
   }
 }


### PR DESCRIPTION
Fixes #3273 

* In this PR we have fixed the blank screen showing in android 13, Also i have found a bug while testing if we grant permission inside the application(on android 10 and below if we have not any zim file in our device) then it's showing same blank screen as showing in android 13 because in ```onRequestPermissionsResult``` we are settings the visibility of ```Recyclerview``` now i have replaced the visibility with ```requestFileSystemCheck()``` method which automatically check the file system and set the UI according to the file system.

**Edited**

* We have add the test cases for testing the ```LocalLibraryFragment``` , we are testing the both scenario if device has not any zim file and after downloading the zim files Zim list is visible or not.
