### PR TITLE
Fixed the redundancy of the 'All-Books-Mode' option for Bookmarks, Notes, and History in custom apps.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -164,4 +164,10 @@ object ActivityExtensions {
       )
     }
   }
+
+  /**
+   * Checks if the package name of the current activity's application is not equal to 'org.kiwix.kiwixmobile',
+   * indicating that it is a custom application.
+   */
+  fun Activity.isCustomApp(): Boolean = packageName != "org.kiwix.kiwixmobile"
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.databinding.FragmentPageBinding
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.page.adapter.OnItemClickListener
@@ -141,8 +142,12 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
     fragmentPageBinding?.recyclerView?.adapter = pageAdapter
     fragmentPageBinding?.noPage?.text = noItemsString
 
-    fragmentPageBinding?.pageSwitch?.text = switchString
-    fragmentPageBinding?.pageSwitch?.isChecked = switchIsChecked
+    fragmentPageBinding?.pageSwitch?.apply {
+      text = switchString
+      isChecked = switchIsChecked
+      // hide switches for custom apps, see more info here https://github.com/kiwix/kiwix-android/issues/3523
+      visibility = if (requireActivity().isCustomApp()) GONE else VISIBLE
+    }
     compositeDisposable.add(pageViewModel.effects.subscribe { it.invokeWith(activity) })
     fragmentPageBinding?.pageSwitch?.setOnCheckedChangeListener { _, isChecked ->
       pageViewModel.actions.offer(Action.UserClickedShowAllToggle(isChecked))


### PR DESCRIPTION
Fixes #3523 

Since custom apps only have a single zim file, there is no need to display these switches, which can potentially confuse users. Therefore, we have hidden these switches in custom apps.


**Custom apps**


https://github.com/kiwix/kiwix-android/assets/34593983/2ed2233a-0ac1-4826-b7dc-31af2f642d6d

**Kiwix App**

https://github.com/kiwix/kiwix-android/assets/34593983/05a93912-d26a-4099-ab74-90993226050f

