### PR TITLE
Fixed intent flag `FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET` is deprecated

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
@@ -81,7 +81,7 @@ class RateDialogHandler @Inject constructor(
     val goToMarket = Intent(Intent.ACTION_VIEW, kiwixLocalMarketUri)
     goToMarket.addFlags(
       Intent.FLAG_ACTIVITY_NO_HISTORY or
-        Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET or
+        Intent.FLAG_ACTIVITY_NEW_DOCUMENT or
         Intent.FLAG_ACTIVITY_MULTIPLE_TASK
     )
     try {


### PR DESCRIPTION
Fixes #3331 

**Issue**
We were using an intent flag in `RateDialogHandler` when users go to the play store to rate our application, this intent flag is deprecated.

https://github.com/kiwix/kiwix-android/blob/1a31752f564e404858f3511bd127a92b8368a430/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt#L84

**Fix**
Now we are using the recommended Intent flag by [official docs ](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET).
This new start supporting from android 21 and our minimum SDK version is 21 so we are using this flag without adding any condition.