### PR TITLE
Fixed NotificationCompat.Builder(context) is deprecated

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotNotificationManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotNotificationManager.kt
@@ -73,7 +73,7 @@ class HotspotNotificationManager @Inject constructor(
     } else {
       PendingIntent.getService(context, 0, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT)
     }
-    return NotificationCompat.Builder(context)
+    return NotificationCompat.Builder(context, HOTSPOT_SERVICE_CHANNEL_ID)
       .setContentTitle(context.getString(R.string.hotspot_notification_content_title))
       .setContentText(context.getString(R.string.hotspot_running))
       .setContentIntent(contentIntent)
@@ -84,7 +84,6 @@ class HotspotNotificationManager @Inject constructor(
         context.getString(R.string.stop),
         stopHotspot
       )
-      .setChannelId(HOTSPOT_SERVICE_CHANNEL_ID)
       .build()
   }
 


### PR DESCRIPTION
Fixes #3338 

**What is the Issue**
We were currently using NotificationCompat.Builder(context) to create the notification displayed to users when the hotspot is active on their device. However, this method is deprecated


**Fix**
We have replaced the deprecated constructor with a new one, `NotificationCompat.Builder(context, HOTSPOT_SERVICE_CHANNEL_ID)`.