### PR TITLE
Fixes the issue where the "Help" submenu in the sidebar is misleading in custom apps.

### DIFF
--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -105,6 +105,14 @@ class CustomMainActivity : CoreMainActivity() {
        * For more info see https://github.com/kiwix/kiwix-android/pull/3516
        */
       menu.findItem(R.id.menu_host_books)?.isVisible = false
+      /**
+       * Hide the `HelpFragment` from custom apps.
+       * We have not removed the relevant code for `HelpFragment` from custom apps.
+       * If, in the future, we need to display this for all/some custom apps,
+       * we can either remove the line below or configure it according to the requirements.
+       * For more information, see https://github.com/kiwix/kiwix-android/issues/3584
+       */
+      menu.findItem(R.id.menu_help)?.isVisible = false
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()
         onNavigationItemSelected(item)


### PR DESCRIPTION
Fixes #3584 

We have hidden the help screen from our sidebar. See https://github.com/kiwix/kiwix-android/issues/3584#issuecomment-1847290824

![Screenshot_20231213-131603_Test Custom App](https://github.com/kiwix/kiwix-android/assets/34593983/174bab26-e7d0-4809-9873-53bd54fde3a9)
