### PR TITLE
Fixed Application crashing while adding notes

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -25,6 +25,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.text.Editable
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -407,7 +408,10 @@ class AddNoteDialog : DialogFragment() {
     val contents = noteFile.readText()
     dialogNoteAddNoteBinding?.addNoteEditText?.apply {
       setText(contents) // Display the note content
-      text?.length?.minus(1)?.let(::setSelection)
+      text?.takeIf(Editable::isNotEmpty)?.let { text ->
+        val selection = text.length - 1
+        setSelection(selection.coerceAtLeast(0))
+      }
     }
     enableShareNoteMenuItem() // As note content exists which can be shared
     enableDeleteNoteMenuItem()


### PR DESCRIPTION
Fixes #3383 

**Issue**
We are calling the setSelection method if the file already exists in the storage. However, if the file is not deleted for some reason, but doesn't contain any text, it causes a crash.

**Fix**
We have added a condition to check if the file has any content when loading it. If the file contains text, we will call the `setSelection` method; otherwise, we will skip that part.


https://github.com/kiwix/kiwix-android/assets/34593983/264b88cd-4764-4a17-8994-2369c9a11675

