### PR TITLE
Upload bundle on `Play Store` instead of `APK` for custom apps

### DIFF
--- a/buildSrc/src/main/kotlin/custom/Auth.kt
+++ b/buildSrc/src/main/kotlin/custom/Auth.kt
@@ -89,7 +89,7 @@ class Transaction(
       ExpansionFile().apply { referencesVersion = expansionCode }
     ).execute().prettyPrint()
 
-  fun uploadApk(apkVariantOutput: ApkVariantOutput) {
+  fun uploadBundle(apkVariantOutput: ApkVariantOutput) {
     publisher.edits().apks().upload(
       packageName,
       editId,

--- a/buildSrc/src/main/kotlin/custom/Auth.kt
+++ b/buildSrc/src/main/kotlin/custom/Auth.kt
@@ -82,13 +82,13 @@ class Transaction(
       FileContent("application/octet-stream", file)
     ).execute().prettyPrint()
 
-  fun attachExpansionTo(expansionCode: Int, versionCode: Int): ExpansionFile =
+  fun attachExpansionTo(versionCode: Int): ExpansionFile =
     publisher.edits().expansionfiles().update(
       packageName,
       editId,
       versionCode,
       "main",
-      ExpansionFile().apply { referencesVersion = expansionCode }
+      ExpansionFile().apply { referencesVersion = versionCode }
     ).execute().prettyPrint()
 
   fun uploadBundle(outputFile: File) {
@@ -99,12 +99,12 @@ class Transaction(
     ).execute().prettyPrint()
   }
 
-  fun addToTrackInDraft(apkVariants: List<VariantOutput>): Track =
+  fun addToTrackInDraft(versionCode: Int, versionName: String?): Track =
     publisher.edits().tracks().update(packageName, editId, "alpha", Track().apply {
       releases = listOf(TrackRelease().apply {
         status = "draft"
-        name = apkVariants[0].versionName.toString()
-        versionCodes = apkVariants.map { it.versionCode.orNull?.toLong() ?: 0 }
+        name = versionName
+        versionCodes = listOf(versionCode.toLong())
       })
       track = "alpha"
     }).execute().prettyPrint()

--- a/buildSrc/src/main/kotlin/custom/Auth.kt
+++ b/buildSrc/src/main/kotlin/custom/Auth.kt
@@ -16,9 +16,6 @@
 
 package custom
 
-import com.android.build.api.variant.VariantOutput
-import com.android.build.gradle.api.ApkVariantOutput
-import com.android.build.gradle.api.BaseVariantOutput
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.FileContent


### PR DESCRIPTION
Fixes #3290 

* Now we are uploading `Android app bundle` on `Play Store` instead of `APK` for custom apps.
* Previously we are uploading multiple `APK` on `Play Store` for different `ABI` , now we are uploading `Single App Bundle` on `Play Store` like we are uploading for `app module`. So for this we have refactored the code to upload only `app bundle` instead of uploading `Multiple Architecture APK`.
* We have also removed the deprecated methods (`versionCodeOverride`, `versionNameOverride`) , now we are using `VariantOutput.versionCode()` instead of `ApkVariantOutput.getVersionCodeOverride()` 
