### PR TITLE
Fixed, the search is not working in dwds app.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -320,7 +320,6 @@ class ZimFileReader constructor(
   fun dispose() {
     jniKiwixReader.dispose()
     searcher.dispose()
-    assetFileDescriptor?.parcelFileDescriptor?.detachFd()
   }
 
   @Suppress("TooGenericExceptionCaught")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -84,8 +84,11 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
   }
 
   fun copyReader(): ZimFileReader? = zimFile?.let(zimFileReaderFactory::create)
+    ?: assetFileDescriptor?.let(zimFileReaderFactory::create)
 
   val zimFile get() = zimFileReader?.zimFile
+
+  val assetFileDescriptor get() = zimFileReader?.assetFileDescriptor
 
   /**
    * Return the zimFile path if opened from file else return the filePath of assetFileDescriptor


### PR DESCRIPTION
Fixed, the search is not working in dwds app.
* We now utilize `AssetFileDescriptor` to open the ZIM file for custom apps. For the search functionality, we are creating a reader with a file object, but we need to create a reader with the `AssetFileDescriptor` instead of a file for custom apps.


https://github.com/kiwix/kiwix-android/assets/34593983/1880fe3b-237f-4b07-99ea-b8cd9b26f25a


