### PR TITLE
Fixed: Release versions are lower in the custom apps.

### DIFF
--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -55,7 +55,7 @@ data class CustomApp(
     parsedJson.getAndCast("support_url") ?: ""
   )
 
-  val versionCode: Int = formatCurrentDate("YYDDD0").toInt()
+  val versionCode: Int = formatCurrentDate("yyDDD0").toInt()
 
   companion object {
     private fun readVersionOrInfer(parsedJson: JSONObject) =


### PR DESCRIPTION
Fixes #3677 

* Changed the date format from `YYDDD0` to `yyDDD0` to accurately calculate the version code for the last day of the year as well. See https://github.com/kiwix/kiwix-android/issues/3677#issuecomment-1914703084