### PR TITLE
Fixed deprecated getPackageInfo() method of PackageManager

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.compat
 
 import android.content.Intent
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 
@@ -64,4 +65,10 @@ interface Compat {
     intent: Intent,
     flags: ResolveInfoFlagsCompat
   ): List<ResolveInfo>
+
+  fun getPackageInformation(
+    packageName: String,
+    packageManager: PackageManager,
+    flag: Int
+  ): PackageInfo
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.compat
 
 import android.content.Intent
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.os.Build
@@ -59,5 +60,16 @@ class CompatHelper private constructor() {
       intent: Intent,
       flags: ResolveInfoFlagsCompat
     ): List<ResolveInfo> = compat.queryIntentActivities(this, intent, flags)
+
+    fun PackageManager.getPackageInformation(
+      packageName: String,
+      flag: Int
+    ): PackageInfo = compat.getPackageInformation(packageName, this, flag)
+
+    fun PackageInfo.getVersionCode() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      longVersionCode.toInt()
+    } else {
+      versionCode
+    }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV21.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV21.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.compat
 
 import android.content.Intent
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 
@@ -29,4 +30,10 @@ open class CompatV21 : Compat {
     intent: Intent,
     flags: ResolveInfoFlagsCompat
   ): List<ResolveInfo> = packageManager.queryIntentActivities(intent, flags.value.toInt())
+
+  override fun getPackageInformation(
+    packageName: String,
+    packageManager: PackageManager,
+    flag: Int
+  ): PackageInfo = packageManager.getPackageInfo(packageName, 0)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
@@ -20,7 +20,9 @@ package org.kiwix.kiwixmobile.core.compat
 
 import android.annotation.TargetApi
 import android.content.Intent
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.PackageInfoFlags
 import android.content.pm.ResolveInfo
 
 const val API_33 = 33
@@ -35,4 +37,11 @@ open class CompatV33 : Compat {
     intent,
     PackageManager.ResolveInfoFlags.of(flags.value)
   )
+
+  override fun getPackageInformation(
+    packageName: String,
+    packageManager: PackageManager,
+    flag: Int
+  ): PackageInfo =
+    packageManager.getPackageInfo(packageName, PackageInfoFlags.of(flag.toLong()))
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -26,6 +26,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import org.kiwix.kiwixmobile.core.base.BaseActivity
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInformation
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.databinding.ActivityKiwixErrorBinding
 import org.kiwix.kiwixmobile.core.di.components.CoreComponent
@@ -198,12 +200,12 @@ open class ErrorActivity : BaseActivity() {
   private val versionCode: Int
     @SuppressLint("WrongConstant")
     get() = packageManager
-      .getPackageInfo(packageName, ZERO).versionCode
+      .getPackageInformation(packageName, ZERO).getVersionCode()
 
   private val versionName: String
     @SuppressLint("WrongConstant")
     get() = packageManager
-      .getPackageInfo(packageName, ZERO).versionName
+      .getPackageInformation(packageName, ZERO).versionName
 
   private fun toStackTraceString(exception: Throwable): String =
     StringWriter().apply {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -41,6 +41,8 @@ import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInformation
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.main.AddNoteDialog
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
@@ -203,7 +205,7 @@ abstract class CorePrefsFragment :
     @Suppress("TooGenericExceptionThrown")
     get() = try {
       requireActivity().packageManager
-        .getPackageInfo(requireActivity().packageName, 0).versionCode
+        .getPackageInformation(requireActivity().packageName, 0).getVersionCode()
     } catch (e: PackageManager.NameNotFoundException) {
       throw RuntimeException(e)
     }
@@ -211,7 +213,7 @@ abstract class CorePrefsFragment :
     @Suppress("TooGenericExceptionThrown")
     get() = try {
       requireActivity().packageManager
-        .getPackageInfo(requireActivity().packageName, 0).versionName
+        .getPackageInformation(requireActivity().packageName, 0).versionName
     } catch (e: PackageManager.NameNotFoundException) {
       throw RuntimeException(e)
     }


### PR DESCRIPTION
Fixes #3348 

**What is the issue**
We were using the deprecated `getPackageInfo()` method of the `PackageManager` class to retrieve the application's `package name` and `version code`. However, starting from `Android 13`, this method is deprecated. Additionally, we were relying on the deprecated `versionCode` field of the `PackageInfo` class to obtain the application's version code, which is also deprecated in `Android Pie`. Currently, our target SDK version is 33.

**Fix**
* To handle these deprecations, we have already introduced the `Compat33` and `Compat21` files. In Android 13 and above, we have created an extension function for the `PackageManager` class, utilizing the recommended method to retrieve the package information. For versions below Android 13, we continue to use the existing method as before.

* Regarding the `versionCode`, we now handle the deprecation by creating an extension function for the `PackageInfo` class. We include a condition to ensure compatibility with Android Pie and above. Since we need this code in multiple places, it is more efficient to create an extension function instead of duplicating the same code in multiple files.