### PR TITLE
Fixed, Sidebar adds unwanted space after closing the full screen mode.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1422,7 +1422,7 @@ abstract class CoreReaderFragment :
     exitFullscreenButton?.visibility = View.GONE
     exitFullscreenButton?.background?.alpha = 255
     val window = requireActivity().window
-    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowCompat.setDecorFitsSystemWindows(window, true)
     WindowInsetsControllerCompat(window, window.decorView.rootView).apply {
       show(WindowInsetsCompat.Type.systemBars())
       window.decorView.rootView.requestLayout()


### PR DESCRIPTION
Fixes #3543 

* Previously, when exiting full-screen mode, the `WindowCompat.setDecorFitsSystemWindows` configuration was set to `false`, causing a blank space between the sidebar logo and the Bookmark item because it is preventing to adjust the content.
* This change sets the configuration to `true` when exiting full-screen mode to ensure proper adjustment of the sidebar content, eliminating the undesired blank space.
* The adjustment is necessary to maintain a seamless layout and appearance, particularly after transitioning from full-screen mode.


https://github.com/kiwix/kiwix-android/assets/34593983/fa1ead73-6d8f-4efa-a6c6-ff1fb6571718


https://github.com/kiwix/kiwix-android/assets/34593983/9bdaa154-9669-4c6a-a6aa-1c8013cc2c63

