### PR TITLE
Fixes of getSerializable() method of Intent is deprecated in android 13

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -64,7 +64,11 @@ open class ErrorActivity : BaseActivity() {
     setContentView(activityKiwixErrorBinding!!.root)
     val extras = intent.extras
     exception = if (extras != null && safeContains(extras)) {
-      extras.getSerializable(EXCEPTION_KEY) as Throwable
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        extras.getSerializable(EXCEPTION_KEY, Throwable::class.java)
+      } else {
+        extras.getSerializable(EXCEPTION_KEY) as Throwable
+      }
     } else {
       null
     }


### PR DESCRIPTION
Fixes #3347 

**Issue**
We were using `intent.extras.getSerializable` in ErrorActivity to send the exception via Gmail, but this method is deprecated in `Android 33`.

**Fix**
Since this method is deprecated in Android 13, the Android team introduced a new way to obtain a serializable object in Android 13 and above. This new approach involves using `intent.extras.getSerializable(String, Class)`, where we need to pass the class of the object. This method is more type-safe. For versions below Android 13, we continue to use the same method as before. So to implement this we have placed a condition there.