### PR TITLE
Remove misleadingly unused library versions

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -87,24 +87,6 @@ object Libs {
   /**
    * https://kotlinlang.org/
    */
-  const val kotlin_android_extensions: String = "org.jetbrains.kotlin:kotlin-android-extensions:" +
-    Versions.org_jetbrains_kotlin
-
-  /**
-   * https://kotlinlang.org/
-   */
-  const val kotlin_android_extensions_runtime: String =
-    "org.jetbrains.kotlin:kotlin-android-extensions-runtime:" + Versions.org_jetbrains_kotlin
-
-  /**
-   * https://kotlinlang.org/
-   */
-  const val kotlin_annotation_processing_gradle: String =
-    "org.jetbrains.kotlin:kotlin-annotation-processing-gradle:" + Versions.org_jetbrains_kotlin
-
-  /**
-   * https://kotlinlang.org/
-   */
   const val kotlin_gradle_plugin: String = "org.jetbrains.kotlin:kotlin-gradle-plugin:" +
     Versions.org_jetbrains_kotlin
 
@@ -202,18 +184,8 @@ object Libs {
   /**
    * https://objectbox.io
    */
-  const val objectbox_android: String = "io.objectbox:objectbox-android:" + Versions.io_objectbox
-
-  /**
-   * https://objectbox.io
-   */
   const val objectbox_gradle_plugin: String = "io.objectbox:objectbox-gradle-plugin:" +
     Versions.io_objectbox
-
-  /**
-   * https://objectbox.io
-   */
-  const val objectbox_java: String = "io.objectbox:objectbox-java:" + Versions.io_objectbox
 
   /**
    * https://objectbox.io
@@ -223,28 +195,7 @@ object Libs {
   /**
    * https://objectbox.io
    */
-  const val objectbox_processor: String = "io.objectbox:objectbox-processor:" +
-    Versions.io_objectbox
-
-  /**
-   * https://objectbox.io
-   */
   const val objectbox_rxjava: String = "io.objectbox:objectbox-rxjava:" + Versions.io_objectbox
-
-  /**
-   * https://objectbox.io
-   */
-  const val objectbox_windows: String = "io.objectbox:objectbox-windows:" + Versions.io_objectbox
-
-  /**
-   * http://jacoco.org
-   */
-  const val org_jacoco_agent: String = "org.jacoco:org.jacoco.agent:" + Versions.org_jacoco
-
-  /**
-   * http://jacoco.org
-   */
-  const val org_jacoco_ant: String = "org.jacoco:org.jacoco.ant:" + Versions.org_jacoco
 
   /**
    * http://mockk.io
@@ -267,14 +218,6 @@ object Libs {
    */
   const val com_android_tools_build_gradle: String = "com.android.tools.build:gradle:" +
     Versions.com_android_tools_build_gradle
-
-  const val de_fayard_buildsrcversions_gradle_plugin: String =
-    "de.fayard.buildSrcVersions:de.fayard.buildSrcVersions.gradle.plugin:" +
-      Versions.de_fayard_buildsrcversions_gradle_plugin
-
-  const val com_github_triplet_play_gradle_plugin: String =
-    "com.github.triplet.play:com.github.triplet.play.gradle.plugin:" +
-      Versions.com_github_triplet_play_gradle_plugin
 
   /**
    * http://jcp.org/en/jsr/detail?id=250
@@ -330,11 +273,6 @@ object Libs {
    * https://developer.android.com/jetpack/androidx
    */
   const val fragment_ktx: String = "androidx.fragment:fragment-ktx:" + Versions.fragment_ktx
-
-  /**
-   * https://developer.android.com/studio
-   */
-  const val lint_gradle: String = "com.android.tools.lint:lint-gradle:" + Versions.lint_gradle
 
   /**
    * https://github.com/jraska/livedata-testing
@@ -393,16 +331,6 @@ object Libs {
   const val fetch: String = "com.github.tonyofrancis:fetch:" + Versions.fetch
 
   /**
-   * http://findbugs.sourceforge.net/
-   */
-  const val jsr305: String = "com.google.code.findbugs:jsr305:" + Versions.jsr305
-
-  /**
-   * https://github.com/pinterest/ktlint
-   */
-  const val ktlint: String = "com.pinterest:ktlint:" + Versions.ktlint
-
-  /**
    * https://github.com/ReactiveX/RxJava
    */
   const val rxjava: String = "io.reactivex.rxjava2:rxjava:" + Versions.rxjava
@@ -411,11 +339,6 @@ object Libs {
    * https://developer.android.com/jetpack/androidx
    */
   const val webkit: String = "androidx.webkit:webkit:" + Versions.webkit
-
-  /**
-   * https://developer.android.com/studio
-   */
-  const val aapt2: String = "com.android.tools.build:aapt2:" + Versions.aapt2
 
   /**
    * https://developer.android.com/testing

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -42,8 +42,6 @@ object Versions {
 
   const val io_objectbox: String = "3.5.0"
 
-  const val org_jacoco: String = "0.8.7"
-
   const val io_mockk: String = "1.12.0"
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
@@ -74,8 +72,6 @@ object Versions {
 
   const val fragment_ktx: String = "1.2.5"
 
-  const val lint_gradle: String = "27.1.1"
-
   const val testing_ktx: String = "1.2.0"
 
   const val threetenabp: String = "1.3.0"
@@ -102,24 +98,11 @@ object Versions {
 
   const val fetch: String = "3.1.6"
 
-  const val jsr305: String = "3.0.2"
-
-  const val ktlint: String = "0.39.0"
-
   const val rxjava: String = "2.2.20"
 
   const val webkit: String = "1.3.0"
 
-  const val aapt2: String = "4.1.1-6503028"
-
   const val junit: String = "1.1.4"
-
-  /**
-   * Current version: "6.2"
-   * See issue 19: How to update Gradle itself?
-   * https://github.com/jmfayard/buildSrcVersions/issues/19
-   */
-  const val gradleLatestVersion: String = "6.7.1"
 }
 
 /**


### PR DESCRIPTION
This was split out from https://github.com/kiwix/kiwix-android/pull/3261#discussion_r1138198931 . In that PR, I was going to bump the version of a dependency, but I removed the lines instead when I realized that the lines were unused (the library was used but it ignored those lines).

This PR removes misleadingly unused versions. This was done with a bash script to grep the entire codebase to find variables in the `{Lib,Version}s.kt` files that were unreferenced. `gradle build` continued to succeed with all unit tests passing. It's assumed that it will work at runtime because this PR shouldn't affect the resulting apk. Consider the following misleading versions:

# Gradle

Listed as "6.7.1" at https://github.com/kiwix/kiwix-android/blob/e19bb9cf978ea628935df5f777fc02748b62cc32/buildSrc/src/main/kotlin/Versions.kt#L122 . It's actually "7.6" at https://github.com/kiwix/kiwix-android/blob/e19bb9cf978ea628935df5f777fc02748b62cc32/gradle/wrapper/gradle-wrapper.properties#L3 .

# Ktlint

Listed as "0.39.0" at https://github.com/kiwix/kiwix-android/blob/e19bb9cf978ea628935df5f777fc02748b62cc32/buildSrc/src/main/kotlin/Versions.kt#L107 . It's actually "10.3.0" at https://github.com/kiwix/kiwix-android/blob/e19bb9cf978ea628935df5f777fc02748b62cc32/buildSrc/build.gradle.kts#L17 .

