### PR TITLE
Fixed Start-up message to inform about the restrictions on the Google Store app to open sideloaded ZIM files.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -73,6 +73,7 @@ class DownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -17,22 +17,30 @@
  */
 package org.kiwix.kiwixmobile.help
 
+import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
+import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.utils.KiwixIdlingResource
 
 class HelpFragmentTest : BaseActivityTest() {
+
+  private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
   @Before
   override fun waitForIdle() {
@@ -53,6 +61,7 @@ class HelpFragmentTest : BaseActivityTest() {
 
   @Test
   fun verifyHelpActivity() {
+    setShowPlayStoreRestriction(false)
     activityScenario.onActivity {
       it.navigate(R.id.helpFragment)
     }
@@ -66,8 +75,53 @@ class HelpFragmentTest : BaseActivityTest() {
       clickOnHowToUpdateContent()
       assertHowToUpdateContentIsExpanded()
       clickOnHowToUpdateContent()
+      assertZimFileNotShowingIsNotVisible()
       clickOnSendFeedback()
     }
     LeakAssertions.assertNoLeaks()
+  }
+
+  @Test
+  fun verifyHelpActivityWithPlayStoreRestriction() {
+    setShowPlayStoreRestriction(true)
+    activityScenario.onActivity {
+      it.navigate(R.id.helpFragment)
+    }
+    help {
+      clickOnWhatDoesKiwixDo()
+      assertWhatDoesKiwixDoIsExpanded()
+      clickOnWhatDoesKiwixDo()
+      clickOnWhereIsContent()
+      assertWhereIsContentIsExpanded()
+      clickOnWhereIsContent()
+      clickOnHowToUpdateContent()
+      assertHowToUpdateContentIsExpanded()
+      clickOnHowToUpdateContent()
+      clickOnZimFileNotShowing()
+      assertZimFileNotShowingIsExpanded()
+      clickOnZimFileNotShowing()
+      clickOnSendFeedback()
+    }
+    LeakAssertions.assertNoLeaks()
+  }
+
+  private fun setShowPlayStoreRestriction(showRestriction: Boolean) {
+    context.let {
+      sharedPreferenceUtil = SharedPreferenceUtil(it).apply {
+        setIntroShown()
+        putPrefWifiOnly(false)
+        setIsPlayStoreBuildType(showRestriction)
+        prefIsTest = true
+      }
+    }
+  }
+
+  @After
+  fun finish() {
+    IdlingRegistry.getInstance().unregister(KiwixIdlingResource.getInstance())
+    PreferenceManager.getDefaultSharedPreferences(context).edit {
+      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, false)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
+    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.help
 
+import android.os.Build
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -83,26 +84,28 @@ class HelpFragmentTest : BaseActivityTest() {
 
   @Test
   fun verifyHelpActivityWithPlayStoreRestriction() {
-    setShowPlayStoreRestriction(true)
-    activityScenario.onActivity {
-      it.navigate(R.id.helpFragment)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      setShowPlayStoreRestriction(true)
+      activityScenario.onActivity {
+        it.navigate(R.id.helpFragment)
+      }
+      help {
+        clickOnWhatDoesKiwixDo()
+        assertWhatDoesKiwixDoIsExpanded()
+        clickOnWhatDoesKiwixDo()
+        clickOnWhereIsContent()
+        assertWhereIsContentIsExpanded()
+        clickOnWhereIsContent()
+        clickOnHowToUpdateContent()
+        assertHowToUpdateContentIsExpanded()
+        clickOnHowToUpdateContent()
+        clickOnZimFileNotShowing()
+        assertZimFileNotShowingIsExpanded()
+        clickOnZimFileNotShowing()
+        clickOnSendFeedback()
+      }
+      LeakAssertions.assertNoLeaks()
     }
-    help {
-      clickOnWhatDoesKiwixDo()
-      assertWhatDoesKiwixDoIsExpanded()
-      clickOnWhatDoesKiwixDo()
-      clickOnWhereIsContent()
-      assertWhereIsContentIsExpanded()
-      clickOnWhereIsContent()
-      clickOnHowToUpdateContent()
-      assertHowToUpdateContentIsExpanded()
-      clickOnHowToUpdateContent()
-      clickOnZimFileNotShowing()
-      assertZimFileNotShowingIsExpanded()
-      clickOnZimFileNotShowing()
-      clickOnSendFeedback()
-    }
-    LeakAssertions.assertNoLeaks()
   }
 
   private fun setShowPlayStoreRestriction(showRestriction: Boolean) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
@@ -17,6 +17,9 @@
  */
 package org.kiwix.kiwixmobile.help
 
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
@@ -76,6 +79,19 @@ class HelpRobot : BaseRobot() {
 
   fun clickOnSendFeedback() {
     clickOn(ViewId(id.activity_help_feedback_text_view))
+  }
+
+  fun clickOnZimFileNotShowing() {
+    clickOn(TextId(string.zim_files_not_showing))
+  }
+
+  fun assertZimFileNotShowingIsExpanded() {
+    isVisible(TextId(string.zim_files_not_showing_description))
+  }
+
+  fun assertZimFileNotShowingIsNotVisible() {
+    onView(withText("Zim files not showing?"))
+      .check(doesNotExist())
   }
 
   private fun helpTextFormat(vararg stringIds: Int) =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -63,6 +63,7 @@ class InitialDownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -75,6 +75,7 @@ class LanguageFragmentTest {
       .edit {
         putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
         putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+        putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -166,6 +166,7 @@ class LocalFileTransferTest {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, shouldShowShowCase)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     if (isResetShowCaseId) {
       // To clear showCaseID to ensure the showcase view will show.

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -61,6 +61,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -52,6 +52,7 @@ class MimeTypeTest : BaseActivityTest() {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogRobot.kt
@@ -1,0 +1,65 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.nav.destination
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import applyWithViewHierarchyPrinting
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.ViewId
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.TestUtils
+
+fun playStoreRestriction(func: PlayStoreRestrictionDialogRobot.() -> Unit) =
+  PlayStoreRestrictionDialogRobot().applyWithViewHierarchyPrinting(func)
+
+class PlayStoreRestrictionDialogRobot : BaseRobot() {
+
+  fun clickLibraryOnBottomNav() {
+    pauseForBetterTestPerformance()
+    clickOn(ViewId(R.id.libraryFragment))
+  }
+
+  fun assertPlayStoreRestrictionDialogDisplayed() {
+    pauseForBetterTestPerformance()
+    onView(withText("UNDERSTOOD"))
+      .check(matches(isDisplayed()))
+  }
+
+  fun assetPlayStoreRestrictionDialogNotDisplayed() {
+    pauseForBetterTestPerformance()
+    onView(withText("UNDERSTOOD"))
+      .check(doesNotExist())
+  }
+
+  fun clickOnUnderstood() {
+    pauseForBetterTestPerformance()
+    onView(withText("UNDERSTOOD"))
+      .perform(click())
+  }
+
+  private fun pauseForBetterTestPerformance() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.nav.destination
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
+import leakcanary.LeakAssertions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
+
+class PlayStoreRestrictionDialogTest {
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
+  private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+
+  private lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+
+  private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.NEARBY_WIFI_DEVICES
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.ACCESS_COARSE_LOCATION,
+      Manifest.permission.ACCESS_FINE_LOCATION
+    )
+  }
+
+  @Rule
+  @JvmField
+  var permissionRules: GrantPermissionRule =
+    GrantPermissionRule.grant(*permissions)
+  private var context: Context? = null
+
+  @Before
+  fun waitForIdle() {
+    context = InstrumentationRegistry.getInstrumentation().targetContext
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
+        TestUtils.closeSystemDialogs(context)
+      }
+      waitForIdle()
+    }
+  }
+
+  @Test
+  fun showPlayStoreRestrictionDialog() {
+    setShowPlayStoreRestrictionDialog(true)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
+    playStoreRestriction {
+      clickLibraryOnBottomNav()
+      assertPlayStoreRestrictionDialogDisplayed()
+      clickOnUnderstood()
+    }
+    LeakAssertions.assertNoLeaks()
+  }
+
+  @Test
+  fun testPlayStoreDialogShowOnlyOnce() {
+    setShowPlayStoreRestrictionDialog(false)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
+    playStoreRestriction {
+      clickLibraryOnBottomNav()
+      assetPlayStoreRestrictionDialogNotDisplayed()
+    }
+    LeakAssertions.assertNoLeaks()
+  }
+
+  private fun setShowPlayStoreRestrictionDialog(showDialog: Boolean) {
+    context?.let {
+      sharedPreferenceUtil = SharedPreferenceUtil(it).apply {
+        setIntroShown()
+        putPrefWifiOnly(false)
+        setIsPlayStoreBuildType(true)
+        prefIsTest = true
+        playStoreRestrictionPermissionDialog = showDialog
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -78,29 +78,33 @@ class PlayStoreRestrictionDialogTest {
 
   @Test
   fun showPlayStoreRestrictionDialog() {
-    setShowPlayStoreRestrictionDialog(true)
-    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      setShowPlayStoreRestrictionDialog(true)
+      activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+        moveToState(Lifecycle.State.RESUMED)
+      }
+      playStoreRestriction {
+        clickLibraryOnBottomNav()
+        assertPlayStoreRestrictionDialogDisplayed()
+        clickOnUnderstood()
+      }
+      LeakAssertions.assertNoLeaks()
     }
-    playStoreRestriction {
-      clickLibraryOnBottomNav()
-      assertPlayStoreRestrictionDialogDisplayed()
-      clickOnUnderstood()
-    }
-    LeakAssertions.assertNoLeaks()
   }
 
   @Test
   fun testPlayStoreDialogShowOnlyOnce() {
-    setShowPlayStoreRestrictionDialog(false)
-    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      setShowPlayStoreRestrictionDialog(false)
+      activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+        moveToState(Lifecycle.State.RESUMED)
+      }
+      playStoreRestriction {
+        clickLibraryOnBottomNav()
+        assetPlayStoreRestrictionDialogNotDisplayed()
+      }
+      LeakAssertions.assertNoLeaks()
     }
-    playStoreRestriction {
-      clickLibraryOnBottomNav()
-      assetPlayStoreRestrictionDialogNotDisplayed()
-    }
-    LeakAssertions.assertNoLeaks()
   }
 
   private fun setShowPlayStoreRestrictionDialog(showDialog: Boolean) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -70,6 +70,7 @@ class LocalLibraryTest : BaseActivityTest() {
       // the manage external storage permission dialog on Android 11 and above
       // while refreshing the content in LocalLibraryFragment.
       putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, false)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -63,6 +63,7 @@ class NavigationHistoryTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -62,6 +62,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -62,6 +62,7 @@ class SearchFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -85,6 +85,7 @@ class ZimHostFragmentTest {
         putPrefWifiOnly(false)
         setIsPlayStoreBuildType(true)
         prefIsTest = true
+        playStoreRestrictionPermissionDialog = false
       }
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
@@ -18,13 +18,25 @@
 
 package org.kiwix.kiwixmobile.help
 
+import android.os.Build
+import org.kiwix.kiwixmobile.BuildConfig.IS_PLAYSTORE
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.help.HelpFragment
 
 class KiwixHelpFragment : HelpFragment() {
-  override fun rawTitleDescriptionMap() = listOf(
-    R.string.help_2 to R.array.description_help_2,
-    R.string.help_5 to R.array.description_help_5,
-    R.string.how_to_update_content to R.array.update_content_description
-  )
+  override fun rawTitleDescriptionMap() =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && IS_PLAYSTORE) {
+      listOf(
+        R.string.help_2 to R.array.description_help_2,
+        R.string.help_5 to R.array.description_help_5,
+        R.string.how_to_update_content to R.array.update_content_description,
+        R.string.zim_files_not_showing to R.array.description_help_6
+      )
+    } else {
+      listOf(
+        R.string.help_2 to R.array.description_help_2,
+        R.string.help_5 to R.array.description_help_5,
+        R.string.how_to_update_content to R.array.update_content_description
+      )
+    }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
@@ -18,14 +18,12 @@
 
 package org.kiwix.kiwixmobile.help
 
-import android.os.Build
-import org.kiwix.kiwixmobile.BuildConfig.IS_PLAYSTORE
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.help.HelpFragment
 
 class KiwixHelpFragment : HelpFragment() {
   override fun rawTitleDescriptionMap() =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && IS_PLAYSTORE) {
+    if (sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove()) {
       listOf(
         R.string.help_2 to R.array.description_help_2,
         R.string.help_5 to R.array.description_help_5,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -363,13 +363,24 @@ class LocalLibraryFragment : BaseFragment() {
 
   override fun onResume() {
     super.onResume()
-    if (!sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove() &&
+    if (sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove() &&
+      sharedPreferenceUtil.playStoreRestrictionPermissionDialog
+    ) {
+      showPlayStoreRestrictionInformationToUser()
+    } else if (!sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove() &&
       !sharedPreferenceUtil.prefIsTest && !permissionDeniedLayoutShowing
     ) {
       checkPermissions()
     } else if (!permissionDeniedLayoutShowing) {
       fragmentDestinationLibraryBinding?.zimfilelist?.visibility = VISIBLE
     }
+  }
+
+  private fun showPlayStoreRestrictionInformationToUser() {
+    // We should only ask for first time
+    sharedPreferenceUtil.playStoreRestrictionPermissionDialog = false
+    // Show Dialog to the user to inform about the play store restriction
+    dialogShower.show(KiwixDialog.PlayStoreRestrictionPopup)
   }
 
   override fun onDestroyView() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -64,10 +64,12 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isManageExternalStoragePermissionGranted
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
+import org.kiwix.kiwixmobile.core.extensions.browserIntent
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
 import org.kiwix.kiwixmobile.core.extensions.setBottomMarginToFragmentContainerView
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.main.KIWIX_APK_WEBSITE_URL
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
@@ -380,7 +382,15 @@ class LocalLibraryFragment : BaseFragment() {
     // We should only ask for first time
     sharedPreferenceUtil.playStoreRestrictionPermissionDialog = false
     // Show Dialog to the user to inform about the play store restriction
-    dialogShower.show(KiwixDialog.PlayStoreRestrictionPopup)
+    dialogShower.show(
+      KiwixDialog.PlayStoreRestrictionPopup,
+      {},
+      ::openKiwixWebsiteForDownloadingApk
+    )
+  }
+
+  private fun openKiwixWebsiteForDownloadingApk() {
+    requireActivity().startActivity(KIWIX_APK_WEBSITE_URL.toUri().browserIntent())
   }
 
   override fun onDestroyView() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpAdapter.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.help
 
 import android.animation.ObjectAnimator
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -62,7 +63,10 @@ internal class HelpAdapter(titleDescriptionMap: Map<String, String>) :
     override fun bind(item: HelpItem) {
       itemHelpBinding.itemHelpTitle.setOnClickListener { toggleDescriptionVisibility() }
       itemHelpBinding.itemHelpToggleExpand.setOnClickListener { toggleDescriptionVisibility() }
-      itemHelpBinding.itemHelpDescription.text = item.description
+      itemHelpBinding.itemHelpDescription.apply {
+        text = item.description
+        movementMethod = LinkMovementMethod.getInstance()
+      }
       itemHelpBinding.itemHelpTitle.text = item.title
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
@@ -39,9 +39,13 @@ import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.CONTACT_EMAIL_ADDRESS
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import javax.inject.Inject
 
 @Suppress("UnnecessaryAbstractClass")
 abstract class HelpFragment : BaseFragment() {
+  @Inject
+  lateinit var sharedPreferenceUtil: SharedPreferenceUtil
   private var fragmentHelpBinding: FragmentHelpBinding? = null
   protected open fun rawTitleDescriptionMap(): List<Pair<Int, Int>> = emptyList()
   override val fragmentToolbar: Toolbar? by lazy {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -55,6 +55,7 @@ import javax.inject.Inject
 import kotlin.system.exitProcess
 
 const val KIWIX_SUPPORT_URL = "https://www.kiwix.org/support"
+const val KIWIX_APK_WEBSITE_URL = "https://download.kiwix.org/release/kiwix-android/"
 const val PAGE_URL_KEY = "pageUrl"
 const val SHOULD_OPEN_IN_NEW_TAB = "shouldOpenInNewTab"
 const val FIND_IN_PAGE_SEARCH_STRING = "findInPageSearchString"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -206,6 +206,12 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
           manageExternalFilesPermissionDialogOnRefresh
         )
       }
+  var playStoreRestrictionPermissionDialog: Boolean
+    get() = sharedPreferences.getBoolean(PREF_PLAY_STORE_RESTRICTION, true)
+    set(playStoreRestrictionPermissionDialog) =
+      sharedPreferences.edit {
+        putBoolean(PREF_PLAY_STORE_RESTRICTION, playStoreRestrictionPermissionDialog)
+      }
 
   var hostedBooks: Set<String>
     get() = sharedPreferences.getStringSet(PREF_HOSTED_BOOKS, null)?.toHashSet() ?: HashSet()
@@ -266,5 +272,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
     const val PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH = "pref_show_manage_external_files"
     const val IS_PLAY_STORE_BUILD = "is_play_store_build"
+    const val PREF_PLAY_STORE_RESTRICTION = "pref_play_store_restriction"
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -174,7 +174,8 @@ sealed class KiwixDialog(
     null,
     R.string.zim_files_not_showing_description,
     R.string.understood,
-    R.string.download
+    R.string.download,
+    cancelable = false
   )
 
   data class ShowRate(override val args: List<Any>, val customIcon: Int?) :

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -170,6 +170,13 @@ sealed class KiwixDialog(
     neutralMessage = R.string.do_not_ask_anymore
   )
 
+  object PlayStoreRestrictionPopup : KiwixDialog(
+    null,
+    R.string.zim_files_not_showing_description,
+    R.string.understood,
+    null
+  )
+
   data class ShowRate(override val args: List<Any>, val customIcon: Int?) :
     KiwixDialog(
       R.string.rate_dialog_title,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -174,7 +174,7 @@ sealed class KiwixDialog(
     null,
     R.string.zim_files_not_showing_description,
     R.string.understood,
-    null
+    R.string.download
   )
 
   data class ShowRate(override val args: List<Any>, val customIcon: Int?) :

--- a/core/src/main/res/layout/item_help.xml
+++ b/core/src/main/res/layout/item_help.xml
@@ -35,6 +35,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     android:textColor="?textSecondary"
     android:visibility="gone"
+    android:autoLink="web"
     app:layout_constraintTop_toBottomOf="@id/item_help_title"
     tools:text="@string/help_3"
     tools:visibility="visible" />

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -304,7 +304,7 @@
   <string name="open_drawer">Open Drawer</string>
   <string name="close_drawer">Close Drawer</string>
   <string name="zim_files_not_showing">Zim files not showing?</string>
-  <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix from <a href="https://download.kiwix.org/release/kiwix-android/">our official website</a></string>
+  <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix app from our official website <a href="https://download.kiwix.org/release/kiwix-android/">https://download.kiwix.org/release/kiwix-android/</a></string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -209,6 +209,9 @@
     <item>@string/help_10</item>
     <item>@string/help_11</item>
   </string-array>
+  <string-array name="description_help_6">
+    <item>@string/zim_files_not_showing_description</item>
+  </string-array>
   <string name="bookmarks_from_current_book">View Bookmarks From All Books</string>
   <string name="search_bookmarks">Search bookmarks</string>
   <string name="switch_tabs">Switch tabs</string>
@@ -300,6 +303,8 @@
   <string name="tabs_restored">Tabs restored</string>
   <string name="open_drawer">Open Drawer</string>
   <string name="close_drawer">Close Drawer</string>
+  <string name="zim_files_not_showing">Zim files not showing?</string>
+  <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix from <a href="https://download.kiwix.org/release/kiwix-android/">our official website</a></string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -305,6 +305,7 @@
   <string name="close_drawer">Close Drawer</string>
   <string name="zim_files_not_showing">Zim files not showing?</string>
   <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix app from our official website <a href="https://download.kiwix.org/release/kiwix-android/">https://download.kiwix.org/release/kiwix-android/</a></string>
+  <string name="understood">Understood</string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>


### PR DESCRIPTION
Fixes #3576 

* Showing Play Store restriction to the users in the help screen in the Play Store variant.
![1702044522576](https://github.com/kiwix/kiwix-android/assets/34593983/9df228dd-82d9-40a0-9b4a-c4cc49e0051f)
* Showing play store restriction dialog to the user on the first run.
* Introduced test cases for the new functionality to ensure its expected behavior in both variants, such as Play Store and non-Play Store. 
