### PR TITLE
Fixed crashes occurring in Version 3.8.1 when opening ZIM files.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -2236,7 +2236,7 @@ abstract class CoreReaderFragment :
     }
 
   private fun setActionAndStartTTSService(action: String, isPauseTTS: Boolean = false) {
-    requireActivity().startService(
+    activity?.startService(
       createReadAloudIntent(action, isPauseTTS)
     ).also {
       isReadAloudServiceRunning = action == ACTION_PAUSE_OR_RESUME_TTS


### PR DESCRIPTION
Fixes #3600 

* A user-provided [logs](https://github.com/kiwix/kiwix-android/issues/3600#issuecomment-1874973135) indicating that, during the attempt to open ZIM files, a crash occurred when stopping the TTS service. The logs revealed that, in the absence of any activity to stop the service, using `requireActivity()` resulted in an error and application crash. To address this issue, we replaced `requireActivity()` with `activity`. Now, if there is no activity present, using `activity` avoids the error that would lead to a crash.


Waiting for the user's reply, and then we will mark this ready for review.