### PR TITLE
Fixed: The chooser UI now defaults to displaying external storage.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -28,6 +28,7 @@ import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.ConnectivityManager
 import android.os.Build
 import android.os.Bundle
+import android.provider.DocumentsContract
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.Menu
@@ -88,6 +89,7 @@ import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.SelectFolder
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.YesNoDialog.WifiOnly
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getPathFromUri
+import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getSdCardUri
 import org.kiwix.kiwixmobile.databinding.FragmentDestinationDownloadBinding
 import org.kiwix.kiwixmobile.zimManager.NetworkState
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel
@@ -402,13 +404,19 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   }
 
   private fun selectFolder() {
-    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-    intent.addFlags(
-      Intent.FLAG_GRANT_READ_URI_PERMISSION
-        or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-        or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-        or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
-    )
+    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        getSdCardUri(requireActivity())?.let {
+          putExtra(DocumentsContract.EXTRA_INITIAL_URI, it)
+        }
+      }
+      addFlags(
+        Intent.FLAG_GRANT_READ_URI_PERMISSION
+          or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+          or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+          or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
+      )
+    }
     selectFolderLauncher.launch(intent)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -26,6 +26,7 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.provider.DocumentsContract
 import android.view.LayoutInflater
 import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContracts
@@ -55,6 +56,7 @@ import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.OpenCredits
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.SelectFolder
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getPathFromUri
+import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getSdCardUri
 import java.io.File
 import java.util.Locale
 import javax.inject.Inject
@@ -345,6 +347,11 @@ abstract class CorePrefsFragment :
 
   private fun selectFolder() {
     val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        getSdCardUri(requireActivity())?.let {
+          putExtra(DocumentsContract.EXTRA_INITIAL_URI, it)
+        }
+      }
       addFlags(
         Intent.FLAG_GRANT_READ_URI_PERMISSION
           or Intent.FLAG_GRANT_WRITE_URI_PERMISSION

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -31,6 +31,7 @@ import android.util.Log
 import android.webkit.URLUtil
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -292,6 +293,27 @@ object FileUtils {
     context.getExternalFilesDirs("")
       .firstOrNull { it.path.contains(storageName) }
       ?.path?.substringBefore(context.getString(R.string.android_directory_seperator))
+
+  @JvmStatic
+  fun getSdCardUri(context: Context): Uri? {
+    // Get the external SD card path
+    val externalSdCardPath = context.getExternalFilesDirs("")[1]
+      ?.path?.substringBefore(context.getString(R.string.android_directory_seperator))
+
+    // Extract the SD card name from the path
+    val sdCardName = externalSdCardPath?.substringAfterLast("/storage/")
+
+    // If SD card name is null or empty, return null
+    return if (sdCardName.isNullOrEmpty()) {
+      null
+    } else {
+      // Build and return the URI for the SD card
+      val sdCardPath =
+        "content://com.android.externalstorage.documents/tree/" +
+          "$sdCardName%3A/document/$sdCardName%3A/"
+      sdCardPath.toUri()
+    }
+  }
 
   @SuppressLint("WrongConstant")
   @JvmStatic


### PR DESCRIPTION
Fixes #3604 

* Previously, it displayed the last known location when selecting a folder for external storage, which could confuse the user. We have now resolved this by defaulting to opening the SD card when choosing the SD card folder.