### PR TITLE
Fixed: Add Configuration Option for Custom Apps: "About" Link in Sidebar

### DIFF
--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -36,7 +36,8 @@ data class CustomApp(
   val disableTabs: Boolean = false,
   val disableReadAloud: Boolean = false,
   val disableTitle: Boolean = false,
-  val disableExternalLinks: Boolean = false
+  val disableExternalLinks: Boolean = false,
+  val aboutAppUrl: String = ""
 ) {
   constructor(name: String, parsedJson: JSONObject) : this(
     name,
@@ -48,7 +49,8 @@ data class CustomApp(
     parsedJson.getAndCast("disable_tabs") ?: false,
     parsedJson.getAndCast("disable_read_aloud") ?: false,
     parsedJson.getAndCast("disable_title") ?: false,
-    parsedJson.getAndCast("disable_external_links") ?: false
+    parsedJson.getAndCast("disable_external_links") ?: false,
+    parsedJson.getAndCast("about_app_url") ?: ""
   )
 
   val versionCode: Int = formatCurrentDate("YYDDD0").toInt()

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -46,6 +46,7 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       applicationIdSuffix = ".kiwixcustom${customApp.name}"
       buildConfigField("String", "ZIM_URL", "\"${customApp.url}\"")
       buildConfigField("String", "ENFORCED_LANG", "\"${customApp.enforcedLanguage}\"")
+      buildConfigField("String", "ABOUT_APP_URL", "\"${customApp.aboutAppUrl}\"")
       // Add asset file name in buildConfig file, we will use later to receive the zim file.
       buildConfigField("String", "PLAY_ASSET_FILE", "\"${customApp.name}.zim\"")
       buildConfigField("Boolean", "DISABLE_SIDEBAR", "${customApp.disableSideBar}")

--- a/core/src/main/res/drawable/ic_baseline_info.xml
+++ b/core/src/main/res/drawable/ic_baseline_info.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2023 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:tint="#000000"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z" />
+
+</vector>

--- a/core/src/main/res/menu/menu_drawer_main.xml
+++ b/core/src/main/res/menu/menu_drawer_main.xml
@@ -51,6 +51,13 @@
       android:icon="@drawable/ic_support_24px"
       android:title="@string/menu_support_kiwix"
       app:showAsAction="never" />
+
+    <item
+      android:id="@+id/menu_about_app"
+      android:visible="false"
+      android:icon="@drawable/ic_baseline_info"
+      android:title="@string/menu_about_app"
+      app:showAsAction="never" />
   </group>
 
 </menu>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
   <string name="menu_read_aloud">Read aloud</string>
   <string name="menu_read_aloud_stop">Stop reading aloud</string>
   <string name="menu_support_kiwix">Support Kiwix</string>
+  <string name="menu_about_app">About the app</string>
   <string name="menu_wifi_hotspot">WiFi Hotspot</string>
   <string name="save_media">Save Media</string>
   <string name="save_media_error">An error occurred when trying to save the media!</string>

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -19,14 +19,18 @@
 package org.kiwix.kiwixmobile.custom.main
 
 import android.os.Bundle
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.net.toUri
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.navigation.NavigationView
 import org.kiwix.kiwixmobile.core.di.components.CoreComponent
+import org.kiwix.kiwixmobile.core.extensions.browserIntent
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.R
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.ActivityCustomMainBinding
@@ -113,11 +117,31 @@ class CustomMainActivity : CoreMainActivity() {
        * For more information, see https://github.com/kiwix/kiwix-android/issues/3584
        */
       menu.findItem(R.id.menu_help)?.isVisible = false
+
+      /**
+       * If custom app is configured to show the "About the app" in navigation
+       * then show it navigation.
+       */
+      if (BuildConfig.ABOUT_APP_URL.isNotEmpty()) {
+        menu.findItem(R.id.menu_about_app)?.isVisible = true
+      }
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()
         onNavigationItemSelected(item)
       }
     }
+  }
+
+  /**
+   * Overrides the method to configure the click of `About the app`
+   * When the "About the app" is enabled
+   * in a custom app, this function handled that click.
+   */
+  override fun onNavigationItemSelected(item: MenuItem): Boolean {
+    if (item.itemId == R.id.menu_about_app) {
+      externalLinkOpener.openExternalUrl(BuildConfig.ABOUT_APP_URL.toUri().browserIntent())
+    }
+    return super.onNavigationItemSelected(item)
   }
 
   override fun getIconResId() = R.mipmap.ic_launcher


### PR DESCRIPTION
Fixes #3590 
* Introduced the `About the app` option in the navigation for custom apps.
* If the custom app is configured to display the 'About the app' option in navigation, it will be visible. Clicking on it will redirect the user to the configured URL.

<img src="https://github.com/kiwix/kiwix-android/assets/34593983/6e37a70f-d279-4217-b2ac-6eaf8ffc6c91" width="300px"></img>