### PR TITLE
Added tmpfs filesystem to `support 4GB filesystem` list and improved the writing test file name

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/FileWritingFileSystemChecker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/FileWritingFileSystemChecker.kt
@@ -27,7 +27,7 @@ import java.io.RandomAccessFile
 
 class FileWritingFileSystemChecker : FileSystemChecker {
   override fun checkFilesystemSupports4GbFiles(path: String): FileSystemCapability {
-    val resultFile = File("$path/.file_writing_result")
+    val resultFile = File("$path/.kiwix_4gb_writing_test_result")
     if (resultFile.exists()) {
       when (val capability = readCapability(resultFile)) {
         CAN_WRITE_4GB,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/MountPointProducer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/MountPointProducer.kt
@@ -45,7 +45,7 @@ data class MountInfo(val device: String, val mountPoint: String, val fileSystem:
 
   companion object {
     private val VIRTUAL_FILE_SYSTEMS = listOf("fuse", "sdcardfs", "sdfat")
-    private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat")
+    private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat", "tmpfs")
     private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat")
   }
 }


### PR DESCRIPTION
Fixes #2889 

See https://github.com/kiwix/kiwix-android/issues/2889#issuecomment-1695520167

Enhanced FileSystem Check.

* Added `tmpfs` filesystem to `support 4GB filesystem` list since this type supports writing files over 4GB.
* Updated the name of the writing test result file to `kiwix_4gb_writing_test_result` to enhance readability.