### PR TITLE
Use latest version of android-emulator action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: create instrumentation coverage
-        uses: ReactiveCircus/android-emulator-runner@v2.25.0
+        uses: ReactiveCircus/android-emulator-runner@v2
         env:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         if: ${{ matrix.api-level != 33 }}
@@ -55,7 +55,7 @@ jobs:
           script: bash contrib/instrumentation.sh
 
       - name: create instrumentation coverage on google_apis for android 33
-        uses: ReactiveCircus/android-emulator-runner@v2.25.0
+        uses: ReactiveCircus/android-emulator-runner@v2
         env:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         if: ${{ matrix.api-level == 33 }}


### PR DESCRIPTION
This is the recommended (by https://github.com/ReactiveCircus/android-emulator-runner) way/version to instanciate. This allows as well to catch a more recent version.