### PR TITLE
Fixed Zimit archives are not displaying correctly.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -208,9 +208,9 @@ class ZimFileReader constructor(
     }
 
   private fun toRedirect(url: String) =
-    "$CONTENT_PREFIX${getActualUrl(url, true)}".toUri()
+    "$CONTENT_PREFIX${getActualUrl(url)}".toUri()
 
-  private fun getActualUrl(url: String, actualUrl: Boolean = false): String {
+  private fun getActualUrl(url: String): String {
     val actualPath = url.toUri().filePath.decodeUrl
     var redirectPath = try {
       jniKiwixReader.getEntryByPath(actualPath)
@@ -220,7 +220,7 @@ class ZimFileReader constructor(
     } catch (ignore: Exception) {
       actualPath.replaceWithEncodedString
     }
-    if (actualUrl && url.decodeUrl.contains("?")) {
+    if (url.decodeUrl.contains("?")) {
       redirectPath += extractQueryParam(url)
     }
     return redirectPath
@@ -294,7 +294,9 @@ class ZimFileReader constructor(
 
   private fun getItem(url: String): Item? =
     try {
-      jniKiwixReader.getEntryByPath(getActualUrl(url)).getItem(true)
+      val actualPath = url.toUri().filePath.decodeUrl
+      jniKiwixReader.getEntryByPath(actualPath)
+        .getItem(true)
     } catch (exception: Exception) {
       Log.e(TAG, "Could not get Item for url = $url \n original exception = $exception")
       null


### PR DESCRIPTION
Fixes #3578 

* The getEntryByPath method was being called twice when retrieving content. Consequently, the initial call returned the content entry URL with additional parameters. Subsequently, when making the second call with the provided URL, it resulted in an "entry not found" exception. This issue prevented the loading of the CSS and content of the Zim file.
* Additionally, the getActualUrl method was primarily implemented to retrieve the redirect entry of the URL provided by the webView. It is unnecessary to invoke this method when obtaining content.

**Before fix**


https://github.com/kiwix/kiwix-android/assets/34593983/dc697ced-bc8a-43e0-acd3-ea8b81b96d45

**After fixing**


https://github.com/kiwix/kiwix-android/assets/34593983/650454c2-29f3-461d-b110-d0b5f36bfd99


