### PR TITLE
Replaced `ApkVariantOutput` with `VariantOutput`

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.internal.dsl.ProductFlavor
 import custom.CustomApps
@@ -40,9 +39,9 @@ android {
 fun ProductFlavor.createDownloadTask(file: File): Task {
   return tasks.create(
     "download${
-    name.replaceFirstChar {
-      if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it"
-    }
+      name.replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it"
+      }
     }Zim"
   ) {
     group = "Downloading"
@@ -84,9 +83,9 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
         .transactionWithCommit(packageName) {
           val variants =
             applicationVariants.releaseVariantsFor(this@createPublishApkWithExpansionTask)
-          variants.forEach(::uploadApk)
-          uploadExpansionTo(file, variants[0].versionCodeOverride)
-          variants.drop(1).forEach { attachExpansionTo(variants[0].versionCodeOverride, it) }
+          variants.forEach { _ -> uploadApk() }
+          uploadExpansionTo(file, variants[0].versionCode.get())
+          variants.drop(1).forEach { attachExpansionTo(variants[0].versionCode.get(), it) }
           addToTrackInDraft(variants)
         }
     }
@@ -96,7 +95,10 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
 @Suppress("DEPRECATION")
 fun DomainObjectSet<ApplicationVariant>.releaseVariantsFor(productFlavor: ProductFlavor) =
   find { it.name.equals("${productFlavor.name}Release", true) }!!
-    .outputs.filterIsInstance<ApkVariantOutput>().sortedBy { it.versionCodeOverride }
+    .outputs.filterIsInstance<com.android.build.api.variant.VariantOutput>()
+    .sortedBy { it.versionCode.get() }
+
+
 
 afterEvaluate {
   tasks.filter { it.name.contains("ReleaseApkWithExpansionFile") }.forEach {

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -38,10 +38,9 @@ android {
 
 fun ProductFlavor.createDownloadTask(file: File): Task {
   return tasks.create(
-    "download${
-      name.replaceFirstChar {
-        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it"
-      }
+    "download${name.replaceFirstChar {
+      if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else "$it"
+    }
     }Zim"
   ) {
     group = "Downloading"
@@ -97,8 +96,6 @@ fun DomainObjectSet<ApplicationVariant>.releaseVariantsFor(productFlavor: Produc
   find { it.name.equals("${productFlavor.name}Release", true) }!!
     .outputs.filterIsInstance<com.android.build.api.variant.VariantOutput>()
     .sortedBy { it.versionCode.get() }
-
-
 
 afterEvaluate {
   tasks.filter { it.name.contains("ReleaseApkWithExpansionFile") }.forEach {


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes https://github.com/kiwix/kiwix-android-custom/issues/95

In this pull request, I've made changes to our Android Gradle code to replace deprecated `ApkVariantOutput` usage with `VariantOutput`. The `ApkVariantOutput.getVersionCodeOverride()` & `ApkVarientOutput. getVersionNameOverride()` API have been deprecated as of Android Gradle Plugin 7.0 and has been replaced by `VariantOutput.versionCode()` & `VariantOutput.VersionName()` respectively.

Key changes:

Changed `ApkVariantOutput` to `VariantOutput` We have moved away from using the deprecated `ApkVariantOutput` in our code and replaced it with VariantOutput. This is in line with the new Android Gradle Plugin API and helps avoid deprecation warnings.

Replaced `getVersionCodeOverride() & getVersionNameOverride()`  with `versionCode.get()` & `versionName.get()`: Instead of using the deprecated getVersionCodeOverride() method, we are now using versionCode.get() and so on, which is the recommended approach in the Android Gradle Plugin 7.0 and above.
