### PR TITLE
Removing `QUERY_ALL_PACKAGES` permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,9 +12,6 @@
     android:usesPermissionFlags="neverForLocation"
     tools:targetApi="s" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-  <uses-permission
-    android:name="android.permission.QUERY_ALL_PACKAGES"
-    tools:ignore="QueryAllPackagesPermission" />
   <uses-permission android:name="${permission}" />
 
   <queries>


### PR DESCRIPTION
Fixes #3361 

**Issue**
We introduced this permission in https://github.com/kiwix/kiwix-android/pull/2810 to address the Wi-Fi issue on the Android 30 emulator on CI. However, the Play Store marks this permission as sensitive, and not allowing us to publish our application with it on the Play Store.

**Fix**
We have removed the permission from our application as now we have updated many test dependencies and now android 30 emulator is working without this permission so we don't need to use this permission.