### PR TITLE
Fixes of View Notes from all books Switch is always enabled

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesFragment.kt
@@ -39,7 +39,7 @@ class NotesFragment : PageFragment() {
 
   override val noItemsString: String by lazy { getString(R.string.no_notes) }
   override val switchString: String by lazy { getString(R.string.notes_from_all_books) }
-  override val switchIsChecked: Boolean = true
+  override val switchIsChecked: Boolean by lazy { sharedPreferenceUtil.showNotesAllBooks }
 
   override fun inject(baseActivity: BaseActivity) {
     baseActivity.cachedComponent.inject(this)


### PR DESCRIPTION
Fixes #3448 
We were saving the switch value in the sharePreference but in the `NotesFragment`, we are not initially setting the saved value to `switcher`. Now we have set the saved value to the `switcher`.

https://github.com/kiwix/kiwix-android/assets/34593983/898a2492-3443-4f24-a730-adf6851d12af

