### PR TITLE
Fixed Bookmark toggle is not ON for saved bookmarks

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile
 
 import android.Manifest.permission
 import android.content.Context
+import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -35,13 +36,22 @@ abstract class BaseActivityTest {
   @get:Rule
   open var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)
 
-  @get:Rule
-  var readPermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(permission.READ_EXTERNAL_STORAGE)
+  private val permissions = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    arrayOf(
+      permission.READ_EXTERNAL_STORAGE,
+      permission.WRITE_EXTERNAL_STORAGE,
+      permission.SYSTEM_ALERT_WINDOW
+    )
+  } else {
+    arrayOf(
+      permission.READ_EXTERNAL_STORAGE,
+      permission.WRITE_EXTERNAL_STORAGE
+    )
+  }
 
   @get:Rule
-  var writePermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(permission.WRITE_EXTERNAL_STORAGE)
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
 
   val context: Context by lazy {
     getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile
 
 import android.Manifest
+import android.os.Build
 import android.util.Log
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
@@ -57,15 +58,23 @@ class NetworkTest {
   // @Inject
   // MockWebServer mockWebServer
 
-  @Rule
-  @JvmField
-  var readPermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
+  private val permissions = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.SYSTEM_ALERT_WINDOW
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+  }
 
   @Rule
   @JvmField
-  var writePermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
 
   @Before fun setUp() {
     val component = DaggerTestComponent.builder().context(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.language
 
 import android.Manifest
 import android.app.Instrumentation
+import android.os.Build
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.test.ext.junit.rules.ActivityScenarioRule
@@ -49,13 +50,23 @@ class LanguageFragmentTest {
   @get:Rule
   var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)
 
-  @get:Rule
-  var readPermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
+  private val permissions = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.SYSTEM_ALERT_WINDOW
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+  }
 
-  @get:Rule
-  var writePermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+  @Rule
+  @JvmField
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
 
   private val instrumentation: Instrumentation by lazy {
     InstrumentationRegistry.getInstrumentation()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.settings
 
 import android.Manifest
+import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
@@ -45,11 +46,23 @@ class KiwixSettingsFragmentTest {
   @get:Rule
   var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)
 
-  @Rule @JvmField var readPermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
+  private val permissions = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.SYSTEM_ALERT_WINDOW
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+  }
 
-  @Rule @JvmField var writePermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+  @Rule
+  @JvmField
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.splash
 
 import android.Manifest
 import android.content.Context
+import android.os.Build
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
@@ -58,15 +59,23 @@ class KiwixSplashActivityTest {
   private val activityScenario: ActivityScenario<KiwixMainActivity> =
     ActivityScenario.launch(KiwixMainActivity::class.java)
 
-  @Rule
-  @JvmField
-  var readPermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
+  private val permissions = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.SYSTEM_ALERT_WINDOW
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+  }
 
   @Rule
   @JvmField
-  var writePermissionRule: GrantPermissionRule =
-    GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
   private var context: Context? = null
 
   @Before

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -255,6 +255,8 @@ class KiwixReaderFragment : CoreReaderFragment() {
           TAG_KIWIX,
           "Kiwix normal start, Opened last used zimFile: -> $zimFile"
         )
+      } else {
+        zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
       }
     } else {
       getCurrentWebView()?.snack(R.string.zim_not_opened)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1431,24 +1431,28 @@ abstract class CoreReaderFragment :
       zimFileReader?.let { zimFileReader ->
         mainMenu?.onFileOpened(urlIsValid())
         openArticle(zimFileReader.mainPage)
-        safeDispose()
-        bookmarkingDisposable = Flowable.combineLatest(
-          newBookmarksDao?.bookmarkUrlsForCurrentBook(zimFileReader),
-          webUrlsProcessor,
-          List<String?>::contains
-        )
-          .observeOn(AndroidSchedulers.mainThread())
-          .subscribe({ isBookmarked: Boolean ->
-            this.isBookmarked = isBookmarked
-            bottomToolbarBookmark?.setImageResource(
-              if (isBookmarked) R.drawable.ic_bookmark_24dp else R.drawable.ic_bookmark_border_24dp
-            )
-          }, Throwable::printStackTrace)
-        updateUrlProcessor()
+        setUpBookmarks(zimFileReader)
       } ?: kotlin.run {
         requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
       }
     }
+  }
+
+  protected fun setUpBookmarks(zimFileReader: ZimFileReader) {
+    safeDispose()
+    bookmarkingDisposable = Flowable.combineLatest(
+      newBookmarksDao?.bookmarkUrlsForCurrentBook(zimFileReader),
+      webUrlsProcessor,
+      List<String?>::contains
+    )
+      .observeOn(AndroidSchedulers.mainThread())
+      .subscribe({ isBookmarked: Boolean ->
+        this.isBookmarked = isBookmarked
+        bottomToolbarBookmark?.setImageResource(
+          if (isBookmarked) R.drawable.ic_bookmark_24dp else R.drawable.ic_bookmark_border_24dp
+        )
+      }, Throwable::printStackTrace)
+    updateUrlProcessor()
   }
 
   private fun safeDispose() {


### PR DESCRIPTION
Fixes #3472 

* We have `bookmarkingDisposeble` for handling the bookmark which is perfectly working when we are opening a new zim file and with a previously open zim file, but the problem was if a zim file is opened and we are switching between screens then the bookmark functionality was broken. Because we are disposing the `bookmarkingDisposeble` if the screen is not visible to the user, to avoid memory leak. But when the screen is again visible to the user then we were not setting up `bookmarkingDisposeble` to handle the bookmarks that's the reason the bookmark functionality was broken, now we have set up the `bookmarkingDisposeble` again when the reader is visible to the user.

https://github.com/kiwix/kiwix-android/assets/34593983/3df8a8f7-5dd3-4289-bbd5-858d6fc63f75

* Improved test case for API level 21:
  This issue came some time back in the CI emulator while launching the application. Locally all the test cases are passed. But in the emulator it sometimes did not launch the activity which is the main reason for test failure, this issue occurs if the application does not have `Display pop-up windows while running in the background` permission. So to fix this we have added this permission in our test cases for API level 23 and below. Since this permission can not automatically be granted in API level 24 and above and we don't need this permission on these devices so we have placed a check.

```
E/TestRunner( 3053): ----- begin exception -----
E/TestRunner( 3053): java.lang.RuntimeException: Could not launch intent Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10008000 cmp=org.kiwix.kiwixmobile/.main.KiwixMainActivity } within 45000 milliseconds. Perhaps the main thread has not gone idle within a reasonable amount of time? There could be an animation or something constantly repainting the screen. Or the activity is doing network calls on creation? See the threaddump logs. For your reference the last time the event queue was idle before your activity launch request was 1693324889093 and now the last time the queue went idle was: 1693324889155. If these numbers are the same your activity might be hogging the event queue.
E/TestRunner( 3053): 	at androidx.test.runner.MonitoringInstrumentation.startActivitySync(MonitoringInstrumentation.java:550)
E/TestRunner( 3053): 	at androidx.test.core.app.InstrumentationActivityInvoker.startActivity(InstrumentationActivityInvoker.java:413)
E/TestRunner( 3053): 	at androidx.test.core.app.InstrumentationActivityInvoker.startActivity(InstrumentationActivityInvoker.java:422)
E/TestRunner( 3053): 	at androidx.test.core.app.ActivityScenario.launchInternal(ActivityScenario.java:362)
E/TestRunner( 3053): 	at androidx.test.core.app.ActivityScenario.launch(ActivityScenario.java:202)
E/TestRunner( 3053): 	at androidx.test.ext.junit.rules.ActivityScenarioRule.lambda$new$0(ActivityScenarioRule.java:76)
E/TestRunner( 3053): 	at androidx.test.ext.junit.rules.ActivityScenarioRule$$ExternalSyntheticLambda1.get(D8$$SyntheticClass)
E/TestRunner( 3053): 	at androidx.test.ext.junit.rules.ActivityScenarioRule.before(ActivityScenarioRule.java:109)
E/TestRunner( 3053): 	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
E/TestRunner( 3053): 	at androidx.test.rule.GrantPermissionRule$RequestPermissionStatement.evaluate(GrantPermissionRule.java:136)
E/TestRunner( 3053): 	at org.kiwix.kiwixmobile.testutils.RetryRule$statement$1.evaluate(RetryRule.kt:38)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
E/TestRunner( 3053): 	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
E/TestRunner( 3053): 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
E/TestRunner( 3053): 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
E/TestRunner( 3053): 	at androidx.test.ext.junit.runners.AndroidJUnit4.run(AndroidJUnit4.java:162)
E/TestRunner( 3053): 	at org.junit.runners.Suite.runChild(Suite.java:128)
E/TestRunner( 3053): 	at org.junit.runners.Suite.runChild(Suite.java:27)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
E/TestRunner( 3053): 	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
E/TestRunner( 3053): 	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
E/TestRunner( 3053): 	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
E/TestRunner( 3053): 	at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:67)
E/TestRunner( 3053): 	at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
E/TestRunner( 3053): 	at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:446)
E/TestRunner( 3053): 	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
E/TestRunner( 3053): ----- end exception -----

```
