### PR TITLE
Fixed Downloading ZIM files are not working in Play Store Variant

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -42,3 +42,10 @@
 -keepclassmembers class * {
     @org.simpleframework.xml.* *;
 }
+
+## keep everything in MetaLinkNetworkEntity.kt
+
+-keepnames class org.kiwix.kiwixmobile.core.entity.MetaLinkNetworkEntity$*
+-keepclassmembers class org.kiwix.kiwixmobile.core.entity.MetaLinkNetworkEntity$* {
+    <init>(...);
+}


### PR DESCRIPTION
Fixes #3287 

**What is the issue**

We are using `isMinifyEnabled=true` in this variant [More Information Here](https://developer.android.com/build/shrink-code). The issue caused by the minification process. `MetaLinkNetworkEntity$Pieces` , `MetaLinkNetworkEntity$FileElement` constructors has changed or removed by the minification process.

**Solution**

We have added the code in `app/proguard-rules.pro` to keep all the classes of `MetaLinkNetworkEntity.kt` as it is in `Play Store Variant`.

**Video Sample After Fixing**


https://user-images.githubusercontent.com/34593983/231706478-962741b0-e189-4ffb-abc1-55866ce8148d.mp4




