### PR TITLE
Fixed Custom apps back button doesn't work from setting screen

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CoreSettingsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CoreSettingsFragment.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -51,10 +52,17 @@ abstract class CoreSettingsFragment : BaseFragment() {
 
   private fun setUpToolbar() {
     val activity = requireActivity() as AppCompatActivity
-    activity.setSupportActionBar(settingsBinding?.root?.findViewById(R.id.toolbar))
-    activity.supportActionBar!!.title = getString(R.string.menu_settings)
-    activity.supportActionBar!!.setHomeButtonEnabled(true)
-    activity.supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+    settingsBinding?.root?.findViewById<Toolbar>(R.id.toolbar)?.apply {
+      activity.setSupportActionBar(this)
+      setNavigationOnClickListener {
+        requireActivity().onBackPressedDispatcher.onBackPressed()
+      }
+    }
+    activity.supportActionBar?.apply {
+      title = getString(R.string.menu_settings)
+      setHomeButtonEnabled(true)
+      setDisplayHomeAsUpEnabled(true)
+    }
   }
 
   override fun onDestroyView() {


### PR DESCRIPTION
Fixes #3385 

**Issue**
we were not handling the back-pressed event if the back button was clicked in the setting fragment, so we are seeing this error.

**Fix**
* We have modified the `setUpToolbar()` to handle the back icon click event properly like we are handling in other screens e.g. notes, bookmark, etc.
* Previously we were using the double bang operator on `supportActionBar` object to set its values, but this is not recommended because if the `supportActionBar` is null then it will lead to a crash, so we have refactored the code. Now we have placed a null check after that we are setting its values.


https://github.com/kiwix/kiwix-android/assets/34593983/0093dc41-1aa4-49bb-9aa4-6b5145d3ba8e

 