### PR TITLE
Fixed deprecated inline modifer

### DIFF
--- a/core/src/main/java/eu/mhutti1/utils/storage/Bytes.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/Bytes.kt
@@ -26,7 +26,8 @@ const val Tb = Gb * 1024
 const val Pb = Tb * 1024
 const val Eb = Pb * 1024
 
-inline class Bytes(val size: Long) {
+@JvmInline
+value class Bytes(val size: Long) {
   val humanReadable
     get() = when {
       size < Kb -> "$size Bytes"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/Base64String.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/Base64String.kt
@@ -22,7 +22,8 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Base64
 
-inline class Base64String(private val encodedString: String?) {
+@JvmInline
+value class Base64String(private val encodedString: String?) {
   fun toBitmap(): Bitmap? = try {
     encodedString?.let { nonNullString ->
       Base64.decode(nonNullString, Base64.DEFAULT)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/Seconds.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/Seconds.kt
@@ -23,7 +23,8 @@ import org.kiwix.kiwixmobile.core.R
 import java.util.Locale
 import kotlin.math.roundToLong
 
-inline class Seconds(val seconds: Long) {
+@JvmInline
+value class Seconds(val seconds: Long) {
   fun toHumanReadableTime(): String {
     val minutes = 60.0
     val hours = 60 * minutes

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/HeaderizableList.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/HeaderizableList.kt
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.core.extensions
 
-inline class HeaderizableList<SUPERTYPE, out ITEM : SUPERTYPE, in HEADER : SUPERTYPE>(
+@JvmInline
+value class HeaderizableList<SUPERTYPE, out ITEM : SUPERTYPE, in HEADER : SUPERTYPE>(
   val list: List<ITEM>
 ) {
   fun foldOverAddingHeaders(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ImageUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ImageUtils.kt
@@ -97,7 +97,8 @@ object ImageUtils {
   }
 }
 
-inline class MeasuredView(private val view: View) {
+@JvmInline
+value class MeasuredView(private val view: View) {
   val width: Int
     get() = view.measuredWidth
   val height: Int

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/KiloByte.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/KiloByte.kt
@@ -22,7 +22,8 @@ import java.text.DecimalFormat
 import kotlin.math.log10
 import kotlin.math.pow
 
-inline class KiloByte(private val kilobyteString: String?) {
+@JvmInline
+value class KiloByte(private val kilobyteString: String?) {
   val humanReadable
     get() = kilobyteString?.toLongOrNull()?.let {
       val units = arrayOf("KB", "MB", "GB", "TB")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/fileselect_view/ArticleCount.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/fileselect_view/ArticleCount.kt
@@ -25,7 +25,8 @@ import java.text.DecimalFormat
 import kotlin.math.log10
 import kotlin.math.pow
 
-inline class ArticleCount(val articleCount: String) {
+@JvmInline
+value class ArticleCount(val articleCount: String) {
   fun toHumanReadable(context: Context): String = try {
     val size = Integer.parseInt(articleCount)
     if (size <= 0) {


### PR DESCRIPTION
Fixes #3328 

**Issue**
We are using the inline modifier when defining the class, but in newer versions of Kotlin, this modifier is deprecated for classes. This deprecation was introduced in Kotlin 1.5.

**Fix**
now we are using `value` modifier which is recommended by the official kotlin page [mentioned here](https://kotlinlang.org/docs/whatsnew15.html#inline-classes)