### PR TITLE
Fixed Keyboard repeatedly disappearing and reappearing in search when any article is loading in the background

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1886,7 +1886,7 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("MagicNumber")
-  override fun webViewProgressChanged(progress: Int) {
+  override fun webViewProgressChanged(progress: Int, webView: WebView) {
     if (isAdded) {
       progressBar?.apply {
         visibility = View.VISIBLE
@@ -1897,6 +1897,7 @@ abstract class CoreReaderFragment :
           Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView()?.url)
         }
       }
+      (webView.context as AppCompatActivity).invalidateOptionsMenu()
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebChromeClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebChromeClient.kt
@@ -19,7 +19,6 @@ package org.kiwix.kiwixmobile.core.main
 
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.videowebview.VideoEnabledWebChromeClient
 
 class KiwixWebChromeClient(
@@ -29,8 +28,7 @@ class KiwixWebChromeClient(
   webView: KiwixWebView?
 ) : VideoEnabledWebChromeClient(nonVideoView, videoView, null, webView) {
   override fun onProgressChanged(view: WebView, progress: Int) {
-    callback.webViewProgressChanged(progress)
-    (view.context as AppCompatActivity).invalidateOptionsMenu()
+    callback.webViewProgressChanged(progress, view)
   }
 
   override fun onReceivedTitle(view: WebView, title: String) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
@@ -18,13 +18,14 @@
 package org.kiwix.kiwixmobile.core.main
 
 import android.content.Intent
+import android.webkit.WebView
 
 interface WebViewCallback {
   fun webViewUrlLoading()
   fun webViewUrlFinishedLoading()
   fun webViewFailedLoading(failingUrl: String)
   fun openExternalUrl(intent: Intent)
-  fun webViewProgressChanged(progress: Int)
+  fun webViewProgressChanged(progress: Int, webView: WebView)
   fun webViewTitleUpdated(title: String)
   fun webViewPageChanged(page: Int, maxPages: Int)
   fun webViewLongClick(url: String)


### PR DESCRIPTION
Fixes #3468 

Fixed Keyboard repeatedly disappearing and reappearing in search when any article is loading in the background.

* When any article is loading then we invalidate the `OptionMenu` from `KiwixWebChromeClient` (It does not check whether the fragment is visible or not) which also invalidates the toolbar and the search bar is inside the toolbar that's the reason the keyboard showing and hiding repeatedly.
* Now we are invalidating the `OptionMenu` inside the `CoreReaderFragment` when it is visible to the user since this fragment loads the content in the webview. Hence, it is better to update the UI when it is visible to the user so it would not affect any other UI part.