### PR TITLE
Fixed deprecated constructor of `FileObserver`

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.zimManager
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.FileObserver
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
@@ -63,11 +64,19 @@ class Fat32Checker constructor(
   }
 
   private fun fileObserver(it: String): FileObserver {
-    return object : FileObserver(File(it), MOVED_FROM or DELETE) {
-      override fun onEvent(event: Int, path: String?) {
-        requestCheckSystemFileType.onNext(Unit)
-      }
-    }.apply { startWatching() }
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return object : FileObserver(File(it), MOVED_FROM or DELETE) {
+        override fun onEvent(event: Int, path: String?) {
+          requestCheckSystemFileType.onNext(Unit)
+        }
+      }.apply { startWatching() }
+    } else {
+      object : FileObserver(it, FileObserver.MOVED_FROM or FileObserver.DELETE) {
+        override fun onEvent(event: Int, path: String?) {
+          requestCheckSystemFileType.onNext(Unit)
+        }
+      }.apply { startWatching() }
+    }
   }
 
   private fun toFileSystemState(it: String) =


### PR DESCRIPTION
Fixes #3341 

**Issue**
We are currently utilizing the deprecated constructor `FileObserver(String, Int)` to check the available space in the device.

**Fix**
* To address this, we have adopted the usage of the new constructor for `FileObserver`. ( `FileObserver(File, Int)` ) In this updated constructor, we now directly pass the `File` object instead of the `file path`.
* We have made the argument in the `fileObserver` method as non-null because the file path is guaranteed to never be null. If we did not make it non-null, we would need to use the double bang operator in the `FileObserver` constructor to ensure a non-null path is passed to the file object. Therefore, it is preferable to declare the string as non-null since it always has a value.
* The new constructor, `FileObserver(File(path), Int)`, is supported starting from Android 24. However, in older versions, this constructor is not supported by the Android OS, and attempting to use it will result in an error. Therefore, we have implemented a version check to ensure compatibility and create the `FileObserver` object accordingly.

```
Caused by: java.lang.NoSuchMethodError: No direct method <init>(Ljava/io/File;I)V in class Landroid/os/FileObserver; or its super classes (declaration of 'android.os.FileObserver' appears in /system/framework/framework.jar)
        at org.kiwix.kiwixmobile.zimManager.Fat32Checker$fileObserver$1.<init>(Fat32Checker.kt:66)
        at org.kiwix.kiwixmobile.zimManager.Fat32Checker.fileObserver(Fat32Checker.kt:66)
        at org.kiwix.kiwixmobile.zimManager.Fat32Checker._init_$lambda-2(Fat32Checker.kt:59)
        at org.kiwix.kiwixmobile.zimManager.Fat32Checker.$r8$lambda$qFAKoPi7GWGXdtHXd4q0qCUOpJg(Fat32Checker.kt)
        at org.kiwix.kiwixmobile.zimManager.Fat32Checker$$ExternalSyntheticLambda2.accept(D8$$SyntheticClass)
        at io.reactivex.internal.subscribers.LambdaSubscriber.onNext(LambdaSubscriber.java:65)
        at io.reactivex.internal.operators.flowable.FlowableSubscribeOn$SubscribeOnSubscriber.onNext(FlowableSubscribeOn.java:97)
        at io.reactivex.internal.operators.flowable.FlowableObserveOn$ObserveOnSubscriber.runAsync(FlowableObserveOn.java:407)
        at io.reactivex.internal.operators.flowable.FlowableObserveOn$BaseObserveOnSubscriber.run(FlowableObserveOn.java:176)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57) 
        at java.util.concurrent.FutureTask.run(FutureTask.java:237) 
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run
```