### PR TITLE
Fixed notes are not saving in custom app

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -179,7 +179,7 @@ class AddNoteDialog : DialogFragment() {
    * For null input or on being unable to find required text, returns null
     */
   private fun getTextAfterLastSlashWithoutExtension(path: String): String =
-    path.substringAfterLast('/', "").substringBeforeLast('.', "")
+    path.substringAfterLast('/', "").substringBeforeLast('.')
 
   // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {


### PR DESCRIPTION
Fixes #3389 

**Issue**
We encountered an issue while using the `substringBeforeLast('.', "")` method to extract the name from the URL for the file name. In the URL (https://kiwix.app/A/Portail:Tunisie/Index_th%C3%A9matique), there is no dot (.) present after the last slash (/), and we are passing an empty string as the `missingDelimiterValue` in the second parameter of this method. The implementation of this method checks if the `delimiter` is present in the string and returns the `missingDelimiterValue` if it is not found. In this case, we are passing an empty string, which is then returned by the method.

As a result, when we have an empty file name, we set the article name as the file name, as mentioned here
https://github.com/kiwix/kiwix-android/blob/3f86175a8b81244037ac17ec08b7751cdfd564ff/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt#L173

The article's name is `Portail:Tunisie/Index thématique`, which contains a slash (/). When we try to create a file object, it treats `Portail:Tunisie` as a folder and `Index thématique` as a file name. However, we do not have any folder named `Portail:Tunisie`, causing the file saving to fail.

You can find the implementation of the method below:
```
public fun String.substringBeforeLast(delimiter: Char, missingDelimiterValue: String = this): String {
    val index = lastIndexOf(delimiter)
    return if (index == -1) missingDelimiterValue else substring(0, index)
}
```

**Fix**
We have removed the second parameter from `substringBeforeLast` method, so if it is not found any `.` in the URL, then it will return the same string as we have passed to it.


https://github.com/kiwix/kiwix-android/assets/34593983/772792a0-e8ea-499e-93f0-f9894aaa1ceb



