### PR TITLE
Fixed: Version 3.8.0 shuts down after searching for an entry.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -61,7 +61,6 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ActivityResultReceived
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ClickedSearchInText
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ExitedSearch
-import org.kiwix.kiwixmobile.core.search.viewmodel.Action.Filter
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemLongClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnOpenInNewTabClick
@@ -219,7 +218,7 @@ class SearchFragment : BaseFragment() {
           searchView?.setOnQueryTextListener(
             SimpleTextListener {
               if (it.isNotEmpty()) {
-                searchViewModel.actions.trySend(Filter(it)).isSuccess
+                searchViewModel.searchResults(it)
               }
             }
           )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -65,6 +67,8 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.StartSpeechInput
 import org.kiwix.libzim.SuggestionSearch
 import javax.inject.Inject
 
+const val DEBOUNCE_DELAY = 500L
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModel @Inject constructor(
   private val recentSearchDao: NewRecentSearchDao,
@@ -88,10 +92,24 @@ class SearchViewModel @Inject constructor(
   val actions = Channel<Action>(Channel.UNLIMITED)
   private val filter = ConflatedBroadcastChannel("")
   private val searchOrigin = ConflatedBroadcastChannel(FromWebView)
+  private val debouncedSearchQuery = MutableStateFlow("")
 
   init {
     viewModelScope.launch { reducer() }
     viewModelScope.launch { actionMapper() }
+    viewModelScope.launch { debouncedSearchQuery() }
+  }
+
+  private suspend fun debouncedSearchQuery() {
+    // Observe and collect the debounced search query
+    debouncedSearchQuery
+      // Applying debouncing to delay the emission of consecutive search queries
+      .debounce(DEBOUNCE_DELAY)
+      // Ensuring that only distinct search queries are processed
+      .distinctUntilChanged()
+      .collect { query ->
+        actions.trySend(Filter(query)).isSuccess
+      }
   }
 
   @Suppress("DEPRECATION")
@@ -200,6 +218,10 @@ class SearchViewModel @Inject constructor(
       emitter.onComplete()
     }, LATEST)
       .subscribeOn(Schedulers.io())
+  }
+
+  fun searchResults(query: String) {
+    debouncedSearchQuery.value = query
   }
 }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -59,7 +59,6 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ClickedSearchInText
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ConfirmedDelete
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.CreatedWithArguments
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ExitedSearch
-import org.kiwix.kiwixmobile.core.search.viewmodel.Action.Filter
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemLongClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnOpenInNewTabClick
@@ -129,6 +128,7 @@ internal class SearchViewModelTest {
           searchResult(searchTerm2, suggestionSearch, testScheduler)
           delay(100)
           searchResult(searchTerm3, suggestionSearch, testScheduler)
+          delay(DEBOUNCE_DELAY)
           it.assertValue(
             SearchState(
               searchTerm3,
@@ -341,7 +341,7 @@ internal class SearchViewModelTest {
     coEvery {
       searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
     } returns suggestionSearch
-    viewModel.actions.trySend(Filter(searchTerm)).isSuccess
+    viewModel.searchResults(searchTerm)
     recentsFromDb.trySend(databaseResults).isSuccess
     viewModel.actions.trySend(ScreenWasStartedFrom(searchOrigin)).isSuccess
     testScheduler.apply {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -29,10 +29,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.resetMain
@@ -107,6 +109,93 @@ internal class SearchViewModelTest {
     every { zimReaderContainer.id } returns "id"
     every { recentSearchDao.recentSearches("id") } returns recentsFromDb.consumeAsFlow()
     viewModel = SearchViewModel(recentSearchDao, zimReaderContainer, searchResultGenerator)
+  }
+
+  @Nested
+  inner class DebouncedTest {
+    @Test
+    fun `Search action is debounced`() = runTest {
+      val searchTerm1 = "query1"
+      val searchTerm2 = "query2"
+      val searchTerm3 = "query3"
+      val searchOrigin = FromWebView
+      val suggestionSearch: SuggestionSearch = mockk()
+
+      viewModel.state
+        .test(this)
+        .also {
+          searchResult(searchTerm1, suggestionSearch, testScheduler)
+          delay(100)
+          searchResult(searchTerm2, suggestionSearch, testScheduler)
+          delay(100)
+          searchResult(searchTerm3, suggestionSearch, testScheduler)
+          it.assertValue(
+            SearchState(
+              searchTerm3,
+              SearchResultsWithTerm(searchTerm3, suggestionSearch),
+              emptyList(),
+              searchOrigin
+            )
+          )
+        }
+        .finish()
+    }
+
+    @Test
+    fun `Search action is not debounced if time hasn't passed`() = runTest {
+      val searchTerm1 = "query1"
+      val searchTerm2 = "query2"
+      val searchTerm3 = "query3"
+      val searchOrigin = FromWebView
+      val suggestionSearch: SuggestionSearch = mockk()
+
+      viewModel.state
+        .test(this)
+        .also {
+          searchResult(searchTerm1, suggestionSearch, testScheduler)
+          delay(50) // assume user rapidly typing
+          searchResult(searchTerm2, suggestionSearch, testScheduler)
+          delay(50)
+          // test value is not passed to searchResult as time has not passed and user still typing
+          // Match if it is initial `SearchState`
+          it.assertValue(
+            SearchState(
+              "",
+              SearchResultsWithTerm("", null),
+              emptyList(),
+              searchOrigin
+            )
+          )
+          searchResult(searchTerm3, suggestionSearch, testScheduler)
+          delay(DEBOUNCE_DELAY)
+          it.assertValue(
+            SearchState(
+              searchTerm3,
+              SearchResultsWithTerm(searchTerm3, suggestionSearch),
+              emptyList(),
+              searchOrigin
+            )
+          )
+        }
+        .finish()
+    }
+
+    private fun searchResult(
+      searchTerm: String,
+      suggestionSearch: SuggestionSearch,
+      testScheduler: TestCoroutineScheduler
+    ) {
+      coEvery {
+        searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
+      } returns suggestionSearch
+      viewModel.searchResults(searchTerm)
+      recentsFromDb.trySend(emptyList()).isSuccess
+      viewModel.actions.trySend(ScreenWasStartedFrom(FromWebView)).isSuccess
+      testScheduler.apply {
+        advanceTimeBy(400)
+        runCurrent()
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Fixes #3556 


**Issue**

The application was crashing when users rapidly typed to search for an entry. This was caused by frequent retrieval of search data from libkiwix, and the previous search job not being properly cleared, leading to it being retained in memory and causing crashes. 


https://github.com/kiwix/kiwix-android/assets/34593983/0daa7719-361a-4c64-add0-db731e7ea22f



**Logs**
```kotlin
Cmdline: org.kiwix.kiwixmobile
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A  pid: 19615, tid: 19747, name: DefaultDispatch  >>> org.kiwix.kiwixmobile <<<
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #00 pc 000000000042014c  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #01 pc 0000000000420a04  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #02 pc 0000000000422880  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #03 pc 0000000000412b80  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #04 pc 0000000000448bb0  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #05 pc 00000000003f1cac  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #06 pc 00000000003ef908  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000) (Xapian::Query::Internal::postlist_sub_or_like(Xapian::Internal::OrContext&, QueryOptimiser*, double) const+28)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #07 pc 00000000003f5778  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #08 pc 00000000003f5778  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #09 pc 00000000003f54fc  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #10 pc 00000000004486b0  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #11 pc 000000000044bc1c  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #12 pc 00000000003e38c4  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libkiwix.so (offset 0xe99000) (Xapian::Enquire::Internal::get_mset(unsigned int, unsigned int, unsigned int, Xapian::RSet const*, Xapian::MatchDecider const*) const+504)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #13 pc 000000000019215c  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libzim.so (offset 0x83e000) (zim::SuggestionSearch::getEstimatedMatches() const+92)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #14 pc 0000000000027060  /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!libzim_wrapper.so (offset 0x80b000) (Java_org_kiwix_libzim_SuggestionSearch_getEstimatedMatches+124) (BuildId: 6c0d6ee977af86c7d817e067ec4176543043faa4)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #20 pc 00000000000073b0  /data/data/org.kiwix.kiwixmobile/code_cache/.overlay/base.apk/classes11.dex (org.kiwix.kiwixmobile.core.search.viewmodel.SearchState.getVisibleResults+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #25 pc 00000000000063a8  /data/data/org.kiwix.kiwixmobile/code_cache/.overlay/base.apk/classes10.dex (org.kiwix.kiwixmobile.core.search.SearchFragment$render$1$searchResult$1.invokeSuspend+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #30 pc 000000000016f50c  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #35 pc 00000000001da870  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.DispatchedTask.run+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #40 pc 00000000002359b8  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.internal.LimitedDispatcher.run+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #45 pc 0000000000242d20  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.scheduling.TaskImpl.run+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #50 pc 00000000002413a0  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #55 pc 000000000023f4b0  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #60 pc 000000000023f6ac  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker+0)
2023-11-28 17:14:15.098 19904-19904 DEBUG                   pid-19904                            A        #65 pc 000000000023f680  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~y5CudkmP7NaN7eUraxL42Q==/org.kiwix.kiwixmobile-j7pc34vRN3W8MRPBoXqAXQ==/base.apk!classes29.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run+0)
```

**Fix**

Implemented a debouncing mechanism to enhance the handling of search functionalities. This approach is employed to prevent unnecessary data loads from libkiwix, addressing the issue of crashes when users rapidly type and search for results.


https://github.com/kiwix/kiwix-android/assets/34593983/ef558e51-e2c7-42fb-b54e-d1bfa48fc975

