### PR TITLE
Fixed: Extracted the website link from the string file for the Play Store restriction dialog.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
@@ -26,6 +26,7 @@ import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.core.R.id
 import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.main.KIWIX_APK_WEBSITE_URL
 
 fun help(func: HelpRobot.() -> Unit) = HelpRobot().apply(func)
 
@@ -86,7 +87,14 @@ class HelpRobot : BaseRobot() {
   }
 
   fun assertZimFileNotShowingIsExpanded() {
-    isVisible(TextId(string.zim_files_not_showing_description))
+    isVisible(
+      Text(
+        context.getString(
+          string.zim_files_not_showing_description,
+          KIWIX_APK_WEBSITE_URL
+        )
+      )
+    )
   }
 
   fun assertZimFileNotShowingIsNotVisible() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.help
 
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.help.HelpFragment
+import org.kiwix.kiwixmobile.core.main.KIWIX_APK_WEBSITE_URL
 
 class KiwixHelpFragment : HelpFragment() {
   override fun rawTitleDescriptionMap() =
@@ -28,7 +29,10 @@ class KiwixHelpFragment : HelpFragment() {
         R.string.help_2 to R.array.description_help_2,
         R.string.help_5 to R.array.description_help_5,
         R.string.how_to_update_content to R.array.update_content_description,
-        R.string.zim_files_not_showing to R.array.description_help_6
+        R.string.zim_files_not_showing to getString(
+          R.string.zim_files_not_showing_description,
+          KIWIX_APK_WEBSITE_URL
+        )
       )
     } else {
       listOf(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -391,7 +391,7 @@ class LocalLibraryFragment : BaseFragment() {
     sharedPreferenceUtil.playStoreRestrictionPermissionDialog = false
     // Show Dialog to the user to inform about the play store restriction
     dialogShower.show(
-      KiwixDialog.PlayStoreRestrictionPopup,
+      KiwixDialog.PlayStoreRestrictionPopup(KIWIX_APK_WEBSITE_URL),
       {},
       ::openKiwixWebsiteForDownloadingApk
     )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
@@ -47,7 +47,7 @@ abstract class HelpFragment : BaseFragment() {
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
   private var fragmentHelpBinding: FragmentHelpBinding? = null
-  protected open fun rawTitleDescriptionMap(): List<Pair<Int, Int>> = emptyList()
+  protected open fun rawTitleDescriptionMap(): List<Pair<Int, Any>> = emptyList()
   override val fragmentToolbar: Toolbar? by lazy {
     fragmentHelpBinding?.root?.findViewById(R.id.toolbar)
   }
@@ -55,8 +55,15 @@ abstract class HelpFragment : BaseFragment() {
 
   private val titleDescriptionMap by lazy {
     rawTitleDescriptionMap().associate { (title, description) ->
-      getString(title) to resources.getStringArray(description)
-        .joinToString(separator = "\n")
+      val descriptionValue = when (description) {
+        is String -> description
+        is Int -> resources.getStringArray(description).joinToString(separator = "\n")
+        else -> {
+          throw IllegalArgumentException("Invalid description resource type for title: $title")
+        }
+      }
+
+      getString(title) to descriptionValue
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -170,13 +170,19 @@ sealed class KiwixDialog(
     neutralMessage = R.string.do_not_ask_anymore
   )
 
-  object PlayStoreRestrictionPopup : KiwixDialog(
-    null,
-    R.string.zim_files_not_showing_description,
-    R.string.understood,
-    R.string.download,
-    cancelable = false
-  )
+  data class PlayStoreRestrictionPopup(override val args: List<Any>) :
+    KiwixDialog(
+      null,
+      R.string.zim_files_not_showing_description,
+      R.string.understood,
+      R.string.download,
+      cancelable = false
+    ),
+    HasBodyFormatArgs {
+    constructor(websiteUrl: String) : this(
+      listOf(websiteUrl)
+    )
+  }
 
   data class ShowRate(override val args: List<Any>, val customIcon: Int?) :
     KiwixDialog(

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -210,9 +210,6 @@
     <item>@string/help_10</item>
     <item>@string/help_11</item>
   </string-array>
-  <string-array name="description_help_6">
-    <item>@string/zim_files_not_showing_description</item>
-  </string-array>
   <string name="bookmarks_from_current_book">View Bookmarks From All Books</string>
   <string name="search_bookmarks">Search bookmarks</string>
   <string name="switch_tabs">Switch tabs</string>
@@ -305,7 +302,7 @@
   <string name="open_drawer">Open Drawer</string>
   <string name="close_drawer">Close Drawer</string>
   <string name="zim_files_not_showing">Zim files not showing?</string>
-  <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix app from our official website <a href="https://download.kiwix.org/release/kiwix-android/">https://download.kiwix.org/release/kiwix-android/</a></string>
+  <string name="zim_files_not_showing_description">Due to Google Play policies on Android 11 and above, this Google Store app can\’t open sideloaded ZIM files. You can either download them through the app or, instead, install the full version of kiwix app from our official website %s</string>
   <string name="understood">Understood</string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>


### PR DESCRIPTION
Fixes #3625 

* Removed the link from `zim_files_not_showing_description`.
* Modified the dialog for displaying the link in `PlayStoreRestrictionPopup`.
* Refactored the `rawTitleDescriptionMap`() method in `HelpFragment` to accommodate both strings and arrays for showing links inside the HelpFragment.


https://github.com/kiwix/kiwix-android/assets/34593983/e5599cf2-ce41-4f89-9eb5-070eaa89ebd2

