### PR TITLE
Fixed `Toast.getView()` and `Html.fromHtml()` is deprecated

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -18,18 +18,14 @@
 
 package org.kiwix.kiwixmobile.zimManager.libraryView.adapter
 
-import android.annotation.SuppressLint
-import android.view.Gravity
 import android.view.View
-import android.view.View.MeasureSpec
-import android.widget.Toast
-import androidx.annotation.StringRes
 import com.tonyodev.fetch2.Status
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
 import org.kiwix.kiwixmobile.core.downloader.model.Base64String
 import org.kiwix.kiwixmobile.core.extensions.setBitmap
 import org.kiwix.kiwixmobile.core.extensions.setTextAndVisibility
+import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.zim_manager.KiloByte
 import org.kiwix.kiwixmobile.databinding.ItemDownloadBinding
@@ -75,9 +71,10 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
         else
           View.VISIBLE
       itemLibraryBinding.unableToDownload.setOnLongClickListener {
+        val context = itemLibraryBinding.root.context
         when (item.fileSystemState) {
-          CannotWrite4GbFile -> it.centreToast(R.string.file_system_does_not_support_4gb)
-          DetectingFileSystem -> it.centreToast(R.string.detecting_file_system)
+          CannotWrite4GbFile -> context.toast(R.string.file_system_does_not_support_4gb)
+          DetectingFileSystem -> context.toast(R.string.detecting_file_system)
           else -> {
             if (item.canBeDownloaded && !hasAvailableSpaceInStorage) {
               clickAction.invoke(item)
@@ -118,22 +115,4 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       libraryDividerBinding.dividerText.setText(item.stringId)
     }
   }
-}
-
-@SuppressLint("ShowToast")
-private fun View.centreToast(@StringRes id: Int) {
-  val locationXAndY = intArrayOf(0, 0)
-  getLocationOnScreen(locationXAndY)
-  val midX = locationXAndY[0] + width / 2
-  val midY = locationXAndY[1] + height / 2
-  Toast.makeText(context, id, Toast.LENGTH_LONG).apply {
-    view?.let { view ->
-      view.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
-      setGravity(
-        Gravity.TOP or Gravity.START,
-        midX - view.measuredWidth / 2,
-        midY - view.measuredHeight
-      )
-    }
-  }.show()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -18,12 +18,12 @@
 
 package org.kiwix.kiwixmobile.core.utils.dialog
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Dialog
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.net.Uri
-import android.text.Html
 import android.view.Gravity
 import android.view.ViewGroup.LayoutParams
 import android.widget.FrameLayout
@@ -33,6 +33,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
+import org.kiwix.kiwixmobile.core.utils.StyleUtils.fromHtml
 import javax.inject.Inject
 
 class AlertDialogShower @Inject constructor(private val activity: Activity) :
@@ -89,7 +90,8 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
               ).show()
               true
             }
-            text = Html.fromHtml("</br><a href=$uri> <b>$uri</b>")
+            @SuppressLint("SetTextI18n")
+            text = "</br><a href=$uri> <b>$uri</b>".fromHtml()
           }
           frameLayout.addView(textView)
           setView(frameLayout)


### PR DESCRIPTION
Fixes #3430 

* We already handled the deprecation of `fromHtml`, we have a string's extension function to handle the this so we are now using that function.
* Since `Toast.getView()` is no longer supported after Android 11 (it always returns null on Android 11 and above devices), we no longer need to show the toast on the ZIM file that is clicked by the user for UI enhancement. Therefore, we have removed this function and are now using the context class extension function to display the toast message.


**Before**



https://github.com/kiwix/kiwix-android/assets/34593983/822f2d80-96f9-479b-b9a7-a07906f40c1a





**After**


https://github.com/kiwix/kiwix-android/assets/34593983/2205d6f9-a9b7-4318-a745-0fe71763fa46







Please ignore the downloading start after showing the snack bar and toast it is only to demonstrate how it will look.