### PR TITLE
Fixes of Fragment's onActivityCreated is deprecated

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
@@ -55,8 +55,8 @@ abstract class HelpFragment : BaseFragment() {
     (baseActivity as CoreMainActivity).cachedComponent.inject(this)
   }
 
-  override fun onActivityCreated(savedInstanceState: Bundle?) {
-    super.onActivityCreated(savedInstanceState)
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
     val activity = requireActivity() as AppCompatActivity
     fragmentHelpBinding?.activityHelpFeedbackTextView?.setOnClickListener { sendFeedback() }
     fragmentHelpBinding?.activityHelpFeedbackImageView?.setOnClickListener { sendFeedback() }


### PR DESCRIPTION
Fixes #3428 


`onActivityCreated` is deprecated and replaced by the `onViewCreated` method of fragment, so now we are using this updated method in our `HelpFragment`.