### PR TITLE
Fixed, Using TTS on Wikivoyage 2023-06 (Android 13) reads code aloud.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -300,7 +300,6 @@ class KiwixTextToSpeech internal constructor(
               bundle,
               bundle.getString(Engine.KEY_PARAM_UTTERANCE_ID)
             )
-            currentPiece.getAndIncrement()
           }
         }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -151,7 +151,7 @@ class KiwixTextToSpeech internal constructor(
       """
         javascript:
         body = document.getElementsByTagName('body')[0].cloneNode(true);
-        toRemove = body.querySelectorAll('sup.reference, #toc, .thumbcaption,     title, .navbox');
+        toRemove = body.querySelectorAll('sup.reference, #toc, .thumbcaption, title, .navbox, style');
         Array.prototype.forEach.call(toRemove, function(elem) {    
           elem.parentElement.removeChild(elem);});
         tts.speakAloud(body.innerText);


### PR DESCRIPTION
Fixes #3530 

**Issues**
* It was reading the code part(that is style element) in `Wikivoyage 2023-06` ZIM file.
* While reading the article it is skipping lines. For example:- It reads the first line then skips the second line, then it reads the third line, and skips the fourth line.

**Fix**
* We have removed the including of the `style` attribute if any is present in the content to avoid this type of issue, like we are removing the `(title, .navbox etc)`.
https://github.com/kiwix/kiwix-android/blob/252d846b64fc669670b3028f5d59a3ffc211f51e/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt#L154
* The issue was caused by an unnecessary increment of the 'currentPiece' index in the onDone callback of the TextToSpeech engine. This double increment led to the skipping of lines. The redundant increment at the end of the method has been removed, ensuring that each line is read correctly.