### PR TITLE
Fixed: Inconsistent Visibility Behavior: Text and Button Overlay When Opening Tabs.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
@@ -121,16 +121,16 @@ class MainMenu(
     }
 
   fun onFileOpened(urlIsValid: Boolean) {
-    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, fullscreen)
+    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, fullscreen, tabSwitcher)
     search.setOnMenuItemClickListener { navigateToSearch() }
   }
 
   fun hideBookSpecificMenuItems() {
-    setVisibility(false, search, tabSwitcher, randomArticle, addNote)
+    setVisibility(false, search, tabSwitcher, randomArticle, addNote, readAloud)
   }
 
   fun showBookSpecificMenuItems() {
-    setVisibility(true, search, tabSwitcher, randomArticle, addNote)
+    setVisibility(true, search, tabSwitcher, randomArticle, addNote, readAloud)
   }
 
   fun showTabSwitcherOptions() {
@@ -141,7 +141,7 @@ class MainMenu(
   fun showWebViewOptions(urlIsValid: Boolean) {
     isInTabSwitcher = false
     fullscreen.isVisible = true
-    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote)
+    setVisibility(urlIsValid, randomArticle, search, readAloud, addNote, tabSwitcher)
   }
 
   fun updateTabIcon(tabs: Int) {


### PR DESCRIPTION
Fixes #3623 

* Fixed the tab icon showing when there is no ZIM file opened in the reader which causes the unexpected UI behavior.
* Fixed "Read Aloud" menu item is showing when we close all tabs(which means currently no ZIM file is opened in the reader) so showing this button is redundant.


**Before Fix**


https://github.com/kiwix/kiwix-android/assets/34593983/93c44947-b200-4b25-9bed-cea0b05bab19



**After Fix**


https://github.com/kiwix/kiwix-android/assets/34593983/ed6fc494-a692-4959-8c74-b173af8db03d

