### PR TITLE
Fixed setting `android:extractNativeLibs=false` in manifest file is deprecated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
   <application
     android:name=".KiwixApp"
     android:allowBackup="true"
-    android:extractNativeLibs="false"
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -128,6 +128,7 @@ class AllProjectConfigurer {
           add("META-INF/notice.txt")
           add("META-INF/ASL2.0")
         }
+        jniLibs.useLegacyPackaging = false
       }
       sourceSets {
         getByName("test") {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
 
   <application
     android:allowBackup="true"
-    android:extractNativeLibs="false"
     android:fullBackupContent="@xml/backup_rules"
     android:dataExtractionRules = "@xml/data_extraction_rules"
     android:hardwareAccelerated="true"

--- a/custom/src/main/AndroidManifest.xml
+++ b/custom/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
   <application
     android:name=".CustomApp"
-    android:extractNativeLibs="false"
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"


### PR DESCRIPTION
Fixes #3342 

**Issue**
We have been setting `android:extractNativeLibs=false` in each module of our application. However, this approach is deprecated in newer Gradle versions and may not work correctly in upcoming versions of Gradle.

**Fixes**
Now, we are using `jniLibs.useLegacyPackaging = false` in the `packagingOptions`, which is recommended in newer Gradle versions.

We have defined this in the `AllProjectConfigurer` class, as we include this class in every module.
Furthermore, we have removed the deprecated `android:extractNativeLibs="false"` from each manifest.