### PR TITLE
Fixed: Made a small improvement to the sidebar entries for "About the app" and "Support app."

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -148,6 +148,6 @@ class ZimHostRobot : BaseRobot() {
   }
 
   private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
   }
 }

--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -37,7 +37,8 @@ data class CustomApp(
   val disableReadAloud: Boolean = false,
   val disableTitle: Boolean = false,
   val disableExternalLinks: Boolean = false,
-  val aboutAppUrl: String = ""
+  val aboutAppUrl: String = "",
+  val supportUrl: String = ""
 ) {
   constructor(name: String, parsedJson: JSONObject) : this(
     name,
@@ -50,7 +51,8 @@ data class CustomApp(
     parsedJson.getAndCast("disable_read_aloud") ?: false,
     parsedJson.getAndCast("disable_title") ?: false,
     parsedJson.getAndCast("disable_external_links") ?: false,
-    parsedJson.getAndCast("about_app_url") ?: ""
+    parsedJson.getAndCast("about_app_url") ?: "",
+    parsedJson.getAndCast("support_url") ?: ""
   )
 
   val versionCode: Int = formatCurrentDate("YYDDD0").toInt()

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -47,6 +47,7 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       buildConfigField("String", "ZIM_URL", "\"${customApp.url}\"")
       buildConfigField("String", "ENFORCED_LANG", "\"${customApp.enforcedLanguage}\"")
       buildConfigField("String", "ABOUT_APP_URL", "\"${customApp.aboutAppUrl}\"")
+      buildConfigField("String", "SUPPORT_URL", "\"${customApp.supportUrl}\"")
       // Add asset file name in buildConfig file, we will use later to receive the zim file.
       buildConfigField("String", "PLAY_ASSET_FILE", "\"${customApp.name}.zim\"")
       buildConfigField("Boolean", "DISABLE_SIDEBAR", "${customApp.disableSideBar}")

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -11,7 +11,8 @@
   <string name="menu_read_aloud">Read aloud</string>
   <string name="menu_read_aloud_stop">Stop reading aloud</string>
   <string name="menu_support_kiwix">Support Kiwix</string>
-  <string name="menu_about_app">About the app</string>
+  <string name="menu_support_kiwix_for_custom_apps">Support %s</string>
+  <string name="menu_about_app">About %s app</string>
   <string name="menu_wifi_hotspot">WiFi Hotspot</string>
   <string name="save_media">Save Media</string>
   <string name="save_media_error">An error occurred when trying to save the media!</string>

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -119,11 +119,32 @@ class CustomMainActivity : CoreMainActivity() {
       menu.findItem(R.id.menu_help)?.isVisible = false
 
       /**
-       * If custom app is configured to show the "About the app" in navigation
-       * then show it navigation.
+       * If custom app is configured to show the "About app_name app" in navigation
+       * then show it navigation. "app_name" will be replaced with custom app name.
        */
       if (BuildConfig.ABOUT_APP_URL.isNotEmpty()) {
-        menu.findItem(R.id.menu_about_app)?.isVisible = true
+        menu.findItem(R.id.menu_about_app)?.apply {
+          title = getString(R.string.menu_about_app, getString(R.string.app_name))
+          isVisible = true
+        }
+      }
+
+      /**
+       * If custom app is configured to show the "Support app_name" in navigation
+       * then show it navigation. "app_name" will be replaced with custom app name.
+       */
+      if (BuildConfig.SUPPORT_URL.isNotEmpty()) {
+        menu.findItem(R.id.menu_support_kiwix)?.apply {
+          title =
+            getString(R.string.menu_support_kiwix_for_custom_apps, getString(R.string.app_name))
+          isVisible = true
+        }
+      } else {
+        /**
+         * If custom app is not configured to show the "Support app_name" in navigation
+         * then hide it from navigation.
+         */
+        menu.findItem(R.id.menu_support_kiwix)?.isVisible = false
       }
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()
@@ -133,15 +154,31 @@ class CustomMainActivity : CoreMainActivity() {
   }
 
   /**
-   * Overrides the method to configure the click of `About the app`
-   * When the "About the app" is enabled
-   * in a custom app, this function handled that click.
+   * Overrides the method to configure the click behavior of the "About the app"
+   * and "Support URL" features. When the "About the app" and "Support URL"
+   * are enabled in a custom app, this function handles those clicks.
    */
   override fun onNavigationItemSelected(item: MenuItem): Boolean {
-    if (item.itemId == R.id.menu_about_app) {
-      externalLinkOpener.openExternalUrl(BuildConfig.ABOUT_APP_URL.toUri().browserIntent())
+    return when (item.itemId) {
+      R.id.menu_about_app -> {
+        openExternalUrl(BuildConfig.ABOUT_APP_URL)
+        true
+      }
+
+      R.id.menu_support_kiwix -> {
+        openExternalUrl(BuildConfig.SUPPORT_URL)
+        true
+      }
+
+      else -> super.onNavigationItemSelected(item)
     }
-    return super.onNavigationItemSelected(item)
+  }
+
+  private fun openExternalUrl(url: String) {
+    // check if the provided url is not empty.
+    if (url.isNotEmpty()) {
+      externalLinkOpener.openExternalUrl(url.toUri().browserIntent())
+    }
   }
 
   override fun getIconResId() = R.mipmap.ic_launcher


### PR DESCRIPTION
Fixes #3601 

* Enhanced the 'Support Kiwix' option, which is configurable in the navigation for custom apps. If the custom app is set to display the "Support" menu item in navigation, it will be shown; otherwise, it will be hidden from the app.
* Replaced the "kiwix" and "the" prefixes in "Support kiwix" and "About the app" with the app name in the navigation.


| Support Url configured  | Support Url not configured | Kiwix App |
| ------------- | ------------- | ------------- |
| ![Screenshot_20231215-161405_Dwds](https://github.com/kiwix/kiwix-android/assets/34593983/61100373-338d-409c-bb5c-05e10ed9d1ee)  | ![Screenshot_20231215-163753_Dwds](https://github.com/kiwix/kiwix-android/assets/34593983/1247f089-3985-4ddf-8fa9-e74eabf3423d)  | ![Screenshot_20231215-163844_Kiwix](https://github.com/kiwix/kiwix-android/assets/34593983/53c3f24c-e5c9-40de-8405-dcb50c02437b)  |

* Increased timeout for waiting for the views in `ZimHostFragmentTest` since on Android 13 it takes more time to find the views.

![Screenshot from 2023-12-15 18-57-23](https://github.com/kiwix/kiwix-android/assets/34593983/2a9798ce-c3f8-41f0-ad5c-34c0ee6ce754)
