### PR TITLE
Fixed the custom app (wikispecies, wikimed) bundle build problem.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx5096m
+org.gradle.jvmargs=-Xmx6096m
 kotlin.code.style=1.7


### PR DESCRIPTION
Fixes #3634

* We utilize `Play Asset Delivery` in our bundle, housing the ZIM file within it. The size of the wikispecies ZIM file is 2.13GB. To process all resources inside the bundle, we require a minimum of 6GB of Java heap memory.
* Our CI is mainly failing on this task `shrinkBundleWikispeciesReleaseResources` which is necessary to reduce the size of the bundle.
* We have increased the `java heap memory` from 5GB to 6GB which is enough to create the bundle with wikispecies ZIM file.