### PR TITLE
Fixed the app crashes that occurred when deleting letters in a search.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -260,7 +260,7 @@ class SearchFragment : BaseFragment() {
     fragmentSearchBinding?.searchLoadingIndicator?.isShowing(true)
     renderingJob = searchViewModel.viewModelScope.launch(Dispatchers.Main) {
       val searchResult = withContext(Dispatchers.IO) {
-        state.getVisibleResults(0)
+        state.getVisibleResults(0, renderingJob)
       }
 
       fragmentSearchBinding?.searchLoadingIndicator?.isShowing(false)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -43,7 +43,10 @@ import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.android.schedulers.AndroidSchedulers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -86,6 +89,7 @@ class SearchFragment : BaseFragment() {
   private var searchAdapter: SearchAdapter? = null
   private var isDataLoading = false
   private var renderingJob: Job? = null
+  private val searchMutex = Mutex()
 
   override fun inject(baseActivity: BaseActivity) {
     baseActivity.cachedComponent.inject(this)
@@ -252,22 +256,25 @@ class SearchFragment : BaseFragment() {
     )
   }
 
-  private fun render(state: SearchState) {
-    renderingJob?.cancel()
-    isDataLoading = false
-    searchInTextMenuItem?.isVisible = state.searchOrigin == FromWebView
-    searchInTextMenuItem?.isEnabled = state.searchTerm.isNotBlank()
-    fragmentSearchBinding?.searchLoadingIndicator?.isShowing(true)
-    renderingJob = searchViewModel.viewModelScope.launch(Dispatchers.Main) {
-      val searchResult = withContext(Dispatchers.IO) {
-        state.getVisibleResults(0, renderingJob)
-      }
+  private suspend fun render(state: SearchState) {
+    searchMutex.withLock {
+      // `cancelAndJoin` cancels the previous running job and waits for it to completely cancel.
+      renderingJob?.cancelAndJoin()
+      isDataLoading = false
+      searchInTextMenuItem?.isVisible = state.searchOrigin == FromWebView
+      searchInTextMenuItem?.isEnabled = state.searchTerm.isNotBlank()
+      fragmentSearchBinding?.searchLoadingIndicator?.isShowing(true)
+      renderingJob = searchViewModel.viewModelScope.launch(Dispatchers.Main) {
+        val searchResult = withContext(Dispatchers.IO) {
+          state.getVisibleResults(0, renderingJob)
+        }
 
-      fragmentSearchBinding?.searchLoadingIndicator?.isShowing(false)
+        fragmentSearchBinding?.searchLoadingIndicator?.isShowing(false)
 
-      searchResult?.let {
-        fragmentSearchBinding?.searchNoResults?.isVisible = it.isEmpty()
-        searchAdapter?.items = it
+        searchResult?.let {
+          fragmentSearchBinding?.searchNoResults?.isVisible = it.isEmpty()
+          searchAdapter?.items = it
+        }
       }
     }
   }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -35,7 +35,7 @@ internal class SearchStateTest {
     val suggestionSearchWrapper: SuggestionSearchWrapper = mockk()
     val searchIteratorWrapper: SuggestionIteratorWrapper = mockk()
     val entryWrapper: SuggestionItemWrapper = mockk()
-    val estimatedMatches = 1
+    val estimatedMatches = 100
     every { suggestionSearchWrapper.estimatedMatches } returns estimatedMatches.toLong()
     // Settings list to hasNext() to ensure it returns true only for the first call.
     // Otherwise, if we do not set this, the method will always return true when checking if the iterator has a next value,


### PR DESCRIPTION
Fixes #3581 

* Removed the unnecessary estimation matches call on `libkiwix`, as we do not need this since `libkiwix` can handle this automatically.
* Cancelled the previously running job if a new `searchTerm` is in progress; this will avoid unnecessary memory allocation and data load on libkiwix.

