### PR TITLE
Upgraded `java-libkiwix` to 2.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -86,7 +86,7 @@ object Versions {
 
   const val core_ktx: String = "1.3.2"
 
-  const val libkiwix: String = "1.0.0"
+  const val libkiwix: String = "2.0.0"
 
   const val material: String = "1.2.1"
 


### PR DESCRIPTION
Fixes #3693 

A new version of `java-libkiwix` has been released so we are using the new version of `java-libkiwix` in our project.