### PR TITLE
Fixes of deprecated methods in `NetworkTest`

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
@@ -19,14 +19,14 @@ package org.kiwix.kiwixmobile
 
 import android.Manifest
 import android.util.Log
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.ActivityTestRule
 import androidx.test.rule.GrantPermissionRule
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaDialogInteractions
@@ -56,12 +56,6 @@ class NetworkTest {
 
   // @Inject
   // MockWebServer mockWebServer
-
-  @Rule
-  @JvmField
-  var mActivityTestRule = ActivityTestRule(
-    KiwixMainActivity::class.java, false, false
-  )
 
   @Rule
   @JvmField
@@ -99,7 +93,7 @@ class NetworkTest {
 
   @Test @Ignore("Broken in 2.5") // TODO Fix in 3.0
   fun networkTest() {
-    mActivityTestRule.launchActivity(null)
+    ActivityScenario.launch(KiwixMainActivity::class.java)
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     clickMenu(TestUtils.getResourceString(R.string.library))
     TestUtils.allowStoragePermissionsIfNeeded()


### PR DESCRIPTION
Fixes #3345 

* Now we are using updated `androidx.test.platform.app.InstrumentationRegistry` instead of deprecated `androidx.test.InstrumentationRegistry`.
* Now we are using `ActivityScenario` to launch the application instead of deprecated `ActivityTestRule`.