### PR TITLE
Fixed Invasive access photos and media permission request at start

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1199,6 +1199,10 @@ abstract class CoreReaderFragment :
           isPermissionGranted = true
         } else {
           if (shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            requestPermissions(
+              arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+              REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE
+            )
             /* shouldShowRequestPermissionRationale() returns false when:
                *  1) User has previously checked on "Don't ask me again", and/or
                *  2) Permission has been disabled on device
@@ -1207,11 +1211,12 @@ abstract class CoreReaderFragment :
               R.string.ext_storage_permission_rationale_add_note,
               Toast.LENGTH_LONG
             )
+          } else {
+            alertDialogShower?.show(
+              KiwixDialog.ReadPermissionRequired,
+              requireActivity()::navigateToAppSettings
+            )
           }
-          requestPermissions(
-            arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
-            REQUEST_WRITE_STORAGE_PERMISSION_ADD_NOTE
-          )
         }
       } else { // For Android versions below Marshmallow 6.0 (API 23)
         isPermissionGranted = true // As already requested at install time
@@ -1269,8 +1274,8 @@ abstract class CoreReaderFragment :
     externalLinkOpener?.openExternalUrl(intent)
   }
 
-  protected fun openZimFile(file: File) {
-    if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+  protected fun openZimFile(file: File, isCustomApp: Boolean = false) {
+    if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
       if (file.isFileExist()) {
         openAndSetInContainer(file)
         updateTitle()

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -30,8 +30,6 @@ import org.kiwix.kiwixmobile.custom.R
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.ActivityCustomMainBinding
 
-const val REQUEST_READ_FOR_OBB = 5002
-
 class CustomMainActivity : CoreMainActivity() {
 
   override val navController: NavController by lazy {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -18,12 +18,8 @@
 
 package org.kiwix.kiwixmobile.custom.main
 
-import android.Manifest
-import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.annotation.TargetApi
 import android.app.Dialog
-import android.content.pm.PackageManager
-import android.content.pm.PackageManager.PERMISSION_DENIED
 import android.os.Build
 import android.os.Bundle
 import android.view.Menu
@@ -31,8 +27,6 @@ import android.view.MenuInflater
 import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -43,12 +37,10 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setupDrawerToggl
 import org.kiwix.kiwixmobile.core.main.CoreReaderFragment
 import org.kiwix.kiwixmobile.core.main.FIND_IN_PAGE_SEARCH_STRING
 import org.kiwix.kiwixmobile.core.main.MainMenu
-import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchItemToOpen
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.TAG_FILE_SEARCHED
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
-import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.titleToUrl
 import org.kiwix.kiwixmobile.core.utils.urlSuffixToParsableUrl
 import org.kiwix.kiwixmobile.custom.BuildConfig
@@ -160,53 +152,10 @@ class CustomReaderFragment : CoreReaderFragment() {
         }
       },
       onNoFilesFound = {
-        if (ContextCompat.checkSelfPermission(
-            requireActivity(),
-            READ_EXTERNAL_STORAGE
-          ) == PERMISSION_DENIED &&
-          sharedPreferenceUtil?.isPlayStoreBuildWithAndroid11OrAbove() == false &&
-          Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
-        ) {
-          requestPermissions(arrayOf(READ_EXTERNAL_STORAGE), REQUEST_READ_FOR_OBB)
-        } else {
-          findNavController().navigate(R.id.customDownloadFragment)
-        }
+        findNavController().navigate(R.id.customDownloadFragment)
       }
     )
   }
-
-  override fun onRequestPermissionsResult(
-    requestCode: Int,
-    permissions: Array<String>,
-    grantResults: IntArray
-  ) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-    if (permissions.isNotEmpty() && permissions[0] == Manifest.permission.READ_EXTERNAL_STORAGE) {
-      if (readStorageHasBeenPermanentlyDenied(grantResults)) {
-        if (permissionRequiredDialog?.isShowing != true) {
-          permissionRequiredDialog = dialogShower?.create(
-            KiwixDialog.ReadPermissionRequired,
-            {
-              requireActivity().navigateToAppSettings()
-              appSettingsLaunched = true
-            }
-          )
-          permissionRequiredDialog?.show()
-        }
-      } else {
-        openObbOrZim()
-        permissionRequiredDialog?.dismiss()
-        permissionRequiredDialog = null
-      }
-    }
-  }
-
-  private fun readStorageHasBeenPermanentlyDenied(grantResults: IntArray) =
-    grantResults[0] == PackageManager.PERMISSION_DENIED &&
-      !ActivityCompat.shouldShowRequestPermissionRationale(
-        requireActivity(),
-        Manifest.permission.READ_EXTERNAL_STORAGE
-      )
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     super.onCreateOptionsMenu(menu, inflater)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -151,10 +151,10 @@ class CustomReaderFragment : CoreReaderFragment() {
     customFileValidator.validate(
       onFilesFound = {
         when (it) {
-          is ValidationState.HasFile -> openZimFile(it.file)
+          is ValidationState.HasFile -> openZimFile(it.file, true)
           is ValidationState.HasBothFiles -> {
             it.zimFile.delete()
-            openZimFile(it.obbFile)
+            openZimFile(it.obbFile, true)
           }
           else -> {}
         }


### PR DESCRIPTION
Fixes #3370 

**Issue**
We are requesting `read-write` permission at app startup, but it is unnecessary because we can read the zim file without this permission in custom apps.

**Fix**
* We have removed the permission request at app startup. To implement this, we modified our `OpenZimFile` method in the `CoreReaderFragment`. Now, if this method is called from custom apps, it will not prompt for storage permission. https://github.com/kiwix/kiwix-android/blob/8e7df7921a789ce976c9bbb5f66f7c2cf22e3e81/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt#L1272 

* However, we still require storage permission for saving notes. Therefore, we made modifications to our `requestExternalStorageWritePermissionForNotes()` method. It now asks for permission from the user when the note option is clicked. If the user denies the permission and attempts to save the notes, a `ReadPermissionRequired` dialog will be displayed, indicating `Storage Permission Denied`. To save notes, the user will need to grant permission from the app settings.

* It is worth noting that custom apps do not require this permission for saving images. We have tested saving pictures without this permission on various devices, including Android 21, Android 24, Android 30, Android 32, and Android 33. All devices successfully save pictures without requiring this permission. So we are not asking permission when saving the pictures.

* The scanning mechanism for zim files has been enhanced to include all files within the app-specific folder. Previously, only files inside the `files` folder were scanned, if zim files were moved outside that folder, then it was not recognizing that file during scanning. Now we are scanning from the root folder of the app-specific directory as our `ContextCompat.getExternalFilesDirs(context, null)` method returns the path to the `files` directory.

* Removed the requirement for storage permission at app startup for downloading zim files, since we are downloading the zim files inside the `app-specific` directory so for downloading we don't need the storage permission.