### PR TITLE
Fixed bottom view lost issue

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -85,6 +85,7 @@ import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestMultiSelection
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestNavigateTo
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestSelect
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestDeleteMultiSelection
 import org.kiwix.kiwixmobile.zimManager.fileselectView.FileSelectListState
 import java.io.File
 import javax.inject.Inject
@@ -338,7 +339,7 @@ class LocalLibraryFragment : BaseFragment() {
 
   private fun fileSelectActions() = zimManageViewModel.fileSelectActions
     .observeOn(AndroidSchedulers.mainThread())
-    .filter { it === FileSelectActions.RequestDeleteMultiSelection }
+    .filter { it === RequestDeleteMultiSelection }
     .subscribe(
       {
         animateBottomViewToOrigin()

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -90,6 +90,7 @@ import java.io.File
 import javax.inject.Inject
 
 private const val WAS_IN_ACTION_MODE = "WAS_IN_ACTION_MODE"
+private const val MATERIAL_BOTTOM_VIEW_ENTER_ANIMATION_DURATION = 225L
 
 class LocalLibraryFragment : BaseFragment() {
 
@@ -196,6 +197,7 @@ class LocalLibraryFragment : BaseFragment() {
         }
       }
     disposable.add(sideEffects())
+    disposable.add(fileSelectActions())
     zimManageViewModel.deviceListIsRefreshing.observe(viewLifecycleOwner) {
       fragmentDestinationLibraryBinding?.zimSwiperefresh?.isRefreshing = it!!
     }
@@ -333,6 +335,23 @@ class LocalLibraryFragment : BaseFragment() {
         }
       }, Throwable::printStackTrace
     )
+
+  private fun fileSelectActions() = zimManageViewModel.fileSelectActions
+    .observeOn(AndroidSchedulers.mainThread())
+    .filter { it === FileSelectActions.RequestDeleteMultiSelection }
+    .subscribe(
+      {
+        animateBottomViewToOrigin()
+      },
+      Throwable::printStackTrace
+    )
+
+  private fun animateBottomViewToOrigin() {
+    getBottomNavigationView().animate()
+      .translationY(0F)
+      .setDuration(MATERIAL_BOTTOM_VIEW_ENTER_ANIMATION_DURATION)
+      .start()
+  }
 
   private fun render(state: FileSelectListState) {
     val items: List<BooksOnDiskListItem> = state.bookOnDiskListItems


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #3407 

<!-- Add here what changes were made in this issue and if possible provide links. -->
**Issue**
Scenario / workflow  where bottom view is lost 

**Approach**
The bottom view animated back to it's original position when the user proceeds to delete item/s i.e. when the delete action is detected.

* Observed for the "RequestDeleteMultiSelection" action.

* Set the translationY of the bottom view to 0F which resets the vertical translation of the view to it's original position . Also animated it to a duration of 225L which is the default behaviour of the *HideBottomViewOnScrollBehaviour* of the material bottom view ,making sure consistent reappearing behaviour. 
![Screenshot (513)](https://github.com/kiwix/kiwix-android/assets/111702455/6b067bab-2bb3-4a1e-bad3-3e7c60b93c24)



<!-- If possible, please add relevant screenshots / GIFs -->

**Result** 

https://github.com/kiwix/kiwix-android/assets/111702455/07de4e83-4755-4bea-8efd-831d758c9983

@kelson42 This is ready to be reviewed