### PR TITLE
Fixed: ErrorActivity was not appearing in the non-debug version when the application crashed.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.main
 
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Bundle
 import android.os.Process
 import android.view.ActionMode
@@ -96,6 +97,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
         val extras = Bundle()
         extras.putSerializable(ErrorActivity.EXCEPTION_KEY, paramThrowable)
         intent.putExtras(extras)
+        intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
         appContext.startActivity(intent)
         finish()
         Process.killProcess(Process.myPid())


### PR DESCRIPTION
Fixes #3620 

* We are using the `applicationContext` to start the `ErrorActivity`, which is outside the `Activity`. Therefore, to initiate the activity with an external context of the `Activity`, we must include the `FLAG_ACTIVITY_NEW_TASK` flag in the intent. Without this flag, the activity will not start.


https://github.com/kiwix/kiwix-android/assets/34593983/5d483820-d403-48bc-8727-47e8dd143635

