### PR TITLE
Fixed: Nowdays CI frequently failing on API level 24, and 33.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -53,14 +53,16 @@ class ZimHostFragmentTest {
     arrayOf(
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
-      Manifest.permission.NEARBY_WIFI_DEVICES
+      Manifest.permission.NEARBY_WIFI_DEVICES,
+      Manifest.permission.ACCESS_NETWORK_STATE
     )
   } else {
     arrayOf(
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
       Manifest.permission.ACCESS_COARSE_LOCATION,
-      Manifest.permission.ACCESS_FINE_LOCATION
+      Manifest.permission.ACCESS_FINE_LOCATION,
+      Manifest.permission.ACCESS_NETWORK_STATE
     )
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
@@ -64,14 +65,21 @@ class ZimHostRobot : BaseRobot() {
   }
 
   fun clickOnTestZim() {
+    pauseForBetterTestPerformance()
     clickOn(Text("Test_Zim"))
   }
 
   fun startServer() {
+    // stop the server if it is already running.
+    stopServerIfAlreadyStarted()
     clickOn(ViewId(R.id.startServerButton))
+    assetWifiDialogDisplayed()
+    onView(withText("PROCEED")).perform(click())
+  }
+
+  private fun assetWifiDialogDisplayed() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.wifi_dialog_title))
-    clickOn(TextId(R.string.hotspot_dialog_neutral_button))
+    isVisible(Text("WiFi connection detected"))
   }
 
   fun assertServerStarted() {
@@ -110,7 +118,6 @@ class ZimHostRobot : BaseRobot() {
   }
 
   private fun selectZimFile(position: Int) {
-    pauseForBetterTestPerformance()
     try {
       onView(
         RecyclerViewMatcher(R.id.recyclerViewZimHost).atPositionOnView(
@@ -119,7 +126,6 @@ class ZimHostRobot : BaseRobot() {
         )
       ).check(matches(ViewMatchers.isChecked()))
     } catch (assertionError: AssertionFailedError) {
-      pauseForBetterTestPerformance()
       onView(
         RecyclerViewMatcher(R.id.recyclerViewZimHost).atPositionOnView(
           position,
@@ -148,6 +154,6 @@ class ZimHostRobot : BaseRobot() {
   }
 
   private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Enable Wi-Fi on the emulator
+adb shell svc wifi enable
 adb logcat -c
 adb logcat ./*:E -v color &
 retry=0
@@ -11,6 +13,8 @@ do
   else
     adb kill-server
     adb start-server
+    # Enable Wi-Fi on the emulator
+    adb shell svc wifi enable
     adb logcat -c
     adb logcat ./*:E -v color &
     ./gradlew clean

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -3,7 +3,8 @@
 # Enable Wi-Fi on the emulator
 adb shell svc wifi enable
 adb logcat -c
-adb logcat ./*:E -v color &
+# shellcheck disable=SC2035
+adb logcat *:E -v color &
 retry=0
 while [ $retry -le 3 ]
 do
@@ -16,7 +17,8 @@ do
     # Enable Wi-Fi on the emulator
     adb shell svc wifi enable
     adb logcat -c
-    adb logcat ./*:E -v color &
+    # shellcheck disable=SC2035
+    adb logcat *:E -v color &
     ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
@@ -23,9 +23,9 @@ import io.mockk.Called
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
@@ -38,7 +38,7 @@ internal class SaveSearchToRecentsTest {
   private val searchListItem = RecentSearchListItem("", ZimFileReader.CONTENT_PREFIX)
 
   private val activity: AppCompatActivity = mockk()
-  private val testDispatcher = TestCoroutineScope()
+  private val testDispatcher = TestScope()
 
   @Test
   fun `invoke with null Id does nothing`() {
@@ -54,7 +54,7 @@ internal class SaveSearchToRecentsTest {
   }
 
   @Test
-  fun `invoke with non null Id saves search`() = testDispatcher.runBlockingTest {
+  fun `invoke with non null Id saves search`() = testDispatcher.runTest {
     val id = "id"
     SaveSearchToRecents(
       newRecentSearchDao,


### PR DESCRIPTION
Fixes #3627

* Addressed an issue with the `SaveSearchToRecentsTest` test, which occasionally failed. The primary cause of this was the recent modification to save the `RecentSearch` on a background thread using `coroutines`. In some cases, the test validates the output before the coroutine completes its execution. Consequently, we have adjusted our test case to properly wait for the coroutine to finish its work before validating the output.
* To fix `ZimHostFragment` test on API level 33 we have enabled the wifi programmatically on the emulator since it is by default not enabled on the emulator of API level 33.
* Improved test case for showing "Wifi connection dialog".
* Improved the permission.
* Removed the unnecessary logs from CI.

