### PR TITLE
Authentication created for DWDS app

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItem.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryListItem.kt
@@ -85,7 +85,7 @@ sealed class LibraryListItem {
       downloadModel.totalSizeOfDownload,
       downloadModel.progress,
       Seconds(downloadModel.etaInMilliSeconds / 1000L),
-      DownloadState.from(downloadModel.state, downloadModel.error),
+      DownloadState.from(downloadModel.state, downloadModel.error, downloadModel.book.url),
       downloadModel.book.id.hashCode().toLong(),
       downloadModel.state
     )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -1,0 +1,42 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.data.remote
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+class BasicAuthInterceptor : Interceptor {
+
+  @Throws(IOException::class)
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request: Request = chain.request()
+    val url = request.url.toString()
+    if (url.contains("dwds")) {
+      val userName = System.getenv("DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION_USER_NAME") ?: ""
+      val password = System.getenv("DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION_PASSWORD") ?: ""
+      val credentials = okhttp3.Credentials.basic(userName, password)
+      val authenticatedRequest: Request = request.newBuilder()
+        .header("Authorization", credentials).build()
+      return chain.proceed(authenticatedRequest)
+    }
+    return chain.proceed(request)
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.data.remote
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+import org.kiwix.kiwixmobile.core.reader.decodeUrl
 import java.io.IOException
 
 class BasicAuthInterceptor : Interceptor {
@@ -30,8 +31,12 @@ class BasicAuthInterceptor : Interceptor {
     val request: Request = chain.request()
     val url = request.url.toString()
     if (url.contains("dwds")) {
-      val userName = System.getenv("DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION_USER_NAME") ?: ""
-      val password = System.getenv("DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION_PASSWORD") ?: ""
+      val secretKey = url.decodeUrl
+        .substringAfterLast("{")
+        .substringBefore("}")
+      val userNameAndPassword = System.getenv(secretKey) ?: ""
+      val userName = userNameAndPassword.substringBefore(":", "")
+      val password = userNameAndPassword.substringAfter(":", "")
       val credentials = okhttp3.Credentials.basic(userName, password)
       val authenticatedRequest: Request = request.newBuilder()
         .header("Authorization", credentials).build()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -29,7 +29,7 @@ class BasicAuthInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val request: Request = chain.request()
-    val url = request.url.toString().decodeUrl
+    val url = request.url.toString()
     if (url.isAuthenticationUrl) {
       val userNameAndPassword = System.getenv(url.secretKey) ?: ""
       val userName = userNameAndPassword.substringBefore(":", "")
@@ -43,7 +43,8 @@ class BasicAuthInterceptor : Interceptor {
   }
 }
 
-val String.isAuthenticationUrl: Boolean get() = trim().matches(Regex("https://[^@]+@.*\\.zim"))
+val String.isAuthenticationUrl: Boolean
+  get() = decodeUrl.trim().matches(Regex("https://[^@]+@.*\\.zim"))
 
 val String.secretKey: String
   get() = substringAfter("{{", "")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -48,5 +48,5 @@ val String.isAuthenticationUrl: Boolean
 
 val String.secretKey: String
   get() = substringAfter("{{", "")
-    .substringBefore("}", "")
+    .substringBefore("}}", "")
     .trim()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
@@ -28,6 +28,7 @@ import dagger.Provides
 import okhttp3.OkHttpClient
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
+import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
 import org.kiwix.kiwixmobile.core.downloader.Downloader
@@ -82,6 +83,7 @@ object DownloaderModule {
     OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIME_OUT, TimeUnit.MINUTES)
       .readTimeout(READ_TIME_OUT, TimeUnit.MINUTES)
+      .addInterceptor(BasicAuthInterceptor())
       .followRedirects(true)
       .followSslRedirects(true)
       .build()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/NetworkModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/NetworkModule.kt
@@ -24,6 +24,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level.BASIC
 import okhttp3.logging.HttpLoggingInterceptor.Level.NONE
 import org.kiwix.kiwixmobile.core.BuildConfig
+import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService.ServiceCreator
 import org.kiwix.kiwixmobile.core.data.remote.UserAgentInterceptor
@@ -51,6 +52,7 @@ class NetworkModule {
         }
       )
       .addNetworkInterceptor(UserAgentInterceptor(USER_AGENT))
+      .addInterceptor(BasicAuthInterceptor())
       .build()
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/NetworkModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/NetworkModule.kt
@@ -24,7 +24,6 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level.BASIC
 import okhttp3.logging.HttpLoggingInterceptor.Level.NONE
 import org.kiwix.kiwixmobile.core.BuildConfig
-import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService.ServiceCreator
 import org.kiwix.kiwixmobile.core.data.remote.UserAgentInterceptor
@@ -52,7 +51,6 @@ class NetworkModule {
         }
       )
       .addNetworkInterceptor(UserAgentInterceptor(USER_AGENT))
-      .addInterceptor(BasicAuthInterceptor())
       .build()
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/DownloadItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/DownloadItem.kt
@@ -57,15 +57,19 @@ data class DownloadItem(
     Seconds(downloadModel.etaInMilliSeconds / 1000L),
     DownloadState.from(
       downloadModel.state,
-      downloadModel.error
+      downloadModel.error,
+      downloadModel.book.url
     )
   )
 }
 
-sealed class DownloadState(private val stringId: Int) {
+sealed class DownloadState(
+  private val stringId: Int,
+  open val zimUrl: String? = null
+) {
 
   companion object {
-    fun from(state: Status, error: Error): DownloadState =
+    fun from(state: Status, error: Error, zimUrl: String?): DownloadState =
       when (state) {
         NONE,
         ADDED,
@@ -76,7 +80,7 @@ sealed class DownloadState(private val stringId: Int) {
         CANCELLED,
         FAILED,
         REMOVED,
-        DELETED -> Failed(error)
+        DELETED -> Failed(error, zimUrl)
       }
   }
 
@@ -84,7 +88,8 @@ sealed class DownloadState(private val stringId: Int) {
   object Running : DownloadState(R.string.running_state)
   object Successful : DownloadState(R.string.complete)
   object Paused : DownloadState(R.string.paused_state)
-  data class Failed(val reason: Error) : DownloadState(R.string.failed_state)
+  data class Failed(val reason: Error, override val zimUrl: String?) :
+    DownloadState(R.string.failed_state, zimUrl)
 
   override fun toString(): String = javaClass.simpleName
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -335,7 +335,7 @@ private val String.filePath: String
   get() = substringAfter(CONTENT_PREFIX).substringBefore("#").substringBefore("?")
 
 // Decode the URL if it is encoded because libkiwix does not return the path for encoded paths.
-private val String.decodeUrl: String
+val String.decodeUrl: String
   get() = URLDecoder.decode(this, "UTF-8")
 
 // Truncate mime-type (everything after the first space and semi-colon(if exists)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -215,6 +215,7 @@
   <string name="complete">Complete</string>
   <string name="paused_state">Paused</string>
   <string name="failed_state">Failed: %s</string>
+  <string name="custom_download_error_message_for_authentication_failed">The zim file could not be downloaded, please try reinstalling the application from the play store.</string>
   <string name="save">Save</string>
   <string name="note">Note</string>
   <string name="wiki_article_title">Wiki Article Title</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.remote
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.kiwix.kiwixmobile.core.data.remote.isAuthenticationUrl
+import org.kiwix.kiwixmobile.core.data.remote.secretKey
+
+class BasicAuthInterceptorTest {
+
+  private val authenticationUrl =
+    "https://{{BASIC_AUTH_KEY}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-09-12.zim"
+
+  private val normalUrl = "https://download.kiwix.org/zim/wikipedia_fr_test.zim"
+
+  @Test
+  fun checkUrlIsAuthenticationUrl() {
+    assertEquals(true, authenticationUrl.isAuthenticationUrl)
+  }
+
+  @Test
+  fun checkUrlIsNormalUrl() {
+    assertEquals(false, normalUrl.isAuthenticationUrl)
+  }
+
+  @Test
+  fun testGetSecretKeyFromAuthenticationUrl() {
+    assertEquals("BASIC_AUTH_KEY", authenticationUrl.secretKey)
+  }
+
+  @Test
+  fun testGetSecretKeyFromNormalUrl() {
+    assertEquals("", normalUrl.secretKey)
+  }
+
+  @Test
+  fun testEmptyUrl() {
+    val emptyUrl = ""
+    assertEquals(false, emptyUrl.isAuthenticationUrl)
+    assertEquals("", emptyUrl.secretKey)
+  }
+
+  @Test
+  fun testUrlWithoutAuthentication() {
+    val urlWithoutAuth = "https://example.com/kiwix/f/somefile.zim"
+    assertEquals(false, urlWithoutAuth.isAuthenticationUrl)
+    assertEquals("", urlWithoutAuth.secretKey)
+  }
+
+  @Test
+  fun testUrlWithDifferentPlaceholder() {
+    val urlWithDifferentPlaceholder =
+      "https://{{ANOTHER_AUTH_KEY}}@example.com/kiwix/f/somefile.zim"
+    assertEquals(true, urlWithDifferentPlaceholder.isAuthenticationUrl)
+    assertEquals("ANOTHER_AUTH_KEY", urlWithDifferentPlaceholder.secretKey)
+  }
+
+  @Test
+  fun testUrlWithFormattingVariations() {
+    val formattedUrl1 = "https:// {{ BASIC_AUTH_KEY } } @example.com/kiwix/f/somefile.zim"
+    val formattedUrl2 = "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/somefile.zim  "
+    assertEquals(true, formattedUrl1.isAuthenticationUrl)
+    assertEquals(true, formattedUrl2.isAuthenticationUrl)
+    assertEquals("BASIC_AUTH_KEY", formattedUrl1.secretKey)
+    assertEquals("BASIC_AUTH_KEY", formattedUrl2.secretKey)
+  }
+
+  @Test
+  fun testUrlWithOtherExtensions() {
+    val urlWithTxtExtension = "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/somefile.txt"
+    val urlWithHtmlExtension = "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/somefile.html"
+    assertEquals(false, urlWithTxtExtension.isAuthenticationUrl)
+    assertEquals(false, urlWithHtmlExtension.isAuthenticationUrl)
+    assertEquals("BASIC_AUTH_KEY", urlWithTxtExtension.secretKey)
+    assertEquals("BASIC_AUTH_KEY", urlWithHtmlExtension.secretKey)
+  }
+
+  @Test
+  fun testUrlWithMultiplePlaceholders() {
+    val urlWithMultiplePlaceholders =
+      "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/{{ANOTHER_KEY}}.zim"
+    assertEquals(true, urlWithMultiplePlaceholders.isAuthenticationUrl)
+    assertEquals("BASIC_AUTH_KEY", urlWithMultiplePlaceholders.secretKey)
+  }
+}

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.custom.download
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -28,10 +29,13 @@ import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
+import org.kiwix.kiwixmobile.core.data.remote.isAuthenticationUrl
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadItem
+import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
 import org.kiwix.kiwixmobile.core.extensions.setDistinctDisplayedChild
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.custom.R
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.FragmentCustomDownloadBinding
 import org.kiwix.kiwixmobile.custom.download.Action.ClickedDownload
@@ -112,14 +116,39 @@ class CustomDownloadFragment : BaseFragment(), FragmentActivityExtensions {
 
       is DownloadFailed -> {
         fragmentCustomDownloadBinding?.cdViewAnimator?.setDistinctDisplayedChild(2)
-        fragmentCustomDownloadBinding?.customDownloadError?.cdErrorText?.text =
-          context?.let(state.downloadState::toReadableState)
+        val errorMessage = context?.let { context ->
+          if (state.downloadState.zimUrl?.isAuthenticationUrl == false) {
+            return@let getErrorMessageFromDownloadState(state.downloadState, context)
+          }
+
+          val defaultErrorMessage = getErrorMessageFromDownloadState(state.downloadState, context)
+          // Check if `REQUEST_NOT_SUCCESSFUL` indicates an unsuccessful response from the server.
+          // If the server does not respond to the URL, we will display a custom message to the user.
+          if (defaultErrorMessage == context.getString(
+              R.string.failed_state,
+              "REQUEST_NOT_SUCCESSFUL"
+            )
+          ) {
+            context.getString(
+              R.string.failed_state,
+              context.getString(R.string.custom_download_error_message_for_authentication_failed)
+            )
+          } else {
+            defaultErrorMessage
+          }
+        }
+        fragmentCustomDownloadBinding?.customDownloadError?.cdErrorText?.text = errorMessage
       }
 
       DownloadComplete ->
         fragmentCustomDownloadBinding?.cdViewAnimator?.setDistinctDisplayedChild(3)
     }
   }
+
+  private fun getErrorMessageFromDownloadState(
+    downloadState: DownloadState,
+    context: Context
+  ): String = "${downloadState.toReadableState(context)}"
 
   private fun showDownloadingProgress(downloadItem: DownloadItem) {
     fragmentCustomDownloadBinding?.customDownloadInProgress?.apply {

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
@@ -115,8 +115,8 @@ internal class CustomDownloadViewModelTest {
     internal fun `Emission with data+failure moves state from InProgress to Failed`() {
       assertStateTransition(
         DownloadInProgress(listOf()),
-        DatabaseEmission(listOf(downloadItem(state = Failed(NONE)))),
-        DownloadFailed(Failed(NONE))
+        DatabaseEmission(listOf(downloadItem(state = Failed(NONE, null)))),
+        DownloadFailed(Failed(NONE, null))
       )
     }
 


### PR DESCRIPTION
Fixes https://github.com/kiwix/kiwix-android/issues/3499

* Implemented downloading for authentication URLs in custom apps.
* Secret name extracted from the URL itself to avoid adding additional code for future apps similar to this one.
* For this we have made two extension functions one for checking whether the URL is an authentication URL or not, second one is for extracting a secret key from the URL.
* To properly test functionality for these functions we have added test cases for it.
* We properly handling the download at the first run, we are now showing a custom error message to the user if the zim file is unable to download(when the server returns an unsuccessful response).

![1696412526454](https://github.com/kiwix/kiwix-android/assets/34593983/f05066d2-ce4e-4f1b-9a35-393285cd6281)
