### PR TITLE
Fixes of unable to navigate between the fragments

### DIFF
--- a/app/src/main/res/navigation/kiwix_nav_graph.xml
+++ b/app/src/main/res/navigation/kiwix_nav_graph.xml
@@ -50,7 +50,8 @@
       android:id="@+id/action_navigation_reader_to_navigation_library"
       app:destination="@id/libraryFragment"
       app:popUpTo="@id/readerFragment"
-      app:popUpToSaveState="true" />
+      app:popUpToSaveState="true"
+      app:restoreState="true" />
 
     <action
       android:id="@+id/action_readerFragment_to_searchFragment"
@@ -75,7 +76,8 @@
       android:id="@+id/action_navigation_library_to_navigation_downloads"
       app:destination="@id/downloadsFragment"
       app:popUpTo="@id/libraryFragment"
-      app:popUpToInclusive="true" />
+      app:popUpToInclusive="true"
+      app:restoreState="true" />
     <action
       android:id="@+id/action_libraryFragment_to_localFileTransferFragment"
       app:destination="@id/localFileTransferFragment" />

--- a/app/src/main/res/navigation/kiwix_nav_graph.xml
+++ b/app/src/main/res/navigation/kiwix_nav_graph.xml
@@ -48,7 +48,10 @@
 
     <action
       android:id="@+id/action_navigation_reader_to_navigation_library"
-      app:destination="@id/libraryFragment" />
+      app:destination="@id/libraryFragment"
+      app:popUpTo="@id/readerFragment"
+      app:popUpToSaveState="true" />
+
     <action
       android:id="@+id/action_readerFragment_to_searchFragment"
       app:destination="@id/searchFragment" />
@@ -70,7 +73,9 @@
       app:popUpTo="@id/readerFragment" />
     <action
       android:id="@+id/action_navigation_library_to_navigation_downloads"
-      app:destination="@id/downloadsFragment" />
+      app:destination="@id/downloadsFragment"
+      app:popUpTo="@id/libraryFragment"
+      app:popUpToInclusive="true" />
     <action
       android:id="@+id/action_libraryFragment_to_localFileTransferFragment"
       app:destination="@id/localFileTransferFragment" />


### PR DESCRIPTION
Fixes #3246 

**What is the issue**
When we are clicking on the buttons (`Download Books` and `Open Library`) to navigate between fragments then the navigation history is empty because we are not defined the history of the navigation graph, which is the reason the `reader` and `library` buttons are disabled after navigating through the action.

**Solution**
We have added the `popUpTo` tag in both actions to make the history of navigation. Like it makes when we clicked on the bottom navigation button.

**Before**

https://user-images.githubusercontent.com/34593983/234534466-5fc08cb0-4220-4082-94a5-bbc22e5087af.mp4

**After**



https://user-images.githubusercontent.com/34593983/234570182-c8a516cf-04c0-46a4-a8d6-05c94197a927.mp4


 
