### PR TITLE
Implementing Android 13: Themed Icons Integration into the App

### DIFF
--- a/core/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/core/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+  <background android:drawable="@color/ic_launcher_background" />
+  <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+  <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/core/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/core/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+  <background android:drawable="@color/ic_launcher_background" />
+  <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+  <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION



Fixes #3291 

This pull request implements the latest Android 13 feature, Themed Icons, into the app. Themed Icons provide a fresh and modern look to the app, aligned with the updated Android design guidelines. This enhancement adds a new set of icons that are designed to dynamically adapt to the app's current theme, whether it's light or dark, without compromising on visual consistency.



Changes made in this pull request:

Added a new set of Themed Icons that follow the Android 13 design guidelines.

Testing:
* Tested the app on various Android devices running Android 13 and confirmed that the Themed Icons are displayed correctly in both light and dark themes.
* Conducted thorough manual testing of the app's functionality, including icon usage and theming, to ensure that the implementation does not introduce any regressions.

Screenshots:
<img width="190" alt="Screen Shot 2023-04-15 at 23 20 06" src="https://user-images.githubusercontent.com/43576162/232245631-f1c8d780-52bc-4f3d-a328-fa87b57d8f23.png"><img width="190" alt="Screen Shot 2023-04-15 at 23 20 33" src="https://user-images.githubusercontent.com/43576162/232245628-26f76fd5-f3d6-4e98-89ae-2344245ce6ed.png">                <img width="190" alt="Screen Shot 2023-04-15 at 23 32 55" src="https://user-images.githubusercontent.com/43576162/232245872-858f3802-6178-4fb3-9a2b-577b238b57ad.png">


