### PR TITLE
Updated the CHANGELOG for milestone `3.8.1`.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+3.8.1
+Bug Fixes:
+* Application crash occurring when users rapidly typed during a search for an entry. (https://github.com/kiwix/kiwix-android/pull/3558)
+* Play Store deep linking issue on Android 12 and above. (https://github.com/kiwix/kiwix-android/pull/3550)
+
 3.8.0
 New Features:
 * Download pause/resume feature. (https://github.com/kiwix/kiwix-android/pull/3459)


### PR DESCRIPTION
Parent issue #3560
