### PR TITLE
Fixes of WifiConfiguration is deprecated

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.core.utils.dialog
 
 import android.app.Activity
-import android.net.wifi.WifiConfiguration
 import android.view.View
 import org.kiwix.kiwixmobile.core.R
 
@@ -123,8 +122,8 @@ sealed class KiwixDialog(
       null
     ),
     HasBodyFormatArgs {
-    constructor(wifiConfiguration: WifiConfiguration) : this(
-      listOf(wifiConfiguration.SSID, wifiConfiguration.preSharedKey)
+    constructor(ssid: String, preSharedKey: String) : this(
+      listOf(ssid, preSharedKey)
     )
   }
 


### PR DESCRIPTION
Fixes #3329 

**Issue**
We are using WifiConfiguration in the `ShowHotspotDetails` dialog.
https://github.com/kiwix/kiwix-android/blob/1a31752f564e404858f3511bd127a92b8368a430/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt#L126

**Fix**

The `WifiConfiguration` class has been deprecated in Android 29, and although this method is still functional for those versions which are below android 29, we are currently not utilizing it anywhere in our codebase. However, to address the deprecation, we will adopt the [WifiNetworkSuggestion API](https://developer.android.com/reference/android/net/wifi/WifiNetworkSuggestion) as recommended in the [official documentation](https://developer.android.com/reference/android/net/wifi/WifiConfiguration). As a result, we have modified the parameters of the dialog constructor accordingly. Whenever we need to display this dialog, we will handle the usage of the new API within that specific context.