### PR TITLE
Fixes of toggleSoftInput(Int, Int) method of InputMethodManager is deprecated

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
@@ -39,7 +39,7 @@ fun Fragment.toast(stringId: Int, length: Int = Toast.LENGTH_LONG) {
 fun Fragment.closeKeyboard() {
   val inputMethodManager =
     requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-  inputMethodManager.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0)
+  inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
 }
 
 fun View.closeKeyboard() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -32,6 +32,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.Toolbar
@@ -289,15 +290,22 @@ class AddNoteDialog : DialogFragment() {
     )
     if (!noteFileExists) {
       // Prepare for input in case of empty/new note
-      dialogNoteAddNoteBinding?.addNoteEditText?.requestFocus()
-      showKeyboard()
+      dialogNoteAddNoteBinding?.addNoteEditText?.apply {
+        requestFocus()
+        showKeyboard(this)
+      }
     }
   }
 
-  private fun showKeyboard() {
+  @Suppress("MagicNumber")
+  private fun showKeyboard(editText: EditText) {
     val inputMethodManager =
       requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-    inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
+    editText.postDelayed(
+      {
+        inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
+      }, 100
+    )
   }
 
   private fun saveNote(noteText: String) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -204,6 +204,9 @@ class AddNoteDialog : DialogFragment() {
       // Closing unedited note dialog straightaway
       dismissAddNoteDialog()
     }
+    if (dialogNoteAddNoteBinding?.addNoteEditText?.isFocused == true) {
+      dialogNoteAddNoteBinding?.addNoteEditText?.clearFocus()
+    }
   }
 
   private fun disableMenuItems() {


### PR DESCRIPTION
Fixes #3349 

**Issue**
we were using the deprecated method `toggleSoftInput` of `InputMethodManager` class.

**Fix**
Now we are using the officially recommended methods `hideSoftInputFromWindow` for hiding the keyboard and `showSoftInput` for showing the keyboard.