### PR TITLE
Change the tags "Pic" and "Vid"

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -264,8 +264,8 @@
   <string name="pref_clear_all_notes_title">Clear all notes</string>
   <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read and write ZIM files on SD card</string>
   <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
-  <string name="tag_pic">Pic</string>
-  <string name="tag_vid">Vid</string>
+  <string name="tag_pic">With images</string>
+  <string name="tag_vid">With videos</string>
   <string name="tag_text_only">Text Only</string>
   <string name="tag_short_text">Short Text</string>
   <string name="storage_permission_denied">Storage Permission Denied</string>


### PR DESCRIPTION
These tags appear in the library view and
they are quite cryptic in English and hard
to translate, too. There's no reason to force
these labels to be so short because there
is enough screen space to show them.

<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #

<!-- Add here what changes were made in this issue and if possible provide links. -->


<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
