### PR TITLE
Fixed Refactor LocalFileTransfer UI.

### DIFF
--- a/app/detekt_baseline.xml
+++ b/app/detekt_baseline.xml
@@ -11,6 +11,7 @@
     <ID>MagicNumber:ShareFiles.kt$ShareFiles$24</ID>
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$5</ID>
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$500</ID>
+    <ID>MagicNumber:LocalFileTransferFragment.kt$LocalFileTransferFragment$500</ID>
     <ID>NestedBlockDepth:LocalLibraryFragment.kt$LocalLibraryFragment$private fun checkPermissions()</ID>
     <ID>NestedBlockDepth:PeerGroupHandshake.kt$PeerGroupHandshake$private fun readHandshakeAndExchangeMetaData(): InetAddress?</ID>
     <ID>NestedBlockDepth:ReceiverHandShake.kt$ReceiverHandShake$override fun exchangeFileTransferMetadata(inputStream: InputStream, outputStream: OutputStream)</ID>

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -61,10 +61,12 @@ class DownloadRobot : BaseRobot() {
   }
 
   private fun assertDeleteDialogDisplayed() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).check(matches(isDisplayed()))
   }
 
   private fun clickOnDeleteZimFile() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).perform(click())
   }
 
@@ -73,9 +75,8 @@ class DownloadRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      pauseForBetterTestPerformance()
     } catch (e: Exception) {
       if (shouldDeleteZimFile) {
         throw Exception(
@@ -122,12 +123,16 @@ class DownloadRobot : BaseRobot() {
     }
   }
 
+  private fun stopDownload() {
+    clickOn(ViewId(R.id.stop))
+  }
+
   fun pauseDownload() {
     clickOn(ViewId(R.id.pauseResume))
   }
 
   fun assertDownloadPaused() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    pauseForBetterTestPerformance()
     onView(withText(org.kiwix.kiwixmobile.core.R.string.paused_state)).check(matches(isDisplayed()))
   }
 
@@ -136,7 +141,7 @@ class DownloadRobot : BaseRobot() {
   }
 
   fun assertDownloadResumed() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    pauseForBetterTestPerformance()
     onView(withText(org.kiwix.kiwixmobile.core.R.string.paused_state)).check(doesNotExist())
   }
 
@@ -148,6 +153,36 @@ class DownloadRobot : BaseRobot() {
       BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
       Log.i("kiwixDownloadTest", "Downloading in progress")
       waitUntilDownloadComplete()
+    }
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+  }
+
+  private fun assertStopDownloadDialogDisplayed() {
+    pauseForBetterTestPerformance()
+    isVisible(Text("Stop download?"))
+  }
+
+  private fun clickOnYesButton() {
+    onView(withText("YES")).perform(click())
+  }
+
+  fun stopDownloadIfAlreadyStarted() {
+    try {
+      pauseForBetterTestPerformance()
+      onView(withId(R.id.stop)).check(matches(isDisplayed()))
+      stopDownload()
+      assertStopDownloadDialogDisplayed()
+      clickOnYesButton()
+      pauseForBetterTestPerformance()
+    } catch (e: Exception) {
+      Log.i(
+        "DOWNLOAD_TEST",
+        "Failed to stop download with title [" + zimFileTitle + "]... " +
+          "Probably because it doesn't download the zim file"
+      )
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -88,6 +88,7 @@ class DownloadTest : BaseActivityTest() {
         deleteZimIfExists(false)
         clickDownloadOnBottomNav()
         waitForDataToLoad()
+        stopDownloadIfAlreadyStarted()
         downloadZimFile()
         assertDownloadStart()
         pauseDownload()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -66,10 +66,12 @@ class InitialDownloadRobot : BaseRobot() {
   }
 
   private fun assertDeleteDialogDisplayed() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).check(matches(isDisplayed()))
   }
 
   private fun clickOnDeleteZimFile() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).perform(click())
   }
 
@@ -78,9 +80,8 @@ class InitialDownloadRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      pauseForBetterTestPerformance()
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",
@@ -142,6 +143,27 @@ class InitialDownloadRobot : BaseRobot() {
     } catch (e: AssertionFailedError) {
       BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
       assertDownloadStop()
+    }
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+  }
+
+  fun stopDownloadIfAlreadyStarted() {
+    try {
+      pauseForBetterTestPerformance()
+      onView(withId(R.id.stop)).check(matches(isDisplayed()))
+      stopDownload()
+      assertStopDownloadDialogDisplayed()
+      clickOnYesToConfirm()
+      pauseForBetterTestPerformance()
+    } catch (e: Exception) {
+      Log.i(
+        "INITIAL_DOWNLOAD_TEST",
+        "Failed to stop download with title [" + zimFileTitle + "]... " +
+          "Probably because it doesn't download the zim file"
+      )
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -80,6 +80,7 @@ class InitialDownloadTest : BaseActivityTest() {
       assertLibraryListDisplayed()
       refreshList()
       waitForDataToLoad()
+      stopDownloadIfAlreadyStarted()
       downloadZimFile()
       assertStorageConfigureDialogDisplayed()
       clickOnYesToConfirm()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -24,12 +24,14 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
 import applyWithViewHierarchyPrinting
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 
 fun language(func: LanguageRobot.() -> Unit) = LanguageRobot().applyWithViewHierarchyPrinting(func)
@@ -54,6 +56,8 @@ class LanguageRobot : BaseRobot() {
   }
 
   fun clickOnLanguageIcon() {
+    // Wait for a few seconds to properly saved selected language.
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     clickOn(ViewId(R.id.select_language))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -18,11 +18,14 @@
 
 package org.kiwix.kiwixmobile.localFileTransfer
 
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
-import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
+import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
@@ -54,5 +57,39 @@ class LocalFileTransferRobot : BaseRobot() {
 
   fun assertLocalLibraryVisible() {
     isVisible(TextId(R.string.library))
+  }
+
+  fun assertClickNearbyDeviceMessageVisible() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.click_nearby_devices_message))
+  }
+
+  fun clickOnGotItButton() {
+    pauseForBetterTestPerformance()
+    clickOn(TextId(R.string.got_it))
+  }
+
+  fun assertDeviceNameMessageVisible() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.your_device_name_message))
+  }
+
+  fun assertNearbyDeviceListMessageVisible() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.nearby_devices_list_message))
+  }
+
+  fun assertTransferZimFilesListMessageVisible() {
+    pauseForBetterTestPerformance()
+    isVisible(TextId(R.string.transfer_zim_files_list_message))
+  }
+
+  fun assertClickNearbyDeviceMessageNotVisible() {
+    pauseForBetterTestPerformance()
+    onView(withText(R.string.click_nearby_devices_message)).check(doesNotExist())
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -90,6 +90,6 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -80,18 +80,14 @@ class LocalFileTransferTest {
       }
       waitForIdle()
     }
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
-      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-    }
-    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-    }
   }
 
   @Test
   fun localFileTransfer() {
+    shouldShowShowCaseFeatureToUser(false)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
         it.navigate(R.id.libraryFragment)
@@ -111,10 +107,49 @@ class LocalFileTransferTest {
     }
   }
 
+  @Test
+  fun testShowCaseFeature() {
+    shouldShowShowCaseFeatureToUser(true)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        it.navigate(R.id.libraryFragment)
+      }
+    }
+    library {
+      assertGetZimNearbyDeviceDisplayed()
+      clickFileTransferIcon {
+        assertClickNearbyDeviceMessageVisible()
+        clickOnGotItButton()
+        assertDeviceNameMessageVisible()
+        clickOnGotItButton()
+        assertNearbyDeviceListMessageVisible()
+        clickOnGotItButton()
+        assertTransferZimFilesListMessageVisible()
+        clickOnGotItButton()
+        pressBack()
+        assertGetZimNearbyDeviceDisplayed()
+        // test show case view show once.
+        clickFileTransferIcon(LocalFileTransferRobot::assertClickNearbyDeviceMessageNotVisible)
+      }
+    }
+    LeakAssertions.assertNoLeaks()
+  }
+
   @After
   fun setIsTestPreference() {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, true)
+    }
+  }
+
+  private fun shouldShowShowCaseFeatureToUser(value: Boolean) {
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, value)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -108,8 +108,8 @@ class LocalFileTransferTest {
   }
 
   @Test
-  fun testShowCaseFeature() {
-    shouldShowShowCaseFeatureToUser(true)
+  fun showCaseFeature() {
+    shouldShowShowCaseFeatureToUser(true, isResetShowCaseId = true)
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
       onActivity {
@@ -129,11 +129,24 @@ class LocalFileTransferTest {
         clickOnGotItButton()
         pressBack()
         assertGetZimNearbyDeviceDisplayed()
-        // test show case view show once.
-        clickFileTransferIcon(LocalFileTransferRobot::assertClickNearbyDeviceMessageNotVisible)
       }
     }
     LeakAssertions.assertNoLeaks()
+  }
+
+  @Test
+  fun testShowCaseFeatureShowOnce() {
+    shouldShowShowCaseFeatureToUser(true)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        it.navigate(R.id.libraryFragment)
+      }
+    }
+    library {
+      // test show case view show once.
+      clickFileTransferIcon(LocalFileTransferRobot::assertClickNearbyDeviceMessageNotVisible)
+    }
   }
 
   @After
@@ -144,12 +157,19 @@ class LocalFileTransferTest {
     }
   }
 
-  private fun shouldShowShowCaseFeatureToUser(value: Boolean) {
+  private fun shouldShowShowCaseFeatureToUser(
+    shouldShowShowCase: Boolean,
+    isResetShowCaseId: Boolean = false
+  ) {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, value)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, shouldShowShowCase)
+    }
+    if (isResetShowCaseId) {
+      // To clear showCaseID to ensure the showcase view will show.
+      uk.co.deanwild.materialshowcaseview.PrefsManager.resetAll(context)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -60,6 +60,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
@@ -100,6 +101,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
   fun setIsTestPreference() {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, true)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -54,6 +54,7 @@ class LibraryRobot : BaseRobot() {
   }
 
   fun assertNoFilesTextDisplayed() {
+    pauseForBetterTestPerformance()
     isVisible(ViewId(R.id.file_management_no_files))
   }
 
@@ -62,9 +63,8 @@ class LibraryRobot : BaseRobot() {
       longClickOnZimFile()
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       clickOnDeleteZimFile()
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+      pauseForBetterTestPerformance()
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",
@@ -79,6 +79,7 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun assertDeleteDialogDisplayed() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE"))
       .check(ViewAssertions.matches(isDisplayed()))
   }
@@ -88,6 +89,11 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnDeleteZimFile() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).perform(click())
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -146,10 +146,12 @@ class LocalFileTransferFragment :
       object : MenuProvider {
         override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
           menuInflater.inflate(R.menu.wifi_file_share_items, menu)
-          Handler(Looper.getMainLooper()).post {
-            searchView =
-              fragmentLocalFileTransferBinding?.root?.findViewById(R.id.menu_item_search_devices)
-            showCaseFeatureToUsers()
+          if (!sharedPreferenceUtil.prefIsTest) {
+            Handler(Looper.getMainLooper()).post {
+              searchView =
+                fragmentLocalFileTransferBinding?.root?.findViewById(R.id.menu_item_search_devices)
+              showCaseFeatureToUsers()
+            }
           }
         }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -195,6 +195,15 @@ class LocalFileTransferFragment :
           getString(R.string.transfer_zim_files_list_message),
           getString(R.string.got_it)
         )
+        setOnItemDismissedListener { showcaseView, _ ->
+          // To fix the memory leak by setting setTarget to null
+          // because the memory leak occurred inside the library.
+          // They had forgotten to detach the view after its successful use,
+          // so it holds the reference of these views in memory.
+          // By setting these views as null we remove the reference from
+          // the memory after they are successfully shown.
+          showcaseView.setTarget(null)
+        }
         start()
       }
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -144,26 +144,7 @@ class LocalFileTransferFragment :
         override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
           if (menuItem.itemId == R.id.menu_item_search_devices) {
             /* Permissions essential for this module */
-            return when {
-              !checkFineLocationAccessPermission() ->
-                true
-              !checkExternalStorageWritePermission() ->
-                true
-              /* Initiate discovery */
-              !wifiDirectManager.isWifiP2pEnabled -> {
-                requestEnableWifiP2pServices()
-                true
-              }
-              Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isLocationServiceEnabled -> {
-                requestEnableLocationServices()
-                true
-              }
-              else -> {
-                showPeerDiscoveryProgressBar()
-                wifiDirectManager.discoverPeerDevices()
-                true
-              }
-            }
+            return onSearchMenuClicked()
           }
           return false
         }
@@ -171,6 +152,29 @@ class LocalFileTransferFragment :
       viewLifecycleOwner,
       Lifecycle.State.RESUMED
     )
+  }
+
+  private fun onSearchMenuClicked(): Boolean {
+    return when {
+      !checkFineLocationAccessPermission() ->
+        true
+      !checkExternalStorageWritePermission() ->
+        true
+      /* Initiate discovery */
+      !wifiDirectManager.isWifiP2pEnabled -> {
+        requestEnableWifiP2pServices()
+        true
+      }
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isLocationServiceEnabled -> {
+        requestEnableLocationServices()
+        true
+      }
+      else -> {
+        showPeerDiscoveryProgressBar()
+        wifiDirectManager.discoverPeerDevices()
+        true
+      }
+    }
   }
 
   private fun setupPeerDevicesList(activity: CoreMainActivity) {
@@ -339,6 +343,15 @@ class LocalFileTransferFragment :
           Log.e(TAG, "Storage write permission not granted")
           toast(R.string.permission_refused_storage, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
+        }
+        else ->
+          super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+      }
+    } else if (grantResults[0] == PERMISSION_GRANTED) {
+      when (requestCode) {
+        PERMISSION_REQUEST_FINE_LOCATION,
+        PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS -> {
+          onSearchMenuClicked()
         }
         else ->
           super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -109,8 +109,8 @@ class LocalFileTransferFragment :
   private var fileListAdapter: FileListAdapter? = null
   private var wifiPeerListAdapter: WifiPeerListAdapter? = null
   private var fragmentLocalFileTransferBinding: FragmentLocalFileTransferBinding? = null
-  private var materialShowcaseSequence: MaterialShowcaseSequence? = null
-  private var searchView: View? = null
+  private var materialShowCaseSequence: MaterialShowcaseSequence? = null
+  private var searchIconView: View? = null
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -146,9 +146,9 @@ class LocalFileTransferFragment :
       object : MenuProvider {
         override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
           menuInflater.inflate(R.menu.wifi_file_share_items, menu)
-          if (!sharedPreferenceUtil.prefIsTest) {
+          if (sharedPreferenceUtil.prefShowShowCaseToUser) {
             Handler(Looper.getMainLooper()).post {
-              searchView =
+              searchIconView =
                 fragmentLocalFileTransferBinding?.root?.findViewById(R.id.menu_item_search_devices)
               showCaseFeatureToUsers()
             }
@@ -169,8 +169,8 @@ class LocalFileTransferFragment :
   }
 
   private fun showCaseFeatureToUsers() {
-    searchView?.let {
-      materialShowcaseSequence = MaterialShowcaseSequence(activity, SHOWCASE_ID).apply {
+    searchIconView?.let {
+      materialShowCaseSequence = MaterialShowcaseSequence(activity, SHOWCASE_ID).apply {
         val config = ShowcaseConfig().apply {
           delay = 500 // half second between each showcase view
         }
@@ -458,8 +458,8 @@ class LocalFileTransferFragment :
     wifiDirectManager.stopWifiDirectManager()
     wifiDirectManager.callbacks = null
     fragmentLocalFileTransferBinding = null
-    searchView = null
-    materialShowcaseSequence = null
+    searchIconView = null
+    materialShowCaseSequence = null
     super.onDestroyView()
   }
 

--- a/app/src/main/res/layout/fragment_local_file_transfer.xml
+++ b/app/src/main/res/layout/fragment_local_file_transfer.xml
@@ -50,7 +50,7 @@
   <View
     android:id="@+id/view_device_list_boundary"
     android:layout_width="match_parent"
-    android:layout_height="2dp"
+    android:layout_height="1dp"
     android:layout_marginStart="5dp"
     android:layout_marginEnd="5dp"
     android:background="@color/dodger_blue"
@@ -112,7 +112,7 @@
     android:layout_width="match_parent"
     android:layout_height="1dp"
     android:layout_marginStart="5dp"
-    android:layout_marginTop="200dp"
+    android:layout_marginTop="201dp"
     android:layout_marginEnd="5dp"
     android:background="@color/dodger_blue"
     app:layout_constraintBottom_toTopOf="@+id/text_view_files_for_transfer"

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -339,4 +339,9 @@ object Libs {
    * https://developer.android.com/testing
    */
   const val junit: String = "androidx.test.ext:junit:" + Versions.junit
+
+  /**
+   * https://github.com/deano2390/MaterialShowcaseView
+   */
+  const val material_show_case_view: String = "com.github.deano2390:MaterialShowcaseView:" + Versions.material_show_case_view
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -101,6 +101,8 @@ object Versions {
   const val webkit: String = "1.3.0"
 
   const val junit: String = "1.1.4"
+
+  const val material_show_case_view: String = "1.3.7"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -207,6 +207,7 @@ class AllProjectConfigurer {
       implementation(Libs.rxandroid)
       implementation(Libs.rxjava)
       implementation(Libs.preference_ktx)
+      implementation(Libs.material_show_case_view)
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -63,6 +63,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsTest: Boolean
     get() = sharedPreferences.getBoolean(PREF_IS_TEST, false)
 
+  val prefShowShowCaseToUser: Boolean
+    get() = sharedPreferences.getBoolean(PREF_SHOW_SHOWCASE, true)
+
   val prefFullScreen: Boolean
     get() = sharedPreferences.getBoolean(PREF_FULLSCREEN, false)
 
@@ -228,6 +231,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_KIWIX_MOBILE = "kiwix-mobile"
     const val PREF_SHOW_INTRO = "showIntro"
     const val PREF_IS_TEST = "is_test"
+    const val PREF_SHOW_SHOWCASE = "showShowCase"
     private const val PREF_BACK_TO_TOP = "pref_backtotop"
     private const val PREF_FULLSCREEN = "pref_fullscreen"
     private const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -342,4 +342,8 @@
   <string name="go_to_settings_label">Go to Settings</string>
   <string name="request_notification_permission_message">To perform this action, please grant notification access</string>
   <string name="empty_string" />
+  <string name="click_nearby_devices_message">Click here to search for nearby devices.</string>
+  <string name="your_device_name_message">Your device name will appear here.</string>
+  <string name="nearby_devices_list_message">Here, you\'ll find a list of nearby devices. Tap on a device\'s name to initiate file transfer.</string>
+  <string name="transfer_zim_files_list_message">Here, you\'ll find the list of available ZIM files for transfer.</string>
 </resources>


### PR DESCRIPTION
Fixes #1532

* Reduced the `view_device_list_boundary` height to match the one below it, resulting in a more consistent appearance.
* Enhanced the permission request scenario; previously, permissions were requested one by one when the user clicked on the search button. Now, we request all necessary permissions at once to improve the user experience.
* Introduce the 'MaterialShowCase' feature to educate users on the file transfer functionality.
* Added test cases to comprehensively assess the `ShowCaseView` functionality. Ensured that the showcase view is displayed in full only once, and subsequent displays are prevented.
* Improved test cases which sometimes fail:
  * Resolved the issue where `testShowCase` sometimes hung and failed. The test was failing because it only allowed showcasing a feature once. We improved the test case by clearing the previously shown `ShowCaseView` from its preferences when the test runs.
  * Fixed failures in `LanguageFragmentTest` caused by a race condition where the test checked for saved language data immediately, sometimes failing to save the data quickly enough. We added a delay before checking the saved data to address this issue.
   * Addressed failures in `DownloadTest` and `InitialDownloadTest` due to issues with previously running downloads. If a download task failed in a previous run, the test couldn't find the download button. In the case of `InitialDownloadTest`, the StorageConfigureDialog is not displaying due to this. We now check for any ongoing downloads before performing new operations and cancel them if necessary, ensuring that the tests run as expected.

**Note**
Any better message suggestion would be welcome.


https://github.com/kiwix/kiwix-android/assets/34593983/3fedb95e-79ae-418e-b54b-640b82cd5016

