### PR TITLE
Fixed Zimit-generated zim files were partially failing to open.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1431,6 +1431,8 @@ abstract class CoreReaderFragment :
       zimReaderContainer.setZimFile(file)
       val zimFileReader = zimReaderContainer.zimFileReader
       zimFileReader?.let { zimFileReader ->
+        // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
+        openArticle(UNINITIALISER_ADDRESS)
         mainMenu?.onFileOpened(urlIsValid())
         openArticle(zimFileReader.mainPage)
         setUpBookmarks(zimFileReader)


### PR DESCRIPTION
Fixes #2561 

The issue was that we were not properly uninitialized the service worker, which was sometimes causing problems and preventing us from reading the `Zimit-generated` zim files. Therefore, we have now implemented the proper uninitialization of the service worker before loading the URLs for new zim files.



https://github.com/kiwix/kiwix-android/assets/34593983/179f5992-015e-411c-b0c0-79bb7962b8cb

