### PR TITLE
Fix potential infinite loop in bash script

### DIFF
--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -15,7 +15,7 @@ do
     adb logcat ./*:E -v color &
     ./gradlew clean
     retry=$(( $retry + 1 ))
-    if [ $retry == 3 ]; then
+    if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png
       exit 1
     fi

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -14,7 +14,7 @@ do
     adb logcat -c
     adb logcat ./*:E -v color &
     ./gradlew clean
-    retry=$(( $retry + 1 ))
+    retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png
       exit 1


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #3613 



**Changes Made:**

Replaced == with `-eq` in the if [ $retry == 3 ] condition to avoid potential infinite loop.
Context:

The current bash script for running Android instrumentation tests and generating a Jacoco coverage report contains a bug in the while loop condition. The use of == for comparison in Bash is incorrect, and it may result in an infinite loop. This pull request addresses the issue by replacing == with `-eq`.

* Fixed: `$/${} is unnecessary on arithmetic variables` error while incrementing the count of retry variable. Since In Bash arithmetic expansion, the `$` is not needed when referencing variables see https://www.shellcheck.net/wiki/SC2004 for more details.