### PR TITLE
Fixed, Reduce mass-storage consumption with Android custom apps with embedded ZIM

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -76,6 +76,7 @@ class MimeTypeTest : BaseActivityTest() {
     }
     val zimFileReader = ZimFileReader(
       zimFile,
+      null,
       Archive(zimFile.canonicalPath),
       NightModeConfig(SharedPreferenceUtil(context), context)
     )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -117,7 +117,7 @@ class AddNoteDialog : DialogFragment() {
       .inject(this)
 
     // Returns name of the form ".../Kiwix/granbluefantasy_en_all_all_nopic_2018-10.zim"
-    zimFileName = zimReaderContainer.zimCanonicalPath
+    zimFileName = zimReaderContainer.zimCanonicalPath ?: zimReaderContainer.name
     if (zimFileName != null) { // No zim file currently opened
       zimFileTitle = zimReaderContainer.zimFileTitle
       zimId = zimReaderContainer.id.orEmpty()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -123,7 +123,7 @@ class AddNoteDialog : DialogFragment() {
       zimId = zimReaderContainer.id.orEmpty()
 
       if (arguments != null) {
-        articleTitle = arguments?.getString(NOTES_TITLE)
+        articleTitle = arguments?.getString(NOTES_TITLE)?.substringAfter(": ")
         zimFileUrl = arguments?.getString(ARTICLE_URL).orEmpty()
       } else {
         val webView = (activity as WebViewProvider?)?.getCurrentWebView()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -38,6 +38,7 @@ import android.os.CountDownTimer
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.os.ParcelFileDescriptor
 import android.provider.Settings
 import android.util.AttributeSet
 import android.util.Log
@@ -154,7 +155,6 @@ import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.deleteCachedFiles
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.readFile
 import java.io.File
-import java.io.FileDescriptor
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -1390,14 +1390,14 @@ abstract class CoreReaderFragment :
   protected fun openZimFile(
     file: File?,
     isCustomApp: Boolean = false,
-    fileDescriptor: FileDescriptor? = null
+    parcelFileDescriptor: ParcelFileDescriptor? = null
   ) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
       if (file?.isFileExist() == true) {
         openAndSetInContainer(file = file)
         updateTitle()
-      } else if (fileDescriptor != null) {
-        openAndSetInContainer(fileDescriptor = fileDescriptor)
+      } else if (parcelFileDescriptor != null) {
+        openAndSetInContainer(parcelFileDescriptor = parcelFileDescriptor)
         updateTitle()
       } else {
         Log.w(TAG_KIWIX, "ZIM file doesn't exist at " + file?.absolutePath)
@@ -1427,7 +1427,10 @@ abstract class CoreReaderFragment :
     )
   }
 
-  private fun openAndSetInContainer(file: File? = null, fileDescriptor: FileDescriptor? = null) {
+  private fun openAndSetInContainer(
+    file: File? = null,
+    parcelFileDescriptor: ParcelFileDescriptor? = null
+  ) {
     try {
       if (isNotPreviouslyOpenZim(file?.canonicalPath)) {
         webViewList.clear()
@@ -1436,8 +1439,8 @@ abstract class CoreReaderFragment :
       e.printStackTrace()
     }
     zimReaderContainer?.let { zimReaderContainer ->
-      if (fileDescriptor != null) {
-        zimReaderContainer.setZimFileDescriptor(fileDescriptor)
+      if (parcelFileDescriptor != null) {
+        zimReaderContainer.setZimFileDescriptor(parcelFileDescriptor)
       } else {
         zimReaderContainer.setZimFile(file)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -26,6 +26,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.content.res.AssetFileDescriptor
 import android.content.res.Configuration
 import android.graphics.Canvas
 import android.graphics.Rect
@@ -38,7 +39,6 @@ import android.os.CountDownTimer
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import android.os.ParcelFileDescriptor
 import android.provider.Settings
 import android.util.AttributeSet
 import android.util.Log
@@ -1390,14 +1390,14 @@ abstract class CoreReaderFragment :
   protected fun openZimFile(
     file: File?,
     isCustomApp: Boolean = false,
-    parcelFileDescriptor: ParcelFileDescriptor? = null
+    assetFileDescriptor: AssetFileDescriptor? = null
   ) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
       if (file?.isFileExist() == true) {
         openAndSetInContainer(file = file)
         updateTitle()
-      } else if (parcelFileDescriptor != null) {
-        openAndSetInContainer(parcelFileDescriptor = parcelFileDescriptor)
+      } else if (assetFileDescriptor != null) {
+        openAndSetInContainer(assetFileDescriptor = assetFileDescriptor)
         updateTitle()
       } else {
         Log.w(TAG_KIWIX, "ZIM file doesn't exist at " + file?.absolutePath)
@@ -1429,7 +1429,7 @@ abstract class CoreReaderFragment :
 
   private fun openAndSetInContainer(
     file: File? = null,
-    parcelFileDescriptor: ParcelFileDescriptor? = null
+    assetFileDescriptor: AssetFileDescriptor? = null
   ) {
     try {
       if (isNotPreviouslyOpenZim(file?.canonicalPath)) {
@@ -1439,8 +1439,8 @@ abstract class CoreReaderFragment :
       e.printStackTrace()
     }
     zimReaderContainer?.let { zimReaderContainer ->
-      if (parcelFileDescriptor != null) {
-        zimReaderContainer.setZimFileDescriptor(parcelFileDescriptor)
+      if (assetFileDescriptor != null) {
+        zimReaderContainer.setZimFileDescriptor(assetFileDescriptor)
       } else {
         zimReaderContainer.setZimFile(file)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
@@ -24,6 +24,7 @@ import org.kiwix.kiwixmobile.core.di.ActivityScope
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.BookmarkItem
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
+import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
 import javax.inject.Inject
 
 private const val TAG = "MainPresenter"
@@ -33,6 +34,7 @@ class MainRepositoryActions @Inject constructor(private val dataSource: DataSour
   private var saveHistoryDisposable: Disposable? = null
   private var saveBookmarkDisposable: Disposable? = null
   private var saveNoteDisposable: Disposable? = null
+  private var saveBookDisposable: Disposable? = null
   private var deleteNoteDisposable: Disposable? = null
 
   fun saveHistory(history: HistoryItem) {
@@ -61,10 +63,16 @@ class MainRepositoryActions @Inject constructor(private val dataSource: DataSour
       .subscribe({}, { e -> Log.e(TAG, "Unable to delete note", e) })
   }
 
+  fun saveBook(book: BookOnDisk) {
+    saveBookDisposable = dataSource.saveBook(book)
+      .subscribe({}, { e -> Log.e(TAG, "Unable to save book", e) })
+  }
+
   fun dispose() {
     saveHistoryDisposable?.dispose()
     saveBookmarkDisposable?.dispose()
     saveNoteDisposable?.dispose()
     deleteNoteDisposable?.dispose()
+    saveBookDisposable?.dispose()
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/BookmarkItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/BookmarkItem.kt
@@ -51,7 +51,7 @@ data class BookmarkItem(
   ) : this(
     zimId = zimFileReader.id,
     zimName = zimFileReader.name,
-    zimFilePath = zimFileReader.zimFile.canonicalPath,
+    zimFilePath = zimFileReader.zimFile?.canonicalPath,
     bookmarkUrl = url,
     title = title,
     favicon = zimFileReader.favicon

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
@@ -48,7 +48,7 @@ sealed class HistoryListItem : PageRelated {
     ) : this(
       zimId = zimFileReader.id,
       zimName = zimFileReader.name,
-      zimFilePath = zimFileReader.zimFile.canonicalPath,
+      zimFilePath = zimFileReader.zimFile?.canonicalPath ?: "",
       favicon = zimFileReader.favicon,
       historyUrl = url,
       title = title,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
@@ -35,7 +35,7 @@ data class NoteListItem(
   ) : this(
     zimId = zimFileReader.id,
     title = title,
-    zimFilePath = zimFileReader.zimFile.canonicalPath,
+    zimFilePath = zimFileReader.zimFile?.canonicalPath,
     zimUrl = url,
     favicon = zimFileReader.favicon,
     noteFilePath = noteFilePath

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowOpenNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowOpenNoteDialog.kt
@@ -45,8 +45,13 @@ data class ShowOpenNoteDialog(
       { effects.offer(OpenPage(page, zimReaderContainer)) },
       {
         val item = page as NoteListItem
-        val file = File(item.zimFilePath.orEmpty())
-        zimReaderContainer.setZimFile(file)
+        // Check if zimFilePath is not null, and then set it in zimReaderContainer.
+        // For custom apps, we are currently using fileDescriptor, and they only have a single file in them,
+        // which is already set in zimReaderContainer, so there's no need to set it again.
+        item.zimFilePath?.let {
+          val file = File(it)
+          zimReaderContainer.setZimFile(file)
+        }
         effects.offer(OpenNote(item.noteFilePath, item.zimUrl, item.title))
       }
     )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -40,7 +40,6 @@ import org.kiwix.libzim.Item
 import org.kiwix.libzim.SuggestionSearch
 import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
-import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStream
@@ -54,13 +53,14 @@ private const val TAG = "ZimFileReader"
 
 class ZimFileReader constructor(
   val zimFile: File?,
+  val parcelFileDescriptor: ParcelFileDescriptor? = null,
   private val jniKiwixReader: Archive,
   private val nightModeConfig: NightModeConfig,
   private val searcher: SuggestionSearcher = SuggestionSearcher(jniKiwixReader)
 ) {
   interface Factory {
     fun create(file: File): ZimFileReader?
-    fun create(fileDescriptor: FileDescriptor): ZimFileReader?
+    fun create(parcelFileDescriptor: ParcelFileDescriptor): ZimFileReader?
 
     class Impl @Inject constructor(private val nightModeConfig: NightModeConfig) :
       Factory {
@@ -79,12 +79,13 @@ class ZimFileReader constructor(
           null
         }
 
-      override fun create(fileDescriptor: FileDescriptor): ZimFileReader? =
+      override fun create(parcelFileDescriptor: ParcelFileDescriptor): ZimFileReader? =
         try {
           ZimFileReader(
             null,
+            parcelFileDescriptor,
             nightModeConfig = nightModeConfig,
-            jniKiwixReader = Archive(fileDescriptor)
+            jniKiwixReader = Archive(parcelFileDescriptor.fileDescriptor)
           ).also {
             Log.e(TAG, "create: with fileDescriptor")
           }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -53,7 +53,7 @@ private const val TAG = "ZimFileReader"
 
 class ZimFileReader constructor(
   val zimFile: File?,
-  private val assetFileDescriptor: AssetFileDescriptor? = null,
+  val assetFileDescriptor: AssetFileDescriptor? = null,
   private val jniKiwixReader: Archive,
   private val nightModeConfig: NightModeConfig,
   private val searcher: SuggestionSearcher = SuggestionSearcher(jniKiwixReader)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -17,7 +17,7 @@
  */
 package org.kiwix.kiwixmobile.core.reader
 
-import android.os.ParcelFileDescriptor
+import android.content.res.AssetFileDescriptor
 import android.webkit.WebResourceResponse
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
@@ -43,10 +43,10 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
       else null
   }
 
-  fun setZimFileDescriptor(parcelFileDescriptor: ParcelFileDescriptor) {
+  fun setZimFileDescriptor(assetFileDescriptor: AssetFileDescriptor) {
     zimFileReader =
-      if (parcelFileDescriptor.fileDescriptor.valid())
-        zimFileReaderFactory.create(parcelFileDescriptor)
+      if (assetFileDescriptor.parcelFileDescriptor.dup().fileDescriptor.valid())
+        zimFileReaderFactory.create(assetFileDescriptor)
       else null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -21,6 +21,7 @@ import android.webkit.WebResourceResponse
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.io.File
+import java.io.FileDescriptor
 import java.net.HttpURLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,12 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
     }
     zimFileReader =
       if (file?.isFileExist() == true) zimFileReaderFactory.create(file)
+      else null
+  }
+
+  fun setZimFileDescriptor(fileDescriptor: FileDescriptor) {
+    zimFileReader =
+      if (fileDescriptor.valid()) zimFileReaderFactory.create(fileDescriptor)
       else null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -17,11 +17,11 @@
  */
 package org.kiwix.kiwixmobile.core.reader
 
+import android.os.ParcelFileDescriptor
 import android.webkit.WebResourceResponse
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.io.File
-import java.io.FileDescriptor
 import java.net.HttpURLConnection
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -43,9 +43,10 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
       else null
   }
 
-  fun setZimFileDescriptor(fileDescriptor: FileDescriptor) {
+  fun setZimFileDescriptor(parcelFileDescriptor: ParcelFileDescriptor) {
     zimFileReader =
-      if (fileDescriptor.valid()) zimFileReaderFactory.create(fileDescriptor)
+      if (parcelFileDescriptor.fileDescriptor.valid())
+        zimFileReaderFactory.create(parcelFileDescriptor)
       else null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -29,6 +29,7 @@ import android.provider.DocumentsContract
 import android.util.Log
 import android.webkit.URLUtil
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.documentfile.provider.DocumentFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -402,4 +403,8 @@ object FileUtils {
       null
     }
   }
+
+  @JvmStatic
+  fun getDemoFilePathForCustomApp(context: Context) =
+    "${ContextCompat.getExternalFilesDirs(context, null)[0]}/demo.zim"
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
@@ -487,13 +487,16 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
         if (it is BookOnDisk) {
           zimReaderFactory.create(it.file)?.let { zimFileReader ->
             val booksOnDiskListItem =
-              (BookOnDisk(zimFileReader.zimFile, zimFileReader) as BooksOnDiskListItem)
-                .apply {
-                  isSelected = true
-                }
-            updatedBooksList.add(booksOnDiskListItem).also {
-              zimFileReader.dispose()
+              zimFileReader.zimFile?.let { file ->
+                (BookOnDisk(file, zimFileReader) as BooksOnDiskListItem)
+                  .apply {
+                    isSelected = true
+                  }
+              }
+            if (booksOnDiskListItem != null) {
+              updatedBooksList.add(booksOnDiskListItem)
             }
+            zimFileReader.dispose()
           }
         } else {
           updatedBooksList.add(it)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
@@ -53,6 +53,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificat
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.ConnectivityReporter
 import org.kiwix.kiwixmobile.core.utils.REQUEST_POST_NOTIFICATION_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.ServerUtils
@@ -60,15 +61,15 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.StartServer
+import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService
+import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_CHECK_IP_ADDRESS
+import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_START_SERVER
+import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_STOP_SERVER
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.SelectionMode
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BookOnDiskDelegate
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskAdapter
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
-import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService
-import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_CHECK_IP_ADDRESS
-import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_START_SERVER
-import org.kiwix.kiwixmobile.core.webserver.wifi_hotspot.HotspotService.Companion.ACTION_STOP_SERVER
 import javax.inject.Inject
 
 class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
@@ -86,6 +87,9 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
 
   @Inject
   lateinit var zimReaderFactory: ZimFileReader.Factory
+
+  @Inject
+  lateinit var zimReaderContainer: ZimReaderContainer
 
   private lateinit var booksAdapter: BooksOnDiskAdapter
   private lateinit var bookDelegate: BookOnDiskDelegate.BookDelegate
@@ -485,18 +489,13 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
       val updatedBooksList: MutableList<BooksOnDiskListItem> = arrayListOf()
       books.forEach {
         if (it is BookOnDisk) {
-          zimReaderFactory.create(it.file)?.let { zimFileReader ->
+          zimReaderContainer.zimFileReader?.let { zimFileReader ->
             val booksOnDiskListItem =
-              zimFileReader.zimFile?.let { file ->
-                (BookOnDisk(file, zimFileReader) as BooksOnDiskListItem)
-                  .apply {
-                    isSelected = true
-                  }
-              }
-            if (booksOnDiskListItem != null) {
-              updatedBooksList.add(booksOnDiskListItem)
-            }
-            zimFileReader.dispose()
+              (BookOnDisk(it.file, zimFileReader) as BooksOnDiskListItem)
+                .apply {
+                  isSelected = true
+                }
+            updatedBooksList.add(booksOnDiskListItem)
           }
         } else {
           updatedBooksList.add(it)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
@@ -49,6 +49,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.databinding.ActivityZimHostBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
@@ -483,7 +484,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   @Suppress("NestedBlockDepth")
   override fun addBooks(books: List<BooksOnDiskListItem>) {
     // Check if this is the app module, as custom apps may have multiple package names
-    if (requireActivity().packageName == "org.kiwix.kiwixmobile") {
+    if (!requireActivity().isCustomApp()) {
       booksAdapter.items = books
     } else {
       val updatedBooksList: MutableList<BooksOnDiskListItem> = arrayListOf()

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -49,6 +49,10 @@ android {
     }
   }
   assetPacks += ":install_time_asset"
+  androidResources {
+    // to not compress zim file in asset folder
+    noCompress.add("zim")
+  }
 }
 
 fun ProductFlavor.createDownloadTask(file: File): Task {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -22,13 +22,12 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.core.content.ContextCompat
-import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasBothFiles
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasFile
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasNothing
 import java.io.File
-import java.io.FileOutputStream
+import java.io.FileDescriptor
 import java.io.IOException
 import javax.inject.Inject
 
@@ -44,10 +43,10 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
   private fun detectInstallationState(
     obbFiles: List<File> = obbFiles(),
     zimFiles: List<File> = zimFiles(),
-    assetFile: File? = getFileFromPlayAssetDelivery()
+    assetFileDescriptor: FileDescriptor? = getFileFromPlayAssetDelivery()
   ): ValidationState {
     return when {
-      assetFile != null -> HasFile(assetFile)
+      assetFileDescriptor != null -> HasFile(null, assetFileDescriptor)
       obbFiles.isNotEmpty() && zimFiles().isNotEmpty() -> HasBothFiles(obbFiles[0], zimFiles[0])
       obbFiles.isNotEmpty() -> HasFile(obbFiles[0])
       zimFiles.isNotEmpty() -> HasFile(zimFiles[0])
@@ -56,30 +55,12 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
   }
 
   @Suppress("NestedBlockDepth", "MagicNumber")
-  private fun getFileFromPlayAssetDelivery(): File? {
-    var zimFile: File? = null
+  private fun getFileFromPlayAssetDelivery(): FileDescriptor? {
     try {
       val context = context.createPackageContext(context.packageName, 0)
       val assetManager = context.assets
-      val inputStream = assetManager.open(BuildConfig.PLAY_ASSET_FILE)
-      val filePath = ContextCompat.getExternalFilesDirs(context, null)[0]
-      zimFile = File(filePath, BuildConfig.PLAY_ASSET_FILE)
-      // Write zim file data if file does not exist or corrupted
-      if (!zimFile.isFileExist() || zimFile.length() == 0L) {
-        // Delete previously corrupted file
-        if (zimFile.isFileExist()) zimFile.delete()
-        zimFile.createNewFile()
-        FileOutputStream(zimFile).use { outputSteam ->
-          inputStream.use { inputStream ->
-            val buffer = ByteArray(1024)
-            var length: Int
-            while (inputStream.read(buffer).also { length = it } > 0) {
-              outputSteam.write(buffer, 0, length)
-            }
-            outputSteam.flush()
-          }
-        }
-      }
+      val inputStream = assetManager.openFd(BuildConfig.PLAY_ASSET_FILE)
+      return inputStream.fileDescriptor
     } catch (packageNameNotFoundException: PackageManager.NameNotFoundException) {
       Log.w(
         "ASSET_PACKAGE_DELIVERY",
@@ -88,7 +69,7 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
     } catch (ioException: IOException) {
       Log.w("ASSET_PACKAGE_DELIVERY", "Unable to copy the content of asset $ioException")
     }
-    return zimFile
+    return null
   }
 
   private fun obbFiles() = scanDirs(ContextCompat.getObbDirs(context), "obb")
@@ -124,6 +105,8 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
 
 sealed class ValidationState {
   data class HasBothFiles(val obbFile: File, val zimFile: File) : ValidationState()
-  data class HasFile(val file: File) : ValidationState()
+  data class HasFile(val file: File?, val fileDescriptor: FileDescriptor? = null) :
+    ValidationState()
+
   object HasNothing : ValidationState()
 }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -95,6 +95,16 @@ class CustomMainActivity : CoreMainActivity() {
   override fun setupDrawerToggle(toolbar: Toolbar) {
     super.setupDrawerToggle(toolbar)
     activityCustomMainBinding.drawerNavView.apply {
+      /**
+       * Hide the 'ZimHostFragment' option from the navigation menu
+       * because we are now using fd (FileDescriptor)
+       * to read the zim file from the asset folder. Currently,
+       * 'KiwixServer' is unable to host zim files via fd.
+       * This feature is temporarily hidden for custom apps.
+       * We will re-enable it for custom apps once the issue is resolved.
+       * For more info see https://github.com/kiwix/kiwix-android/pull/3516
+       */
+      menu.findItem(R.id.menu_host_books)?.isVisible = false
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()
         onNavigationItemSelected(item)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -143,7 +143,13 @@ class CustomReaderFragment : CoreReaderFragment() {
     customFileValidator.validate(
       onFilesFound = {
         when (it) {
-          is ValidationState.HasFile -> openZimFile(it.file, true)
+          is ValidationState.HasFile -> {
+            if (it.fileDescriptor != null) {
+              openZimFile(null, true, it.fileDescriptor)
+            } else {
+              openZimFile(it.file, true)
+            }
+          }
           is ValidationState.HasBothFiles -> {
             it.zimFile.delete()
             openZimFile(it.obbFile, true)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -144,8 +144,8 @@ class CustomReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            if (it.parcelFileDescriptor != null) {
-              openZimFile(null, true, it.parcelFileDescriptor)
+            if (it.assetFileDescriptor != null) {
+              openZimFile(null, true, it.assetFileDescriptor)
             } else {
               openZimFile(it.file, true)
             }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -144,8 +144,8 @@ class CustomReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            if (it.fileDescriptor != null) {
-              openZimFile(null, true, it.fileDescriptor)
+            if (it.parcelFileDescriptor != null) {
+              openZimFile(null, true, it.parcelFileDescriptor)
             } else {
               openZimFile(it.file, true)
             }


### PR DESCRIPTION
Fixes #56
Fixes #3519 
Fixes #3522 
* We are introducing reading zim file content through `fileDescriptor` instead of creating a file to avoid using storage twice for the same zim file.
* As now we are using `fileDescriptor` for custom apps, and our notes functionality breaks with this change so we have refactored our notes functionality to properly work with `fileDescriptor`.
* Fix #3519. The problem was that we were saving the note name combined with `zimFileTitle` and `articleTitle`. When opening the saved note from `NotesFragment`, it retrieved the `noteTitle` from the database, which already contained the combined name. Subsequently, when saving the note again, it redundantly combined the name. To resolve this issue, we now extract the `articleName` when updating notes in `NotesFragment`, ensuring that it updates existing notes instead of creating new ones.

https://github.com/kiwix/kiwix-android/assets/34593983/ccdf906d-fcdb-4f2b-8558-b587b16d8789

* Fixed the issue where the Zim File was not displaying in the `ZimHostFragment` for custom apps.
   * In `ZimHostFragment`, we show Zim files that are saved in the database. These files are typically saved when downloading Zim files. In a custom app, where Zim files are already included within the app and not downloaded separately that's why they are not showing on the `ZimHostFragment`, we have addressed this issue by saving the Zim files in the database to ensure they appear in the `ZimHostFragment`.
   * Regarding the `FileDescriptor`, there are no file objects available because we read Zim files using `FileDescriptor`. To address this, we have created a `demo.zim` file to save it in the database so that it will be displayed in the `ZimHostFragment`. We handle this file within the `KiwixServer`. When the current Zim file is `demo.zim`, we create an `Archive` object with the `FileDescriptor` to host the Zim file on the `KiwixServer`.
* We are temporarily hiding the `kiwixServer` feature from `Custom Apps`. Since we are now using fd (FileDescriptor) to read the zim file from the asset folder. Currently, 'KiwixServer' is unable to host zim files via fd. This feature is temporarily hidden for custom apps. We will re-enable it for custom apps once the issue is resolved. https://github.com/kiwix/libkiwix/issues/1015

https://github.com/kiwix/kiwix-android/assets/34593983/fbd25cd9-d73a-4884-9251-2834c43a3a0b


