### PR TITLE
Introduced the disable external links option for custom apps.

### DIFF
--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -35,7 +35,8 @@ data class CustomApp(
   val disableSideBar: Boolean = false,
   val disableTabs: Boolean = false,
   val disableReadAloud: Boolean = false,
-  val disableTitle: Boolean = false
+  val disableTitle: Boolean = false,
+  val disableExternalLinks: Boolean = false
 ) {
   constructor(name: String, parsedJson: JSONObject) : this(
     name,
@@ -46,7 +47,8 @@ data class CustomApp(
     parsedJson.getAndCast("disable_sidebar") ?: false,
     parsedJson.getAndCast("disable_tabs") ?: false,
     parsedJson.getAndCast("disable_read_aloud") ?: false,
-    parsedJson.getAndCast("disable_title") ?: false
+    parsedJson.getAndCast("disable_title") ?: false,
+    parsedJson.getAndCast("disable_external_links") ?: false
   )
 
   val versionCode: Int = formatCurrentDate("YYDDD0").toInt()

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -52,6 +52,7 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       buildConfigField("Boolean", "DISABLE_TABS", "${customApp.disableTabs}")
       buildConfigField("Boolean", "DISABLE_READ_ALOUD", "${customApp.disableReadAloud}")
       buildConfigField("Boolean", "DISABLE_TITLE", "${customApp.disableTitle}")
+      buildConfigField("Boolean", "DISABLE_EXTERNAL_LINK", "${customApp.disableExternalLinks}")
       configureStrings(customApp.displayName)
     }
   }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -80,6 +80,12 @@ class CustomReaderFragment : CoreReaderFragment() {
         toolbar?.let(::setUpDrawerToggle)
       }
       loadPageFromNavigationArguments()
+      if (BuildConfig.DISABLE_EXTERNAL_LINK) {
+        // If "external links" are disabled in a custom app,
+        // this sets the shared preference to not show the external link popup
+        // when opening external links.
+        sharedPreferenceUtil?.putPrefExternalLinkPopup(false)
+      }
     }
   }
 

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomPrefsFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomPrefsFragment.kt
@@ -27,12 +27,26 @@ import org.kiwix.kiwixmobile.custom.BuildConfig
 class CustomPrefsFragment : CorePrefsFragment() {
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
     super.onCreatePreferences(savedInstanceState, rootKey)
+    if (BuildConfig.DISABLE_EXTERNAL_LINK) {
+      hideExternalLinksPreference()
+    }
     if (BuildConfig.ENFORCED_LANG.isEmpty()) {
       setUpLanguageChooser(PREF_LANG)
     } else {
       preferenceScreen.removePreference(findPreference("pref_language"))
     }
     preferenceScreen.removePreferenceRecursively(PREF_WIFI_ONLY)
+  }
+
+  /**
+   * If "external links" are disabled in a custom app,
+   * this function hides the external links preference from settings
+   * and sets the shared preference to not show the external link popup
+   * when opening external links.
+   */
+  private fun hideExternalLinksPreference() {
+    preferenceScreen.removePreferenceRecursively("pref_external_link_popup")
+    sharedPreferenceUtil?.putPrefExternalLinkPopup(false)
   }
 
   override fun setStorage() {


### PR DESCRIPTION
Fixes #3586

We have introduced the option to disable `external links` for custom apps. If a custom app is configured not to display the `external links popup`, it will both hide the `external links` preference from settings and refrain from showing the `external link popup` when opening external links. Additionally, we have included relevant comments within the methods and code to provide developers with a clear understanding of the reasons behind these changes.

![ExternalLinkPreferenceHide](https://github.com/kiwix/kiwix-android/assets/34593983/8ffd68f2-00da-489a-8492-1165aa43daca)
