### PR TITLE
Fixes of Text to Speech init failed

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -18,6 +18,13 @@
 
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.TTS_SERVICE" />
+    </intent>
+  </queries>
+
+
   <application
     android:allowBackup="true"
     android:fullBackupContent="@xml/backup_rules"


### PR DESCRIPTION
Fixes #3408 

* To use the TTS feature in Android 11 and above we need to declare `TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE` in the queries elements of their manifest to properly use the TTS service on our application.
 You can find this in the [official docs](https://developer.android.com/reference/android/speech/tts/TextToSpeech).
* **Enhanced the TTS feature:**
  Now, during the screen launch, we only set up the TTS service with the WebView. This is necessary to configure the JavaScript interface when the WebView is created. Otherwise, the JavaScript interface is not recognized. We initialize the TTS feature when the user tries to use it for better optimization.
