### PR TITLE
Fixed can't open epub in external app

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/ExternalLinkOpenerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/ExternalLinkOpenerTest.kt
@@ -51,7 +51,7 @@ internal class ExternalLinkOpenerTest {
     every { intent.data } returns Uri.parse(url.toString())
     val lambdaSlot = slot<() -> Unit>()
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
-    externalLinkOpener.openExternalUrl(intent)
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
     verify {
       alertDialogShower.show(
         KiwixDialog.ExternalLinkPopup,
@@ -72,7 +72,7 @@ internal class ExternalLinkOpenerTest {
     every { intent.data } returns uri
     val lambdaSlot = slot<() -> Unit>()
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
-    externalLinkOpener.openExternalUrl(intent)
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
     verify {
       alertDialogShower.show(
         KiwixDialog.ExternalLinkPopup,
@@ -92,7 +92,7 @@ internal class ExternalLinkOpenerTest {
     every { intent.data } returns Uri.parse("https://github.com/")
     val lambdaSlot = slot<() -> Unit>()
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
-    externalLinkOpener.openExternalUrl(intent)
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
     verify {
       alertDialogShower.show(
         KiwixDialog.ExternalLinkPopup,
@@ -112,7 +112,7 @@ internal class ExternalLinkOpenerTest {
     every { intent.data } returns Uri.parse("https://github.com/")
     val lambdaSlot = slot<() -> Unit>()
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
-    externalLinkOpener.openExternalUrl(intent)
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
     verify {
       alertDialogShower.show(
         KiwixDialog.ExternalLinkPopup,
@@ -133,7 +133,7 @@ internal class ExternalLinkOpenerTest {
     every { intent.resolveActivity(activity.packageManager) } returns mockk()
     every { sharedPreferenceUtil.prefExternalLinkPopup } returns false
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
-    externalLinkOpener.openExternalUrl(intent)
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
     verify { activity.startActivity(intent) }
   }
 
@@ -143,9 +143,19 @@ internal class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(activity, sharedPreferenceUtil, alertDialogShower)
     mockkStatic(Toast::class)
     justRun {
-      Toast.makeText(activity, R.string.no_reader_application_installed, Toast.LENGTH_LONG).show()
+      Toast.makeText(activity, R.string.no_browser_application_installed, Toast.LENGTH_LONG).show()
     }
-    externalLinkOpener.openExternalUrl(intent)
-    verify { activity.toast(R.string.no_reader_application_installed) }
+    externalLinkOpener.openExternalUrl(intent, R.string.no_browser_application_installed)
+    verify { activity.toast(R.string.no_browser_application_installed) }
+    justRun {
+      Toast.makeText(activity, R.string.no_pdf_application_installed, Toast.LENGTH_LONG).show()
+    }
+    externalLinkOpener.openExternalUrl(intent, R.string.no_pdf_application_installed)
+    verify { activity.toast(R.string.no_pdf_application_installed) }
+    justRun {
+      Toast.makeText(activity, R.string.no_epub_application_installed, Toast.LENGTH_LONG).show()
+    }
+    externalLinkOpener.openExternalUrl(intent, R.string.no_epub_application_installed)
+    verify { activity.toast(R.string.no_epub_application_installed) }
   }
 }

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE" />
     </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:mimeType="application/epub+zip" />
+    </intent>
   </queries>
 
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -221,7 +221,10 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   }
 
   private fun openSupportKiwixExternalLink() {
-    externalLinkOpener.openExternalUrl(KIWIX_SUPPORT_URL.toUri().browserIntent())
+    externalLinkOpener.openExternalUrl(
+      KIWIX_SUPPORT_URL.toUri().browserIntent(),
+      R.string.no_browser_application_installed
+    )
   }
 
   override fun onBackPressed() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1382,8 +1382,8 @@ abstract class CoreReaderFragment :
     sharedPreferenceUtil?.putPrefFullScreen(false)
   }
 
-  override fun openExternalUrl(intent: Intent) {
-    externalLinkOpener?.openExternalUrl(intent)
+  override fun openExternalUrl(intent: Intent, errorMessageId: Int) {
+    externalLinkOpener?.openExternalUrl(intent, errorMessageId)
   }
 
   protected fun openZimFile(file: File, isCustomApp: Boolean = false) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -29,6 +29,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.FileProvider
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -70,7 +71,7 @@ open class CoreWebViewClient(
 
     // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-    callback.openExternalUrl(intent)
+    callback.openExternalUrl(intent, R.string.no_browser_application_installed)
     return true
   }
 
@@ -102,7 +103,11 @@ open class CoreWebViewClient(
             flags = Intent.FLAG_ACTIVITY_NO_HISTORY
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
           }
-          callback.openExternalUrl(intent)
+          val errorMessage = if (extension == "application/pdf")
+            R.string.no_pdf_application_installed
+          else
+            R.string.no_epub_application_installed
+          callback.openExternalUrl(intent, errorMessage)
         }
       }
       return true

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
@@ -24,7 +24,7 @@ interface WebViewCallback {
   fun webViewUrlLoading()
   fun webViewUrlFinishedLoading()
   fun webViewFailedLoading(failingUrl: String)
-  fun openExternalUrl(intent: Intent)
+  fun openExternalUrl(intent: Intent, errorMessageId: Int)
   fun webViewProgressChanged(progress: Int, webView: WebView)
   fun webViewTitleUpdated(title: String)
   fun webViewPageChanged(page: Int, maxPages: Int)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.core.utils
 import android.app.Activity
 import android.content.Intent
 import android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
-import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -33,7 +32,7 @@ class ExternalLinkOpener @Inject constructor(
   private val alertDialogShower: AlertDialogShower
 ) {
 
-  fun openExternalUrl(intent: Intent) {
+  fun openExternalUrl(intent: Intent, errorMessageId: Int) {
     if (intent.resolveActivity(activity.packageManager) != null) {
       // Show popup with warning that this url is external and could lead to additional costs
       // or may event not work when the user is offline.
@@ -43,7 +42,7 @@ class ExternalLinkOpener @Inject constructor(
         openLink(intent)
       }
     } else {
-      activity.toast(R.string.no_reader_application_installed)
+      activity.toast(errorMessageId)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -73,11 +73,11 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
         }
         uri?.let {
           /*
-          Check if it is valid url then show it to the user
-          otherwise don't show uri to the user as they are not directly openable in the external app.
+          Check if it is external browser url then show it to the user
+          otherwise don't show uri to the user as they are not directly openable in the external browser.
           We place this condition to improve the user experience see https://github.com/kiwix/kiwix-android/pull/3455
            */
-          if (!"$it".startsWith("content://")) {
+          if ("$it".startsWith("http://") || "$it".startsWith("https://")) {
             showUrlInDialog(this, it)
           }
           dialog.getView?.let { setView(it()) }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
   <string name="tts_lang_not_supported">The language of this page is not supported. The article may not be properly read.</string>
   <string name="no_reader_application_installed">Could not find an installed application for this type of file</string>
   <string name="no_email_application_installed">Please install an email service provider or email us at %1s</string>
+  <string name="no_browser_application_installed">Please install any web browser to open it e.g. chrome or firefox.</string>
+  <string name="no_pdf_application_installed">Please install any pdf reader application to open it.</string>
+  <string name="no_epub_application_installed">Please install any epub reader application to open it.</string>
   <string name="no_section_info">No Content Headers Found</string>
   <string name="request_storage">To access offline content we need access to your storage</string>
   <string name="request_write_storage">To download zim files we need write access to your storage</string>


### PR DESCRIPTION
Fixes #3453 

* Added EPUB application viewing query to the manifest. This query provides access to check if an EPUB viewer application is installed on the user's device or not
* Added this query in `core/manifest` file so it will add this query to both `kiwix` and `custom` app.



https://github.com/kiwix/kiwix-android/assets/34593983/6867b2a3-5583-485d-841a-442034c87129


* To enhance the user experience, a condition has been implemented to check if a URI is a valid URL. If it is an external browser URL, it will be shown to the user; otherwise, the URI will not be displayed in the external link popup. This improvement ensured that only external browser URLs would be present to the user, providing a more user-friendly interface.

| With Epub Uri  | With Pdf Uri | With External browser URL |
| ------------- | ------------- | ------------- |
| ![epubUri](https://github.com/kiwix/kiwix-android/assets/34593983/77acd2d1-9695-4622-95ba-aa10398a3b93) |  ![pdfUri](https://github.com/kiwix/kiwix-android/assets/34593983/de058e19-f375-46c9-9a5b-4dd6c4d9d45a) | ![validUrl](https://github.com/kiwix/kiwix-android/assets/34593983/0dfe815a-7c23-4e5d-b30e-ec9f8000fc7d) |

* We are now showing proper error messages to the user when there is no app installed on their device to handle the pdf/epub/URL.

![1697026304072](https://github.com/kiwix/kiwix-android/assets/34593983/92e63cec-aa1d-43c4-a5f2-3028acf40ec3)
