### PR TITLE
Fixed default constructor for Handler is deprecated

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.util.Log
 import android.view.Menu
@@ -159,7 +160,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
   }
 
   override fun openHomeScreen() {
-    Handler().postDelayed({
+    Handler(Looper.getMainLooper()).postDelayed({
       if (webViewList.size == 0) {
         hideTabSwitcher()
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -37,6 +37,7 @@ import android.os.Bundle
 import android.os.CountDownTimer
 import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.provider.Settings
 import android.util.AttributeSet
 import android.util.Log
@@ -519,7 +520,7 @@ abstract class CoreReaderFragment :
   @Suppress("MagicNumber")
   private fun handleNotificationIntent(intent: Intent) {
     if (intent.hasExtra(DOWNLOAD_NOTIFICATION_TITLE)) {
-      Handler().postDelayed(
+      Handler(Looper.getMainLooper()).postDelayed(
         {
           intent.getStringExtra(DOWNLOAD_NOTIFICATION_TITLE)?.let {
             newBookDao?.bookMatching(it)?.let { bookOnDiskEntity ->
@@ -1440,7 +1441,7 @@ abstract class CoreReaderFragment :
 
   @Suppress("MagicNumber")
   protected open fun openHomeScreen() {
-    Handler().postDelayed({
+    Handler(Looper.getMainLooper()).postDelayed({
       if (webViewList.size == 0) {
         createNewTab()
         hideTabSwitcher()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.os.Handler
+import android.os.Looper
 import android.os.Message
 import android.util.AttributeSet
 import android.view.ContextMenu
@@ -165,7 +166,7 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
     private val zimReaderContainer: ZimReaderContainer,
     private val sharedPreferenceUtil: SharedPreferenceUtil
   ) :
-    Handler() {
+    Handler(Looper.getMainLooper()) {
 
     @SuppressWarnings("NestedBlockDepth")
     override fun handleMessage(msg: Message) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Typeface
 import android.os.Handler
+import android.os.Looper
 import android.util.TypedValue
 import android.view.ViewGroup
 import android.widget.TextView
@@ -105,7 +106,7 @@ class LanguageUtils(private val context: Context) {
   }
 
   private fun setTyfaceToTextView(child: TextView, activity: Activity) {
-    Handler().post {
+    Handler(Looper.getMainLooper()).post {
       child.apply {
         setTypeface(
           Typeface.createFromAsset(


### PR DESCRIPTION
Fixes #3335 

**Issue**
We are using the default constructor of `Handler()` in our code base, which is now deprecated because it is implicitly choosing a Looper during Handler construction which sometimes leads to a crash (if a handler is sometimes created on a thread without a Looper active, mentioned on the official docs).

**Fix**
Now we are using the android-recommended Handler's constructor, we are passing the `mainLooper()` to Handler() constructor.
