### PR TITLE
Fixes of Some deprecation warnings are showing in the logs but they are already fixed

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -212,6 +212,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     setBottomMarginToNavHostContainer(0)
   }
 
+  @Suppress("DEPRECATION")
   override fun onCreateOptionsMenu(menu: Menu, menuInflater: MenuInflater) {
     super.onCreateOptionsMenu(menu, menuInflater)
     if (zimReaderContainer?.zimFileReader == null) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ConnectivityBroadcastReceiver.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ConnectivityBroadcastReceiver.kt
@@ -32,6 +32,7 @@ class ConnectivityBroadcastReceiver @Inject constructor(
 ) :
   BaseBroadcastReceiver() {
 
+  @Suppress("DEPRECATION")
   override val action: String = ConnectivityManager.CONNECTIVITY_ACTION
 
   private val _networkStates = BehaviorProcessor.createDefault(connectivityManager.networkState)

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
@@ -63,6 +63,7 @@ class Fat32Checker constructor(
       )
   }
 
+  @Suppress("DEPRECATION")
   private fun fileObserver(it: String): FileObserver {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       return object : FileObserver(File(it), MOVED_FROM or DELETE) {

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -95,6 +95,8 @@ class ZimManageViewModelTest {
   private val defaultLanguageProvider: DefaultLanguageProvider = mockk()
   private val dataSource: DataSource = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+
+  @Suppress("DEPRECATION")
   private val networkInfo: NetworkInfo = mockk()
   private val sharedPreferenceUtil: SharedPreferenceUtil = mockk()
   lateinit var viewModel: ZimManageViewModel
@@ -119,6 +121,7 @@ class ZimManageViewModelTest {
     resetSchedulers()
   }
 
+  @Suppress("DEPRECATION")
   @BeforeEach
   fun init() {
     clearAllMocks()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/KiwixService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/KiwixService.kt
@@ -35,6 +35,7 @@ interface KiwixService {
 
   /******** Helper class that sets up new services  */
   object ServiceCreator {
+    @Suppress("DEPRECATION")
     fun newHackListService(okHttpClient: OkHttpClient, baseUrl: String): KiwixService {
       val retrofit = Retrofit.Builder()
         .baseUrl(baseUrl)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -69,6 +69,7 @@ open class ErrorActivity : BaseActivity() {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         extras.getSerializable(EXCEPTION_KEY, Throwable::class.java)
       } else {
+        @Suppress("DEPRECATION")
         extras.getSerializable(EXCEPTION_KEY) as Throwable
       }
     } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ContextExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ContextExtensions.kt
@@ -55,7 +55,9 @@ fun Context.registerReceiver(baseBroadcastReceiver: BaseBroadcastReceiver): Inte
 val Context.locale: Locale
   get() =
     if (VERSION.SDK_INT >= VERSION_CODES.N) resources.configuration.locales.get(0)
-    else resources.configuration.locale
+    else
+      @Suppress("DEPRECATION")
+      resources.configuration.locale
 
 fun Context.getAttribute(@AttrRes attributeRes: Int) = with(TypedValue()) {
   if (theme.resolveAttribute(attributeRes, this, true))

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -98,6 +98,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     }
   }
 
+  @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     activeFragments().iterator().forEach { it.onActivityResult(requestCode, resultCode, data) }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -387,6 +387,7 @@ abstract class CoreReaderFragment :
     savedInstanceState: Bundle?
   ) {
     super.onViewCreated(view, savedInstanceState)
+    @Suppress("DEPRECATION")
     setHasOptionsMenu(true)
     val activity = requireActivity() as AppCompatActivity?
     activity?.let {
@@ -1173,6 +1174,7 @@ abstract class CoreReaderFragment :
     }
   }
 
+  @Suppress("DEPRECATION")
   override fun onOptionsItemSelected(item: MenuItem): Boolean =
     mainMenu?.onOptionsItemSelected(item) == true || super.onOptionsItemSelected(item)
 
@@ -1747,6 +1749,7 @@ abstract class CoreReaderFragment :
     }
   }
 
+  @Suppress("DEPRECATION")
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     super<BaseFragment>.onCreateOptionsMenu(menu, inflater)
     menu.clear()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/NavigationHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/NavigationHostFragment.kt
@@ -28,6 +28,7 @@ import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions.Super.ShouldCa
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions.Super.ShouldNotCall
 
 class NavigationHostFragment : NavHostFragment(), WebViewProvider, FragmentActivityExtensions {
+  @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     childFragmentManager.fragments.iterator()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -209,6 +209,7 @@ class SearchFragment : BaseFragment() {
     searchViewModel.actions.trySend(OnOpenInNewTabClick(it)).isSuccess
   }
 
+  @Suppress("DEPRECATION")
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     searchViewModel.actions.trySend(ActivityResultReceived(requestCode, resultCode, data)).isSuccess

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -82,6 +82,7 @@ class SearchViewModel @Inject constructor(
     viewModelScope.launch { actionMapper() }
   }
 
+  @Suppress("DEPRECATION")
   private suspend fun reducer() {
     combine(
       filter.asFlow(),
@@ -97,6 +98,7 @@ class SearchViewModel @Inject constructor(
       .collect { state.value = it }
   }
 
+  @Suppress("DEPRECATION")
   private fun searchResults() = filter.asFlow()
     .mapLatest {
       val zimFileReader = zimReaderContainer.copyReader()
@@ -122,6 +124,7 @@ class SearchViewModel @Inject constructor(
           actions
         )
       ).isSuccess
+
       ReceivedPromptForSpeechInput -> _effects.trySend(StartSpeechInput(actions)).isSuccess
       StartSpeechInputFailed -> _effects.trySend(ShowToast(R.string.speech_not_supported)).isSuccess
       is ActivityResultReceived ->
@@ -133,6 +136,7 @@ class SearchViewModel @Inject constructor(
             actions
           )
         ).isSuccess
+
       is ScreenWasStartedFrom -> searchOrigin.trySendBlocking(it.searchOrigin)
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
@@ -31,6 +31,7 @@ import java.util.Locale
 
 data class StartSpeechInput(private val actions: Channel<Action>) : SideEffect<Unit> {
 
+  @Suppress("DEPRECATION")
   override fun invokeWith(activity: AppCompatActivity) {
     try {
       activity.startActivityForResult(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageUtils.kt
@@ -156,6 +156,7 @@ class LanguageUtils(private val context: Context) {
     }
 
     @SuppressLint("AppBundleLocaleChanges")
+    @Suppress("DEPRECATION")
     @JvmStatic
     fun handleLocaleChange(
       activity: Activity,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInputTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInputTest.kt
@@ -37,6 +37,7 @@ internal class StartSpeechInputTest {
 
   private val actions = mockk<Channel<Action>>(relaxed = true)
 
+  @Suppress("DEPRECATION")
   @Test
   fun `when invoke with throws exception offer StartSpeechInputFailed action`() {
     val activity = mockk<AppCompatActivity>(relaxed = true)
@@ -45,6 +46,7 @@ internal class StartSpeechInputTest {
     verify { actions.trySend(StartSpeechInputFailed).isSuccess }
   }
 
+  @Suppress("DEPRECATION")
   @Test
   fun `invoke with starts an activity for speech recognition`() {
     val activity = mockk<AppCompatActivity>()

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -157,6 +157,7 @@ class CustomReaderFragment : CoreReaderFragment() {
     )
   }
 
+  @Suppress("DEPRECATION")
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     super.onCreateOptionsMenu(menu, inflater)
     menu.findItem(R.id.menu_help)?.isVisible = false


### PR DESCRIPTION
Fixes #3443 

As we already fixed the deprecated code for Android 13 and below, we have suppressed the deprecation warning because we do not have any alternative for these methods and these are only deprecated in Android 13.
