### PR TITLE
Improved the permission asking scenario for custom apps

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -342,10 +342,25 @@ abstract class CoreReaderFragment :
         // Successfully granted permission, so opening the note keeper
         showAddNoteDialog()
       } else {
-        Toast.makeText(
-          requireActivity().applicationContext,
-          getString(R.string.ext_storage_write_permission_denied_add_note), Toast.LENGTH_LONG
-        ).show()
+        if (shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          /* shouldShowRequestPermissionRationale() returns false when:
+             *  1) User has previously checked on "Don't ask me again", and/or
+             *  2) Permission has been disabled on device
+             */
+          requireActivity().toast(
+            R.string.ext_storage_permission_rationale_add_note,
+            Toast.LENGTH_LONG
+          )
+        } else {
+          requireActivity().toast(
+            R.string.ext_storage_write_permission_denied_add_note,
+            Toast.LENGTH_LONG
+          )
+          alertDialogShower?.show(
+            KiwixDialog.ReadPermissionRequired,
+            requireActivity()::navigateToAppSettings
+          )
+        }
       }
     }
 
@@ -1306,22 +1321,7 @@ abstract class CoreReaderFragment :
         ) {
           isPermissionGranted = true
         } else {
-          if (shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            storagePermissionForNotesLauncher?.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            /* shouldShowRequestPermissionRationale() returns false when:
-               *  1) User has previously checked on "Don't ask me again", and/or
-               *  2) Permission has been disabled on device
-               */
-            requireActivity().toast(
-              R.string.ext_storage_permission_rationale_add_note,
-              Toast.LENGTH_LONG
-            )
-          } else {
-            alertDialogShower?.show(
-              KiwixDialog.ReadPermissionRequired,
-              requireActivity()::navigateToAppSettings
-            )
-          }
+          storagePermissionForNotesLauncher?.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
         }
       } else { // For Android versions below Marshmallow 6.0 (API 23)
         isPermissionGranted = true // As already requested at install time


### PR DESCRIPTION
Fixes #3370 

**Issue**
The custom permission dialog is shown directly without asking the permission.

**Fix**
We have made improvements to the permission-asking process for custom apps. It will now check if the permission has been asked before, and if not, it will ask for permission. If the user denies the permission twice, then the custom permission dialog will be shown.

**Permission granted scenario**


https://github.com/kiwix/kiwix-android/assets/34593983/41ab11cc-f749-4c38-a674-cf12b026551d

**Permission deny scenario**

https://github.com/kiwix/kiwix-android/assets/34593983/538347f4-fd8a-4565-95a3-b648352b3a65

