### PR TITLE
Fixed Auth.kt file using some deprecated method

### DIFF
--- a/buildSrc/src/main/kotlin/custom/Auth.kt
+++ b/buildSrc/src/main/kotlin/custom/Auth.kt
@@ -16,7 +16,6 @@
 
 package custom
 
-import com.android.build.api.variant.VariantOutput
 import com.android.build.gradle.api.ApkVariantOutput
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
@@ -34,6 +33,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.security.KeyStore
 
+@Suppress("DEPRECATION")
 fun createPublisher(auth: File): AndroidPublisher {
   val transport = buildTransport()
   val factory = JacksonFactory.getDefaultInstance()
@@ -81,6 +81,7 @@ class Transaction(
       FileContent("application/octet-stream", file)
     ).execute().prettyPrint()
 
+  @Suppress("DEPRECATION")
   fun attachExpansionTo(expansionCode: Int, apkVariantOutput: ApkVariantOutput): ExpansionFile =
     publisher.edits().expansionfiles().update(
       packageName,
@@ -90,6 +91,7 @@ class Transaction(
       ExpansionFile().apply { referencesVersion = expansionCode }
     ).execute().prettyPrint()
 
+  @Suppress("DEPRECATION")
   fun uploadApk(apkVariantOutput: ApkVariantOutput) {
     publisher.edits().apks().upload(
       packageName,
@@ -98,12 +100,13 @@ class Transaction(
     ).execute().prettyPrint()
   }
 
+  @Suppress("DEPRECATION")
   fun addToTrackInDraft(apkVariants: List<ApkVariantOutput>): Track =
     publisher.edits().tracks().update(packageName, editId, "internal", Track().apply {
       releases = listOf(TrackRelease().apply {
         status = "draft"
         name = apkVariants[0].versionNameOverride
-        versionCodes =  apkVariants.map { it.versionCodeOverride.toLong() }
+        versionCodes = apkVariants.map { it.versionCodeOverride.toLong() }
       })
       track = "internal"
     }).execute().prettyPrint()

--- a/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
@@ -73,6 +73,7 @@ class AppConfigurer {
        * for APKs).
       */
       applicationVariants.all {
+        @Suppress("DEPRECATION")
         outputs.filterIsInstance<ApkVariantOutput>().forEach { output: ApkVariantOutput ->
           val abiVersionCode = abiCodes[output.getFilter(VariantOutput.FilterType.ABI)] ?: 7
           output.versionCodeOverride = abiVersionCode * 1_000_000 + output.versionCode

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -7,6 +7,7 @@ import custom.transactionWithCommit
 import plugin.KiwixConfigurationPlugin
 import java.net.URI
 import java.net.URL
+import java.util.Locale
 
 plugins {
   android
@@ -37,7 +38,13 @@ android {
 }
 
 fun ProductFlavor.createDownloadTask(file: File): Task {
-  return tasks.create("download${name.capitalize()}Zim") {
+  return tasks.create(
+    "download${
+    name.replaceFirstChar {
+      if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it"
+    }
+    }Zim"
+  ) {
     group = "Downloading"
     doLast {
       if (!file.exists()) {
@@ -65,7 +72,8 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
   file: File,
   applicationVariants: DomainObjectSet<ApplicationVariant>
 ): Task {
-  val capitalizedName = name.capitalize()
+  val capitalizedName =
+    name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it" }
   return tasks.create("publish${capitalizedName}ReleaseApkWithExpansionFile") {
     group = "publishing"
     description = "Uploads $capitalizedName to the Play Console with an Expansion file"
@@ -85,6 +93,7 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
   }
 }
 
+@Suppress("DEPRECATION")
 fun DomainObjectSet<ApplicationVariant>.releaseVariantsFor(productFlavor: ProductFlavor) =
   find { it.name.equals("${productFlavor.name}Release", true) }!!
     .outputs.filterIsInstance<ApkVariantOutput>().sortedBy { it.versionCodeOverride }


### PR DESCRIPTION
Fixes #3429 

* We have suppressed the lint warning for `ApkVariantOutput` because we had previously refactored this deprecated method when uploading the app bundle for custom apps on the Play Store. However, we have recently uploaded the APK again and added this deprecated code. https://github.com/kiwix/kiwix-android/pull/3356.
* We have reduced the usage of the `androidpublisher` library for `GoogleCredential` and `JacksonFactory` in order to fix the issue with uploading the Kiwix app on the Play Store. This reduction in usage introduced deprecation. Currently, we have suppressed the deprecation warning for this. https://github.com/kiwix/kiwix-android/pull/3286.
* For the `capitalize` method of the String class, we are now using the `replaceFirstChar` method, which is recommended by the official documentation.