### PR TITLE
Fixes of requestPermission is deprecated

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -322,6 +322,7 @@ class LocalFileTransferFragment :
     ActivityCompat.requestPermissions(requireActivity(), arrayOf(permission), requestCode)
   }
 
+  @Suppress("DEPRECATION")
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<String>,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -464,6 +464,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private fun shouldShowRationale(permission: String) =
     ActivityCompat.shouldShowRequestPermissionRationale(requireActivity(), permission)
 
+  @Suppress("DEPRECATION")
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<out String>,

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -226,6 +226,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
       true
     }
 
+  @Suppress("DEPRECATION")
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<out String>,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -125,6 +125,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     drawerContainerLayout.setDrawerLockMode(lockMode, this)
   }
 
+  @Suppress("DEPRECATION")
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<out String>,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/NavigationHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/NavigationHostFragment.kt
@@ -39,6 +39,7 @@ class NavigationHostFragment : NavHostFragment(), WebViewProvider, FragmentActiv
       ?.getCurrentWebView()
   }
 
+  @Suppress("DEPRECATION")
   override fun onRequestPermissionsResult(
     requestCode: Int,
     permissions: Array<out String>,


### PR DESCRIPTION
Fixes #3332 

Changed the `requestPermission` method of the fragment to utilize the new permission API `registerForActivityResult`.

* Updated the permission request for write storage permission, which is required for saving notes.
* Updated the permission request for read/write storage, necessary for scanning the file system in the LocalLibraryFragment.
* Fixed an issue where the permission layout would be displayed alongside the library list if the user swiped down to refresh.
* Suppressing the deprecation warning on onRequestPermissionsResult is necessary because we are requesting permission from the activity (as shown in the below code) and obtaining the result in the fragments. As a result, we cannot remove these methods, which is why we are currently suppressing the warning.

```
ActivityCompat.requestPermissions(
      requireActivity(), arrayOf(Manifest.permission.NEARBY_WIFI_DEVICES),
      PERMISSION_REQUEST_CODE_COARSE_LOCATION
    )
```
