### PR TITLE
Fixed: Can't download 4+ gb files.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/MountPointProducer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/MountPointProducer.kt
@@ -45,7 +45,7 @@ data class MountInfo(val device: String, val mountPoint: String, val fileSystem:
 
   companion object {
     private val VIRTUAL_FILE_SYSTEMS = listOf("fuse", "sdcardfs", "sdfat")
-    private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat", "tmpfs")
+    private val SUPPORTS_4GB_FILE_SYSTEMS = listOf("ext4", "exfat", "tmpfs", "f2fs")
     private val DOES_NOT_SUPPORT_4GB_FILE_SYSTEMS = listOf("fat32", "vfat")
   }
 }


### PR DESCRIPTION
Fixes #3684 

* A few Samsung devices use the `f2fs` file system, such as the [Samsung Galaxy Note 10](https://www.sammobile.com/news/galaxy-note-10-uses-f2fs-not-ext4-file-system-whats-the-difference/) and `Samsung s23 ultra` confirmed in the below logs user has provided https://github.com/kiwix/kiwix-android/issues/3684#issuecomment-1917643339. Therefore, we have added the f2fs file system to the support 4GB filesystem list because this file system type allows the writing of files larger than 4GB.
```
MountInfo(device=/dev/block/dm-58, mountPoint=/data/user_de/0/org.kiwix.kiwixmobile, fileSystem=f2fs)
, MountInfo(device=/dev/block/dm-58, mountPoint=/data/data/org.kiwix.kiwixmobile, fileSystem=f2fs)
, MountInfo(device=/dev/block/dm-58, mountPoint=/data/user_de/0/com.google.android.gms, fileSystem=f2fs)
, MountInfo(device=/dev/block/dm-58, mountPoint=/data/data/com.google.android.gms, fileSystem=f2fs)
, MountInfo(device=tmpfs, mountPoint=/data/misc/profiles/cur, fileSystem=tmpfs)
, MountInfo(device=tmpfs, mountPoint=/data/misc/profiles/ref, fileSystem=tmpfs)
, MountInfo(device=/dev/block/dm-58, mountPoint=/data/misc/profiles/cur/0/org.kiwix.kiwixmobile, fileSystem=f2fs)
, MountInfo(device=/dev/block/dm-58, mountPoint=/data/misc/profiles/ref/org.kiwix.kiwixmobile, fileSystem=f2fs)
```