### PR TITLE
Bug: Protocol added for the geo location 

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/ExternalLinkOpenerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/ExternalLinkOpenerTest.kt
@@ -65,6 +65,27 @@ internal class ExternalLinkOpenerTest {
   }
 
   @Test
+  internal fun alertDialogShowerOpensLinkIfGeoProtocolAdded() {
+    every { intent.resolveActivity(activity.packageManager) } returns mockk()
+    every { sharedPreferenceUtil.prefExternalLinkPopup } returns true
+    val uri = Uri.parse("geo:28.61388888888889,77.20833333333334")
+    every { intent.data } returns uri
+    val lambdaSlot = slot<() -> Unit>()
+    val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
+    externalLinkOpener.openExternalUrl(intent)
+    verify {
+      alertDialogShower.show(
+        KiwixDialog.ExternalLinkPopup,
+        capture(lambdaSlot),
+        any(),
+        any()
+      )
+    }
+    lambdaSlot.captured.invoke()
+    verify { activity.startActivity(intent) }
+  }
+
+  @Test
   internal fun alertDialogShowerDoesNoOpenLinkIfNegativeButtonIsClicked() {
     every { intent.resolveActivity(activity.packageManager) } returns mockk()
     every { sharedPreferenceUtil.prefExternalLinkPopup } returns true

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
@@ -25,7 +25,6 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
-import java.net.URL
 import javax.inject.Inject
 
 class ExternalLinkOpener @Inject constructor(
@@ -61,7 +60,7 @@ class ExternalLinkOpener @Inject constructor(
         sharedPreferenceUtil.putPrefExternalLinkPopup(false)
         openLink(intent)
       },
-      url = URL(intent.data.toString())
+      uri = intent.data
     )
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -22,6 +22,7 @@ import android.app.Activity
 import android.app.Dialog
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.net.Uri
 import android.text.Html
 import android.view.Gravity
 import android.view.ViewGroup.LayoutParams
@@ -32,7 +33,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
-import java.net.URL
 import javax.inject.Inject
 
 class AlertDialogShower @Inject constructor(private val activity: Activity) :
@@ -44,10 +44,10 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
     const val externalLinkBottomMargin = 0
   }
 
-  override fun show(dialog: KiwixDialog, vararg clickListeners: () -> Unit, url: URL?) =
-    create(dialog, *clickListeners, url = url).show()
+  override fun show(dialog: KiwixDialog, vararg clickListeners: () -> Unit, uri: Uri?) =
+    create(dialog, *clickListeners, uri = uri).show()
 
-  override fun create(dialog: KiwixDialog, vararg clickListeners: () -> Unit, url: URL?): Dialog {
+  override fun create(dialog: KiwixDialog, vararg clickListeners: () -> Unit, uri: Uri?): Dialog {
     return AlertDialog.Builder(activity)
       .apply {
         dialog.title?.let(this::setTitle)
@@ -70,7 +70,7 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
               ?.invoke()
           }
         }
-        url?.let {
+        uri?.let {
           val frameLayout = FrameLayout(activity.baseContext)
 
           val textView = TextView(activity.baseContext).apply {
@@ -80,7 +80,7 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
             setOnLongClickListener {
               val clipboard =
                 ContextCompat.getSystemService(activity.baseContext, ClipboardManager::class.java)
-              val clip = ClipData.newPlainText("External Url", "$url")
+              val clip = ClipData.newPlainText("External Url", "$uri")
               clipboard?.setPrimaryClip(clip)
               Toast.makeText(
                 activity.baseContext,
@@ -89,7 +89,7 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
               ).show()
               true
             }
-            text = Html.fromHtml("</br><a href=$url> <b>$url</b>")
+            text = Html.fromHtml("</br><a href=$uri> <b>$uri</b>")
           }
           frameLayout.addView(textView)
           setView(frameLayout)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/DialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/DialogShower.kt
@@ -18,18 +18,18 @@
 package org.kiwix.kiwixmobile.core.utils.dialog
 
 import android.app.Dialog
-import java.net.URL
+import android.net.Uri
 
 interface DialogShower {
   fun show(
     dialog: KiwixDialog,
     vararg clickListeners: (() -> Unit),
-    url: URL? = null
+    uri: Uri? = null
   )
 
   fun create(
     dialog: KiwixDialog,
     vararg clickListeners: (() -> Unit),
-    url: URL? = null
+    uri: Uri? = null
   ): Dialog
 }


### PR DESCRIPTION
<!--
- A

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #3279 

Previously we were using `URL` Java API to parse the given the url. Which makes sense for basic url protocol but in geo location case the api couldn't parse the url because it was designed by Android and the Java API doesn't support it. So in this case we put the Androids `Uri` to access all the Android related protocol plus basic protocol.

<!-- Add here what changes were made in this issue and if possible provide links. -->


<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
