### PR TITLE
Upgraded `webkit` version to latest to work with latest `chromium` dependencies.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -76,7 +76,7 @@ object Versions {
 
   const val uiautomator: String = "2.3.0-alpha03"
 
-  const val annotation: String = "1.1.0"
+  const val annotation: String = "1.2.0"
 
   const val simple_xml: String = "2.7.1"
 
@@ -98,7 +98,7 @@ object Versions {
 
   const val rxjava: String = "2.2.20"
 
-  const val webkit: String = "1.3.0"
+  const val webkit: String = "1.7.0"
 
   const val junit: String = "1.1.4"
 


### PR DESCRIPTION
Fixes #3644 

* Upgraded the `WebKit` version to the latest (from 1.3.0 to 1.7.0) to leverage improvements and bug fixes. This update is essential to address the issue with the latest `chromium` dependency, as outlined in #3644.
* Additionally, elevated the `androidx.annotation:annotation` dependency from `1.1.0` to `1.2.0` to meet the requirements of the updated WebKit version.