### PR TITLE
Fixed unable to open zim files on sd card in version 3.8.1

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -26,6 +26,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +66,10 @@ class LocalLibraryTest : BaseActivityTest() {
       // set PREF_MANAGE_EXTERNAL_FILES false for hiding
       // manage external storage permission dialog on android 11 and above
       putBoolean(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES, false)
+      // Set PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH to false to hide
+      // the manage external storage permission dialog on Android 11 and above
+      // while refreshing the content in LocalLibraryFragment.
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
@@ -102,5 +107,14 @@ class LocalLibraryTest : BaseActivityTest() {
     }
     refresh(R.id.zim_swiperefresh)
     library(LibraryRobot::assertLibraryListDisplayed)
+  }
+
+  @After
+  fun finish() {
+    PreferenceManager.getDefaultSharedPreferences(
+      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    ).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, true)
+    }
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -37,6 +37,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -44,6 +45,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -59,6 +61,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.downloader.Downloader
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isManageExternalStoragePermissionGranted
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
@@ -69,6 +72,7 @@ import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
+import org.kiwix.kiwixmobile.core.navigateToSettings
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
@@ -523,6 +527,12 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           }
           else -> if (sharedPreferenceUtil.showStorageOption) {
             showStorageConfigureDialog()
+          } else if (!requireActivity().isManageExternalStoragePermissionGranted(
+              sharedPreferenceUtil
+            )
+          ) {
+            @Suppress("NewApi")
+            showManageExternalStoragePermissionDialog()
           } else {
             availableSpaceCalculator.hasAvailableSpaceFor(
               item,
@@ -568,6 +578,21 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   }
 
   private fun clickOnBookItem() {
-    downloadBookItem?.let(::onBookItemClick)
+    if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
+      @Suppress("NewApi")
+      showManageExternalStoragePermissionDialog()
+    } else {
+      downloadBookItem?.let(::onBookItemClick)
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  private fun showManageExternalStoragePermissionDialog() {
+    dialogShower.show(
+      KiwixDialog.ManageExternalFilesPermissionDialog,
+      {
+        this.activity?.let(FragmentActivity::navigateToSettings)
+      }
+    )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -19,11 +19,13 @@
 package org.kiwix.kiwixmobile.core.extensions
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -170,4 +172,16 @@ object ActivityExtensions {
    * indicating that it is a custom application.
    */
   fun Activity.isCustomApp(): Boolean = packageName != "org.kiwix.kiwixmobile"
+
+  @SuppressLint("NewApi")
+  fun Activity.isManageExternalStoragePermissionGranted(
+    sharedPreferenceUtil: SharedPreferenceUtil?
+  ): Boolean =
+    if (sharedPreferenceUtil?.isNotPlayStoreBuildWithAndroid11OrAbove() == true &&
+      !sharedPreferenceUtil.prefIsTest
+    ) {
+      Environment.isExternalStorageManager()
+    } else {
+      true
+    }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -178,7 +178,8 @@ object ActivityExtensions {
     sharedPreferenceUtil: SharedPreferenceUtil?
   ): Boolean =
     if (sharedPreferenceUtil?.isNotPlayStoreBuildWithAndroid11OrAbove() == true &&
-      !sharedPreferenceUtil.prefIsTest
+      !sharedPreferenceUtil.prefIsTest &&
+      sharedPreferenceUtil.manageExternalFilesPermissionDialogOnRefresh
     ) {
       Environment.isExternalStorageManager()
     } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -224,6 +224,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   fun isPlayStoreBuildWithAndroid11OrAbove(): Boolean =
     isPlayStoreBuild && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 
+  fun isNotPlayStoreBuildWithAndroid11OrAbove(): Boolean =
+    !isPlayStoreBuild && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
   companion object {
     // Prefs
     const val PREF_LANG = "pref_language_chooser"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -196,6 +196,17 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
         putBoolean(PREF_MANAGE_EXTERNAL_FILES, prefManageExternalFilesPermissionDialog)
       }
 
+  // this is only used for test cases
+  var manageExternalFilesPermissionDialogOnRefresh: Boolean
+    get() = sharedPreferences.getBoolean(PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, true)
+    set(manageExternalFilesPermissionDialogOnRefresh) =
+      sharedPreferences.edit {
+        putBoolean(
+          PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH,
+          manageExternalFilesPermissionDialogOnRefresh
+        )
+      }
+
   var hostedBooks: Set<String>
     get() = sharedPreferences.getStringSet(PREF_HOSTED_BOOKS, null)?.toHashSet() ?: HashSet()
     set(hostedBooks) {
@@ -253,6 +264,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     private const val TEXT_ZOOM = "true_text_zoom"
     private const val DEFAULT_ZOOM = 100
     const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
+    const val PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH = "pref_show_manage_external_files"
     const val IS_PLAY_STORE_BUILD = "is_play_store_build"
   }
 }


### PR DESCRIPTION
Fixes #3577 

If the `ManageExternalStorage` permission has not been granted, introduce the request, particularly when accessing features that necessitate this permission, such as downloading ZIM files, selecting a ZIM file from storage via the file picker, and refreshing the list of available ZIM files in storage.