### PR TITLE
Removed deprecated `requireFragmentManager()` method

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -551,7 +551,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     .apply {
       onSelectAction = ::storeDeviceInPreferences
     }
-    .show(requireFragmentManager(), getString(R.string.pref_storage))
+    .show(parentFragmentManager, getString(R.string.pref_storage))
 
   private fun showStorageConfigureDialog() {
     alertDialogShower.show(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -139,7 +139,7 @@ class AddNoteDialog : DialogFragment() {
   private fun onFailureToCreateAddNoteDialog() {
     context.toast(R.string.error_file_not_found, Toast.LENGTH_LONG)
     closeKeyboard()
-    requireFragmentManager().beginTransaction().remove(this).commit()
+    parentFragmentManager.beginTransaction().remove(this).commit()
   }
 
   override fun onCreateView(


### PR DESCRIPTION
Fixes #3334 

We were using the `requireFragmentManager()` which is deprecated now, it returns `getParentFragmentManager()` as shown in the below image. Now we are directly using the `getParentFragmentManager()` method in our code instead of using this deprecated method.

![Screenshot from 2023-05-26 14-57-10](https://github.com/kiwix/kiwix-android/assets/34593983/fdd33dcc-261f-4a92-8753-df89f8b3818e)
