### PR TITLE
Fixed: 3.9.0 Welcome screen does not run, and Kiwix does not prompt for permissions.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -139,7 +139,14 @@ class LocalLibraryFragment : BaseFragment() {
   private val bookDelegate: BookOnDiskDelegate.BookDelegate by lazy {
     BookOnDiskDelegate.BookDelegate(
       sharedPreferenceUtil,
-      { offerAction(RequestNavigateTo(it)) },
+      {
+        if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
+          @Suppress("NewApi")
+          showManageExternalStoragePermissionDialog()
+        } else {
+          offerAction(RequestNavigateTo(it))
+        }
+      },
       { offerAction(RequestMultiSelection(it)) },
       { offerAction(RequestSelect(it)) }
     )
@@ -266,6 +273,10 @@ class LocalLibraryFragment : BaseFragment() {
         if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
           @Suppress("NewApi")
           showManageExternalStoragePermissionDialog()
+          // Set loading to false since the dialog is currently being displayed.
+          // If the user clicks on "No" in the permission dialog,
+          // the loading icon remains visible infinitely.
+          fragmentDestinationLibraryBinding?.zimSwiperefresh?.isRefreshing = false
         } else {
           requestFileSystemCheck()
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -38,7 +38,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.Toolbar
@@ -141,7 +140,6 @@ class LocalLibraryFragment : BaseFragment() {
       sharedPreferenceUtil,
       {
         if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
-          @Suppress("NewApi")
           showManageExternalStoragePermissionDialog()
         } else {
           offerAction(RequestNavigateTo(it))
@@ -271,7 +269,6 @@ class LocalLibraryFragment : BaseFragment() {
         fragmentDestinationLibraryBinding?.zimSwiperefresh?.isRefreshing = false
       } else {
         if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
-          @Suppress("NewApi")
           showManageExternalStoragePermissionDialog()
           // Set loading to false since the dialog is currently being displayed.
           // If the user clicks on "No" in the permission dialog,
@@ -284,14 +281,15 @@ class LocalLibraryFragment : BaseFragment() {
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.R)
   private fun showManageExternalStoragePermissionDialog() {
-    dialogShower.show(
-      KiwixDialog.ManageExternalFilesPermissionDialog,
-      {
-        this.activity?.let(FragmentActivity::navigateToSettings)
-      }
-    )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      dialogShower.show(
+        KiwixDialog.ManageExternalFilesPermissionDialog,
+        {
+          this.activity?.let(FragmentActivity::navigateToSettings)
+        }
+      )
+    }
   }
 
   private fun getBottomNavigationView() =
@@ -314,7 +312,6 @@ class LocalLibraryFragment : BaseFragment() {
 
     fragmentDestinationLibraryBinding?.selectFile?.setOnClickListener {
       if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
-        @Suppress("NewApi")
         showManageExternalStoragePermissionDialog()
       } else {
         showFileChooser()

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -37,7 +37,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -531,7 +530,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
               sharedPreferenceUtil
             )
           ) {
-            @Suppress("NewApi")
             showManageExternalStoragePermissionDialog()
           } else {
             availableSpaceCalculator.hasAvailableSpaceFor(
@@ -579,20 +577,20 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   private fun clickOnBookItem() {
     if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
-      @Suppress("NewApi")
       showManageExternalStoragePermissionDialog()
     } else {
       downloadBookItem?.let(::onBookItemClick)
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.R)
   private fun showManageExternalStoragePermissionDialog() {
-    dialogShower.show(
-      KiwixDialog.ManageExternalFilesPermissionDialog,
-      {
-        this.activity?.let(FragmentActivity::navigateToSettings)
-      }
-    )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      dialogShower.show(
+        KiwixDialog.ManageExternalFilesPermissionDialog,
+        {
+          this.activity?.let(FragmentActivity::navigateToSettings)
+        }
+      )
+    }
   }
 }


### PR DESCRIPTION
Fixes #3611 

* This PR addresses the scenario where, for any reason, shared preferences and the database are retained on the device, and the list of ZIM files is visible in the library. However, the `MANAGE_EXTERNAL_PERMISSION` is not found, and when a user attempts to open a file, the application lacks the necessary permission. To improve this scenario, we now prompt the user for permission if it is not available when opening ZIM files from the library.
* Additionally, fixed the behavior of the swipe refresh layout if the user clicks on the "NO" button in the permission dialog, since it was showing loading progress and did nothing.
* Removed the lint suppression for "NewApi" which is unnecessary here.


**Issue**


https://github.com/kiwix/kiwix-android/assets/34593983/dde27b80-8bb7-4df2-89c5-e2baad547eb7


**Fix**

https://github.com/kiwix/kiwix-android/assets/34593983/b303ba2c-a51c-4139-ae38-2a878340bd13


