### PR TITLE
Fixed, can not open ZIM files from phone storage via the file picker in Android 13.

### DIFF
--- a/app/detekt_baseline.xml
+++ b/app/detekt_baseline.xml
@@ -12,7 +12,7 @@
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$5</ID>
     <ID>MagicNumber:ZimManageViewModel.kt$ZimManageViewModel$500</ID>
     <ID>MagicNumber:LocalFileTransferFragment.kt$LocalFileTransferFragment$500</ID>
-    <ID>NestedBlockDepth:LocalLibraryFragment.kt$LocalLibraryFragment$private fun checkPermissions()</ID>
+    <ID>NestedBlockDepth:LocalLibraryFragment.kt$LocalLibraryFragment$private fun checkManageExternalStoragePermission()</ID>
     <ID>NestedBlockDepth:PeerGroupHandshake.kt$PeerGroupHandshake$private fun readHandshakeAndExchangeMetaData(): InetAddress?</ID>
     <ID>NestedBlockDepth:ReceiverHandShake.kt$ReceiverHandShake$override fun exchangeFileTransferMetadata(inputStream: InputStream, outputStream: OutputStream)</ID>
     <ID>PackageNaming:AvailableSpaceCalculator.kt$package

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -430,33 +430,37 @@ class LocalLibraryFragment : BaseFragment() {
           )
         )
       } else {
-        requestFileSystemCheck()
+        checkManageExternalStoragePermission()
       }
     } else {
-      if (sharedPreferenceUtil.isPlayStoreBuild) {
-        requestFileSystemCheck()
-      } else {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-          if (Environment.isExternalStorageManager()) {
-            // We already have permission!!
-            requestFileSystemCheck()
-          } else {
-            if (sharedPreferenceUtil.manageExternalFilesPermissionDialog) {
-              // We should only ask for first time, If the users wants to revoke settings
-              // then they can directly toggle this feature from settings screen
-              sharedPreferenceUtil.manageExternalFilesPermissionDialog = false
-              // Show Dialog and  Go to settings to give permission
-              dialogShower.show(
-                KiwixDialog.ManageExternalFilesPermissionDialog,
-                {
-                  this.activity?.let(FragmentActivity::navigateToSettings)
-                }
-              )
-            }
-          }
-        } else {
+      checkManageExternalStoragePermission()
+    }
+  }
+
+  private fun checkManageExternalStoragePermission() {
+    if (sharedPreferenceUtil.isPlayStoreBuild) {
+      requestFileSystemCheck()
+    } else {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (Environment.isExternalStorageManager()) {
+          // We already have permission!!
           requestFileSystemCheck()
+        } else {
+          if (sharedPreferenceUtil.manageExternalFilesPermissionDialog) {
+            // We should only ask for first time, If the users wants to revoke settings
+            // then they can directly toggle this feature from settings screen
+            sharedPreferenceUtil.manageExternalFilesPermissionDialog = false
+            // Show Dialog and  Go to settings to give permission
+            dialogShower.show(
+              KiwixDialog.ManageExternalFilesPermissionDialog,
+              {
+                this.activity?.let(FragmentActivity::navigateToSettings)
+              }
+            )
+          }
         }
+      } else {
+        requestFileSystemCheck()
       }
     }
   }


### PR DESCRIPTION
Fixes #3515
* Fixed, can not open ZIM files from phone storage via the file picker in Android 13.
* Improved the permission request scenario for 'MANAGE_EXTERNAL_STORAGE' in Android 13. In the non-play store variant, we were not prompting users to grant this permission, and they were unaware that it was necessary to access the ZIM files in their storage. To resolve this issue, we now request this permission.

**Issue**

https://github.com/kiwix/kiwix-android/assets/34593983/2b428621-859e-41b5-b58b-31dec81c89ae

**Fix**

https://github.com/kiwix/kiwix-android/assets/34593983/dea7750d-1181-4bae-ae42-cc9fbcb932bf

