### PR TITLE
Fixed, The File transfer feature does not work in android 12, android 13.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -19,9 +19,12 @@
 package org.kiwix.kiwixmobile.localFileTransfer
 
 import applyWithViewHierarchyPrinting
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.TestUtils
 
 /**
  * Authored by Ayush Shrivastava on 29/10/20
@@ -32,7 +35,24 @@ fun localFileTransfer(func: LocalFileTransferRobot.() -> Unit) =
 
 class LocalFileTransferRobot : BaseRobot() {
 
-  init {
+  fun assertReceiveFileTitleVisible() {
     isVisible(TextId(R.string.receive_files_title))
+  }
+
+  fun assertSearchDeviceMenuItemVisible() {
+    isVisible(ViewId(R.id.menu_item_search_devices))
+  }
+
+  fun clickOnSearchDeviceMenuItem() {
+    clickOn(ViewId(R.id.menu_item_search_devices))
+  }
+
+  fun assertLocalFileTransferScreenVisible() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+    assertReceiveFileTitleVisible()
+  }
+
+  fun assertLocalLibraryVisible() {
+    isVisible(TextId(R.string.library))
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.localFileTransfer
+
+import android.Manifest
+import android.app.Instrumentation
+import android.content.Context
+import android.os.Build
+import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
+import leakcanary.LeakAssertions
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
+
+class LocalFileTransferTest {
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
+  private var context: Context? = null
+  private lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+
+  private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    arrayOf(
+      Manifest.permission.NEARBY_WIFI_DEVICES
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.ACCESS_COARSE_LOCATION,
+      Manifest.permission.ACCESS_FINE_LOCATION
+    )
+  }
+
+  @Rule
+  @JvmField
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
+
+  private val instrumentation: Instrumentation by lazy {
+    InstrumentationRegistry.getInstrumentation()
+  }
+
+  @Before
+  fun setup() {
+    context = instrumentation.targetContext.applicationContext
+    UiDevice.getInstance(instrumentation).apply {
+      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
+        TestUtils.closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+    }
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
+  }
+
+  @Test
+  fun localFileTransfer() {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
+      activityScenario.onActivity {
+        it.navigate(R.id.libraryFragment)
+      }
+      library {
+        assertGetZimNearbyDeviceDisplayed()
+        clickFileTransferIcon {
+          assertReceiveFileTitleVisible()
+          assertSearchDeviceMenuItemVisible()
+          clickOnSearchDeviceMenuItem()
+          assertLocalFileTransferScreenVisible()
+          pressBack()
+          assertLocalLibraryVisible()
+        }
+      }
+      LeakAssertions.assertNoLeaks()
+    }
+  }
+
+  @After
+  fun setIsTestPreference() {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+    }
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.help.HelpRobot
+import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
 import org.kiwix.kiwixmobile.nav.destination.library.OnlineLibraryRobot
 import org.kiwix.kiwixmobile.settings.SettingsRobot
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -72,8 +73,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
       }
       clickLibraryOnBottomNav {
         assertGetZimNearbyDeviceDisplayed()
-        clickFileTransferIcon {
-        }
+        clickFileTransferIcon(LocalFileTransferRobot::assertReceiveFileTitleVisible)
       }
       clickDownloadOnBottomNav(OnlineLibraryRobot::assertLibraryListDisplayed)
       clickBookmarksOnNavDrawer {

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/KiwixWifiP2pBroadcastReceiver.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/KiwixWifiP2pBroadcastReceiver.kt
@@ -25,7 +25,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.NetworkInfo
 import android.net.wifi.p2p.WifiP2pDevice
-import android.net.wifi.p2p.WifiP2pManager
+import android.net.wifi.p2p.WifiP2pManager.EXTRA_NETWORK_INFO
 import android.net.wifi.p2p.WifiP2pManager.EXTRA_WIFI_P2P_DEVICE
 import android.net.wifi.p2p.WifiP2pManager.EXTRA_WIFI_STATE
 import android.net.wifi.p2p.WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION
@@ -54,10 +54,14 @@ class KiwixWifiP2pBroadcastReceiver(
       }
       WIFI_P2P_PEERS_CHANGED_ACTION -> p2pEventListener.onPeersChanged()
       WIFI_P2P_CONNECTION_CHANGED_ACTION -> {
-        val networkInfo =
-          intent.getParcelableExtra<NetworkInfo>(
-            WifiP2pManager.EXTRA_NETWORK_INFO
+        val networkInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          intent.getParcelableExtra(
+            EXTRA_NETWORK_INFO,
+            NetworkInfo::class.java
           )
+        } else {
+          intent.getParcelableExtra(EXTRA_NETWORK_INFO)
+        }
         networkInfo?.let {
           p2pEventListener.onConnectionChanged(networkInfo.isConnected)
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.localFileTransfer
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
-import android.net.ConnectivityManager
 import android.net.Uri
 import android.net.wifi.WpsInfo
 import android.net.wifi.p2p.WifiP2pConfig
@@ -62,8 +61,7 @@ class WifiDirectManager @Inject constructor(
   private val context: Context,
   private val sharedPreferenceUtil: SharedPreferenceUtil,
   private val alertDialogShower: AlertDialogShower,
-  private val manager: WifiP2pManager?,
-  private val connectivityManager: ConnectivityManager
+  private val manager: WifiP2pManager?
 ) : ChannelListener, PeerListListener, ConnectionInfoListener, P2pEventListener {
   var callbacks: Callbacks? = null
 
@@ -98,7 +96,7 @@ class WifiDirectManager @Inject constructor(
   }
 
   private fun registerWifiDirectBroadcastReceiver() {
-    receiver = KiwixWifiP2pBroadcastReceiver(this, connectivityManager)
+    receiver = KiwixWifiP2pBroadcastReceiver(this)
 
     // For specifying broadcasts (of the P2P API) that the module needs to respond to
     val intentFilter = IntentFilter()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
@@ -74,7 +74,7 @@ class BasicAuthInterceptorTest {
 
   @Test
   fun testUrlWithFormattingVariations() {
-    val formattedUrl1 = "https:// {{ BASIC_AUTH_KEY } } @example.com/kiwix/f/somefile.zim"
+    val formattedUrl1 = "https:// {{ BASIC_AUTH_KEY }} @example.com/kiwix/f/somefile.zim"
     val formattedUrl2 = "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/somefile.zim  "
     assertEquals(true, formattedUrl1.isAuthenticationUrl)
     assertEquals(true, formattedUrl2.isAuthenticationUrl)


### PR DESCRIPTION
Fixes #3491 

* In Android 13, we previously used `intent.getParcelableArrayExtra` to retrieve the status of `P2P_DEVICE_CHANGED`. However, this method returned null because it's not actually an array. To resolve this issue, we have updated it to use `intent.getParcelableExtra`.
* For Android 12, we used to check the network state through `ConnectivityManager` every time the `WIFI_P2P_CONNECTION_CHANGED_ACTION` action was triggered. However, this approach wasn't reliable, as the action being triggered didn't guarantee a change in the network state. Instead, it sends an intent that we should now check for network changes. As a result, we have modified our code to utilize this intent within the `KiwixWifiP2pBroadcastReceiver`.
* Added test case for testing the functionality of `FileTransferFragment`
   * This test case is designed to verify that the functionality works correctly, especially addressing the issue where `LocalFileTransferFragment` would shut down when attempting to search nearby devices for connection.


**Android 12**

https://github.com/kiwix/kiwix-android/assets/34593983/fbb6805d-b184-49ea-bc8e-6df3be05373c

**Android 13**


https://github.com/kiwix/kiwix-android/assets/34593983/e1c46d1c-df61-49f6-8e8e-1e7d4b650e48

