### PR TITLE
Moved version-related properties from individual build.gradle files to a common configuration file (`Config.kt`).

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,13 +8,7 @@ plugins.apply(KiwixConfigurationPlugin::class)
 
 apply(from = rootProject.file("jacoco.gradle"))
 
-ext {
-  set("versionMajor", 3)
-  set("versionMinor", 7)
-  set("versionPatch", 1)
-}
-
-fun generateVersionName() = "${ext["versionMajor"]}.${ext["versionMinor"]}.${ext["versionPatch"]}"
+fun generateVersionName() = "${Config.versionMajor}.${Config.versionMinor}.${Config.versionPatch}"
 
 /*
 * max version code: 21-0-0-00-00-00
@@ -30,9 +24,9 @@ fun generateVersionName() = "${ext["versionMajor"]}.${ext["versionMinor"]}.${ext
 
 fun generateVersionCode() =
   20 * 10000 +
-    ext["versionMajor"] as Int * 10000 +
-    ext["versionMinor"] as Int * 100 +
-    ext["versionPatch"] as Int
+    Config.versionMajor * 10000 +
+    Config.versionMinor * 100 +
+    Config.versionPatch
 
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -27,4 +27,9 @@ object Config {
   const val targetSdk = 33 // Target SDK (Maximum Support Device) is 33 (Android 13).
 
   val javaVersion = JavaVersion.VERSION_1_8
+
+  // Version Information
+  const val versionMajor = 3 // Major version component of the app's version name and version code.
+  const val versionMinor = 8 // Minor version component of the app's version name and version code.
+  const val versionPatch = 0 // Patch version component of the app's version name and version code.
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,11 +18,6 @@ plugins {
 plugins.apply(KiwixConfigurationPlugin::class)
 apply(plugin = "io.objectbox")
 apply(plugin = "com.jakewharton.butterknife")
-ext {
-  set("versionMajor", 3)
-  set("versionMinor", 8)
-  set("versionPatch", 0)
-}
 
 /*
 * max version code: 21-0-0-00-00-00
@@ -38,9 +33,9 @@ ext {
 
 fun generateVersionCode() =
   20 * 10000 +
-    ext["versionMajor"] as Int * 10000 +
-    ext["versionMinor"] as Int * 100 +
-    ext["versionPatch"] as Int
+    Config.versionMajor * 10000 +
+    Config.versionMinor * 100 +
+    Config.versionPatch
 
 android {
   defaultConfig {


### PR DESCRIPTION
**Issue** 

_Originally posted by @MohitMaliFtechiz in https://github.com/kiwix/kiwix-android/issues/3538#issuecomment-1820293303_

**Fix**
* The `Config.kt` now holds the version information we can directly change the versionCode here and it will automatically replace in both gradle files.
* Removed duplicate version configurations from the `build.gradle` files.
