### PR TITLE
Fixes of Storage configured dialog showing again in OnlineLibraryFragment if we configured it from settings's screen

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -314,6 +314,7 @@ abstract class CorePrefsFragment :
         findPreference<Preference>(SharedPreferenceUtil.PREF_STORAGE)?.title =
           getString(R.string.internal_storage)
         sharedPreferenceUtil.putStoragePosition(INTERNAL_SELECT_POSITION)
+        setShowStorageOption()
       } else {
         if (sharedPreferenceUtil.isPlayStoreBuild) {
           setExternalStoragePath(storageDevice)
@@ -339,6 +340,7 @@ abstract class CorePrefsFragment :
     findPreference<Preference>(SharedPreferenceUtil.PREF_STORAGE)?.title =
       getString(R.string.external_storage)
     sharedPreferenceUtil?.putStoragePosition(EXTERNAL_SELECT_POSITION)
+    setShowStorageOption()
   }
 
   private fun selectFolder() {
@@ -362,10 +364,15 @@ abstract class CorePrefsFragment :
             findPreference<Preference>(SharedPreferenceUtil.PREF_STORAGE)?.title =
               getString(R.string.external_storage)
             sharedPreferenceUtil?.putStoragePosition(EXTERNAL_SELECT_POSITION)
+            setShowStorageOption()
           }
         }
       }
     }
+
+  private fun setShowStorageOption() {
+    sharedPreferenceUtil?.showStorageOption = false
+  }
 
   companion object {
     const val PREF_VERSION = "pref_version"


### PR DESCRIPTION
Fixes #3463 

Now we are not showing the storage selection dialog in `OnlineLibraryFragment` if the user already configured the storage in `settings`.


https://github.com/kiwix/kiwix-android/assets/34593983/bf43ddc8-1625-4fd9-85ea-e3bcae9418cc

