### PR TITLE
Fixed fullscreen feature is broken in custom app

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -288,7 +288,6 @@ class KiwixReaderFragment : CoreReaderFragment() {
   private fun hideNavBar() {
     requireActivity().findViewById<BottomNavigationView>(R.id.bottom_nav_view).visibility = GONE
     setBottomMarginToNavHostContainer(0)
-    getCurrentWebView()?.translationY = 0f
   }
 
   private fun showNavBar() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1243,7 +1243,10 @@ abstract class CoreReaderFragment :
     val classicScreenFlag = WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN
     requireActivity().window.addFlags(fullScreenFlag)
     requireActivity().window.clearFlags(classicScreenFlag)
-    getCurrentWebView()?.requestLayout()
+    getCurrentWebView()?.apply {
+      requestLayout()
+      translationY = 0f
+    }
     sharedPreferenceUtil?.putPrefFullScreen(true)
   }
 


### PR DESCRIPTION
Fixes #3371 

**What is the issue**
In the custom app, the webview does not adjust its height correctly when we open the full-screen mode. This causes a blank top bar to appear, as depicted in the image below. However, this feature works properly in our main app because we programmatically adjust the webview's height in our `Kiwix-android` app.

Please ignore the temporary red background, as it is added only to highlight the difference.

| Kiwix-android app  | Custom app |
| ------------- | ------------- |
| ![1685430529741](https://github.com/kiwix/kiwix-android/assets/34593983/303cf192-8591-4a28-b183-ca5c0beff56d) | ![1685430530747](https://github.com/kiwix/kiwix-android/assets/34593983/74492a86-8f58-4954-a107-7adb702ec841) |

**Fix**

To address this issue, we have made the following changes:

* We now adjust the webview's height in the `CoreReaderFragment`, as both the `KiwixReaderFragment` and `CustomReaderFragment` extend this class.
* The code for adjusting the height has been removed from the `KiwixReaderFragment` and moved to the `CoreReaderFragment` class.

After fixing the issue webview adjusted its height in both apps.

| Kiwix-android app  | Custom app |
| ------------- | ------------- |
| ![1685431281902](https://github.com/kiwix/kiwix-android/assets/34593983/35def0be-41fb-4d9c-ad33-cdee0bba73e8) | ![1685430529480](https://github.com/kiwix/kiwix-android/assets/34593983/ce453f35-d1dc-450d-91db-13a4b3f238b4) |
