### PR TITLE
Fixed some `lintOptions` are deprecated

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,7 +73,7 @@ android {
     }
     create("nightly") {
       initWith(getByName("debug"))
-      setMatchingFallbacks("debug")
+      matchingFallbacks += "debug"
     }
   }
   bundle {

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -20,6 +20,7 @@ package plugin
 
 import Config
 import Libs
+import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.BaseExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
@@ -42,7 +43,7 @@ class AllProjectConfigurer {
     target.plugins.apply("androidx.navigation.safeargs")
   }
 
-  fun configureBaseExtension(target: Project, path: String) {
+  fun configureBaseExtension(target: Project) {
     target.configureExtension<BaseExtension> {
       setCompileSdkVersion(Config.compileSdk)
       defaultConfig {
@@ -89,32 +90,6 @@ class AllProjectConfigurer {
           }
         }
       }
-
-      lintOptions {
-        isAbortOnError = true
-        isCheckAllWarnings = true
-        isWarningsAsErrors = true
-
-        ignore(
-          "SyntheticAccessor",
-          "GoogleAppIndexingApiWarning",
-          "LockedOrientationActivity",
-          //TODO stop ignoring below this
-          "LabelFor",
-          "LogConditional",
-          "ConvertToWebp",
-          "UnknownNullness",
-          "SelectableText",
-          "MissingTranslation",
-          "IconDensities",
-          "ContentDescription",
-          "IconDipSize",
-          "UnusedResources",
-          "NonConstantResourceId",
-          "NotifyDataSetChanged"
-        )
-        lintConfig = target.rootProject.file("lintConfig.xml")
-      }
       packagingOptions {
         resources.excludes.apply {
           add("META-INF/DEPENDENCIES")
@@ -135,6 +110,36 @@ class AllProjectConfigurer {
           java.srcDir("${target.rootDir}/core/src/sharedTestFunctions/java")
           resources.srcDir("${target.rootDir}/core/src/test/resources")
         }
+      }
+    }
+  }
+
+  fun configureCommonExtension(target: Project) {
+    target.configureExtension<CommonExtension<*, *, *, *>> {
+      lint {
+        abortOnError = true
+        checkAllWarnings = true
+        warningsAsErrors = true
+
+        disable.apply {
+          add("SyntheticAccessor")
+          add("GoogleAppIndexingApiWarning")
+          add("LockedOrientationActivity")
+          // TODO stop ignoring below this
+          add("LabelFor")
+          add("LogConditional")
+          add("ConvertToWebp")
+          add("UnknownNullness")
+          add("SelectableText")
+          add("MissingTranslation")
+          add("IconDensities")
+          add("ContentDescription")
+          add("IconDipSize")
+          add("UnusedResources")
+          add("NonConstantResourceId")
+          add("NotifyDataSetChanged")
+        }
+        lintConfig = target.rootProject.file("lintConfig.xml")
       }
     }
   }

--- a/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
@@ -48,6 +48,7 @@ class KiwixConfigurationPlugin : Plugin<Project> {
   }
 
   private fun doDefaultConfiguration(target: Project) {
-    allProjectConfigurer.configureBaseExtension(target, "${target.projectDir}")
+    allProjectConfigurer.configureBaseExtension(target)
+    allProjectConfigurer.configureCommonExtension(target)
   }
 }

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     applicationId = "org.kiwix"
   }
 
-  flavorDimensions("default")
+  flavorDimensions += "default"
   productFlavors.apply {
     CustomApps.createDynamically(project.file("src"), this)
     all {


### PR DESCRIPTION
Fixes #3351

**Issue**
Some lint options are deprecated in new Gradle version.


**Fix**
* We have introduced a new method, `configureCommonExtension`, in the `AllProjectConfigurer.kt` file since `Lint` is only available in `CommonExtension`. This allows us to configure Lint in one place for every module. Previously, we couldn't directly use Lint in the `android-library` project, but with this approach, we can now configure Lint for the `android-library` project as well.
* We have replaced the deprecated `ignore` method with updated `diseble` option.
* We have remove some small deprecation e.g. `setMatchingFallbacks` and `flavorDimensions`.