### PR TITLE
Fixed: Added the ability to press Enter to skip the search.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -118,8 +118,8 @@ class LanguageFragment : BaseFragment() {
           menuInflater.inflate(R.menu.menu_language, menu)
           val search = menu.findItem(R.id.menu_language_search)
           (search.actionView as SearchView).setOnQueryTextListener(
-            SimpleTextListener {
-              languageViewModel.actions.offer(Filter(it))
+            SimpleTextListener { query, _ ->
+              languageViewModel.actions.offer(Filter(query))
             }
           )
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -220,7 +220,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           getZimItem?.isVisible = false
 
           (searchItem?.actionView as? SearchView)?.setOnQueryTextListener(
-            SimpleTextListener(zimManageViewModel.requestFiltering::onNext)
+            SimpleTextListener { query, _ ->
+              zimManageViewModel.requestFiltering.onNext(query)
+            }
           )
           zimManageViewModel.requestFiltering.onNext("")
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -107,8 +107,8 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
           val search = menu.findItem(R.id.menu_page_search).actionView as SearchView
           search.queryHint = searchQueryHint
           search.setOnQueryTextListener(
-            SimpleTextListener {
-              pageViewModel.actions.offer(Action.Filter(it))
+            SimpleTextListener { query, _ ->
+              pageViewModel.actions.offer(Action.Filter(query))
             }
           )
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -221,9 +221,17 @@ class SearchFragment : BaseFragment() {
           searchMenuItem.expandActionView()
           searchView = searchMenuItem.actionView as SearchView
           searchView?.setOnQueryTextListener(
-            SimpleTextListener {
-              if (it.isNotEmpty()) {
-                searchViewModel.actions.trySend(Filter(it)).isSuccess
+            SimpleTextListener { query, isSubmit ->
+              if (query.isNotEmpty()) {
+                when {
+                  isSubmit -> {
+                    // if user press the search/enter button on keyboard,
+                    // try to open the article if present
+                    getSearchListItemForQuery(query)?.let(::onItemClick)
+                  }
+
+                  else -> searchViewModel.actions.trySend(Filter(query)).isSuccess
+                }
               }
             }
           )
@@ -256,6 +264,11 @@ class SearchFragment : BaseFragment() {
       Lifecycle.State.RESUMED
     )
   }
+
+  private fun getSearchListItemForQuery(query: String): SearchListItem? =
+    searchAdapter?.items?.firstOrNull {
+      it.value.equals(query, ignoreCase = true)
+    }
 
   private suspend fun render(state: SearchState) {
     searchMutex.withLock {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SimpleTextListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SimpleTextListener.kt
@@ -20,12 +20,15 @@ package org.kiwix.kiwixmobile.core.utils
 
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
 
-class SimpleTextListener(private val onQueryTextChangeAction: (String) -> Unit) :
+class SimpleTextListener(private val onQueryTextChangeAction: (String, Boolean) -> Unit) :
   OnQueryTextListener {
-  override fun onQueryTextSubmit(s: String): Boolean = false
+  override fun onQueryTextSubmit(s: String): Boolean {
+    onQueryTextChangeAction.invoke(s, true)
+    return true
+  }
 
   override fun onQueryTextChange(s: String): Boolean {
-    onQueryTextChangeAction.invoke(s)
+    onQueryTextChangeAction.invoke(s, false)
     return true
   }
 }


### PR DESCRIPTION
Fixes #2896 

* If the search/enter button is pressed and an article is found with the exact query, it will directly open that article. Otherwise, it will proceed with the regular search operation as before.


https://github.com/kiwix/kiwix-android/assets/34593983/a97f74ca-2a36-485b-a8d3-13cbde1ce874

