### PR TITLE
Fixed, Bookmark toggle is not on when opening bookmarks for existing opened book.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -89,6 +89,12 @@ class KiwixReaderFragment : CoreReaderFragment() {
     if (args.pageUrl.isNotEmpty()) {
       if (args.zimFileUri.isNotEmpty()) {
         tryOpeningZimFile(args.zimFileUri)
+      } else {
+        // Set up bookmarks for the current book when opening bookmarks from the Bookmark screen.
+        // This is necessary because we are not opening the ZIM file again; the bookmark is
+        // inside the currently opened book. Bookmarks are set up when opening the ZIM file.
+        // See https://github.com/kiwix/kiwix-android/issues/3541
+        zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
       }
       loadUrlWithCurrentWebview(args.pageUrl)
     } else {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -81,6 +81,9 @@ class CustomReaderFragment : CoreReaderFragment() {
     val args = CustomReaderFragmentArgs.fromBundle(requireArguments())
     if (args.pageUrl.isNotEmpty()) {
       loadUrlWithCurrentWebview(args.pageUrl)
+      // Setup bookmark for current book
+      // See https://github.com/kiwix/kiwix-android/issues/3541
+      zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
     } else {
       openObbOrZim()
       manageExternalLaunchAndRestoringViewState()


### PR DESCRIPTION
Fixes #3541 

* Previously, the bookmark toggle was not being activated when opening bookmarks for an already opened book.
* Fixed the issue by correctly setting up the bookmark disposable for the current ZIM file when opening bookmarks for the currently opened book.

**Kiwix app**

https://github.com/kiwix/kiwix-android/assets/34593983/83a34032-a786-4bd6-99b8-727f4ab659ac

**Custom app**

https://github.com/kiwix/kiwix-android/assets/34593983/1576324c-b86a-404d-9bf3-c4de085fcff0



