### PR TITLE
Fixes of KiwixWifiP2pBroadcastReceiver using some deprecated methods

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.localFileTransfer
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
+import android.net.ConnectivityManager
 import android.net.Uri
 import android.net.wifi.WpsInfo
 import android.net.wifi.p2p.WifiP2pConfig
@@ -61,7 +62,8 @@ class WifiDirectManager @Inject constructor(
   private val context: Context,
   private val sharedPreferenceUtil: SharedPreferenceUtil,
   private val alertDialogShower: AlertDialogShower,
-  private val manager: WifiP2pManager?
+  private val manager: WifiP2pManager?,
+  private val connectivityManager: ConnectivityManager
 ) : ChannelListener, PeerListListener, ConnectionInfoListener, P2pEventListener {
   var callbacks: Callbacks? = null
 
@@ -96,7 +98,7 @@ class WifiDirectManager @Inject constructor(
   }
 
   private fun registerWifiDirectBroadcastReceiver() {
-    receiver = KiwixWifiP2pBroadcastReceiver(this)
+    receiver = KiwixWifiP2pBroadcastReceiver(this, connectivityManager)
 
     // For specifying broadcasts (of the P2P API) that the module needs to respond to
     val intentFilter = IntentFilter()


### PR DESCRIPTION
Fixes #3431 

* Since `NetworkInfo` is deprecated, and we are already handling this type of deprecation in the `Compat` class, we were using the `NetworkInfo` class here to check the internet connection status. Now, we are using the Compat method to check the internet connection status.
* To address the deprecation of `intent.getParcelableArrayExtra(String)` (which was deprecated in Android 13), we are now using the `intent.getParcelableArrayExtra(String, Class)` method. This method was introduced in API level 33. However, for earlier versions of Android, we will continue using the deprecated method to handle the deprecation of `intent.getParcelableArrayExtra(String)`.



