### PR TITLE
Fixed USB-OTG not working on android 11 and above devices

### DIFF
--- a/core/detekt_baseline.xml
+++ b/core/detekt_baseline.xml
@@ -36,6 +36,7 @@
     <ID>MaxLineLength:MetaLinkNetworkEntityTest.kt$MetaLinkNetworkEntityTest$"http://www.mirrorservice.org/sites/download.kiwix.org/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"</ID>
     <ID>MaxLineLength:NetworkUtilsTest.kt$NetworkUtilsTest$// Here the Method should return the substring between the first '?' character and the nearest '/' character preceeding it</ID>
     <ID>NestedBlockDepth:FileUtils.kt$FileUtils$@JvmStatic @Synchronized fun deleteZimFile(path: String)</ID>
+    <ID>NestedBlockDepth:FileUtils.kt$FileUtils$@JvmStatic fun getLocalFilePathByUri( context: Context, uri: Uri ): String?</ID>
     <ID>NestedBlockDepth:ImageUtils.kt$ImageUtils$private fun getBitmapFromView(width: Int, height: Int, viewToDrawFrom: View): Bitmap?</ID>
     <ID>NestedBlockDepth:JNIInitialiser.kt$JNIInitialiser$private fun loadICUData(context: Context): String?</ID>
     <ID>NestedBlockDepth:OnSwipeTouchListener.kt$OnSwipeTouchListener.GestureListener$override fun onFling( e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float ): Boolean</ID>


### PR DESCRIPTION
Fixes #3462 

Previously, we had added support for `USB-OTG` for Android 10 and below devices in https://github.com/kiwix/kiwix-android/pull/3311 but at that time we did have not any way to add support for `Android 10` and above devices, because `context.getExternalFilesDirs("")` does not provide the USB path in `Android 10` and above devices for security reasons. There is no direct way to access the `USB-OTG` on these devices, but `USB-OTG` is mounted under the `/mnt/media_rw` directory, so now we are directly using this to open zim files from the USB drive for Android 10 and above devices.


https://github.com/kiwix/kiwix-android/assets/34593983/e475cc53-3598-4ae1-b454-fdc10a3ac9a9


