### PR TITLE
Fixed, unable to open the support link with default browser.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,14 +14,6 @@
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
   <uses-permission android:name="${permission}" />
 
-  <queries>
-    <intent>
-      <action android:name="android.intent.action.VIEW" />
-      <category android:name="android.intent.category.BROWSABLE" />
-      <data android:scheme="https" />
-    </intent>
-  </queries>
-
   <application
     android:name=".KiwixApp"
     android:allowBackup="true"

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -22,6 +22,24 @@
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE" />
     </intent>
+    <intent>
+      <action android:name="android.intent.action.SEND" />
+      <data android:mimeType="*/*" />
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="https" />
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.BROWSABLE" />
+      <data android:scheme="http" />
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:mimeType="application/pdf" />
+    </intent>
   </queries>
 
 


### PR DESCRIPTION
Fixes #3426 

**Issue**

The issue was introduced after we removed `QUERY_ALL_PACKAGE` tag from our manifest due to Play Store policy. It failed to open `pdf/supportLinks/zimfileUrlLinks/sendingEmails` on Android 10 and above with the default browser, because `intent.resolveActivity(activity.packageManager)` failed to resolve the intent with the default apps of the phone.

https://github.com/kiwix/kiwix-android/assets/34593983/476d49e7-8a2c-47b4-bbe7-13cf79931435

https://github.com/kiwix/kiwix-android/assets/34593983/ae3c0081-eb88-4cc8-989a-80cf94dfe358

**Fix**

We have added the query in the manifest to resolve the intent with the default apps of phones.
* Fixed, pdf is not opening with default pdf viewer.
* Fixed, sending emails failed with the default email service.
* Fixed, opening support link, and external URLs with default browser.



https://github.com/kiwix/kiwix-android/assets/34593983/ea7b3cf6-f3f0-4173-bd46-235584ddb4b0


https://github.com/kiwix/kiwix-android/assets/34593983/01b6b165-7b9b-45ad-925c-3731f0257529




