### PR TITLE
Fixed open ZIM-File on external USB-Stick in Android

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -118,7 +118,7 @@ object FileUtils {
           return "${Environment.getExternalStorageDirectory()}/${documentId[1]}"
         }
         return try {
-          "${getSdCardMainPath(context)}/${documentId[1]}"
+          "${getSdCardMainPath(context, documentId[0])}/${documentId[1]}"
         } catch (ignore: Exception) {
           null
         }
@@ -264,9 +264,10 @@ object FileUtils {
     filePath.endsWith(".zim") || filePath.endsWith(".zimaa")
 
   @JvmStatic
-  fun getSdCardMainPath(context: Context): String =
-    "${context.getExternalFilesDirs("")[1]}"
-      .substringBefore(context.getString(R.string.android_directory_seperator))
+  fun getSdCardMainPath(context: Context, storageName: String) =
+    context.getExternalFilesDirs("")
+      .first { it.path.contains(storageName) }
+      .path.substringBefore(context.getString(R.string.android_directory_seperator))
 
   @SuppressLint("WrongConstant")
   @JvmStatic


### PR DESCRIPTION
Fixes #3304 

**What is the issue**
When there is already an attached sd card in the phone and we are opening the zim file from a USB stick via the `+` icon it fails to load the zim file because we are taking the first index from `getExternalFilesDirs()` when the selected zim file is not from primary storage.

https://github.com/kiwix/kiwix-android/blob/ce423820f0b2aee20cdd69e064095ba4db24b4a2/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt#L268

**Fix**
* When we select zim files using the `+` button, it returns the `DocumentId`, which includes the storage name as shown in the screenshots below. To obtain the actual storage path from where we select the zim file, we have made modifications to our getSdCardMainPath() method.
* Now, the `getExternalFilesDirs()` method returns the path which contains the storage name. So by using this approach, we are avoiding writing the hard-coded index in the method as well as it fixed the scenario where the sd card is also present in the phone and we are selecting the zim file from `USB stick`.

| SD Card  | USB Stick |
| ------------- | ------------- |
| ![Screenshot_20230518-115152_Kiwix](https://github.com/kiwix/kiwix-android/assets/34593983/e9f58c02-e294-4833-be09-48100b4d0267) | ![Screenshot_20230518-115353_Kiwix](https://github.com/kiwix/kiwix-android/assets/34593983/999f088f-f4b8-4c9a-a17b-24d8ad83f84b) |


**Important Note**
This fix is applicable for `Android 10` and below devices. Above `android 10` `getExternalFilesDirs()` not giving a path for externally attached storages like `USB stick` for privacy concerns of users. Above `Android 10` we can only access files via `SAF (Storage Access Framework)`. However, this method requires reading the zim file through an `input stream` and creating a File from it. This approach is not ideal because if the user has a `50GB` file, creating a File from the `input stream` would require storing that file in the device's storage. There are various edge cases to consider, such as insufficient storage in the file system. Additionally, this method takes time to write the file via the input stream, causing the user to wait, depending on the file size. In my opinion, this is not a good approach. 


Any better suggestion would be welcome.

