### PR TITLE
Fixes of Zim file does not download / pending forever

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
@@ -101,7 +101,7 @@ class FetchDownloadNotificationManager(private val context: Context) :
           .addAction(
             R.drawable.fetch_notification_cancel,
             context.getString(R.string.cancel),
-            getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.CANCEL)
+            getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.DELETE)
           )
       downloadNotification.isPaused ->
         notificationBuilder.setTimeoutAfter(getNotificationTimeOutMillis())
@@ -113,7 +113,7 @@ class FetchDownloadNotificationManager(private val context: Context) :
           .addAction(
             R.drawable.fetch_notification_cancel,
             context.getString(R.string.cancel),
-            getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.CANCEL)
+            getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.DELETE)
           )
       downloadNotification.isQueued ->
         notificationBuilder.setTimeoutAfter(getNotificationTimeOutMillis())


### PR DESCRIPTION
Fixes #3441 

We encountered an issue where the download remained pending indefinitely if we canceled it from the notification. This happened because when we canceled the download by clicking the notification cancel button, it kept a reference in the fetch system. Consequently, if we tried to download the same file again, fetch created a new download ID, resulting in a conflict with the existing instance of the file. As a result, the download did not start.

However, when we canceled the download within the app itself, it deletes the instance from fetch, which automatically deletes the temporary file from storage.

To resolve this issue, we have made a change. Instead of using the CANCEL action, we now use the DELETE action. So, if the user cancels the download from the notification, it will function the same way as if they have canceled it from within the application.


https://github.com/kiwix/kiwix-android/assets/34593983/b8d130f5-d58c-44de-a875-707d31d70253



