### PR TITLE
Fixed red effect while changing the tabs

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -45,6 +45,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.consumeObservabl
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setupDrawerToggle
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.setBottomMarginToFragmentContainerView
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
 import org.kiwix.kiwixmobile.core.extensions.snack
@@ -241,7 +242,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     val settings = requireActivity().getSharedPreferences(SharedPreferenceUtil.PREF_KIWIX_MOBILE, 0)
     val zimFile = settings.getString(TAG_CURRENT_FILE, null)
 
-    if (zimFile != null && File(zimFile).exists()) {
+    if (zimFile != null && File(zimFile).isFileExist()) {
       if (zimReaderContainer?.zimFile == null) {
         openZimFile(File(zimFile))
         Log.d(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -133,7 +133,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
       requireActivity().applicationContext, Uri.parse(zimFileUri)
     )
 
-    if (filePath == null || !File(filePath).exists()) {
+    if (filePath == null || !File(filePath).isFileExist()) {
       activity.toast(R.string.error_file_not_found)
       return
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
@@ -25,6 +25,9 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.settings.CorePrefsFragment
@@ -41,8 +44,9 @@ class KiwixPrefsFragment : CorePrefsFragment() {
 
   override fun setStorage() {
     sharedPreferenceUtil?.let {
+      val internalStorage = runBlocking { internalStorage() }
       findPreference<Preference>(PREF_STORAGE)?.title = getString(
-        if (it.prefStorage == internalStorage()?.let(
+        if (it.prefStorage == internalStorage?.let(
             it::getPublicDirectoryPath
           )
         ) R.string.internal_storage
@@ -52,8 +56,9 @@ class KiwixPrefsFragment : CorePrefsFragment() {
     findPreference<Preference>(PREF_STORAGE)?.summary = storageCalculator?.calculateAvailableSpace()
   }
 
-  private fun internalStorage(): String? =
+  private suspend fun internalStorage(): String? = withContext(Dispatchers.IO) {
     ContextCompat.getExternalFilesDirs(requireContext(), null).firstOrNull()?.path
+  }
 
   private fun setMangeExternalStoragePermission() {
     val permissionPref = findPreference<Preference>(PREF_MANAGE_EXTERNAL_STORAGE_PERMISSION)

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -24,6 +24,7 @@ import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
@@ -68,7 +69,7 @@ data class DeleteFiles(private val booksOnDiskListItems: List<BookOnDisk>) :
   private fun deleteSpecificZimFile(book: BookOnDisk): Boolean {
     val file = book.file
     FileUtils.deleteZimFile(file.path)
-    if (file.exists()) {
+    if (file.isFileExist()) {
       return false
     }
     newBookDao.delete(book.databaseId)

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
@@ -23,6 +23,7 @@ import androidx.core.net.toUri
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
+import org.kiwix.kiwixmobile.core.extensions.canReadFile
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
@@ -32,7 +33,7 @@ data class OpenFileWithNavigation(private val bookOnDisk: BooksOnDiskListItem.Bo
 
   override fun invokeWith(activity: AppCompatActivity) {
     val file = bookOnDisk.file
-    if (!file.canRead()) {
+    if (!file.canReadFile()) {
       activity.toast(R.string.error_file_not_found)
     } else {
       activity.navigate(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -28,3 +28,9 @@ fun File.isFileExist(): Boolean = runBlocking {
     exists()
   }
 }
+
+fun File.freeSpace(): Long = runBlocking {
+  withContext(Dispatchers.IO) {
+    freeSpace
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -46,3 +46,9 @@ fun File.canReadFile(): Boolean = runBlocking {
     canRead()
   }
 }
+
+fun File.deleteFile(): Boolean = runBlocking {
+  withContext(Dispatchers.IO) {
+    delete()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -34,3 +34,9 @@ fun File.freeSpace(): Long = runBlocking {
     freeSpace
   }
 }
+
+fun File.totalSpace(): Long = runBlocking {
+  withContext(Dispatchers.IO) {
+    totalSpace
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -40,3 +40,9 @@ fun File.totalSpace(): Long = runBlocking {
     totalSpace
   }
 }
+
+fun File.canReadFile(): Boolean = runBlocking {
+  withContext(Dispatchers.IO) {
+    canRead()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -1,0 +1,30 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.io.File
+
+fun File.isFileExist(): Boolean = runBlocking {
+  withContext(Dispatchers.IO) {
+    exists()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -102,6 +102,7 @@ import org.kiwix.kiwixmobile.core.downloader.fetch.DOWNLOAD_NOTIFICATION_TITLE
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.findFirstTextView
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.DocumentParser.SectionsListener
@@ -1267,7 +1268,7 @@ abstract class CoreReaderFragment :
 
   protected fun openZimFile(file: File) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE)) {
-      if (file.exists()) {
+      if (file.isFileExist()) {
         openAndSetInContainer(file)
         updateTitle()
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.reader
 
 import android.webkit.WebResourceResponse
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.io.File
 import java.net.HttpURLConnection
@@ -37,7 +38,7 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
       return
     }
     zimFileReader =
-      if (file?.exists() == true) zimFileReaderFactory.create(file)
+      if (file?.isFileExist() == true) zimFileReaderFactory.create(file)
       else null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/StorageCalculator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/StorageCalculator.kt
@@ -19,6 +19,8 @@
 package org.kiwix.kiwixmobile.core.settings
 
 import eu.mhutti1.utils.storage.Bytes
+import org.kiwix.kiwixmobile.core.extensions.freeSpace
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import java.io.File
 import javax.inject.Inject
@@ -34,7 +36,7 @@ class StorageCalculator @Inject constructor(
     Bytes(totalBytes(file)).humanReadable
 
   fun availableBytes(file: File = File(sharedPreferenceUtil.prefStorage)) =
-    if (file.exists()) file.freeSpace
+    if (file.isFileExist()) file.freeSpace()
     else 0L
 
   private fun totalBytes(file: File) = if (file.exists()) file.totalSpace else 0L

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/StorageCalculator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/StorageCalculator.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.settings
 
 import eu.mhutti1.utils.storage.Bytes
 import org.kiwix.kiwixmobile.core.extensions.freeSpace
+import org.kiwix.kiwixmobile.core.extensions.totalSpace
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import java.io.File
@@ -39,5 +40,5 @@ class StorageCalculator @Inject constructor(
     if (file.isFileExist()) file.freeSpace()
     else 0L
 
-  private fun totalBytes(file: File) = if (file.exists()) file.totalSpace else 0L
+  private fun totalBytes(file: File) = if (file.isFileExist()) file.totalSpace() else 0L
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -29,6 +29,7 @@ import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.NightModeConfig.Mode.Companion.from
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import java.io.File
 import java.util.Locale
 import javax.inject.Inject
@@ -91,7 +92,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
           putPrefStorage(it)
           putStoragePosition(0)
         }
-        !File(storage).exists() -> getPublicDirectoryPath(defaultStorage()).also {
+        !File(storage).isFileExist() -> getPublicDirectoryPath(defaultStorage()).also {
           putStoragePosition(0)
         }
         else -> storage

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -30,6 +30,9 @@ import android.util.Log
 import android.webkit.URLUtil
 import android.widget.Toast
 import androidx.documentfile.provider.DocumentFile
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.downloader.ChunkUtils
@@ -55,7 +58,9 @@ object FileUtils {
   @JvmStatic
   @Synchronized
   fun deleteCachedFiles(context: Context) {
-    getFileCacheDir(context)?.deleteRecursively()
+    CoroutineScope(Dispatchers.IO).launch {
+      getFileCacheDir(context)?.deleteRecursively()
+    }
   }
 
   @JvmStatic

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -37,7 +37,9 @@ import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.downloader.ChunkUtils
 import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity.Book
+import org.kiwix.kiwixmobile.core.extensions.deleteFile
 import org.kiwix.kiwixmobile.core.extensions.get
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -79,8 +81,8 @@ object FileUtils {
         while (alphabetSecond <= 'z') {
           val chunkPath = path.substring(0, path.length - 2) + alphabetFirst + alphabetSecond
           val fileChunk = File(chunkPath)
-          if (fileChunk.exists()) {
-            fileChunk.delete()
+          if (fileChunk.isFileExist()) {
+            fileChunk.deleteFile()
           } else if (!deleteZimFileParts(chunkPath)) {
             break@fileloop
           }
@@ -89,7 +91,7 @@ object FileUtils {
         alphabetFirst++
       }
     } else {
-      file.delete()
+      file.deleteFile()
       deleteZimFileParts(path)
     }
   }
@@ -97,13 +99,13 @@ object FileUtils {
   @Synchronized
   private fun deleteZimFileParts(path: String): Boolean {
     val file = File(path + ChunkUtils.PART)
-    if (file.exists()) {
-      file.delete()
+    if (file.isFileExist()) {
+      file.deleteFile()
       return true
     }
     val singlePart = File("$path.part")
-    if (singlePart.exists()) {
-      singlePart.delete()
+    if (singlePart.isFileExist()) {
+      singlePart.deleteFile()
       return true
     }
     return false
@@ -200,7 +202,7 @@ object FileUtils {
     val files = ArrayList<File>()
     book.file?.let {
       if (it.path.endsWith(".zim") || it.path.endsWith(".zim.part")) {
-        if (it.exists()) {
+        if (it.isFileExist()) {
           files.add(it)
         } else {
           files.add(File("$it.part"))
@@ -211,8 +213,8 @@ object FileUtils {
           for (secondCharacter in 'a'..'z') {
             path = path.substring(0, path.length - 2) + firstCharacter + secondCharacter
             when {
-              File(path).exists() -> files.add(File(path))
-              File("$path.part").exists() -> files.add(File("$path.part"))
+              File(path).isFileExist() -> files.add(File(path))
+              File("$path.part").isFileExist() -> files.add(File("$path.part"))
               else -> return@getAllZimParts files
             }
           }
@@ -237,9 +239,9 @@ object FileUtils {
       for (secondCharacter in 'a'..'z') {
         val chunkPath = path.substring(0, path.length - 2) + firstCharacter + secondCharacter
         val fileChunk = File("$chunkPath.part")
-        if (fileChunk.exists()) {
+        if (fileChunk.isFileExist()) {
           return true
-        } else if (!File(chunkPath).exists()) {
+        } else if (!File(chunkPath).isFileExist()) {
           return false
         }
       }
@@ -250,8 +252,8 @@ object FileUtils {
   @JvmStatic
   fun getFileName(fileName: String) =
     when {
-      File(fileName).exists() -> fileName
-      File("$fileName.part").exists() -> "$fileName.part"
+      File(fileName).isFileExist() -> fileName
+      File("$fileName.part").isFileExist() -> "$fileName.part"
       else -> "${fileName}aa"
     }
 
@@ -362,9 +364,9 @@ object FileUtils {
           "${Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)}" +
             "/org.kiwix"
         )
-      if (!root.exists()) root.mkdir()
+      if (!root.isFileExist()) root.mkdir()
     }
-    if (File(root, fileName).exists()) return File(root, fileName)
+    if (File(root, fileName).isFileExist()) return File(root, fileName)
     val fileToSave = sequence {
       yield(File(root, fileName))
       yieldAll(
@@ -374,7 +376,7 @@ object FileUtils {
           )
         }
       )
-    }.first { !it.exists() }
+    }.first { !it.isFileExist() }
     val source = if (url == null) Uri.parse(src) else Uri.parse(url)
     return try {
       zimReaderContainer.load("$source", emptyMap()).data.use { inputStream ->


### PR DESCRIPTION
Fixes #3250 

**What is the issue**

* We have `StrictModePolicy` warning in our project while using the `File` object methods e.g. `exists()`,  `freeSpace`, `totalSpace`, `canRead()`, `delete()`.
* This warning showing because we are performing a disk read operation on the main thread, which can result in UI freezing and decreased performance.

**What is the solution**

* We created a class for `File extensions` that performs disk operations on a background thread using `Coroutine`.

**Before Fix**

https://user-images.githubusercontent.com/34593983/236447464-177ea47e-f05e-42a9-a911-05ca1d035942.mp4


**After Fix**


https://user-images.githubusercontent.com/34593983/236447504-90bdbf06-176b-4a05-acd6-fb334a369193.mp4