### PR TITLE
Updated to Android 14 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         api-level: [ 24, 30, 33 , 34]
+        system-image:
+          - { api: 34, image: "default" }
       fail-fast: false
     runs-on: macos-11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 24, 30, 33 ]
+        api-level: [ 24, 30, 33 , 34]
       fail-fast: false
     runs-on: macos-11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         api-level: [ 24, 30, 33 , 34]
-        system-image:
-          - { api: 34, image: "default" }
       fail-fast: false
     runs-on: macos-11
     steps:
@@ -44,7 +42,7 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2
         env:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
-        if: ${{ matrix.api-level != 33 }}
+        if: ${{ matrix.api-level != 33 && matrix.api-level != 34 }}
         with:
           api-level: ${{ matrix.api-level }}
           target: default
@@ -60,7 +58,7 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2
         env:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
-        if: ${{ matrix.api-level == 33 }}
+        if: ${{ matrix.api-level == 33 || matrix.api-level == 34 }}
         with:
           api-level: ${{ matrix.api-level }}
           target: google_apis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Restore Cache
         uses: actions/cache@v3

--- a/.github/workflows/fdroid_nightly.yml
+++ b/.github/workflows/fdroid_nightly.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: build debug

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache
@@ -93,10 +93,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache
@@ -131,10 +131,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build all configurations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Retrieve secrets to files

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ fun generateVersionCode() =
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
 
 android {
-
+  namespace = "org.kiwix.kiwixmobile"
   defaultConfig {
     base.archivesName.set(apkPrefix)
     resValue("string", "app_name", "Kiwix")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,9 @@ fun generateVersionCode() =
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
 
 android {
+  // Added namespace in response to Gradle 8.0 and above.
+  // This is now specified in the Gradle configuration instead of declaring
+  // it directly in the AndroidManifest file.
   namespace = "org.kiwix.kiwixmobile"
   defaultConfig {
     base.archivesName.set(apkPrefix)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -52,3 +52,33 @@
 -keepclassmembers class org.kiwix.kiwixmobile.core.entity.MetaLinkNetworkEntity$* {
     <init>(...);
 }
+
+-keep class javax.xml.stream.** { *; }
+-dontwarn javax.xml.stream.Location
+-dontwarn javax.xml.stream.XMLEventReader
+-dontwarn javax.xml.stream.XMLInputFactory
+-dontwarn javax.xml.stream.events.Attribute
+-dontwarn javax.xml.stream.events.Characters
+-dontwarn javax.xml.stream.events.StartElement
+-dontwarn javax.xml.stream.events.XMLEvent
+
+-keep class okhttp3.internal.** { *; }
+-dontwarn okhttp3.internal.Version
+-dontwarn okhttp3.internal.annotations.EverythingIsNonNull
+-dontwarn okhttp3.internal.http.HttpDate
+-dontwarn okhttp3.internal.http.UnrepeatableRequestBody
+
+-keep class org.bouncycastle.jsse.** { *; }
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+
+-keep class org.conscrypt.** { *; }
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+
+-keep class org.openjsse.javax.net.ssl.** { *; }
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.kiwix.kiwixmobile">
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
   <!-- support for androidx.test.orchestrator clearPackageData for android 33
        see more information here https://github.com/kiwix/kiwix-android/issues/3172

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
@@ -47,6 +47,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
+import org.kiwix.kiwixmobile.core.R.string
 
 /**
  * Created by mhutti1 on 14/04/17.
@@ -95,7 +96,7 @@ class NetworkTest {
   fun networkTest() {
     ActivityScenario.launch(KiwixMainActivity::class.java)
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    clickMenu(TestUtils.getResourceString(R.string.library))
+    clickMenu(TestUtils.getResourceString(string.library))
     TestUtils.allowStoragePermissionsIfNeeded()
     Espresso.onData(TestUtils.withContent("wikipedia_ab_all_2017-03"))
       .inAdapterView(ViewMatchers.withId(R.id.libraryList))
@@ -105,7 +106,7 @@ class NetworkTest {
     } catch (e: RuntimeException) {
       Log.w(NETWORK_TEST_TAG, "failed to perform click action on the view : ${e.localizedMessage} ")
     }
-    clickOn(R.string.local_zims)
+    clickOn(string.local_zims)
     try {
       Espresso.onData(CoreMatchers.allOf(ViewMatchers.withId(R.id.zim_swiperefresh)))
       refresh(R.id.zim_swiperefresh)
@@ -124,7 +125,7 @@ class NetworkTest {
         .inAdapterView(ViewMatchers.withId(R.id.zimfilelist))
       // TODO how can we get a count of the items matching the dataInteraction?
       dataInteraction.atPosition(0).perform(ViewActions.click())
-      clickMenu(R.string.library)
+      clickMenu(string.library)
       val dataInteraction1 = Espresso.onData(TestUtils.withContent("wikipedia_ab_all_2017-03"))
         .inAdapterView(ViewMatchers.withId(R.id.zimfilelist))
       dataInteraction1.atPosition(0).perform(ViewActions.longClick()) // to delete the zim file

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroRobot.kt
@@ -24,6 +24,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.main.TopLevelDestinationRobot
 import org.kiwix.kiwixmobile.main.topLevel
 
@@ -35,11 +36,11 @@ class IntroRobot : BaseRobot() {
 
   fun swipeLeft() {
     isVisible(getStarted)
-    isVisible(TextId(R.string.welcome_to_the_family))
-    isVisible(TextId(R.string.humankind_knowledge))
+    isVisible(TextId(string.welcome_to_the_family))
+    isVisible(TextId(string.humankind_knowledge))
     attempt(10) {
-      isVisible(TextId(R.string.save_books_offline))
-      isVisible(TextId(R.string.download_books_message))
+      isVisible(TextId(string.save_books_offline))
+      isVisible(TextId(string.download_books_message))
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -27,6 +27,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 /**
@@ -56,37 +57,37 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   fun assertLocalLibraryVisible() {
-    isVisible(TextId(R.string.library))
+    isVisible(TextId(string.library))
   }
 
   fun assertClickNearbyDeviceMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.click_nearby_devices_message))
+    isVisible(TextId(string.click_nearby_devices_message))
   }
 
   fun clickOnGotItButton() {
     pauseForBetterTestPerformance()
-    clickOn(TextId(R.string.got_it))
+    clickOn(TextId(string.got_it))
   }
 
   fun assertDeviceNameMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.your_device_name_message))
+    isVisible(TextId(string.your_device_name_message))
   }
 
   fun assertNearbyDeviceListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.nearby_devices_list_message))
+    isVisible(TextId(string.nearby_devices_list_message))
   }
 
   fun assertTransferZimFilesListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.transfer_zim_files_list_message))
+    isVisible(TextId(string.transfer_zim_files_list_message))
   }
 
   fun assertClickNearbyDeviceMessageNotVisible() {
     pauseForBetterTestPerformance()
-    onView(withText(R.string.click_nearby_devices_message)).check(doesNotExist())
+    onView(withText(string.click_nearby_devices_message)).check(doesNotExist())
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
@@ -23,6 +23,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.help.help
 import org.kiwix.kiwixmobile.nav.destination.library.LibraryRobot
@@ -73,7 +74,7 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickBookmarksOnNavDrawer(func: BookmarksRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.bookmarks))
+      clickOn(TextId(string.bookmarks))
       bookmarks(func)
       pressBack()
     }
@@ -81,7 +82,7 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickHistoryOnSideNav(func: HistoryRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.history))
+      clickOn(TextId(string.history))
       history(func)
       pressBack()
     }
@@ -89,32 +90,32 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickHostBooksOnSideNav(func: ZimHostRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_wifi_hotspot))
+      clickOn(TextId(string.menu_wifi_hotspot))
       zimHost(func)
     }
   }
 
   fun clickSettingsOnSideNav(func: SettingsRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_settings))
+      clickOn(TextId(string.menu_settings))
       settingsRobo(func)
     }
   }
 
   fun clickHelpOnSideNav(func: HelpRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_help))
+      clickOn(TextId(string.menu_help))
       help(func)
     }
   }
 
   fun clickSupportKiwixOnSideNav() {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_support_kiwix))
+      clickOn(TextId(string.menu_support_kiwix))
     }
   }
 
   fun assertExternalLinkDialogDisplayed() {
-    isVisible(TextId(R.string.external_link_popup_dialog_title))
+    isVisible(TextId(string.external_link_popup_dialog_title))
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
@@ -21,7 +21,7 @@ package org.kiwix.kiwixmobile.nav.destination.reader
 import applyWithViewHierarchyPrinting
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 
 fun reader(func: ReaderRobot.() -> Unit) = ReaderRobot().applyWithViewHierarchyPrinting(func)
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -23,7 +23,7 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 
 fun bookmarks(func: BookmarksRobot.() -> Unit) =
   BookmarksRobot().applyWithViewHierarchyPrinting(func)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
@@ -23,7 +23,7 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 
 fun history(func: HistoryRobot.() -> Unit) = HistoryRobot().applyWithViewHierarchyPrinting(func)
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -26,7 +26,7 @@ import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 fun navigationHistory(func: NavigationHistoryRobot.() -> Unit) =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
@@ -27,6 +27,7 @@ import com.adevinta.android.barista.interaction.BaristaDialogInteractions
 import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawerWithGravity
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 /**
@@ -35,7 +36,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 object StandardActions {
   fun enterSettings() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    clickOn(TestUtils.getResourceString(R.string.menu_settings))
+    clickOn(TestUtils.getResourceString(string.menu_settings))
   }
 
   fun openDrawer() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -33,7 +33,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.RecyclerViewItemCount
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
@@ -50,7 +50,7 @@ class ZimHostRobot : BaseRobot() {
 
   fun refreshLibraryList() {
     pauseForBetterTestPerformance()
-    refresh(R.id.zim_swiperefresh)
+    refresh(org.kiwix.kiwixmobile.R.id.zim_swiperefresh)
   }
 
   fun assertZimFilesLoaded() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission
     android:name="android.permission.ACCESS_FINE_LOCATION"

--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -35,6 +35,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.drawable
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -82,8 +84,8 @@ class LanguageFragment : BaseFragment() {
 
     activity.supportActionBar?.let {
       it.setDisplayHomeAsUpEnabled(true)
-      it.setHomeAsUpIndicator(R.drawable.ic_clear_white_24dp)
-      it.setTitle(R.string.select_languages)
+      it.setHomeAsUpIndicator(drawable.ic_clear_white_24dp)
+      it.setTitle(string.select_languages)
     }
     activityLanguageBinding?.languageRecyclerView?.run {
       adapter = languageAdapter

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -55,6 +55,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -177,23 +179,23 @@ class LocalFileTransferFragment :
         setConfig(config)
         addSequenceItem(
           it,
-          getString(R.string.click_nearby_devices_message),
-          getString(R.string.got_it)
+          getString(string.click_nearby_devices_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.textViewDeviceName,
-          getString(R.string.your_device_name_message),
-          getString(R.string.got_it)
+          getString(string.your_device_name_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.listPeerDevices,
-          getString(R.string.nearby_devices_list_message),
-          getString(R.string.got_it)
+          getString(string.nearby_devices_list_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.recyclerViewTransferFiles,
-          getString(R.string.transfer_zim_files_list_message),
-          getString(R.string.got_it)
+          getString(string.transfer_zim_files_list_message),
+          getString(string.got_it)
         )
         setOnItemDismissedListener { showcaseView, _ ->
           // To fix the memory leak by setting setTarget to null
@@ -245,7 +247,7 @@ class LocalFileTransferFragment :
     toolbar.title =
       if (isReceiver) getString(R.string.receive_files_title)
       else getString(R.string.send_files_title)
-    toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
+    toolbar.setNavigationIcon(drawable.ic_close_white_24dp)
     toolbar.setNavigationOnClickListener { activity.popNavigationBackstack() }
   }
 
@@ -390,12 +392,12 @@ class LocalFileTransferFragment :
       when (requestCode) {
         PERMISSION_REQUEST_FINE_LOCATION -> {
           Log.e(TAG, "Location permission not granted")
-          toast(R.string.permission_refused_location, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_location, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
         PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS -> {
           Log.e(TAG, "Storage write permission not granted")
-          toast(R.string.permission_refused_storage, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_storage, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
         else ->
@@ -437,7 +439,7 @@ class LocalFileTransferFragment :
       KiwixDialog.EnableLocationServices, {
         enableLocationServicesLauncher.launch(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
       },
-      { toast(R.string.discovery_needs_location, Toast.LENGTH_SHORT) }
+      { toast(string.discovery_needs_location, Toast.LENGTH_SHORT) }
     )
   }
 
@@ -446,7 +448,7 @@ class LocalFileTransferFragment :
       KiwixDialog.EnableWifiP2pServices, {
         startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
       },
-      { toast(R.string.discovery_needs_wifi, Toast.LENGTH_SHORT) }
+      { toast(string.discovery_needs_wifi, Toast.LENGTH_SHORT) }
     )
   }
 
@@ -458,7 +460,7 @@ class LocalFileTransferFragment :
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
       if (result.resultCode != Activity.RESULT_OK) {
         if (!isLocationServiceEnabled) {
-          toast(R.string.permission_refused_location, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_location, Toast.LENGTH_SHORT)
         }
       }
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -39,7 +39,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.LifecycleCoroutineScope
 import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -33,6 +33,8 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.navigation.NavigationView
 import org.kiwix.kiwixmobile.BuildConfig
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.R.mipmap
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -116,18 +118,25 @@ class KiwixMainActivity : CoreMainActivity() {
     super.onConfigurationChanged(newConfig)
     if (::activityKiwixMainBinding.isInitialized) {
       activityKiwixMainBinding.bottomNavView.menu.apply {
-        findItem(R.id.readerFragment)?.title = resources.getString(R.string.reader)
-        findItem(R.id.libraryFragment)?.title = resources.getString(R.string.library)
-        findItem(R.id.downloadsFragment)?.title = resources.getString(R.string.download)
+        findItem(R.id.readerFragment)?.title = resources.getString(string.reader)
+        findItem(R.id.libraryFragment)?.title = resources.getString(string.library)
+        findItem(R.id.downloadsFragment)?.title = resources.getString(string.download)
       }
       activityKiwixMainBinding.drawerNavView.menu.apply {
-        findItem(R.id.menu_bookmarks_list)?.title = resources.getString(R.string.bookmarks)
-        findItem(R.id.menu_history)?.title = resources.getString(R.string.history)
-        findItem(R.id.menu_notes)?.title = resources.getString(R.string.pref_notes)
-        findItem(R.id.menu_host_books)?.title = resources.getString(R.string.menu_wifi_hotspot)
-        findItem(R.id.menu_settings)?.title = resources.getString(R.string.menu_settings)
-        findItem(R.id.menu_help)?.title = resources.getString(R.string.menu_help)
-        findItem(R.id.menu_support_kiwix)?.title = resources.getString(R.string.menu_support_kiwix)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_bookmarks_list)?.title =
+          resources.getString(string.bookmarks)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_history)?.title =
+          resources.getString(string.history)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_notes)?.title =
+          resources.getString(string.pref_notes)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.title =
+          resources.getString(string.menu_wifi_hotspot)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_settings)?.title =
+          resources.getString(string.menu_settings)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_help)?.title =
+          resources.getString(string.menu_help)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_support_kiwix)?.title =
+          resources.getString(string.menu_support_kiwix)
       }
     }
   }
@@ -184,5 +193,5 @@ class KiwixMainActivity : CoreMainActivity() {
     }
   }
 
-  override fun getIconResId() = R.mipmap.ic_launcher
+  override fun getIconResId() = mipmap.ic_launcher
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -57,6 +57,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -122,9 +123,9 @@ class LocalLibraryFragment : BaseFragment() {
           fileManagementNoFiles.visibility = VISIBLE
           goToDownloadsButtonNoFiles.visibility = VISIBLE
           fileManagementNoFiles.text =
-            requireActivity().resources.getString(R.string.grant_read_storage_permission)
+            requireActivity().resources.getString(string.grant_read_storage_permission)
           goToDownloadsButtonNoFiles.text =
-            requireActivity().resources.getString(R.string.go_to_settings_label)
+            requireActivity().resources.getString(string.go_to_settings_label)
           zimfilelist.visibility = GONE
         }
       } else if (isGranted) {
@@ -165,7 +166,7 @@ class LocalLibraryFragment : BaseFragment() {
     activity.setSupportActionBar(toolbar)
     activity.supportActionBar?.apply {
       setDisplayHomeAsUpEnabled(true)
-      setTitle(R.string.library)
+      setTitle(string.library)
     }
     if (toolbar != null) {
       activity.setupDrawerToggle(toolbar)
@@ -312,12 +313,12 @@ class LocalLibraryFragment : BaseFragment() {
       requireActivity().applicationContext, uri
     )
     if (filePath == null || !File(filePath).exists()) {
-      activity.toast(R.string.error_file_not_found)
+      activity.toast(string.error_file_not_found)
       return null
     }
     val file = File(filePath)
     return if (!FileUtils.isValidZimFile(file.path)) {
-      activity.toast(R.string.error_file_invalid)
+      activity.toast(string.error_file_invalid)
       null
     } else {
       file
@@ -326,7 +327,7 @@ class LocalLibraryFragment : BaseFragment() {
 
   private fun navigateToReaderFragment(file: File) {
     if (!file.canRead()) {
-      activity.toast(R.string.unable_to_read_zim_file)
+      activity.toast(string.unable_to_read_zim_file)
     } else {
       activity?.navigate(
         LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
@@ -395,9 +396,9 @@ class LocalLibraryFragment : BaseFragment() {
     actionMode?.title = String.format("%d", state.selectedBooks.size)
     fragmentDestinationLibraryBinding?.apply {
       if (items.isEmpty()) {
-        fileManagementNoFiles.text = requireActivity().resources.getString(R.string.no_files_here)
+        fileManagementNoFiles.text = requireActivity().resources.getString(string.no_files_here)
         goToDownloadsButtonNoFiles.text =
-          requireActivity().resources.getString(R.string.download_books)
+          requireActivity().resources.getString(string.download_books)
 
         fileManagementNoFiles.visibility = View.VISIBLE
         goToDownloadsButtonNoFiles.visibility = View.VISIBLE
@@ -422,7 +423,7 @@ class LocalLibraryFragment : BaseFragment() {
       ) != PackageManager.PERMISSION_GRANTED
     ) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-        context.toast(R.string.request_storage)
+        context.toast(string.request_storage)
         storagePermissionLauncher?.launch(
           arrayOf(
             Manifest.permission.READ_EXTERNAL_STORAGE,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -53,6 +53,7 @@ import com.tonyodev.fetch2.Status
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageSelectDialog
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -163,7 +164,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     activity.setSupportActionBar(toolbar)
     activity.supportActionBar?.apply {
       setDisplayHomeAsUpEnabled(true)
-      setTitle(R.string.download)
+      setTitle(string.download)
     }
     if (toolbar != null) {
       activity.setupDrawerToggle(toolbar)
@@ -250,7 +251,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       {
         onRefreshStateChange(false)
         context.toast(
-          resources.getString(R.string.denied_internet_permission_message),
+          resources.getString(string.denied_internet_permission_message),
           Toast.LENGTH_SHORT
         )
         hideRecyclerviewAndShowSwipeDownForLibraryErrorText()
@@ -268,7 +269,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private fun hideRecyclerviewAndShowSwipeDownForLibraryErrorText() {
     fragmentDestinationDownloadBinding?.apply {
       libraryErrorText.setText(
-        R.string.swipe_down_for_library
+        string.swipe_down_for_library
       )
       libraryErrorText.visibility = View.VISIBLE
       libraryList.visibility = View.GONE
@@ -314,7 +315,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       noInternetSnackbar()
     } else {
       fragmentDestinationDownloadBinding?.libraryErrorText?.setText(
-        R.string.no_network_connection
+        string.no_network_connection
       )
       fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
     }
@@ -323,9 +324,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   private fun noInternetSnackbar() {
     fragmentDestinationDownloadBinding?.libraryList?.snack(
-      R.string.no_network_connection,
+      string.no_network_connection,
       requireActivity().findViewById(R.id.bottom_nav_view),
-      R.string.menu_settings,
+      string.menu_settings,
       ::openNetworkSettings
     )
   }
@@ -340,8 +341,8 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     }
     if (it?.isEmpty() == true) {
       fragmentDestinationDownloadBinding?.libraryErrorText?.setText(
-        if (isNotConnected) R.string.no_network_connection
-        else R.string.no_items_msg
+        if (isNotConnected) string.no_network_connection
+        else string.no_items_msg
       )
       fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
     } else {
@@ -382,7 +383,8 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
           Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
         ) {
-          val view = LayoutInflater.from(activity).inflate(R.layout.select_folder_dialog, null)
+          val view = LayoutInflater.from(activity)
+            .inflate(org.kiwix.kiwixmobile.core.R.layout.select_folder_dialog, null)
           dialogShower.show(SelectFolder { view }, ::selectFolder)
         } else {
           setExternalStoragePath(storageDevice)
@@ -418,7 +420,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         } ?: run {
           activity.toast(
             resources
-              .getString(R.string.system_unable_to_grant_permission_message),
+              .getString(string.system_unable_to_grant_permission_message),
             Toast.LENGTH_SHORT
           )
         }
@@ -530,11 +532,11 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
               {
                 fragmentDestinationDownloadBinding?.libraryList?.snack(
                   """ 
-                ${getString(R.string.download_no_space)}
-                ${getString(R.string.space_available)} $it
+                ${getString(string.download_no_space)}
+                ${getString(string.space_available)} $it
                   """.trimIndent(),
                   requireActivity().findViewById(R.id.bottom_nav_view),
-                  R.string.download_change_storage,
+                  string.download_change_storage,
                   ::showStorageSelectDialog
                 )
               }
@@ -551,7 +553,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     .apply {
       onSelectAction = ::storeDeviceInPreferences
     }
-    .show(parentFragmentManager, getString(R.string.pref_storage))
+    .show(parentFragmentManager, getString(string.pref_storage))
 
   private fun showStorageConfigureDialog() {
     alertDialogShower.show(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -36,6 +36,8 @@ import androidx.core.net.toFile
 import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R.anim
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -107,7 +109,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     )
 
     if (filePath == null || !File(filePath).isFileExist()) {
-      activity.toast(R.string.error_file_not_found)
+      activity.toast(string.error_file_not_found)
       return
     }
     openZimFile(File(filePath))
@@ -121,7 +123,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
   private fun exitBook() {
     showNoBookOpenViews()
     bottomToolbar?.visibility = GONE
-    actionBar?.title = getString(R.string.reader)
+    actionBar?.title = getString(string.reader)
     contentFrame?.visibility = GONE
     mainMenu?.hideBookSpecificMenuItems()
     closeZimBook()
@@ -146,7 +148,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
 
       setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
 
-      closeAllTabsButton?.setImageDrawableCompat(R.drawable.ic_close_black_24dp)
+      closeAllTabsButton?.setImageDrawableCompat(drawable.ic_close_black_24dp)
       if (tabSwitcherRoot?.visibility == View.VISIBLE) {
         tabSwitcherRoot?.visibility = GONE
         startAnimation(tabSwitcherRoot, anim.slide_up)
@@ -233,7 +235,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
         zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
       }
     } else {
-      getCurrentWebView()?.snack(R.string.zim_not_opened)
+      getCurrentWebView()?.snack(string.zim_not_opened)
     }
     restoreTabs(zimArticles, zimPositions, currentTab)
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
@@ -62,7 +62,8 @@ class ScrollingViewWithBottomNavigationBehavior(context: Context, attrs: Attribu
     navigationBar: BottomNavigationView,
     coordinatorLayout: CoordinatorLayout
   ): Boolean {
-    val readerBottomAppBar: BottomAppBar? = fragmentContainer.findViewById(R.id.bottom_toolbar)
+    val readerBottomAppBar: BottomAppBar? =
+      fragmentContainer.findViewById(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar)
     if (readerBottomAppBar != null) {
       val newBottomMargin = calculateNewBottomMargin(navigationBar, coordinatorLayout)
       if (newBottomMargin != bottomMargin) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
@@ -28,7 +28,7 @@ import androidx.preference.PreferenceCategory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.settings.CorePrefsFragment
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -68,9 +68,9 @@ class KiwixPrefsFragment : CorePrefsFragment() {
       showPermissionPreference()
       val externalStorageManager = Environment.isExternalStorageManager()
       if (externalStorageManager) {
-        permissionPref?.setSummary(org.kiwix.kiwixmobile.core.R.string.allowed)
+        permissionPref?.setSummary(R.string.allowed)
       } else {
-        permissionPref?.setSummary(org.kiwix.kiwixmobile.core.R.string.not_allowed)
+        permissionPref?.setSummary(R.string.not_allowed)
       }
       permissionPref?.onPreferenceClickListener =
         Preference.OnPreferenceClickListener {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/Fat32Checker.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.zimManager
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.FileObserver
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
@@ -62,12 +63,21 @@ class Fat32Checker constructor(
       )
   }
 
+  @Suppress("DEPRECATION")
   private fun fileObserver(it: String): FileObserver =
-    object : FileObserver(File(it), MOVED_FROM or DELETE) {
-      override fun onEvent(event: Int, path: String?) {
-        requestCheckSystemFileType.onNext(Unit)
-      }
-    }.apply { startWatching() }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      object : FileObserver(File(it), MOVED_FROM or DELETE) {
+        override fun onEvent(event: Int, path: String?) {
+          requestCheckSystemFileType.onNext(Unit)
+        }
+      }.apply { startWatching() }
+    } else {
+      object : FileObserver(it, MOVED_FROM or DELETE) {
+        override fun onEvent(event: Int, path: String?) {
+          requestCheckSystemFileType.onNext(Unit)
+        }
+      }.apply { startWatching() }
+    }
 
   private fun toFileSystemState(it: String) =
     when {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -19,7 +19,7 @@
 package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
@@ -20,7 +20,7 @@ package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.canReadFile

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:7.4.2")
+  implementation("com.android.tools.build:gradle:8.1.3")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
   implementation("org.jacoco:org.jacoco.core:0.8.8")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   implementation("com.android.tools.build:gradle:8.1.3")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
   implementation("org.jacoco:org.jacoco.core:0.8.8")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20230406-2.0.0") {

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -22,9 +22,9 @@ object Config {
 
   // Here is a list of all Android versions with their corresponding API
   // levels: https://apilevels.com/
-  const val compileSdk = 33 // SDK version used by Gradle to compile our app.
+  const val compileSdk = 34 // SDK version used by Gradle to compile our app.
   const val minSdk = 24 // Minimum SDK (Minimum Support Device) is 24 (Android 7.0 Nougat).
-  const val targetSdk = 33 // Target SDK (Maximum Support Device) is 33 (Android 13).
+  const val targetSdk = 34 // Target SDK (Maximum Support Device) is 34 (Android 14).
 
   val javaVersion = JavaVersion.VERSION_1_8
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -139,23 +139,6 @@ object Libs {
     Versions.com_google_dagger
 
   /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife: String = "com.jakewharton:butterknife:" + Versions.com_jakewharton
-
-  /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife_compiler: String = "com.jakewharton:butterknife-compiler:" +
-    Versions.com_jakewharton
-
-  /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife_gradle_plugin: String = "com.jakewharton:butterknife-gradle-plugin:" +
-    Versions.com_jakewharton
-
-  /**
    * https://developer.android.com/testing
    */
   const val androidx_test_core: String = "androidx.test:core:" + Versions.androidx_test_core

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -44,7 +44,7 @@ object Versions {
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
-  const val com_android_tools_build_gradle: String = "7.4.2"
+  const val com_android_tools_build_gradle: String = "8.1.3"
 
   const val de_fayard_buildsrcversions_gradle_plugin: String = "0.7.0"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,13 +22,13 @@ object Versions {
 
   const val com_squareup_okhttp3: String = "4.9.0"
 
-  const val org_jetbrains_kotlin: String = "1.7.0"
+  const val org_jetbrains_kotlin: String = "1.9.20"
 
   const val androidx_navigation: String = "2.5.3"
 
   const val navigation_ui_ktx: String = "2.4.1"
 
-  const val com_google_dagger: String = "2.42"
+  const val com_google_dagger: String = "2.48.1"
 
   const val com_jakewharton: String = "10.2.3"
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -45,6 +45,7 @@ class AllProjectConfigurer {
 
   fun configureBaseExtension(target: Project) {
     target.configureExtension<BaseExtension> {
+      namespace = ""
       setCompileSdkVersion(Config.compileSdk)
       defaultConfig {
         minSdk = Config.minSdk
@@ -115,7 +116,7 @@ class AllProjectConfigurer {
   }
 
   fun configureCommonExtension(target: Project) {
-    target.configureExtension<CommonExtension<*, *, *, *>> {
+    target.configureExtension<CommonExtension<*, *, *, *, *>> {
       lint {
         abortOnError = true
         checkAllWarnings = true

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -68,7 +68,15 @@ class AllProjectConfigurer {
       target.tasks.withType(KotlinCompile::class.java) {
         kotlinOptions.jvmTarget = "1.8"
       }
-      buildFeatures.viewBinding = true
+      buildFeatures.apply {
+        viewBinding = true
+        /*
+         * By default, the generation of the `BuildConfig` class is turned off in Gradle `8.1.3`.
+         * Since we are setting and using `buildConfig` properties in our project,
+         * enabling this attribute will generate the `BuildConfig` file.
+         */
+        buildConfig = true
+      }
 
       testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -43,9 +43,18 @@ class AllProjectConfigurer {
     target.plugins.apply("androidx.navigation.safeargs")
   }
 
-  fun configureBaseExtension(target: Project) {
+  fun configureBaseExtension(target: Project, isLibrary: Boolean) {
     target.configureExtension<BaseExtension> {
-      namespace = ""
+      // The namespace cannot be directly set in `LibraryExtension`.
+      // The core module is configured as a library for both Kiwix and custom apps.
+      // Therefore, we set the namespace in `BaseExtension` for the core module,
+      // based on the boolean value of `isLibrary`. This value is passed from the
+      // `KiwixConfigurationPlugin`. If the current plugin is `LibraryPlugin`,
+      // indicating it is the core module, then this value will be true,
+      // and we set the namespace accordingly.
+      if (isLibrary) {
+        namespace = "org.kiwix.kiwixmobile.core"
+      }
       setCompileSdkVersion(Config.compileSdk)
       defaultConfig {
         minSdk = Config.minSdk

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -219,8 +219,6 @@ class AllProjectConfigurer {
       implementation(Libs.core_ktx)
       implementation(Libs.fragment_ktx)
       implementation(Libs.collection_ktx)
-      implementation(Libs.butterknife)
-      kapt(Libs.butterknife_compiler)
       implementation(Libs.fetch)
       implementation(Libs.rxandroid)
       implementation(Libs.rxjava)

--- a/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
@@ -33,10 +33,10 @@ class KiwixConfigurationPlugin : Plugin<Project> {
     target.plugins.all {
       when (this) {
         is LibraryPlugin -> {
-          doDefaultConfiguration(target)
+          doDefaultConfiguration(target, true)
         }
         is AppPlugin -> {
-          doDefaultConfiguration(target)
+          doDefaultConfiguration(target, false)
           appConfigurer.configure(target)
         }
       }
@@ -47,8 +47,8 @@ class KiwixConfigurationPlugin : Plugin<Project> {
     allProjectConfigurer.configureJacoco(target)
   }
 
-  private fun doDefaultConfiguration(target: Project) {
-    allProjectConfigurer.configureBaseExtension(target)
+  private fun doDefaultConfiguration(target: Project, isLibrary: Boolean) {
+    allProjectConfigurer.configureBaseExtension(target, isLibrary)
     allProjectConfigurer.configureCommonExtension(target)
   }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,7 +9,6 @@ buildscript {
 
   dependencies {
     classpath(Libs.objectbox_gradle_plugin)
-    classpath(Libs.butterknife_gradle_plugin)
   }
 }
 plugins {
@@ -17,7 +16,6 @@ plugins {
 }
 plugins.apply(KiwixConfigurationPlugin::class)
 apply(plugin = "io.objectbox")
-apply(plugin = "com.jakewharton.butterknife")
 
 /*
 * max version code: 21-0-0-00-00-00

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile.core"
   android:installLocation="auto">
 
   <uses-permission

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
@@ -18,10 +18,7 @@
 package org.kiwix.kiwixmobile.core.base
 
 import android.os.Bundle
-import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
-import butterknife.ButterKnife
-import butterknife.Unbinder
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
@@ -33,23 +30,11 @@ abstract class BaseActivity : AppCompatActivity() {
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
-  private var unbinder: Unbinder? = null
-
   protected abstract fun injection(coreComponent: CoreComponent)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     injection(CoreApp.coreComponent)
     super.onCreate(savedInstanceState)
     LanguageUtils.handleLocaleChange(this, sharedPreferenceUtil)
-  }
-
-  override fun setContentView(@LayoutRes layoutResID: Int) {
-    super.setContentView(layoutResID)
-    unbinder = ButterKnife.bind(this)
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    unbinder?.unbind()
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
@@ -48,7 +48,8 @@ import com.tonyodev.fetch2.Fetch
 import com.tonyodev.fetch2.util.DEFAULT_NOTIFICATION_TIMEOUT_AFTER_RESET
 import org.kiwix.kiwixmobile.core.Intents
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.R.string
+import com.tonyodev.fetch2.R.string
+import com.tonyodev.fetch2.R.drawable
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 
 const val DOWNLOAD_NOTIFICATION_TITLE = "OPEN_ZIM_FILE"
@@ -62,7 +63,7 @@ class FetchDownloadNotificationManager(private val context: Context) :
     notificationManager: NotificationManager
   ) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      val channelId = context.getString(R.string.fetch_notification_default_channel_id)
+      val channelId = context.getString(string.fetch_notification_default_channel_id)
       if (notificationManager.getNotificationChannel(channelId) == null) {
         notificationManager.createNotificationChannel(createChannel(channelId, context))
       }
@@ -99,23 +100,23 @@ class FetchDownloadNotificationManager(private val context: Context) :
       downloadNotification.isDownloading ->
         notificationBuilder.setTimeoutAfter(getNotificationTimeOutMillis())
           .addAction(
-            R.drawable.fetch_notification_cancel,
+            drawable.fetch_notification_cancel,
             context.getString(R.string.cancel),
             getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.DELETE)
           ).addAction(
-            R.drawable.fetch_notification_pause,
+            drawable.fetch_notification_pause,
             context.getString(R.string.tts_pause),
             getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.PAUSE)
           )
       downloadNotification.isPaused ->
         notificationBuilder.setTimeoutAfter(getNotificationTimeOutMillis())
           .addAction(
-            R.drawable.fetch_notification_resume,
+            drawable.fetch_notification_resume,
             context.getString(R.string.tts_resume),
             getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.RESUME)
           )
           .addAction(
-            R.drawable.fetch_notification_cancel,
+            drawable.fetch_notification_cancel,
             context.getString(R.string.cancel),
             getActionPendingIntent(downloadNotification, DownloadNotification.ActionType.DELETE)
           )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
@@ -25,7 +25,9 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.app.PendingIntent.getActivity
 import android.content.Context
+import android.content.Context.RECEIVER_EXPORTED
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import androidx.annotation.RequiresApi
@@ -184,4 +186,16 @@ class FetchDownloadNotificationManager(private val context: Context) :
       setSound(null, null)
       enableVibration(false)
     }
+
+  override fun registerBroadcastReceiver() {
+    if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(
+        broadcastReceiver,
+        IntentFilter(notificationManagerAction),
+        RECEIVER_EXPORTED
+      )
+    } else {
+      super.registerBroadcastReceiver()
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/fetch/FetchDownloadNotificationManager.kt
@@ -25,7 +25,7 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.app.PendingIntent.getActivity
 import android.content.Context
-import android.content.Context.RECEIVER_EXPORTED
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
@@ -47,11 +47,12 @@ import com.tonyodev.fetch2.EXTRA_NAMESPACE
 import com.tonyodev.fetch2.EXTRA_NOTIFICATION_GROUP_ID
 import com.tonyodev.fetch2.EXTRA_NOTIFICATION_ID
 import com.tonyodev.fetch2.Fetch
+import com.tonyodev.fetch2.R.drawable
+import com.tonyodev.fetch2.R.string
 import com.tonyodev.fetch2.util.DEFAULT_NOTIFICATION_TIMEOUT_AFTER_RESET
+import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.Intents
 import org.kiwix.kiwixmobile.core.R
-import com.tonyodev.fetch2.R.string
-import com.tonyodev.fetch2.R.drawable
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 
 const val DOWNLOAD_NOTIFICATION_TITLE = "OPEN_ZIM_FILE"
@@ -189,10 +190,10 @@ class FetchDownloadNotificationManager(private val context: Context) :
 
   override fun registerBroadcastReceiver() {
     if (Build.VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(
+      CoreApp.instance.applicationContext.registerReceiver(
         broadcastReceiver,
         IntentFilter(notificationManagerAction),
-        RECEIVER_EXPORTED
+        RECEIVER_NOT_EXPORTED
       )
     } else {
       super.registerBroadcastReceiver()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -83,11 +83,6 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnClick
-import butterknife.OnLongClick
-import butterknife.Unbinder
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.bottomappbar.BottomAppBar
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -102,12 +97,12 @@ import org.json.JSONException
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.R2
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewBookmarksDao
+import org.kiwix.kiwixmobile.core.databinding.FragmentReaderBinding
 import org.kiwix.kiwixmobile.core.downloader.fetch.DOWNLOAD_NOTIFICATION_TITLE
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.consumeObservable
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
@@ -179,51 +174,52 @@ abstract class CoreReaderFragment :
   NavigationHistoryClickListener {
   protected val webViewList: MutableList<KiwixWebView> = ArrayList()
   private val webUrlsProcessor = BehaviorProcessor.create<String>()
+  private var fragmentReaderBinding: FragmentReaderBinding? = null
 
-  @JvmField
-  @BindView(R2.id.toolbar)
-  var toolbar: Toolbar? = null
+  val toolbar: Toolbar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.toolbar)
+  }
 
-  @JvmField
-  @BindView(R2.id.fragment_main_app_bar)
-  var toolbarContainer: AppBarLayout? = null
+  val toolbarContainer: AppBarLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.fragment_main_app_bar)
+  }
 
-  @JvmField
-  @BindView(R2.id.main_fragment_progress_view)
-  var progressBar: ContentLoadingProgressBar? = null
+  val progressBar: ContentLoadingProgressBar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.main_fragment_progress_view)
+  }
 
-  @JvmField
-  @BindView(R2.id.navigation_fragment_main_drawer_layout)
-  var drawerLayout: DrawerLayout? = null
+  val drawerLayout: DrawerLayout? by lazy {
+    fragmentReaderBinding?.navigationFragmentMainDrawerLayout
+  }
   protected var tableDrawerRightContainer: NavigationView? = null
 
-  @JvmField
-  @BindView(R2.id.activity_main_content_frame)
-  var contentFrame: FrameLayout? = null
+  val contentFrame: FrameLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_content_frame)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar)
-  var bottomToolbar: BottomAppBar? = null
+  val bottomToolbar: BottomAppBar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_tab_switcher)
-  var tabSwitcherRoot: View? = null
+  val tabSwitcherRoot: View? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tab_switcher)
+  }
 
-  @JvmField
-  @BindView(R2.id.tab_switcher_close_all_tabs)
-  var closeAllTabsButton: FloatingActionButton? = null
+  val closeAllTabsButton: FloatingActionButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_close_all_tabs)
+  }
 
-  @JvmField
-  @BindView(R2.id.fullscreen_video_container)
-  var videoView: ViewGroup? = null
+  val videoView: ViewGroup? by lazy {
+    fragmentReaderBinding?.fullscreenVideoContainer
+  }
 
-  @JvmField
-  @BindView(R2.id.go_to_library_button_no_open_book)
-  var noOpenBookButton: Button? = null
+  val noOpenBookButton: Button? by lazy {
+    fragmentReaderBinding?.goToLibraryButtonNoOpenBook
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_root)
-  var activityMainRoot: View? = null
+  val activityMainRoot: View? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_root)
+  }
 
   @JvmField
   @Inject
@@ -260,49 +256,57 @@ abstract class CoreReaderFragment :
   protected var actionBar: ActionBar? = null
   protected var mainMenu: MainMenu? = null
 
-  @JvmField
-  @BindView(R2.id.activity_main_back_to_top_fab)
-  var backToTopButton: FloatingActionButton? = null
+  val backToTopButton: FloatingActionButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_back_to_top_fab)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_button_stop_tts)
-  var stopTTSButton: Button? = null
+  val stopTTSButton: Button? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_stop_tts)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_button_pause_tts)
-  var pauseTTSButton: Button? = null
+  val pauseTTSButton: Button? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_pause_tts)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_tts_controls)
-  var ttsControls: Group? = null
+  val ttsControls: Group? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tts_controls)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_fullscreen_button)
-  var exitFullscreenButton: ImageButton? = null
+  val exitFullscreenButton: ImageButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_fullscreen_button)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_bookmark)
-  var bottomToolbarBookmark: ImageView? = null
+  val bottomToolbarBookmark: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_bookmark)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_arrow_back)
-  var bottomToolbarArrowBack: ImageView? = null
+  val bottomToolbarArrowBack: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_back)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_arrow_forward)
-  var bottomToolbarArrowForward: ImageView? = null
+  val bottomToolbarArrowForward: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_forward)
+  }
 
-  @JvmField
-  @BindView(R2.id.tab_switcher_recycler_view)
-  var tabRecyclerView: RecyclerView? = null
+  val bottomToolbarHome: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_home)
+  }
 
-  @JvmField
-  @BindView(R2.id.snackbar_root)
-  var snackBarRoot: CoordinatorLayout? = null
+  val tabRecyclerView: RecyclerView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_recycler_view)
+  }
 
-  @JvmField
-  @BindView(R2.id.no_open_book_text)
-  var noOpenBookText: TextView? = null
+  val snackBarRoot: CoordinatorLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.snackbar_root)
+  }
+
+  val noOpenBookText: TextView? by lazy {
+    fragmentReaderBinding?.noOpenBookText
+  }
+
+  val bottomToolbarToc: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_toc)
+  }
 
   @JvmField
   @Inject
@@ -335,7 +339,6 @@ abstract class CoreReaderFragment :
   private var tabCallback: ItemTouchHelper.Callback? = null
   private var bookmarkingDisposable: Disposable? = null
   private var isBookmarked = false
-  private var unbinder: Unbinder? = null
   private lateinit var serviceConnection: ServiceConnection
   private var readAloudService: ReadAloudService? = null
   private var navigationHistoryList: MutableList<NavigationHistoryListItem> = ArrayList()
@@ -516,6 +519,53 @@ abstract class CoreReaderFragment :
       viewLifecycleOwner,
       Observer(::openSearchItem)
     )
+    backToTopButton?.setOnClickListener {
+      backToTop()
+    }
+    stopTTSButton?.setOnClickListener {
+      stopTts()
+    }
+    pauseTTSButton?.setOnClickListener {
+      pauseTts()
+    }
+    exitFullscreenButton?.setOnClickListener {
+      closeFullScreen()
+    }
+    bottomToolbarBookmark?.apply {
+      setOnClickListener {
+        toggleBookmark()
+      }
+      setOnLongClickListener {
+        goToBookmarks()
+      }
+    }
+    bottomToolbarArrowBack?.apply {
+      setOnClickListener {
+        goBack()
+      }
+      setOnLongClickListener {
+        showBackwardHistory()
+        true
+      }
+    }
+    bottomToolbarArrowForward?.apply {
+      setOnClickListener {
+        goForward()
+      }
+      setOnLongClickListener {
+        showForwardHistory()
+        true
+      }
+    }
+    bottomToolbarToc?.setOnClickListener {
+      openToc()
+    }
+    closeAllTabsButton?.setOnClickListener {
+      closeAllTabs()
+    }
+    bottomToolbarHome?.setOnClickListener {
+      openMainPage()
+    }
   }
 
   private fun initTabCallback() {
@@ -575,9 +625,8 @@ abstract class CoreReaderFragment :
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    val root = inflater.inflate(R.layout.fragment_reader, container, false)
-    unbinder = ButterKnife.bind(this, root)
-    return root
+    fragmentReaderBinding = FragmentReaderBinding.inflate(inflater, container, false)
+    return fragmentReaderBinding?.root
   }
 
   private fun handleIntentExtras(intent: Intent) {
@@ -798,19 +847,18 @@ abstract class CoreReaderFragment :
     drawerLayout?.setDrawerLockMode(lockMode)
   }
 
-  @OnClick(R2.id.bottom_toolbar_arrow_back) fun goBack() {
+  fun goBack() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.goBack()
     }
   }
 
-  @OnClick(R2.id.bottom_toolbar_arrow_forward) fun goForward() {
+  fun goForward() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.goForward()
     }
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_arrow_back)
   fun showBackwardHistory() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
@@ -826,7 +874,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_arrow_forward)
   fun showForwardHistory() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
@@ -903,7 +950,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.bottom_toolbar_toc)
   fun openToc() {
     drawerLayout?.openDrawer(GravityCompat.END)
   }
@@ -1023,7 +1069,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_button_pause_tts)
   fun pauseTts() {
     if (tts?.currentTTSTask == null) {
       tts?.stop()
@@ -1043,7 +1088,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_button_stop_tts)
   fun stopTts() {
     tts?.stop()
     setActionAndStartTTSService(ACTION_STOP_TTS)
@@ -1074,7 +1118,6 @@ abstract class CoreReaderFragment :
     tabRecyclerView?.adapter = null
     tableDrawerRight?.adapter = null
     tableDrawerAdapter = null
-    unbinder?.unbind()
     webViewList.clear()
     tempWebViewListForUndo.clear()
     // create a base Activity class that class this.
@@ -1383,7 +1426,6 @@ abstract class CoreReaderFragment :
     return isPermissionGranted
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_bookmark)
   fun goToBookmarks(): Boolean {
     val parentActivity = requireActivity() as CoreMainActivity
     parentActivity.navigate(parentActivity.bookmarksFragmentResId)
@@ -1415,7 +1457,6 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("MagicNumber")
-  @OnClick(R2.id.activity_main_fullscreen_button)
   open fun closeFullScreen() {
     toolbarContainer?.visibility = View.VISIBLE
     updateBottomToolbarVisibility()
@@ -1568,7 +1609,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.tab_switcher_close_all_tabs)
   fun closeAllTabs() {
     closeAllTabsButton?.rotate()
     tempZimFileForUndo = zimReaderContainer?.zimFile
@@ -1628,7 +1668,6 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("NestedBlockDepth")
-  @OnClick(R2.id.bottom_toolbar_bookmark)
   fun toggleBookmark() {
     getCurrentWebView()?.url?.let { articleUrl ->
       if (isBookmarked) {
@@ -1806,7 +1845,6 @@ abstract class CoreReaderFragment :
     openArticle(articleUrl)
   }
 
-  @OnClick(R2.id.bottom_toolbar_home)
   fun openMainPage() {
     val articleUrl = zimReaderContainer?.mainPage
     openArticle(articleUrl)
@@ -1818,7 +1856,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_back_to_top_fab)
   fun backToTop() {
     getCurrentWebView()?.pageUp(true)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -189,9 +189,7 @@ abstract class CoreReaderFragment :
     fragmentReaderBinding?.root?.findViewById(R.id.main_fragment_progress_view)
   }
 
-  val drawerLayout: DrawerLayout? by lazy {
-    fragmentReaderBinding?.navigationFragmentMainDrawerLayout
-  }
+  var drawerLayout: DrawerLayout? = null
   protected var tableDrawerRightContainer: NavigationView? = null
 
   val contentFrame: FrameLayout? by lazy {
@@ -261,7 +259,7 @@ abstract class CoreReaderFragment :
     fragmentReaderBinding?.root?.findViewById(R.id.activity_main_back_to_top_fab)
   }
 
-  val stopTTSButton: Button? by lazy {
+  private val stopTTSButton: Button? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_stop_tts)
   }
 
@@ -273,39 +271,39 @@ abstract class CoreReaderFragment :
     fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tts_controls)
   }
 
-  val exitFullscreenButton: ImageButton? by lazy {
+  private val exitFullscreenButton: ImageButton? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.activity_main_fullscreen_button)
   }
 
-  val bottomToolbarBookmark: ImageView? by lazy {
+  private val bottomToolbarBookmark: ImageView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_bookmark)
   }
 
-  val bottomToolbarArrowBack: ImageView? by lazy {
+  private val bottomToolbarArrowBack: ImageView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_back)
   }
 
-  val bottomToolbarArrowForward: ImageView? by lazy {
+  private val bottomToolbarArrowForward: ImageView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_forward)
   }
 
-  val bottomToolbarHome: ImageView? by lazy {
+  private val bottomToolbarHome: ImageView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_home)
   }
 
-  val tabRecyclerView: RecyclerView? by lazy {
+  private val tabRecyclerView: RecyclerView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_recycler_view)
   }
 
-  val snackBarRoot: CoordinatorLayout? by lazy {
+  private val snackBarRoot: CoordinatorLayout? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.snackbar_root)
   }
 
-  val noOpenBookText: TextView? by lazy {
+  private val noOpenBookText: TextView? by lazy {
     fragmentReaderBinding?.noOpenBookText
   }
 
-  val bottomToolbarToc: ImageView? by lazy {
+  private val bottomToolbarToc: ImageView? by lazy {
     fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_toc)
   }
 
@@ -852,19 +850,19 @@ abstract class CoreReaderFragment :
     drawerLayout?.setDrawerLockMode(lockMode)
   }
 
-  fun goBack() {
+  private fun goBack() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.goBack()
     }
   }
 
-  fun goForward() {
+  private fun goForward() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.goForward()
     }
   }
 
-  fun showBackwardHistory() {
+  private fun showBackwardHistory() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
         navigationHistoryList.clear()
@@ -879,7 +877,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun showForwardHistory() {
+  private fun showForwardHistory() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
         navigationHistoryList.clear()
@@ -955,7 +953,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun openToc() {
+  private fun openToc() {
     drawerLayout?.openDrawer(GravityCompat.END)
   }
 
@@ -1074,7 +1072,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun pauseTts() {
+  private fun pauseTts() {
     if (tts?.currentTTSTask == null) {
       tts?.stop()
       setActionAndStartTTSService(ACTION_STOP_TTS)
@@ -1093,7 +1091,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun stopTts() {
+  private fun stopTts() {
     tts?.stop()
     setActionAndStartTTSService(ACTION_STOP_TTS)
   }
@@ -1142,6 +1140,7 @@ abstract class CoreReaderFragment :
     unRegisterReadAloudService()
     storagePermissionForNotesLauncher?.unregister()
     storagePermissionForNotesLauncher = null
+    fragmentReaderBinding = null
   }
 
   private fun updateTableOfContents() {
@@ -1431,7 +1430,7 @@ abstract class CoreReaderFragment :
     return isPermissionGranted
   }
 
-  fun goToBookmarks(): Boolean {
+  private fun goToBookmarks(): Boolean {
     val parentActivity = requireActivity() as CoreMainActivity
     parentActivity.navigate(parentActivity.bookmarksFragmentResId)
     return true
@@ -1614,7 +1613,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun closeAllTabs() {
+  private fun closeAllTabs() {
     closeAllTabsButton?.rotate()
     tempZimFileForUndo = zimReaderContainer?.zimFile
     tempWebViewListForUndo.apply {
@@ -1673,7 +1672,7 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("NestedBlockDepth")
-  fun toggleBookmark() {
+  private fun toggleBookmark() {
     getCurrentWebView()?.url?.let { articleUrl ->
       if (isBookmarked) {
         repositoryActions?.deleteBookmark(articleUrl)
@@ -1850,7 +1849,7 @@ abstract class CoreReaderFragment :
     openArticle(articleUrl)
   }
 
-  fun openMainPage() {
+  private fun openMainPage() {
     val articleUrl = zimReaderContainer?.mainPage
     openArticle(articleUrl)
   }
@@ -1861,7 +1860,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun backToTop() {
+  private fun backToTop() {
     getCurrentWebView()?.pageUp(true)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -520,6 +520,10 @@ abstract class CoreReaderFragment :
       viewLifecycleOwner,
       Observer(::openSearchItem)
     )
+    handleClicks()
+  }
+
+  private fun handleClicks() {
     backToTopButton?.setOnClickListener {
       backToTop()
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -97,6 +97,7 @@ import org.json.JSONException
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.R
+import com.tonyodev.fetch2.R.string
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
@@ -993,7 +994,7 @@ abstract class CoreReaderFragment :
   }
 
   private fun getValidTitle(zimFileTitle: String?): String =
-    if (isAdded && isInvalidTitle(zimFileTitle)) getString(R.string.app_name)
+    if (isAdded && isInvalidTitle(zimFileTitle)) getString(string.app_name)
     else zimFileTitle.toString()
 
   private fun isInvalidTitle(zimFileTitle: String?): Boolean =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import org.kiwix.kiwixmobile.core.R
+import com.tonyodev.fetch2.R.string
 import kotlin.reflect.KClass
 
 abstract class CoreSearchWidget : AppWidgetProvider() {
@@ -36,7 +37,7 @@ abstract class CoreSearchWidget : AppWidgetProvider() {
     appWidgetManager: AppWidgetManager,
     appWidgetIds: IntArray
   ) {
-    val appName = context.getString(R.string.app_name)
+    val appName = context.getString(string.app_name)
     appWidgetIds.forEach { appWidgetId ->
       val views = RemoteViews(context.packageName, R.layout.kiwix_search_widget)
       views.setTextViewText(R.id.search_widget_text, "Search $appName")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
@@ -51,6 +51,9 @@ open class OnSwipeTouchListener constructor(context: Context) : OnTouchListener 
       return super.onSingleTapUp(event)
     }
 
+    // See:- https://stackoverflow.com/questions/73463685/gesturedetector-ongesturelistener-overridden-methods-are-not-working-in-android
+    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE")
+    @SuppressLint("NestedBlockDepth, ReturnCount")
     override fun onFling(
       e1: MotionEvent,
       e2: MotionEvent,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
@@ -52,8 +52,7 @@ open class OnSwipeTouchListener constructor(context: Context) : OnTouchListener 
     }
 
     // See:- https://stackoverflow.com/questions/73463685/gesturedetector-ongesturelistener-overridden-methods-are-not-working-in-android
-    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE")
-    @SuppressLint("NestedBlockDepth, ReturnCount")
+    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE", "NestedBlockDepth", "ReturnCount")
     override fun onFling(
       e1: MotionEvent,
       e2: MotionEvent,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
@@ -35,6 +35,7 @@ import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
 import org.kiwix.kiwixmobile.core.R
+import com.google.android.material.R.attr
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
 import org.kiwix.kiwixmobile.core.extensions.tint
@@ -65,7 +66,7 @@ class TabsAdapter internal constructor(
       .apply {
         id = R.id.tabsAdapterCloseImageView
         setImageDrawableCompat(R.drawable.ic_clear_white_24dp)
-        tint(context.getAttribute(R.attr.colorOnSurface))
+        tint(context.getAttribute(attr.colorOnSurface))
       }
     val cardView = MaterialCardView(context)
       .apply {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -182,6 +182,7 @@ class ZimFileReader constructor(
 
   fun getRandomArticleUrl(): String? = jniKiwixReader.randomEntry.path
 
+  @Suppress("UnreachableCode")
   fun load(uri: String): InputStream? {
     val extension = uri.substringAfterLast(".")
     if (assetExtensions.any { it == extension }) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
@@ -24,6 +24,7 @@ import android.speech.RecognizerIntent
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.channels.Channel
 import org.kiwix.kiwixmobile.core.R
+import com.tonyodev.fetch2.R.string
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.StartSpeechInputFailed
@@ -41,7 +42,7 @@ data class StartSpeechInput(private val actions: Channel<Action>) : SideEffect<U
           putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
           putExtra(
             RecognizerIntent.EXTRA_PROMPT,
-            activity.getString(R.string.speech_prompt_text, activity.getString(R.string.app_name))
+            activity.getString(R.string.speech_prompt_text, activity.getString(string.app_name))
           )
         },
         REQ_CODE_SPEECH_INPUT

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -218,7 +218,7 @@ abstract class CorePrefsFragment :
       throw RuntimeException(e)
     }
 
-  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
     if (key == SharedPreferenceUtil.PREF_NIGHT_MODE) {
       sharedPreferenceUtil?.updateNightMode()
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NestedCoordinatorLayout.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NestedCoordinatorLayout.kt
@@ -26,7 +26,7 @@ import androidx.annotation.AttrRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
-import org.kiwix.kiwixmobile.core.R
+import androidx.coordinatorlayout.R.attr
 
 /**
  * Taken from
@@ -39,7 +39,7 @@ class NestedCoordinatorLayout @JvmOverloads constructor(
   attrs: AttributeSet? = null,
   @AttrRes
   @SuppressLint("PrivateResource")
-  defStyleAttr: Int = R.attr.coordinatorLayoutStyle
+  defStyleAttr: Int = attr.coordinatorLayoutStyle
 ) : CoordinatorLayout(context, attrs, defStyleAttr), NestedScrollingChild3 {
 
   private val helper = NestedScrollingChildHelper(this)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
@@ -58,8 +58,7 @@ object ServerUtils {
     val ipRegex =
       "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
         .toRegex()
-    val ipMatch = ipRegex.find(ip, 0) ?: throw IllegalArgumentException()
-    return ipMatch.value
+    return ipRegex.find(ip, 0)?.value ?: throw IllegalArgumentException()
   }
 
   @JvmStatic fun getSocketAddress(): String =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -32,6 +32,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import org.kiwix.kiwixmobile.core.R
+import androidx.appcompat.R.attr
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
 import org.kiwix.kiwixmobile.core.utils.StyleUtils.fromHtml
 import javax.inject.Inject
@@ -77,7 +78,7 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
           val textView = TextView(activity.baseContext).apply {
             layoutParams = getFrameLayoutParams()
             gravity = Gravity.CENTER
-            setLinkTextColor(activity.getAttribute(R.attr.colorPrimary))
+            setLinkTextColor(activity.getAttribute(attr.colorPrimary))
             setOnLongClickListener {
               val clipboard =
                 ContextCompat.getSystemService(activity.baseContext, ClipboardManager::class.java)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.utils.dialog
 import android.app.Activity
 import android.view.View
 import org.kiwix.kiwixmobile.core.R
+import com.tonyodev.fetch2.R.string
 
 @Suppress("LongParameterList")
 sealed class KiwixDialog(
@@ -184,7 +185,7 @@ sealed class KiwixDialog(
       listOf(
         String.format(
           activity.getString(R.string.rate_dialog_msg),
-          activity.getString(R.string.app_name)
+          activity.getString(string.app_name)
         )
       ),
       icon

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -33,7 +33,7 @@ android {
       // Added namespace for every custom app to make it compatible with gradle 8.0 and above.
       // This is now specified in the Gradle configuration instead of declaring
       // it directly in the AndroidManifest file.
-      namespace = "org.kiwix.kiwixcustom$name"
+      namespace = "org.kiwix.kiwixmobile.custom"
       File("$projectDir/src", "$name/$name.zim").let {
         createDownloadTask(it)
         createPublishApkWithExpansionTask(it, applicationVariants)

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -30,6 +30,10 @@ android {
   productFlavors.apply {
     CustomApps.createDynamically(project.file("src"), this)
     all {
+      // Added namespace for every custom app to make it compatible with gradle 8.0 and above.
+      // This is now specified in the Gradle configuration instead of declaring
+      // it directly in the AndroidManifest file.
+      namespace = "org.kiwix.kiwixcustom$name"
       File("$projectDir/src", "$name/$name.zim").let {
         createDownloadTask(it)
         createPublishApkWithExpansionTask(it, applicationVariants)

--- a/custom/src/main/AndroidManifest.xml
+++ b/custom/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile.custom">
+  xmlns:tools="http://schemas.android.com/tools">
 
 
   <application

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
@@ -35,7 +35,7 @@ import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
 import org.kiwix.kiwixmobile.core.extensions.setDistinctDisplayedChild
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
-import org.kiwix.kiwixmobile.custom.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.FragmentCustomDownloadBinding
 import org.kiwix.kiwixmobile.custom.download.Action.ClickedDownload

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -104,7 +104,7 @@ class CustomMainActivity : CoreMainActivity() {
        * We will re-enable it for custom apps once the issue is resolved.
        * For more info see https://github.com/kiwix/kiwix-android/pull/3516
        */
-      menu.findItem(R.id.menu_host_books)?.isVisible = false
+      menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.isVisible = false
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()
         onNavigationItemSelected(item)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -66,7 +66,8 @@ class CustomReaderFragment : CoreReaderFragment() {
     if (isAdded) {
       setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
       if (BuildConfig.DISABLE_SIDEBAR) {
-        val toolbarToc = activity?.findViewById<ImageView>(R.id.bottom_toolbar_toc)
+        val toolbarToc =
+          activity?.findViewById<ImageView>(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar_toc)
         toolbarToc?.isEnabled = false
       }
       with(activity as AppCompatActivity) {
@@ -162,8 +163,8 @@ class CustomReaderFragment : CoreReaderFragment() {
   @Suppress("DEPRECATION")
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     super.onCreateOptionsMenu(menu, inflater)
-    menu.findItem(R.id.menu_help)?.isVisible = false
-    menu.findItem(R.id.menu_host_books)?.isVisible = false
+    menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_help)?.isVisible = false
+    menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.isVisible = false
   }
 
   private fun enforcedLanguage(): Boolean {

--- a/custom/src/main/res/values-fr/strings.xml
+++ b/custom/src/main/res/values-fr/strings.xml
@@ -5,5 +5,5 @@
 -->
 <resources>
   <string name="retry">Réessayer</string>
-  <string name="invalid_installation">Installation non valide. Veuillez télécharger Zim.\n Assurez-vous que le Wi-Fi est actif et que vous disposez d’assez d\'espace de stockage.</string>
+  <string name="invalid_installation">Installation non valide. Veuillez télécharger Zim.\n Assurez-vous que le Wi-Fi est actif et que vous disposez d’assez d\’espace de stockage.</string>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 19 16:13:45 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-  <issue id="TypographyQuotes">
+  <!-- TODO After upgrading to Android 14 this attribute will be removed and we will fix these errors on the upstream. -->
+  <issue id="TypographyQuotes" severity="warning">
     <ignore path="**-qq/**.xml" />
     <ignore path="**-iw/**.xml" />
   </issue>


### PR DESCRIPTION
Fixes #3478 

* `BuildConfig` file is by default off in the latest gradle version, so we have enabled this in our `AllProjectConfigure` class to enable this class for both modules.
```
A problem occurred configuring project ':app'.
> com.android.builder.errors.EvalIssueException: Build Type 'debug' contains custom BuildConfig fields, but the feature is disabled.
  To enable the feature, add the following to your module-level build.gradle:
  `android.buildFeatures.buildConfig true`
```