### PR TITLE
Fixed: Resolved the issue where Google Play Store displayed an error during APK upload.

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -176,7 +176,9 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
       createPublisher(File(rootDir, "playstore.json"))
         .transactionWithCommit(packageName) {
           val variants =
-            applicationVariants.releaseVariantsFor(this@createPublishApkWithExpansionTask)
+            applicationVariants.releaseVariantsFor(this@createPublishApkWithExpansionTask).also {
+              print("createPublishApkWithExpansionTask: $it")
+            }
           variants.forEach(::uploadApk)
           uploadExpansionTo(file, variants[0].versionCodeOverride)
           variants.drop(1).forEach { attachExpansionTo(variants[0].versionCodeOverride, it) }
@@ -189,7 +191,9 @@ fun ProductFlavor.createPublishApkWithExpansionTask(
 @Suppress("DEPRECATION")
 fun DomainObjectSet<ApplicationVariant>.releaseVariantsFor(productFlavor: ProductFlavor) =
   find { it.name.equals("${productFlavor.name}Release", true) }!!
-    .outputs.filterIsInstance<ApkVariantOutput>().sortedBy { it.versionCodeOverride }
+    .outputs.filterIsInstance<ApkVariantOutput>()
+    .filter { !it.outputFileName.contains("universal") }
+    .sortedBy { it.versionCodeOverride }
 
 fun ProductFlavor.createPublishBundleWithAssetPlayDelivery(): Task {
   val capitalizedName =


### PR DESCRIPTION
Fixes #3640 

* We have excluded the universal APK from the variant list that is being uploaded to the Play Store.
* This exclusion is necessary because we cannot disable the universal APK, as it is required to set the version code for the bundle. Disabling the universal APK would result in the bundle version code being set exclusively for `x86_64`.

**After placing this fix the variant list not contains the universal apk**

```
[ApkVariantOutputImpl_Decorated{variantOutput=VariantOutputImpl(versionCode=property(java.lang.Integer, fixed(class java.lang.Integer, 3233620)), versionName=property(java.lang.String, fixed(class java.lang.String, 2023-12)), enabled=property(java.lang.Boolean, fixed(class java.lang.Boolean, true)), variantOutputConfiguration=VariantOutputConfigurationImpl(isUniversal=false, filters=[FilterConfiguration(filterType=ABI, identifier=x86)]), baseName=customexample-x86-release, fullName=customexampleX86Release, outputFileName=property(java.lang.String, fixed(class java.lang.String, custom-customexample-x86-release.apk)))}, ApkVariantOutputImpl_Decorated{variantOutput=VariantOutputImpl(versionCode=property(java.lang.Integer, fixed(class java.lang.Integer, 4233620)), versionName=property(java.lang.String, fixed(class java.lang.String, 2023-12)), enabled=property(java.lang.Boolean, fixed(class java.lang.Boolean, true)), variantOutputConfiguration=VariantOutputConfigurationImpl(isUniversal=false, filters=[FilterConfiguration(filterType=ABI, identifier=x86_64)]), baseName=customexample-x86_64-release, fullName=customexampleX86_64Release, outputFileName=property(java.lang.String, fixed(class java.lang.String, custom-customexample-x86_64-release.apk)))}, ApkVariantOutputImpl_Decorated{variantOutput=VariantOutputImpl(versionCode=property(java.lang.Integer, fixed(class java.lang.Integer, 5233620)), versionName=property(java.lang.String, fixed(class java.lang.String, 2023-12)), enabled=property(java.lang.Boolean, fixed(class java.lang.Boolean, true)), variantOutputConfiguration=VariantOutputConfigurationImpl(isUniversal=false, filters=[FilterConfiguration(filterType=ABI, identifier=armeabi-v7a)]), baseName=customexample-armeabi-v7a-release, fullName=customexampleArmeabi-v7aRelease, outputFileName=property(java.lang.String, fixed(class java.lang.String, custom-customexample-armeabi-v7a-release.apk)))}, ApkVariantOutputImpl_Decorated{variantOutput=VariantOutputImpl(versionCode=property(java.lang.Integer, fixed(class java.lang.Integer, 6233620)), versionName=property(java.lang.String, fixed(class java.lang.String, 2023-12)), enabled=property(java.lang.Boolean, fixed(class java.lang.Boolean, true)), variantOutputConfiguration=VariantOutputConfigurationImpl(isUniversal=false, filters=[FilterConfiguration(filterType=ABI, identifier=arm64-v8a)]), baseName=customexample-arm64-v8a-release, fullName=customexampleArm64-v8aRelease, outputFileName=property(java.lang.String, fixed(class java.lang.String, custom-customexample-arm64-v8a-release.apk)))}]

```

**If we disabled the universal apk then the bundle set like it is x86_64 bundle**
![Screenshot from 2023-12-28 19-18-08](https://github.com/kiwix/kiwix-android/assets/34593983/44d97b78-6b13-4e62-ace7-1e6a48537a15)

**So we have not disabled the universal apk**

![Screenshot from 2023-12-28 19-15-59](https://github.com/kiwix/kiwix-android/assets/34593983/8bc930dc-0905-4d84-904d-ae4bdbb544c7)

