### PR TITLE
Remove Authentication from URL before downloading.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.data.remote
 
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
@@ -55,3 +56,6 @@ val String.secretKey: String
 val String.removeAuthenticationFromUrl: String
   get() = decodeUrl.trim()
     .replace(Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@"), "")
+    .also {
+      Log.d("BasicAuthInterceptor", "URL is $it")
+    }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -36,6 +36,7 @@ class BasicAuthInterceptor : Interceptor {
       val password = userNameAndPassword.substringAfter(":", "")
       val credentials = okhttp3.Credentials.basic(userName, password)
       val authenticatedRequest: Request = request.newBuilder()
+        .url(url.removeAuthenticationFromUrl)
         .header("Authorization", credentials).build()
       return chain.proceed(authenticatedRequest)
     }
@@ -47,6 +48,10 @@ val String.isAuthenticationUrl: Boolean
   get() = decodeUrl.trim().matches(Regex("https://[^@]+@.*\\.zim"))
 
 val String.secretKey: String
-  get() = substringAfter("{{", "")
+  get() = decodeUrl.substringAfter("{{", "")
     .substringBefore("}}", "")
     .trim()
+
+val String.removeAuthenticationFromUrl: String
+  get() = decodeUrl.trim()
+    .replace(Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@"), "")

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
@@ -18,9 +18,10 @@
 
 package org.kiwix.kiwixmobile.core.remote
 
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.data.remote.isAuthenticationUrl
+import org.kiwix.kiwixmobile.core.data.remote.removeAuthenticationFromUrl
 import org.kiwix.kiwixmobile.core.data.remote.secretKey
 
 class BasicAuthInterceptorTest {
@@ -62,6 +63,10 @@ class BasicAuthInterceptorTest {
     val urlWithoutAuth = "https://example.com/kiwix/f/somefile.zim"
     assertEquals(false, urlWithoutAuth.isAuthenticationUrl)
     assertEquals("", urlWithoutAuth.secretKey)
+    assertEquals(
+      urlWithoutAuth,
+      urlWithoutAuth.removeAuthenticationFromUrl
+    )
   }
 
   @Test
@@ -90,6 +95,10 @@ class BasicAuthInterceptorTest {
     assertEquals(false, urlWithHtmlExtension.isAuthenticationUrl)
     assertEquals("BASIC_AUTH_KEY", urlWithTxtExtension.secretKey)
     assertEquals("BASIC_AUTH_KEY", urlWithHtmlExtension.secretKey)
+    assertEquals(
+      "https://example.com/kiwix/f/somefile.txt",
+      urlWithTxtExtension.removeAuthenticationFromUrl
+    )
   }
 
   @Test
@@ -98,5 +107,26 @@ class BasicAuthInterceptorTest {
       "https://{{BASIC_AUTH_KEY}}@example.com/kiwix/f/{{ANOTHER_KEY}}.zim"
     assertEquals(true, urlWithMultiplePlaceholders.isAuthenticationUrl)
     assertEquals("BASIC_AUTH_KEY", urlWithMultiplePlaceholders.secretKey)
+    assertEquals(
+      "https://example.com/kiwix/f/{{ANOTHER_KEY}}.zim",
+      urlWithMultiplePlaceholders.removeAuthenticationFromUrl
+    )
+  }
+
+  @Test
+  fun testGetUrlWithoutAuthentication() {
+    assertEquals(
+      "https://www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-09-12.zim",
+      authenticationUrl.removeAuthenticationFromUrl
+    )
+  }
+
+  @Test
+  fun extractSecretKeyFromEncodedUrl() {
+    assertEquals(
+      "BASIC_AUTH_KEY",
+      "https%3A%2F%2F%7B%7BBASIC_AUTH_KEY%7D%7D%40www.dwds.de/kiwix/dwds_de_dictionary_nopic.zim"
+        .secretKey
+    )
   }
 }

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -72,10 +72,10 @@ fun ProductFlavor.fetchUrl(): String {
     .openConnection()
     .apply {
       if (urlString.isAuthenticationUrl) {
-        // setRequestProperty(
-        //   "Authorization",
-        //   "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
-        // )
+        setRequestProperty(
+          "Authorization",
+          "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
+        )
       }
       connect()
       getInputStream()

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -71,13 +71,13 @@ fun ProductFlavor.fetchUrl(): String {
   return url
     .openConnection()
     .apply {
-      connect()
       if (urlString.isAuthenticationUrl){
         setRequestProperty(
           "Authorization",
           "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
         )
       }
+      connect()
       getInputStream()
     }.let {
       it.getHeaderField("Location")?.replace("https", "http") ?: it.url.toString()

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -71,11 +71,11 @@ fun ProductFlavor.fetchUrl(): String {
   return url
     .openConnection()
     .apply {
-      if (urlString.isAuthenticationUrl){
-        setRequestProperty(
-          "Authorization",
-          "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
-        )
+      if (urlString.isAuthenticationUrl) {
+        // setRequestProperty(
+        //   "Authorization",
+        //   "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
+        // )
       }
       connect()
       getInputStream()

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -7,7 +7,9 @@ import custom.transactionWithCommit
 import plugin.KiwixConfigurationPlugin
 import java.net.URI
 import java.net.URL
+import java.net.URLDecoder
 import java.util.Locale
+import java.util.Base64
 
 plugins {
   android
@@ -58,15 +60,43 @@ fun ProductFlavor.createDownloadTask(file: File): Task {
 }
 
 fun ProductFlavor.fetchUrl(): String {
-  return URI.create(buildConfigFields["ZIM_URL"]!!.value.replace("\"", "")).toURL()
+  val urlString = buildConfigFields["ZIM_URL"]!!.value.replace("\"", "")
+  var secretKey = ""
+  val url = if (urlString.isAuthenticationUrl) {
+    secretKey = urlString.secretKey
+    URI.create(urlString.removeAuthenticationFromUrl).toURL()
+  } else {
+    URI.create(urlString).toURL()
+  }
+  return url
     .openConnection()
     .apply {
       connect()
+      if (urlString.isAuthenticationUrl){
+        setRequestProperty(
+          "Authorization",
+          "Basic ${Base64.getEncoder().encodeToString(System.getenv(secretKey).toByteArray())}"
+        )
+      }
       getInputStream()
     }.let {
       it.getHeaderField("Location")?.replace("https", "http") ?: it.url.toString()
     }
 }
+
+val String.decodeUrl: String
+  get() = URLDecoder.decode(this, "UTF-8")
+val String.isAuthenticationUrl: Boolean
+  get() = decodeUrl.trim().matches(Regex("https://[^@]+@.*\\.zim"))
+
+val String.secretKey: String
+  get() = decodeUrl.substringAfter("{{", "")
+    .substringBefore("}}", "")
+    .trim()
+
+val String.removeAuthenticationFromUrl: String
+  get() = decodeUrl.trim()
+    .replace(Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@"), "")
 
 fun ProductFlavor.createPublishApkWithExpansionTask(
   file: File,


### PR DESCRIPTION
* We have removed the authentication of the URL to make it a normal URL because we are adding authentication in headers so does not need to be added to url.
* Enhanced getting secret function, if the URL is encoded then it will fail to get the secret from it so now we are properly decoding the URL before extracting the secret key from it.
* To properly test these two functions we have added test cases for it.