### PR TITLE
Fixes of PreferenceManager.getDefaultSharedPreferences() is deprecated

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -20,7 +20,7 @@ package org.kiwix.kiwixmobile.core.utils
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat.getExternalFilesDirs
 import androidx.core.content.edit


### PR DESCRIPTION
Fixes #3419 

**Issue**
We were using the `PreferenceManager.getDefaultSharedPreferences()` method of `android.preference` package to get the `SharedPreferences`, which is deprecated.

**Fix**
We are using the same method to get the `SharedPreferences`, but now we are using the `androidx.preference` package which is recommended by the [android docs](https://developer.android.com/reference/android/preference/Preference).