### PR TITLE
Fixes of test failing on android 13(API level 33) with google_apis(System image) emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_2
+          heap-size: '512M'
           ram-size: '4096M'
           disk-size: '14G'
-          sdcard-path-or-size: '1000M'
+          sdcard-path-or-size: '4096M'
           disable-animations: false
           script: bash contrib/instrumentation.sh
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
@@ -58,15 +58,18 @@ class NetworkTest {
   // MockWebServer mockWebServer
 
   @Rule
+  @JvmField
   var mActivityTestRule = ActivityTestRule(
     KiwixMainActivity::class.java, false, false
   )
 
   @Rule
+  @JvmField
   var readPermissionRule: GrantPermissionRule =
     GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Rule
+  @JvmField
   var writePermissionRule: GrantPermissionRule =
     GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -73,9 +73,9 @@ class DownloadRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     } catch (e: Exception) {
       if (shouldDeleteZimFile) {
         throw Exception(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.download
 
-import android.os.Build
 import android.util.Log
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
@@ -71,34 +70,32 @@ class DownloadTest : BaseActivityTest() {
 
   @Test
   fun downloadTest() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java)
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      try {
-        downloadRobot {
-          clickLibraryOnBottomNav()
-          deleteZimIfExists(false)
-          clickDownloadOnBottomNav()
-          waitForDataToLoad()
-          downloadZimFile()
-          assertDownloadStart()
-          waitUntilDownloadComplete()
-          clickLibraryOnBottomNav()
-          checkIfZimFileDownloaded()
-          deleteZimIfExists(true)
-        }
-      } catch (e: Exception) {
-        Assert.fail(
-          "Couldn't find downloaded file ' Off the Grid ' Original Exception: ${e.message}"
-        )
+    ActivityScenario.launch(KiwixMainActivity::class.java)
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    try {
+      downloadRobot {
+        clickLibraryOnBottomNav()
+        deleteZimIfExists(false)
+        clickDownloadOnBottomNav()
+        waitForDataToLoad()
+        downloadZimFile()
+        assertDownloadStart()
+        waitUntilDownloadComplete()
+        clickLibraryOnBottomNav()
+        checkIfZimFileDownloaded()
+        deleteZimIfExists(true)
       }
-      try {
-        refresh(R.id.zim_swiperefresh)
-      } catch (e: RuntimeException) {
-        Log.w(KIWIX_DOWNLOAD_TEST, "Failed to refresh ZIM list: " + e.localizedMessage)
-      }
-      LeakAssertions.assertNoLeaks()
+    } catch (e: Exception) {
+      Assert.fail(
+        "Couldn't find downloaded file ' Off the Grid ' Original Exception: ${e.message}"
+      )
     }
+    try {
+      refresh(R.id.zim_swiperefresh)
+    } catch (e: RuntimeException) {
+      Log.w(KIWIX_DOWNLOAD_TEST, "Failed to refresh ZIM list: " + e.localizedMessage)
+    }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -43,6 +43,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
 
@@ -56,7 +58,12 @@ class DownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -26,12 +26,19 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 class HelpFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
   }
 
   @Rule

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.help
 
-import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
@@ -41,23 +40,21 @@ class HelpFragmentTest : BaseActivityTest() {
 
   @Test
   fun verifyHelpActivity() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      activityScenarioRule.scenario.onActivity {
-        it.navigate(R.id.helpFragment)
-      }
-      help {
-        clickOnWhatDoesKiwixDo()
-        assertWhatDoesKiwixDoIsExpanded()
-        clickOnWhatDoesKiwixDo()
-        clickOnWhereIsContent()
-        assertWhereIsContentIsExpanded()
-        clickOnWhereIsContent()
-        clickOnHowToUpdateContent()
-        assertHowToUpdateContentIsExpanded()
-        clickOnHowToUpdateContent()
-        clickOnSendFeedback()
-      }
-      LeakAssertions.assertNoLeaks()
+    activityScenarioRule.scenario.onActivity {
+      it.navigate(R.id.helpFragment)
     }
+    help {
+      clickOnWhatDoesKiwixDo()
+      assertWhatDoesKiwixDoIsExpanded()
+      clickOnWhatDoesKiwixDo()
+      clickOnWhereIsContent()
+      assertWhereIsContentIsExpanded()
+      clickOnWhereIsContent()
+      clickOnHowToUpdateContent()
+      assertHowToUpdateContentIsExpanded()
+      clickOnHowToUpdateContent()
+      clickOnSendFeedback()
+    }
+    LeakAssertions.assertNoLeaks()
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -78,9 +78,9 @@ class InitialDownloadRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -37,6 +37,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -48,7 +50,12 @@ class InitialDownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.initial.download
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
@@ -61,28 +60,26 @@ class InitialDownloadTest : BaseActivityTest() {
 
   @Test
   fun initialDownloadTest() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java)
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
-      initialDownload {
-        clickLibraryOnBottomNav()
-        // This is for if download test fails for some reason after downloading the zim file
-        deleteZimIfExists()
-        clickDownloadOnBottomNav()
-        assertLibraryListDisplayed()
-        refreshList()
-        waitForDataToLoad()
-        downloadZimFile()
-        assertStorageConfigureDialogDisplayed()
-        clickOnYesToConfirm()
-        assertDownloadStart()
-        stopDownload()
-        assertStopDownloadDialogDisplayed()
-        clickOnYesToConfirm()
-        assertDownloadStop()
-      }
-      LeakAssertions.assertNoLeaks()
+    ActivityScenario.launch(KiwixMainActivity::class.java)
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
+    initialDownload {
+      clickLibraryOnBottomNav()
+      // This is for if download test fails for some reason after downloading the zim file
+      deleteZimIfExists()
+      clickDownloadOnBottomNav()
+      assertLibraryListDisplayed()
+      refreshList()
+      waitForDataToLoad()
+      downloadZimFile()
+      assertStorageConfigureDialogDisplayed()
+      clickOnYesToConfirm()
+      assertDownloadStart()
+      stopDownload()
+      assertStopDownloadDialogDisplayed()
+      clickOnYesToConfirm()
+      assertDownloadStop()
     }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.intro
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.platform.app.InstrumentationRegistry
@@ -39,13 +38,11 @@ class IntroFragmentTest : BaseActivityTest() {
 
   @Test
   fun viewIsSwipeableAndNavigatesToMain() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      activityScenarioRule.scenario.onActivity {
-        it.navigate(R.id.introFragment)
-      }
-      intro(IntroRobot::swipeLeft) clickGetStarted {}
-      LeakAssertions.assertNoLeaks()
+    activityScenarioRule.scenario.onActivity {
+      it.navigate(R.id.introFragment)
     }
+    intro(IntroRobot::swipeLeft) clickGetStarted {}
+    LeakAssertions.assertNoLeaks()
   }
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -29,6 +29,8 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 class IntroFragmentTest : BaseActivityTest() {
 
@@ -47,7 +49,12 @@ class IntroFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -35,6 +35,8 @@ import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -61,7 +63,12 @@ class LanguageFragmentTest {
 
   @Before
   fun setUp() {
-    UiDevice.getInstance(instrumentation).waitForIdle()
+    UiDevice.getInstance(instrumentation).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(instrumentation.targetContext.applicationContext)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(instrumentation.targetContext.applicationContext)
       .edit {
         putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -19,7 +19,6 @@ package org.kiwix.kiwixmobile.language
 
 import android.Manifest
 import android.app.Instrumentation
-import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -72,55 +71,52 @@ class LanguageFragmentTest {
 
   @Test
   fun testLanguageFragment() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+    language {
+      clickDownloadOnBottomNav()
+      waitForDataToLoad()
 
-      language {
-        clickDownloadOnBottomNav()
-        waitForDataToLoad()
+      // search and de-select if german language already selected
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("german")
+      deSelectLanguageIfAlreadySelected()
+      clickOnSaveLanguageIcon()
 
-        // search and de-select if german language already selected
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("german")
-        deSelectLanguageIfAlreadySelected()
-        clickOnSaveLanguageIcon()
+      // search and de-select if italian language already selected
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("italiano")
+      deSelectLanguageIfAlreadySelected()
+      clickOnSaveLanguageIcon()
 
-        // search and de-select if italian language already selected
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("italiano")
-        deSelectLanguageIfAlreadySelected()
-        clickOnSaveLanguageIcon()
+      // Search and save language for german
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("german")
+      selectLanguage("German")
+      clickOnSaveLanguageIcon()
 
-        // Search and save language for german
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("german")
-        selectLanguage("German")
-        clickOnSaveLanguageIcon()
+      // Search and save language for italian
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("italiano")
+      selectLanguage("Italian")
+      clickOnSaveLanguageIcon()
 
-        // Search and save language for italian
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("italiano")
-        selectLanguage("Italian")
-        clickOnSaveLanguageIcon()
+      // verify is german language selected
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("german")
+      checkIsLanguageSelected()
+      clickOnSaveLanguageIcon()
 
-        // verify is german language selected
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("german")
-        checkIsLanguageSelected()
-        clickOnSaveLanguageIcon()
-
-        // verify is italian language selected
-        clickOnLanguageIcon()
-        clickOnLanguageSearchIcon()
-        searchLanguage("italiano")
-        checkIsLanguageSelected()
-        clickOnSaveLanguageIcon()
-      }
-      LeakAssertions.assertNoLeaks()
+      // verify is italian language selected
+      clickOnLanguageIcon()
+      clickOnLanguageSearchIcon()
+      searchLanguage("italiano")
+      checkIsLanguageSelected()
+      clickOnSaveLanguageIcon()
     }
+    LeakAssertions.assertNoLeaks()
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.main
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
@@ -57,36 +56,34 @@ class TopLevelDestinationTest : BaseActivityTest() {
 
   @Test
   fun testTopLevelDestination() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java)
-      topLevel {
-        clickReaderOnBottomNav {
-        }
-        clickLibraryOnBottomNav {
-          assertGetZimNearbyDeviceDisplayed()
-          clickFileTransferIcon {
-          }
-        }
-        clickDownloadOnBottomNav(OnlineLibraryRobot::assertLibraryListDisplayed)
-        clickBookmarksOnNavDrawer {
-          assertBookMarksDisplayed()
-          clickOnTrashIcon()
-          assertDeleteBookmarksDialogDisplayed()
-        }
-        clickHistoryOnSideNav {
-          assertHistoryDisplayed()
-          clickOnTrashIcon()
-          assertDeleteHistoryDialogDisplayed()
-        }
-        clickHostBooksOnSideNav(ZimHostRobot::assertMenuWifiHotspotDiplayed)
-        clickSettingsOnSideNav(SettingsRobot::assertMenuSettingsDisplayed)
-        clickHelpOnSideNav(HelpRobot::assertToolbarDisplayed)
-        clickSupportKiwixOnSideNav()
-        assertExternalLinkDialogDisplayed()
-        pressBack()
+    ActivityScenario.launch(KiwixMainActivity::class.java)
+    topLevel {
+      clickReaderOnBottomNav {
       }
-      LeakAssertions.assertNoLeaks()
+      clickLibraryOnBottomNav {
+        assertGetZimNearbyDeviceDisplayed()
+        clickFileTransferIcon {
+        }
+      }
+      clickDownloadOnBottomNav(OnlineLibraryRobot::assertLibraryListDisplayed)
+      clickBookmarksOnNavDrawer {
+        assertBookMarksDisplayed()
+        clickOnTrashIcon()
+        assertDeleteBookmarksDialogDisplayed()
+      }
+      clickHistoryOnSideNav {
+        assertHistoryDisplayed()
+        clickOnTrashIcon()
+        assertDeleteHistoryDialogDisplayed()
+      }
+      clickHostBooksOnSideNav(ZimHostRobot::assertMenuWifiHotspotDiplayed)
+      clickSettingsOnSideNav(SettingsRobot::assertMenuSettingsDisplayed)
+      clickHelpOnSideNav(HelpRobot::assertToolbarDisplayed)
+      clickSupportKiwixOnSideNav()
+      assertExternalLinkDialogDisplayed()
+      pressBack()
     }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -33,6 +33,8 @@ import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.nav.destination.library.OnlineLibraryRobot
 import org.kiwix.kiwixmobile.settings.SettingsRobot
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.webserver.ZimHostRobot
 
 class TopLevelDestinationTest : BaseActivityTest() {
@@ -43,7 +45,12 @@ class TopLevelDestinationTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -30,6 +30,8 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -38,7 +40,12 @@ class MimeTypeTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -62,9 +62,9 @@ class LibraryRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_ESPRESSO.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
-import android.os.Build
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
@@ -61,36 +60,34 @@ class LocalLibraryTest : BaseActivityTest() {
 
   @Test
   fun testLocalLibrary() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
-        it.navigate(R.id.libraryFragment)
-      }
-      library {
-        deleteZimIfExists()
-        assertNoFilesTextDisplayed()
-      }
-      // load a zim file to test, After downloading zim file library list is visible or not
-      val loadFileStream =
-        SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-      val zimFile =
-        File(
-          ContextCompat.getExternalFilesDirs(context, null)[0],
-          "testzim.zim"
-        )
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(inputStream.available())
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+      it.navigate(R.id.libraryFragment)
+    }
+    library {
+      deleteZimIfExists()
+      assertNoFilesTextDisplayed()
+    }
+    // load a zim file to test, After downloading zim file library list is visible or not
+    val loadFileStream =
+      SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+    val zimFile =
+      File(
+        ContextCompat.getExternalFilesDirs(context, null)[0],
+        "testzim.zim"
+      )
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      val outputStream: OutputStream = FileOutputStream(zimFile)
+      outputStream.use { it ->
+        val buffer = ByteArray(inputStream.available())
+        var length: Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+          it.write(buffer, 0, length)
         }
       }
-      refresh(R.id.zim_swiperefresh)
-      library(LibraryRobot::assertLibraryListDisplayed)
     }
+    refresh(R.id.zim_swiperefresh)
+    library(LibraryRobot::assertLibraryListDisplayed)
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -25,6 +25,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
@@ -33,6 +34,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.search.SearchFragmentTest
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -43,8 +46,14 @@ class LocalLibraryTest : BaseActivityTest() {
   @JvmField
   var retryRule = RetryRule()
 
+  @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -27,6 +27,8 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 class NoteFragmentTest : BaseActivityTest() {
 
@@ -36,7 +38,12 @@ class NoteFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.note
 
-import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
@@ -42,16 +41,14 @@ class NoteFragmentTest : BaseActivityTest() {
 
   @Test
   fun verifyNoteFragment() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      activityScenarioRule.scenario.onActivity {
-        it.navigate(R.id.notesFragment)
-      }
-      note {
-        assertToolbarExist()
-        assertNoteRecyclerViewExist()
-        assertSwitchWidgetExist()
-      }
-      LeakAssertions.assertNoLeaks()
+    activityScenarioRule.scenario.onActivity {
+      it.navigate(R.id.notesFragment)
     }
+    note {
+      assertToolbarExist()
+      assertNoteRecyclerViewExist()
+      assertSwitchWidgetExist()
+    }
+    LeakAssertions.assertNoLeaks()
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.page.history
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
@@ -61,48 +60,46 @@ class NavigationHistoryTest : BaseActivityTest() {
 
   @Test
   fun navigationHistoryDialogTest() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
-        kiwixMainActivity = it
-        kiwixMainActivity.navigate(R.id.libraryFragment)
-      }
-      val loadFileStream =
-        NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-      val zimFile = File(context.cacheDir, "testzim.zim")
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(inputStream.available())
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(R.id.libraryFragment)
+    }
+    val loadFileStream =
+      NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+    val zimFile = File(context.cacheDir, "testzim.zim")
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      val outputStream: OutputStream = FileOutputStream(zimFile)
+      outputStream.use { it ->
+        val buffer = ByteArray(inputStream.available())
+        var length: Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+          it.write(buffer, 0, length)
         }
       }
-      UiThreadStatement.runOnUiThread {
-        kiwixMainActivity.navigate(
-          LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
-            .apply { zimFileUri = zimFile.toUri().toString() }
-        )
-      }
-      navigationHistory {
-        checkZimFileLoadedSuccessful(R.id.readerFragment)
-        clickOnAndroidArticle()
-        longClickOnBackwardButton()
-        assertBackwardNavigationHistoryDialogDisplayed()
-        pressBack()
-        clickOnBackwardButton()
-        longClickOnForwardButton()
-        assertForwardNavigationHistoryDialogDisplayed()
-        clickOnDeleteHistory()
-        assertDeleteDialogDisplayed()
-        pressBack()
-        pressBack()
-      }
-      LeakAssertions.assertNoLeaks()
     }
+    UiThreadStatement.runOnUiThread {
+      kiwixMainActivity.navigate(
+        LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
+          .apply { zimFileUri = zimFile.toUri().toString() }
+      )
+    }
+    navigationHistory {
+      checkZimFileLoadedSuccessful(R.id.readerFragment)
+      clickOnAndroidArticle()
+      longClickOnBackwardButton()
+      assertBackwardNavigationHistoryDialogDisplayed()
+      pressBack()
+      clickOnBackwardButton()
+      longClickOnForwardButton()
+      assertForwardNavigationHistoryDialogDisplayed()
+      clickOnDeleteHistory()
+      assertDeleteDialogDisplayed()
+      pressBack()
+      pressBack()
+    }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -36,6 +36,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -50,7 +52,12 @@ class NavigationHistoryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -36,6 +36,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -49,7 +51,12 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
@@ -60,41 +59,39 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
 
   @Test
   fun testTabClosedDialog() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
-        kiwixMainActivity = it
-        kiwixMainActivity.navigate(R.id.libraryFragment)
-      }
-      val loadFileStream =
-        KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-      val zimFile = File(context.cacheDir, "testzim.zim")
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(inputStream.available())
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(R.id.libraryFragment)
+    }
+    val loadFileStream =
+      KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+    val zimFile = File(context.cacheDir, "testzim.zim")
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      val outputStream: OutputStream = FileOutputStream(zimFile)
+      outputStream.use { it ->
+        val buffer = ByteArray(inputStream.available())
+        var length: Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+          it.write(buffer, 0, length)
         }
       }
-      UiThreadStatement.runOnUiThread {
-        kiwixMainActivity.navigate(
-          LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
-            .apply { zimFileUri = zimFile.toUri().toString() }
-        )
-      }
-      reader {
-        checkZimFileLoadedSuccessful(R.id.readerFragment)
-        clickOnTabIcon()
-        clickOnClosedAllTabsButton()
-        clickOnUndoButton()
-        assertTabRestored()
-      }
-      LeakAssertions.assertNoLeaks()
     }
+    UiThreadStatement.runOnUiThread {
+      kiwixMainActivity.navigate(
+        LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
+          .apply { zimFileUri = zimFile.toUri().toString() }
+      )
+    }
+    reader {
+      checkZimFileLoadedSuccessful(R.id.readerFragment)
+      clickOnTabIcon()
+      clickOnClosedAllTabsButton()
+      clickOnUndoButton()
+      assertTabRestored()
+    }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -35,6 +35,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -49,7 +51,12 @@ class SearchFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.search
 
-import android.os.Build
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.preference.PreferenceManager
@@ -60,50 +59,48 @@ class SearchFragmentTest : BaseActivityTest() {
 
   @Test
   fun searchFragmentSimple() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
-        kiwixMainActivity = it
-        kiwixMainActivity.navigate(R.id.libraryFragment)
-      }
-      val loadFileStream =
-        SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-      val zimFile = File(context.cacheDir, "testzim.zim")
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(inputStream.available())
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(R.id.libraryFragment)
+    }
+    val loadFileStream =
+      SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+    val zimFile = File(context.cacheDir, "testzim.zim")
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      val outputStream: OutputStream = FileOutputStream(zimFile)
+      outputStream.use { it ->
+        val buffer = ByteArray(inputStream.available())
+        var length: Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+          it.write(buffer, 0, length)
         }
       }
-      UiThreadStatement.runOnUiThread {
-        kiwixMainActivity.navigate(
-          actionNavigationLibraryToNavigationReader()
-            .apply { zimFileUri = zimFile.toUri().toString() }
+    }
+    UiThreadStatement.runOnUiThread {
+      kiwixMainActivity.navigate(
+        actionNavigationLibraryToNavigationReader()
+          .apply { zimFileUri = zimFile.toUri().toString() }
+      )
+    }
+    search { checkZimFileSearchSuccessful(R.id.readerFragment) }
+    UiThreadStatement.runOnUiThread {
+      if (zimFile.canRead()) {
+        kiwixMainActivity.openSearch(searchString = "Android")
+      } else {
+        throw RuntimeException(
+          "File $zimFile is not readable." +
+            " Original File $zimFile is readable = ${zimFile.canRead()}" +
+            " Size ${zimFile.length()}"
         )
       }
-      search { checkZimFileSearchSuccessful(R.id.readerFragment) }
-      UiThreadStatement.runOnUiThread {
-        if (zimFile.canRead()) {
-          kiwixMainActivity.openSearch(searchString = "Android")
-        } else {
-          throw RuntimeException(
-            "File $zimFile is not readable." +
-              " Original File $zimFile is readable = ${zimFile.canRead()}" +
-              " Size ${zimFile.length()}"
-          )
-        }
-      }
-      search {
-        clickOnSearchItemInSearchList()
-        checkZimFileSearchSuccessful(R.id.readerFragment)
-      }
-      LeakAssertions.assertNoLeaks()
     }
+    search {
+      clickOnSearchItemInSearchList()
+      checkZimFileSearchSuccessful(R.id.readerFragment)
+    }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -68,31 +68,29 @@ class KiwixSettingsFragmentTest {
 
   @Test
   fun testSettingsActivity() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      settingsRobo {
-        assertZoomTextViewPresent()
-        assertVersionTextViewPresent()
-        clickLanguagePreference()
-        assertLanguagePrefDialogDisplayed()
-        dismissDialog()
-        toggleBackToTopPref()
-        toggleOpenNewTabInBackground()
-        toggleExternalLinkWarningPref()
-        toggleWifiDownloadsOnlyPref()
-        clickStoragePreference()
-        assertStorageDialogDisplayed()
-        dismissDialog()
-        clickClearHistoryPreference()
-        assertHistoryDialogDisplayed()
-        dismissDialog()
-        clickNightModePreference()
-        assertNightModeDialogDisplayed()
-        dismissDialog()
-        clickCredits()
-        assertContributorsDialogDisplayed()
-        dismissDialog()
-      }
-      LeakAssertions.assertNoLeaks()
+    settingsRobo {
+      assertZoomTextViewPresent()
+      assertVersionTextViewPresent()
+      clickLanguagePreference()
+      assertLanguagePrefDialogDisplayed()
+      dismissDialog()
+      toggleBackToTopPref()
+      toggleOpenNewTabInBackground()
+      toggleExternalLinkWarningPref()
+      toggleWifiDownloadsOnlyPref()
+      clickStoragePreference()
+      assertStorageDialogDisplayed()
+      dismissDialog()
+      clickClearHistoryPreference()
+      assertHistoryDialogDisplayed()
+      dismissDialog()
+      clickNightModePreference()
+      assertNightModeDialogDisplayed()
+      dismissDialog()
+      clickCredits()
+      assertContributorsDialogDisplayed()
+      dismissDialog()
     }
+    LeakAssertions.assertNoLeaks()
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -18,7 +18,6 @@
 package org.kiwix.kiwixmobile.settings
 
 import android.Manifest
-import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
@@ -33,6 +32,8 @@ import org.kiwix.kiwixmobile.intro.IntroRobot
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.StandardActions
 
 class KiwixSettingsFragmentTest {
@@ -53,17 +54,22 @@ class KiwixSettingsFragmentTest {
   @Before
   fun setup() {
     // Go to IntroFragment
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).waitForIdle()
-      UiThreadStatement.runOnUiThread {
-        activityScenarioRule.scenario.onActivity {
-          it.navigate(R.id.introFragment)
-        }
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(
+          InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        )
       }
-      intro(IntroRobot::swipeLeft) clickGetStarted { }
-      StandardActions.openDrawer()
-      StandardActions.enterSettings()
+      waitForIdle()
     }
+    UiThreadStatement.runOnUiThread {
+      activityScenarioRule.scenario.onActivity {
+        it.navigate(R.id.introFragment)
+      }
+    }
+    intro(IntroRobot::swipeLeft) clickGetStarted { }
+    StandardActions.openDrawer()
+    StandardActions.enterSettings()
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -108,8 +108,7 @@ class KiwixSplashActivityTest {
   @Test
   fun testNormalRun() {
     shouldShowIntro(false)
-    activityScenario.recreate()
-    activityScenario.onActivity {
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
     }
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     Intents.intended(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -30,6 +30,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import leakcanary.LeakAssertions
 import org.junit.After
@@ -43,6 +44,8 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -70,6 +73,12 @@ class KiwixSplashActivityTest {
   fun setUp() {
     Intents.init()
     context = InstrumentationRegistry.getInstrumentation().targetContext
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -56,10 +56,12 @@ class KiwixSplashActivityTest {
     ActivityScenario.launch(KiwixMainActivity::class.java)
 
   @Rule
+  @JvmField
   var readPermissionRule: GrantPermissionRule =
     GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Rule
+  @JvmField
   var writePermissionRule: GrantPermissionRule =
     GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
   private var context: Context? = null

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -19,7 +19,6 @@ package org.kiwix.kiwixmobile.splash
 
 import android.Manifest
 import android.content.Context
-import android.os.Build
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
@@ -73,45 +72,41 @@ class KiwixSplashActivityTest {
 
   @Test
   fun testFirstRun() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      shouldShowIntro(true)
-      activityScenario.recreate()
-      activityScenario.onActivity {
-        BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-        Espresso.onView(ViewMatchers.withId(R.id.get_started))
-          .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    shouldShowIntro(true)
+    activityScenario.recreate()
+    activityScenario.onActivity {
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      Espresso.onView(ViewMatchers.withId(R.id.get_started))
+        .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
-        // Verify that the value of the "intro shown" boolean inside
-        // the SharedPreferences Database is not changed until
-        // the "Get started" button is pressed
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        Assert.assertEquals(
-          true,
-          preferences.getBoolean(
-            SharedPreferenceUtil.PREF_SHOW_INTRO,
-            true
-          )
+      // Verify that the value of the "intro shown" boolean inside
+      // the SharedPreferences Database is not changed until
+      // the "Get started" button is pressed
+      val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+      Assert.assertEquals(
+        true,
+        preferences.getBoolean(
+          SharedPreferenceUtil.PREF_SHOW_INTRO,
+          true
         )
-      }
-      LeakAssertions.assertNoLeaks()
+      )
     }
+    LeakAssertions.assertNoLeaks()
   }
 
   @Test
   fun testNormalRun() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      shouldShowIntro(false)
-      activityScenario.recreate()
-      activityScenario.onActivity {
-        BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-        Intents.intended(
-          IntentMatchers.hasComponent(
-            KiwixMainActivity::class.java.canonicalName
-          )
+    shouldShowIntro(false)
+    activityScenario.recreate()
+    activityScenario.onActivity {
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      Intents.intended(
+        IntentMatchers.hasComponent(
+          KiwixMainActivity::class.java.canonicalName
         )
-      }
-      LeakAssertions.assertNoLeaks()
+      )
     }
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -86,22 +86,22 @@ class KiwixSplashActivityTest {
     shouldShowIntro(true)
     activityScenario.recreate()
     activityScenario.onActivity {
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      Espresso.onView(ViewMatchers.withId(R.id.get_started))
-        .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-
-      // Verify that the value of the "intro shown" boolean inside
-      // the SharedPreferences Database is not changed until
-      // the "Get started" button is pressed
-      val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-      Assert.assertEquals(
-        true,
-        preferences.getBoolean(
-          SharedPreferenceUtil.PREF_SHOW_INTRO,
-          true
-        )
-      )
     }
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    Espresso.onView(ViewMatchers.withId(R.id.get_started))
+      .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+    // Verify that the value of the "intro shown" boolean inside
+    // the SharedPreferences Database is not changed until
+    // the "Get started" button is pressed
+    val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+    Assert.assertEquals(
+      true,
+      preferences.getBoolean(
+        SharedPreferenceUtil.PREF_SHOW_INTRO,
+        true
+      )
+    )
     LeakAssertions.assertNoLeaks()
   }
 
@@ -110,13 +110,13 @@ class KiwixSplashActivityTest {
     shouldShowIntro(false)
     activityScenario.recreate()
     activityScenario.onActivity {
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      Intents.intended(
-        IntentMatchers.hasComponent(
-          KiwixMainActivity::class.java.canonicalName
-        )
-      )
     }
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    Intents.intended(
+      IntentMatchers.hasComponent(
+        KiwixMainActivity::class.java.canonicalName
+      )
+    )
     LeakAssertions.assertNoLeaks()
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -18,6 +18,8 @@
 package org.kiwix.kiwixmobile.testutils
 
 import android.Manifest
+import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.os.Build
@@ -28,6 +30,7 @@ import androidx.core.content.ContextCompat
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.screenshot.Screenshot
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
@@ -148,5 +151,14 @@ object TestUtils {
   @JvmStatic fun getResourceString(id: Int): String {
     val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
     return targetContext.resources.getString(id)
+  }
+
+  @JvmStatic
+  fun isSystemUINotRespondingDialogVisible(uiDevice: UiDevice) =
+    uiDevice.findObject(By.textContains("System UI isn't responding")) != null
+
+  @JvmStatic
+  fun closeSystemDialogs(context: Context?) {
+    context?.sendBroadcast(Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS))
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -46,9 +46,8 @@ import java.util.Date
  */
 object TestUtils {
   private const val TAG = "TESTUTILS"
-  @JvmField var TEST_PAUSE_MS = 250
+  @JvmField var TEST_PAUSE_MS = 3000
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
-  var TEST_PAUSE_MS_FOR_ESPRESSO = 3000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
   const val RETRY_COUNT_FOR_FLAKY_TEST = 3
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -30,7 +30,7 @@ import androidx.core.content.ContextCompat
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.screenshot.Screenshot
-import androidx.test.uiautomator.By
+import androidx.test.uiautomator.By.textContains
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
@@ -155,7 +155,9 @@ object TestUtils {
 
   @JvmStatic
   fun isSystemUINotRespondingDialogVisible(uiDevice: UiDevice) =
-    uiDevice.findObject(By.textContains("System UI isn't responding")) != null
+    uiDevice.findObject(textContains("System UI isn't responding")) != null ||
+      uiDevice.findObject(textContains("Process system isn't responding")) != null ||
+      uiDevice.findObject(textContains("Launcher isn't responding")) != null
 
   @JvmStatic
   fun closeSystemDialogs(context: Context?) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
@@ -39,6 +39,7 @@ object StandardActions {
   }
 
   fun openDrawer() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     openDrawerWithGravity(R.id.navigation_container, GravityCompat.START)
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -496,7 +496,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private fun onBookItemClick(item: LibraryListItem.BookItem) {
     if (checkExternalStorageWritePermission()) {
       downloadBookItem = item
-      if (requireActivity().hasNotificationPermission()) {
+      if (requireActivity().hasNotificationPermission(sharedPreferenceUtil)) {
         when {
           isNotConnected -> {
             noInternetSnackbar()

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -148,7 +148,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
         checkNearbyWifiDevicesPermission()
       ) {
-        if (requireActivity().hasNotificationPermission()) {
+        if (requireActivity().hasNotificationPermission(sharedPreferenceUtil)) {
           startStopServer()
         } else {
           requestNotificationPermission()

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -30,7 +30,7 @@ object Libs {
    * https://developer.android.com/testing
    */
   const val espresso_contrib: String = "androidx.test.espresso:espresso-contrib:" +
-    Versions.androidx_test_espresso_contrib
+    Versions.androidx_test_espresso
 
   /**
    * https://developer.android.com/testing

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -16,9 +16,7 @@ object Versions {
 
   const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.4.1"
 
-  const val androidx_test_espresso: String = "3.5.0"
-
-  const val androidx_test_espresso_contrib: String = "3.3.0"
+  const val androidx_test_espresso: String = "3.5.1"
 
   const val com_squareup_retrofit2: String = "2.9.0"
 
@@ -42,7 +40,7 @@ object Versions {
 
   const val io_objectbox: String = "3.5.0"
 
-  const val io_mockk: String = "1.13.4"
+  const val io_mockk: String = "1.13.5"
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
@@ -76,7 +74,7 @@ object Versions {
 
   const val threetenabp: String = "1.3.0"
 
-  const val uiautomator: String = "2.2.0"
+  const val uiautomator: String = "2.3.0-alpha03"
 
   const val annotation: String = "1.1.0"
 
@@ -94,7 +92,7 @@ object Versions {
 
   const val multidex: String = "2.0.1"
 
-  const val barista: String = "4.0.0"
+  const val barista: String = "4.3.0"
 
   const val fetch: String = "3.1.6"
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -42,6 +42,7 @@ import androidx.navigation.NavDirections
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.REQUEST_POST_NOTIFICATION_PERMISSION
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
 object ActivityExtensions {
 
@@ -144,8 +145,10 @@ object ActivityExtensions {
     )
   }
 
-  fun Activity.hasNotificationPermission() =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+  fun Activity.hasNotificationPermission(sharedPreferenceUtil: SharedPreferenceUtil?) =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+      sharedPreferenceUtil?.prefIsTest == false
+    ) {
       ContextCompat.checkSelfPermission(
         this,
         POST_NOTIFICATIONS

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1103,7 +1103,7 @@ abstract class CoreReaderFragment :
 
   @Suppress("NestedBlockDepth")
   override fun onReadAloudMenuClicked() {
-    if (requireActivity().hasNotificationPermission()) {
+    if (requireActivity().hasNotificationPermission(sharedPreferenceUtil)) {
       ttsControls?.let { ttsControls ->
         when (ttsControls.visibility) {
           View.GONE -> {


### PR DESCRIPTION
Fixes #3189 

* Fixed the `DownloadTest` which is failing on `Android 13` due to the `NotificationPermission` permission dialog being visible on the window so we have placed a condition if the test cases are running then it will not ask for `Notification permission`.
* `NetworkTest` is broken for now and we have ignored but somehow it is giving an error on this test in `Android 13`. so we have placed a fix here for this error.
```
04-28 08:50:12.166  5954  6406 E TestRunner: failed: initializationError(org.kiwix.kiwixmobile.NetworkTest)
04-28 08:50:12.166  5954  6406 E TestRunner: ----- begin exception -----
04-28 08:50:12.172  6071  6104 I FontLog : Received query Noto Color Emoji Compat, URI content://com.google.android.gms.fonts [CONTEXT service_id=132 ]
04-28 08:50:12.174  6071  6104 I FontLog : Query [Noto Color Emoji Compat] resolved to {Noto Color Emoji Compat, wdth 100.0, wght 400, ital 0.0, bestEffort false} [CONTEXT service_id=132 ]
04-28 08:50:12.183  5954  6406 E TestRunner: java.lang.RuntimeException: Failed to instantiate test runner class androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
04-28 08:50:12.183  5954  6406 E TestRunner: 
04-28 08:50:12.183  5954  6406 E TestRunner: 
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.ext.junit.runners.AndroidJUnit4.throwInitializationError(AndroidJUnit4.java:129)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.ext.junit.runners.AndroidJUnit4.loadRunner(AndroidJUnit4.java:121)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.ext.junit.runners.AndroidJUnit4.loadRunner(AndroidJUnit4.java:82)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.ext.junit.runners.AndroidJUnit4.<init>(AndroidJUnit4.java:56)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at java.lang.reflect.Constructor.newInstance0(Native Method)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:104)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:86)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.junit4.AndroidAnnotatedBuilder.runnerForClass(AndroidAnnotatedBuilder.java:63)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:70)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:37)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.AndroidRunnerBuilder.runnerForClass(AndroidRunnerBuilder.java:149)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.AndroidLogOnlyBuilder.runnerForClass(AndroidLogOnlyBuilder.java:93)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.ScanningTestLoader.doCreateRunner(ScanningTestLoader.java:50)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.TestLoader.getRunnersFor(TestLoader.java:64)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.TestRequestBuilder.build(TestRequestBuilder.java:835)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.runner.AndroidJUnitRunner.buildRequest(AndroidJUnitRunner.java:650)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:418)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2361)
04-28 08:50:12.183  5954  6406 E TestRunner: Caused by: java.lang.reflect.InvocationTargetException
04-28 08:50:12.183  5954  6406 E TestRunner: 	at java.lang.reflect.Constructor.newInstance0(Native Method)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.ext.junit.runners.AndroidJUnit4.loadRunner(AndroidJUnit4.java:112)
04-28 08:50:12.183  5954  6406 E TestRunner: 	... 17 more
04-28 08:50:12.183  5954  6406 E TestRunner: Caused by: org.junit.runners.model.InvalidTestClassError: Invalid test class 'org.kiwix.kiwixmobile.NetworkTest':
04-28 08:50:12.183  5954  6406 E TestRunner:   1. The @Rule 'mActivityTestRule' must be public.
04-28 08:50:12.183  5954  6406 E TestRunner:   2. The @Rule 'readPermissionRule' must be public.
04-28 08:50:12.183  5954  6406 E TestRunner:   3. The @Rule 'writePermissionRule' must be public.
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.runners.ParentRunner.validate(ParentRunner.java:525)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.runners.ParentRunner.<init>(ParentRunner.java:92)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at org.junit.runners.BlockJUnit4ClassRunner.<init>(BlockJUnit4ClassRunner.java:74)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner.<init>(AndroidJUnit4ClassRunner.java:43)
04-28 08:50:12.183  5954  6406 E TestRunner: 	at androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner.<init>(AndroidJUnit4ClassRunner.java:48)
04-28 08:50:12.183  5954  6406 E TestRunner: 	... 20 more
04-28 08:50:12.185  5954  6406 E TestRunner: ----- end exception -----
```

* For the `KiwixSplashActivityTest` in `Android 13` we can not directly use the `BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())` on the main thread so we have moved it from main thread.
* For the `KiwixSplashActivity` `testNormalRun()` which is failing due to `Wanted to match 1 intent. Actually matched 0 intents)`
* Since `google_apis` emulators are heavy, we have increased the heap size and sd card size to 4GB for the Android 13 emulator.
* Increased delay in some test cases for better test performance.
* Sometimes some system dialog is visible on the window for this reason `espresso` and `UiObject` are unable to find views on the window so we have placed a check in test cases if any system dialog is visible on the window then first it will close it and after that run the test cases.
* We have upgraded some test dependencies to support the latest API.
   * Upgraded `espresso-contrib` dependency from `3.3.0` to `3.5.1`.
   * Upgraded `espresso-core` dependency from `3.5.0` to `3.5.1`.
   * Upgraded `espresso-intents` dependency from `3.5.0` to `3.5.1`.
   * Upgraded `espresso-web` dependency from `3.5.0` to `3.5.1`.
   * Upgraded `barista` dependency from `4.0.0` to `4.3.0`.
   * Upgraded `mockk` dependency from `1.13.4` to `1.13.5`.
   * Upgraded `uiautomator` dependency from `2.2.0` to `2.3.0-alpha03`.