### PR TITLE
Refactored onBackPressed method with updated API

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinish.kt
@@ -37,7 +37,7 @@ data class SaveLanguagesAndFinish(
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe({
-        activity.onBackPressed()
+        activity.onBackPressedDispatcher.onBackPressed()
       }, Throwable::printStackTrace)
   }
 }

--- a/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinishTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/SaveLanguagesAndFinishTest.kt
@@ -18,7 +18,9 @@
 
 package org.kiwix.kiwixmobile.language.viewmodel
 
+import androidx.activity.OnBackPressedDispatcher
 import androidx.appcompat.app.AppCompatActivity
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.reactivex.schedulers.Schedulers
@@ -35,11 +37,14 @@ class SaveLanguagesAndFinishTest {
     setScheduler(Schedulers.trampoline())
     val languageDao = mockk<NewLanguagesDao>()
     val activity = mockk<AppCompatActivity>()
+    val onBackPressedDispatcher = mockk<OnBackPressedDispatcher>()
+    every { activity.onBackPressedDispatcher } returns onBackPressedDispatcher
+    every { onBackPressedDispatcher.onBackPressed() } answers { }
     val languages = listOf<Language>()
     SaveLanguagesAndFinish(languages, languageDao).invokeWith(activity)
     verify {
       languageDao.insert(languages)
-      activity.onBackPressed()
+      onBackPressedDispatcher.onBackPressed()
     }
     resetSchedulers()
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
@@ -64,7 +64,7 @@ abstract class HelpFragment : BaseFragment() {
     val toolbar: Toolbar? = fragmentHelpBinding?.root?.findViewById(R.id.toolbar)
     toolbar?.apply {
       activity.setSupportActionBar(this)
-      setNavigationOnClickListener { requireActivity().onBackPressed() }
+      setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
     }
     activity.supportActionBar?.let {
       it.setDisplayHomeAsUpEnabled(true)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -33,6 +33,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
@@ -181,14 +182,21 @@ class AddNoteDialog : DialogFragment() {
   private fun getTextAfterLastSlashWithoutExtension(path: String): String =
     path.substringAfterLast('/', "").substringBeforeLast('.')
 
-  // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar
+  // Add onBackPressedCallBack to respond to user pressing 'Back' button on navigation bar
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    return object : Dialog(requireContext(), theme) {
-      override fun onBackPressed() {
+    val dialog = Dialog(requireContext(), theme)
+    requireActivity().onBackPressedDispatcher.addCallback(
+      viewLifecycleOwner, onBackPressedCallBack
+    )
+    return dialog
+  }
+
+  private val onBackPressedCallBack =
+    object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
         exitAddNoteDialog()
       }
     }
-  }
 
   private fun exitAddNoteDialog() {
     if (noteEdited) {
@@ -465,6 +473,7 @@ class AddNoteDialog : DialogFragment() {
     super.onDestroyView()
     mainRepositoryActions.dispose()
     dialogNoteAddNoteBinding = null
+    onBackPressedCallBack.remove()
   }
 
   override fun onStart() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -185,9 +185,7 @@ class AddNoteDialog : DialogFragment() {
   // Add onBackPressedCallBack to respond to user pressing 'Back' button on navigation bar
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val dialog = Dialog(requireContext(), theme)
-    requireActivity().onBackPressedDispatcher.addCallback(
-      viewLifecycleOwner, onBackPressedCallBack
-    )
+    requireActivity().onBackPressedDispatcher.addCallback(onBackPressedCallBack)
     return dialog
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -229,7 +229,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       return
     }
     if (activeFragments().filterIsInstance<FragmentActivityExtensions>().isEmpty()) {
-      return super.onBackPressed()
+      return super.getOnBackPressedDispatcher().onBackPressed()
     }
     activeFragments().filterIsInstance<FragmentActivityExtensions>().forEach {
       if (it.onBackPressed(this) == FragmentActivityExtensions.Super.ShouldCall) {
@@ -240,7 +240,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
           drawerToggle = null
           finish()
         } else {
-          super.onBackPressed()
+          super.getOnBackPressedDispatcher().onBackPressed()
         }
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -138,7 +138,7 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
     val toolbar = fragmentPageBinding?.root?.findViewById<Toolbar>(R.id.toolbar)
     toolbar?.apply {
       activity.setSupportActionBar(this)
-      setNavigationOnClickListener { requireActivity().onBackPressed() }
+      setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
     }
     activity.supportActionBar?.apply {
       setDisplayHomeAsUpEnabled(true)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
@@ -132,9 +132,7 @@ class NavigationHistoryDialog(
   // Add onBackPressedCallBack to respond to user pressing 'Back' button on navigation bar
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val dialog = Dialog(requireContext(), theme)
-    requireActivity().onBackPressedDispatcher.addCallback(
-      viewLifecycleOwner, onBackPressedCallBack
-    )
+    requireActivity().onBackPressedDispatcher.addCallback(onBackPressedCallBack)
     return dialog
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialog.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -128,14 +129,21 @@ class NavigationHistoryDialog(
     navigationHistoryClickListener.clearHistory()
   }
 
-  // Override onBackPressed() to respond to user pressing 'Back' button on navigation bar
+  // Add onBackPressedCallBack to respond to user pressing 'Back' button on navigation bar
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    return object : Dialog(requireContext(), theme) {
-      override fun onBackPressed() {
+    val dialog = Dialog(requireContext(), theme)
+    requireActivity().onBackPressedDispatcher.addCallback(
+      viewLifecycleOwner, onBackPressedCallBack
+    )
+    return dialog
+  }
+
+  private val onBackPressedCallBack =
+    object : OnBackPressedCallback(true) {
+      override fun handleOnBackPressed() {
         dismissNavigationHistoryDialog()
       }
     }
-  }
 
   private fun dismissNavigationHistoryDialog() {
     dialog?.dismiss()
@@ -145,6 +153,7 @@ class NavigationHistoryDialog(
     super.onDestroyView()
     navigationHistoryAdapter = null
     dialogNavigationHistoryBinding = null
+    onBackPressedCallBack.remove()
   }
 
   private fun onItemClick(item: NavigationHistoryListItem) {


### PR DESCRIPTION
Fixes #3400 

**Issue**
We were using the deprecated `onBackPressed` method.

**Fix**
This PR introduces changes to refactor the usage of the deprecated `onBackPressed` method. The `onBackPressedDispatcher` API is now used instead.

Here's a summary of the changes made:
- Updated `AddNoteDialog.kt` and `NavigationHistoryDialog.kt` to handle the back button press on the navigation bar using the `onBackPressedDispatcher`.
- Modified `CoreMainActivity.kt` to handle all back button press operations in the application using the `onBackPressedDispatcher`.
- Updated `HelpFragment.kt` and `PageFragment.kt` to handle the back button press when the user clicks on the back arrow button in the toolbar.
- Refactored the `onBackPressed` method in `SaveLanguagesAndFinish.kt` to use the updated API, and updated the corresponding test cases accordingly.