### PR TITLE
Fixes of deprecated methods of ConnectivityManager class

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/ConnectivityManagerExtensions.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ConnectivityManagerExtensions.kt
@@ -19,12 +19,13 @@
 package org.kiwix.kiwixmobile
 
 import android.net.ConnectivityManager
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.zimManager.NetworkState
 import org.kiwix.kiwixmobile.zimManager.NetworkState.CONNECTED
 import org.kiwix.kiwixmobile.zimManager.NetworkState.NOT_CONNECTED
 
 val ConnectivityManager.networkState: NetworkState
-  get() = if (activeNetworkInfo?.isConnected == true)
+  get() = if (isNetworkAvailable())
     CONNECTED
   else
     NOT_CONNECTED

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -135,7 +135,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     get() = sharedPreferenceUtil.prefWifiOnly && !NetworkUtils.isWiFi(requireContext())
 
   private val isNotConnected: Boolean
-    get() = NetworkUtils.isNetworkAvailable(requireActivity())
+    get() = !NetworkUtils.isNetworkAvailable(requireActivity())
 
   override fun inject(baseActivity: BaseActivity) {
     baseActivity.cachedComponent.inject(this)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -26,7 +26,6 @@ import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -136,19 +135,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     get() = sharedPreferenceUtil.prefWifiOnly && !NetworkUtils.isWiFi(requireContext())
 
   private val isNotConnected: Boolean
-    get() {
-      return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val network = conMan.activeNetwork
-        if (network != null) {
-          val networkCapabilities = conMan.getNetworkCapabilities(network)
-          networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == false
-        } else {
-          true
-        }
-      } else {
-        conMan.activeNetworkInfo?.isConnected == false
-      }
-    }
+    get() = NetworkUtils.isNetworkAvailable(requireActivity())
 
   override fun inject(baseActivity: BaseActivity) {
     baseActivity.cachedComponent.inject(this)

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -34,6 +34,7 @@ import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
@@ -229,7 +230,7 @@ class ZimManageViewModel @Inject constructor(
       )
     ) { _, _ -> }
       .switchMap {
-        if (connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_WIFI) {
+        if (connectivityManager.isWifi()) {
           Flowable.just(Unit)
         } else {
           sharedPreferenceUtil.prefWifiOnlys

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -20,6 +20,8 @@ package org.kiwix.kiwixmobile.zimManager
 
 import android.app.Application
 import android.net.ConnectivityManager
+import android.net.ConnectivityManager.TYPE_WIFI
+import android.net.NetworkInfo
 import com.jraska.livedata.test
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -93,6 +95,7 @@ class ZimManageViewModelTest {
   private val defaultLanguageProvider: DefaultLanguageProvider = mockk()
   private val dataSource: DataSource = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val networkInfo: NetworkInfo = mockk()
   private val sharedPreferenceUtil: SharedPreferenceUtil = mockk()
   lateinit var viewModel: ZimManageViewModel
 
@@ -128,7 +131,8 @@ class ZimManageViewModelTest {
     every { connectivityBroadcastReceiver.networkStates } returns networkStates
     every { application.registerReceiver(any(), any()) } returns mockk()
     every { dataSource.booksOnDiskAsListItems() } returns booksOnDiskListItems
-    every { connectivityManager.activeNetworkInfo?.type } returns ConnectivityManager.TYPE_WIFI
+    every { connectivityManager.getNetworkInfo(TYPE_WIFI) } returns networkInfo
+    every { networkInfo.isConnected } returns true
     viewModel = ZimManageViewModel(
       downloadDao,
       newBookDao,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.net.ConnectivityManager
 
 /**
  * This interface defines a set of functions that are not available on all platforms.
@@ -71,4 +72,8 @@ interface Compat {
     packageManager: PackageManager,
     flag: Int
   ): PackageInfo
+
+  fun isNetworkAvailable(connectivity: ConnectivityManager): Boolean
+
+  fun isWifi(connectivity: ConnectivityManager): Boolean
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -22,12 +22,14 @@ import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.net.ConnectivityManager
 import android.os.Build
 
 class CompatHelper private constructor() {
   // Note: Needs ": Compat" or the type system assumes `Compat21`
   private val compatValue: Compat = when {
     sdkVersion >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
+    sdkVersion >= Build.VERSION_CODES.M -> CompatV23()
     else -> CompatV21()
   }
 
@@ -69,7 +71,14 @@ class CompatHelper private constructor() {
     fun PackageInfo.getVersionCode() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       longVersionCode.toInt()
     } else {
+      @Suppress("DEPRECATION")
       versionCode
     }
+
+    fun ConnectivityManager.isNetworkAvailable(): Boolean =
+      compat.isNetworkAvailable(this)
+
+    fun ConnectivityManager.isWifi(): Boolean =
+      compat.isWifi(this)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
@@ -24,11 +24,13 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PackageInfoFlags
 import android.content.pm.ResolveInfo
+import android.net.ConnectivityManager
 
 const val API_33 = 33
 
 @TargetApi(API_33)
 open class CompatV33 : Compat {
+  private val compatV23 = CompatV23()
   override fun queryIntentActivities(
     packageManager: PackageManager,
     intent: Intent,
@@ -44,4 +46,10 @@ open class CompatV33 : Compat {
     flag: Int
   ): PackageInfo =
     packageManager.getPackageInfo(packageName, PackageInfoFlags.of(flag.toLong()))
+
+  override fun isNetworkAvailable(connectivity: ConnectivityManager): Boolean =
+    compatV23.isNetworkAvailable(connectivity)
+
+  override fun isWifi(connectivity: ConnectivityManager): Boolean =
+    compatV23.isWifi(connectivity)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ConnectivityReporter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ConnectivityReporter.kt
@@ -19,9 +19,8 @@
 package org.kiwix.kiwixmobile.core.utils
 
 import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
-import android.os.Build
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import javax.inject.Inject
@@ -32,13 +31,7 @@ class ConnectivityReporter @Inject constructor(
 ) {
 
   fun checkWifi(): Boolean =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      val capabilities =
-        connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-      capabilities != null && capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-    } else {
-      wifiManager.isWifiEnabled && wifiManager.connectionInfo.networkId != -1
-    }
+    connectivityManager.isWifi()
 
   fun checkTethering(): Boolean = try {
     val method: Method = wifiManager.javaClass.getDeclaredMethod("isWifiApEnabled")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -19,12 +19,10 @@ package org.kiwix.kiwixmobile.core.utils
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
-import android.net.NetworkInfo
-import android.os.Build
 import android.util.Log
-import androidx.annotation.VisibleForTesting
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import java.util.UUID
 
 object NetworkUtils {
@@ -36,24 +34,8 @@ object NetworkUtils {
   fun isNetworkAvailable(context: Context): Boolean {
     val connectivity: ConnectivityManager = context
       .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      val network = connectivity.activeNetwork
-      if (network != null) {
-        val networkCapabilities = connectivity.getNetworkCapabilities(network)
-        networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
-      } else {
-        false
-      }
-    } else {
-      connectivity.allNetworkInfo.any(::isNetworkConnectionOK)
-    }
+    return connectivity.isNetworkAvailable()
   }
-
-  fun isNetworkConnectionOK(networkInfo: NetworkInfo): Boolean =
-    networkInfo.state == NetworkInfo.State.CONNECTED
-
-  @VisibleForTesting
-  internal var sdkVersionForTesting = Build.VERSION.SDK_INT
 
   /**
    * check if network of type WIFI is connected
@@ -66,14 +48,7 @@ object NetworkUtils {
   fun isWiFi(context: Context): Boolean {
     val connectivity = context
       .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    return if (sdkVersionForTesting >= Build.VERSION_CODES.M) {
-      val network = connectivity.activeNetwork ?: return false
-      val networkCapabilities = connectivity.getNetworkCapabilities(network)
-      networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
-    } else {
-      val wifi = connectivity.getNetworkInfo(ConnectivityManager.TYPE_WIFI)
-      wifi != null && wifi.isConnected
-    }
+    return connectivity.isWifi()
   }
 
   fun getFileNameFromUrl(url: String?): String {


### PR DESCRIPTION
Fixes #3339 

Refactored deprecated methods of ConnectivityManager class.

This PR refactors the deprecated methods of the ConnectivityManager class to ensure compatibility with different Android versions. The changes include:

- Introduced a new `CompatV23` class to handle the deprecation of `NetworkInfo` and utilize the new `NetworkCapabilities` APIs available from Android 23 onwards.
- Retained the existing methods for Android versions below 23 to maintain backward compatibility.
- Updated the test cases to cover both the new and old APIs.

These updates address the deprecation warnings and ensure that the code functions correctly on different Android versions.