### PR TITLE
Fixed deprecated Android dialog strings (android.R.string.yes, android.R.string.no)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -45,51 +45,51 @@ sealed class KiwixDialog(
   object LocationPermissionRationale : KiwixDialog(
     null,
     R.string.permission_rationale_location,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object LocationPermissionRationaleOnHostZimFile : KiwixDialog(
     null,
     R.string.permission_rationale_location_on_host_zim_file,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object NearbyWifiPermissionRationaleOnHostZimFile : KiwixDialog(
     null,
     R.string.permission_rationale_location_on_host_zim_file,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object StoragePermissionRationale : KiwixDialog(
     null,
     R.string.request_storage,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object WriteStoragePermissionRationale : KiwixDialog(
     null,
     R.string.request_write_storage,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object NotificationPermissionDialog : KiwixDialog(
     null,
     R.string.request_notification_permission_message,
-    android.R.string.yes,
+    android.R.string.ok,
     android.R.string.cancel
   )
 
   object EnableWifiP2pServices : KiwixDialog(
-    null, R.string.request_enable_wifi, R.string.yes, android.R.string.no
+    null, R.string.request_enable_wifi, R.string.yes, android.R.string.cancel
   )
 
   object EnableLocationServices : KiwixDialog(
-    null, R.string.request_enable_location, R.string.yes, android.R.string.no
+    null, R.string.request_enable_location, R.string.yes, android.R.string.cancel
   )
 
   object TurnOffHotspotManually : KiwixDialog(


### PR DESCRIPTION
Fixes #3330 

**What is the issue**
We were using `android.R.string.yes` and `android.R.string.no` in KiwixDialog, which is deprecated by the android as mentioned in the below screenshot.

![Screenshot from 2023-05-23 16-12-58](https://github.com/kiwix/kiwix-android/assets/34593983/ee849098-94b9-413e-b999-5911681bc5e3)

**Fixes**
We have replaced the deprecated strings (`android.R.string.yes`, `android.R.string.no`) with their corresponding replacements provided by the Android framework (`android.R.string.ok`, `android.R.string.cancel`). These new strings have the same text as the deprecated ones.