### PR TITLE
Fixed, I can't open Zim from an external download.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -77,6 +77,7 @@ class MimeTypeTest : BaseActivityTest() {
     val zimFileReader = ZimFileReader(
       zimFile,
       null,
+      null,
       Archive(zimFile.canonicalPath),
       NightModeConfig(SharedPreferenceUtil(context), context)
     )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1390,14 +1390,18 @@ abstract class CoreReaderFragment :
   protected fun openZimFile(
     file: File?,
     isCustomApp: Boolean = false,
-    assetFileDescriptor: AssetFileDescriptor? = null
+    assetFileDescriptor: AssetFileDescriptor? = null,
+    filePath: String? = null
   ) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
       if (file?.isFileExist() == true) {
         openAndSetInContainer(file = file)
         updateTitle()
       } else if (assetFileDescriptor != null) {
-        openAndSetInContainer(assetFileDescriptor = assetFileDescriptor)
+        openAndSetInContainer(
+          assetFileDescriptor = assetFileDescriptor,
+          filePath = filePath
+        )
         updateTitle()
       } else {
         Log.w(TAG_KIWIX, "ZIM file doesn't exist at " + file?.absolutePath)
@@ -1429,7 +1433,8 @@ abstract class CoreReaderFragment :
 
   private fun openAndSetInContainer(
     file: File? = null,
-    assetFileDescriptor: AssetFileDescriptor? = null
+    assetFileDescriptor: AssetFileDescriptor? = null,
+    filePath: String? = null
   ) {
     try {
       if (isNotPreviouslyOpenZim(file?.canonicalPath)) {
@@ -1440,7 +1445,10 @@ abstract class CoreReaderFragment :
     }
     zimReaderContainer?.let { zimReaderContainer ->
       if (assetFileDescriptor != null) {
-        zimReaderContainer.setZimFileDescriptor(assetFileDescriptor)
+        zimReaderContainer.setZimFileDescriptor(
+          assetFileDescriptor,
+          filePath = filePath
+        )
       } else {
         zimReaderContainer.setZimFile(file)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/BookmarkItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/BookmarkItem.kt
@@ -51,7 +51,7 @@ data class BookmarkItem(
   ) : this(
     zimId = zimFileReader.id,
     zimName = zimFileReader.name,
-    zimFilePath = zimFileReader.zimFile?.canonicalPath,
+    zimFilePath = zimFileReader.zimFile?.canonicalPath ?: zimFileReader.assetDescriptorFilePath,
     bookmarkUrl = url,
     title = title,
     favicon = zimFileReader.favicon

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
@@ -48,7 +48,9 @@ sealed class HistoryListItem : PageRelated {
     ) : this(
       zimId = zimFileReader.id,
       zimName = zimFileReader.name,
-      zimFilePath = zimFileReader.zimFile?.canonicalPath ?: "",
+      zimFilePath = zimFileReader.zimFile?.canonicalPath
+        ?: zimFileReader.assetDescriptorFilePath
+        ?: "",
       favicon = zimFileReader.favicon,
       historyUrl = url,
       title = title,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
@@ -35,7 +35,7 @@ data class NoteListItem(
   ) : this(
     zimId = zimFileReader.id,
     title = title,
-    zimFilePath = zimFileReader.zimFile?.canonicalPath,
+    zimFilePath = zimFileReader.zimFile?.canonicalPath ?: zimFileReader.assetDescriptorFilePath,
     zimUrl = url,
     favicon = zimFileReader.favicon,
     noteFilePath = noteFilePath

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -51,16 +51,21 @@ import javax.inject.Inject
 
 private const val TAG = "ZimFileReader"
 
+@Suppress("LongParameterList")
 class ZimFileReader constructor(
   val zimFile: File?,
   val assetFileDescriptor: AssetFileDescriptor? = null,
+  val assetDescriptorFilePath: String? = null,
   private val jniKiwixReader: Archive,
   private val nightModeConfig: NightModeConfig,
   private val searcher: SuggestionSearcher = SuggestionSearcher(jniKiwixReader)
 ) {
   interface Factory {
     fun create(file: File): ZimFileReader?
-    fun create(assetFileDescriptor: AssetFileDescriptor): ZimFileReader?
+    fun create(
+      assetFileDescriptor: AssetFileDescriptor,
+      filePath: String? = null
+    ): ZimFileReader?
 
     class Impl @Inject constructor(private val nightModeConfig: NightModeConfig) :
       Factory {
@@ -79,11 +84,15 @@ class ZimFileReader constructor(
           null
         }
 
-      override fun create(assetFileDescriptor: AssetFileDescriptor): ZimFileReader? =
+      override fun create(
+        assetFileDescriptor: AssetFileDescriptor,
+        filePath: String?
+      ): ZimFileReader? =
         try {
           ZimFileReader(
             null,
             assetFileDescriptor,
+            assetDescriptorFilePath = filePath,
             nightModeConfig = nightModeConfig,
             jniKiwixReader = Archive(
               assetFileDescriptor.parcelFileDescriptor.dup().fileDescriptor,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -43,10 +43,13 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
       else null
   }
 
-  fun setZimFileDescriptor(assetFileDescriptor: AssetFileDescriptor) {
+  fun setZimFileDescriptor(
+    assetFileDescriptor: AssetFileDescriptor,
+    filePath: String? = null
+  ) {
     zimFileReader =
       if (assetFileDescriptor.parcelFileDescriptor.dup().fileDescriptor.valid())
-        zimFileReaderFactory.create(assetFileDescriptor)
+        zimFileReaderFactory.create(assetFileDescriptor, filePath)
       else null
   }
 
@@ -84,7 +87,11 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
 
   val zimFile get() = zimFileReader?.zimFile
 
-  val zimCanonicalPath get() = zimFileReader?.zimFile?.canonicalPath
+  /**
+   * Return the zimFile path if opened from file else return the filePath of assetFileDescriptor
+   */
+  val zimCanonicalPath
+    get() = zimFileReader?.zimFile?.canonicalPath ?: zimFileReader?.assetDescriptorFilePath
   val zimFileTitle get() = zimFileReader?.title
   val mainPage get() = zimFileReader?.mainPage
   val id get() = zimFileReader?.id

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -22,6 +22,7 @@ import android.app.Activity
 import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
+import android.content.res.AssetFileDescriptor
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -46,6 +47,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import java.io.BufferedReader
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.IOException
 
 object FileUtils {
@@ -407,4 +409,16 @@ object FileUtils {
   @JvmStatic
   fun getDemoFilePathForCustomApp(context: Context) =
     "${ContextCompat.getExternalFilesDirs(context, null)[0]}/demo.zim"
+
+  @JvmStatic
+  fun getAssetFileDescriptorFromUri(
+    context: Context,
+    uri: Uri
+  ): AssetFileDescriptor? {
+    return try {
+      context.contentResolver.openAssetFileDescriptor(uri, "r")
+    } catch (ignore: FileNotFoundException) {
+      null
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1447 

* We are now using fileDescriptor to open the zim files with uris when someone tries to open the zim file directly from storage.
* As now we are using the assetFileDescriptor instead of direct files, we have refactored the functionality of saving (note, history, bookmark) so that we can open the same pages on the same zimFile.


https://github.com/kiwix/kiwix-android/assets/34593983/d4d1e98d-a279-4ed7-b60c-766bffbc81bf

