### PR TITLE
Fixes of local is deprecated

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/DefaultLanguageProvider.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/DefaultLanguageProvider.kt
@@ -19,12 +19,13 @@
 package org.kiwix.kiwixmobile.zimManager
 
 import android.content.Context
+import org.kiwix.kiwixmobile.core.extensions.locale
 import org.kiwix.kiwixmobile.core.zim_manager.Language
 import javax.inject.Inject
 
 class DefaultLanguageProvider @Inject constructor(private val context: Context) {
   fun provide() = Language(
-    context.resources.configuration.locale.isO3Language,
+    context.locale.isO3Language,
     true,
     1
   )


### PR DESCRIPTION
Fixes #3340 

**Issue**
We were using `context.resources.configuration.locale.isO3Language` in `DefaultLanguageProvider`, this way of getting the locale is deprecated in Android 24.

**Fix**
We already have an extension function for the `Context` class that handles this deprecation. This extension function is being used in our `LanguageUtils` class to retrieve the current locale. Therefore, we have utilized it to handle the deprecation in the `DefaultLanguageProvider`.

https://github.com/kiwix/kiwix-android/blob/8e4fd413ef2b94e13b91cf535e0f599246380def/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ContextExtensions.kt#L55