### PR TITLE
Fixed deprecated resources.getColor(Int) method

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -344,7 +344,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
     configureUrlSharingIcon()
     activityZimHostBinding?.startServerButton?.text = getString(R.string.stop_server_label)
     activityZimHostBinding?.startServerButton?.setBackgroundColor(
-      resources.getColor(R.color.stopServerRed)
+      ContextCompat.getColor(requireActivity(), R.color.stopServerRed)
     )
     bookDelegate.selectionMode = SelectionMode.NORMAL
     booksAdapter.notifyDataSetChanged()
@@ -370,7 +370,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
     activityZimHostBinding?.shareServerUrlIcon?.visibility = View.GONE
     activityZimHostBinding?.startServerButton?.text = getString(R.string.start_server_label)
     activityZimHostBinding?.startServerButton?.setBackgroundColor(
-      resources.getColor(R.color.startServerGreen)
+      ContextCompat.getColor(requireActivity(), R.color.startServerGreen)
     )
     bookDelegate.selectionMode = SelectionMode.MULTI
     booksAdapter.notifyDataSetChanged()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1459,7 +1459,10 @@ abstract class CoreReaderFragment :
                 goToBookmarks()
                 Unit
               },
-              actionTextColor = resources.getColor(R.color.alabaster_white)
+              actionTextColor = ContextCompat.getColor(
+                requireActivity(),
+                R.color.alabaster_white
+              )
             )
           }
         } ?: kotlin.run {
@@ -1856,7 +1859,12 @@ abstract class CoreReaderFragment :
                   webViewList.size - 1
                 )
               }
-              .setActionTextColor(resources.getColor(R.color.alabaster_white))
+              .setActionTextColor(
+                ContextCompat.getColor(
+                  requireActivity(),
+                  R.color.alabaster_white
+                )
+              )
               .show()
           }
         } else {


### PR DESCRIPTION
Fixes #3337 

**What is the issue**
We were using `resources.getColor(Int)` to retrieve colors from the `colors.xml` file and apply them to our views.

**Fix**
We have replaced the deprecated getColor method with the corresponding replacement provided by the Android framework 
`ContextCompat.getColor(context, Int)`