### PR TITLE
Fixes of deprecate objects in LibraryNetworkEntitiy

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/entity/LibraryNetworkEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/entity/LibraryNetworkEntity.kt
@@ -80,11 +80,7 @@ class LibraryNetworkEntity {
     var tags: String? = null
     var searchMatches = 0
 
-    @Deprecated("")
     var file: File? = null
-
-    @Deprecated("")
-    var remoteUrl: String? = null
 
     // Two books are equal if their ids match
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
Fixes #3092 

* Since `remoteUrl` is no longer used in our project and it is marked as deprecated, so it is better to remove this.
* For `File` Object we have not found any good reason on the issue as well as on PR description, so for now we have removed the deprecated annotation from `File` object https://github.com/kiwix/kiwix-android/issues/3092#issuecomment-1453472762 .