### PR TITLE
Fixed: The Play Store has reported some implementation issues.

### DIFF
--- a/core/src/main/res/layout/ic_tab_switcher.xml
+++ b/core/src/main/res/layout/ic_tab_switcher.xml
@@ -5,6 +5,8 @@
   android:layout_width="wrap_content"
   android:layout_height="wrap_content"
   android:background="?attr/actionBarItemBackground"
+  android:minHeight="48dp"
+  android:minWidth="48dp"
   android:paddingStart="12dp"
   android:paddingEnd="12dp">
 


### PR DESCRIPTION
Fixes #3702 

* Increase the clickable area of the tab switcher to align with the ideal menu item size, ensuring users can easily interact with it. Like other menu items.
  
| Before Fix  | After fix |
| ------------- | ------------- |
| ![BeforeFixTabSwitcher](https://github.com/kiwix/kiwix-android/assets/34593983/4ae56d6c-1bc6-4d34-ade1-3730e8eb6226)  | ![AfterFixTabSwitcher](https://github.com/kiwix/kiwix-android/assets/34593983/9b54c93f-a224-44b0-90ae-9b6612bb71b1) |

* Playstore showing a warning to convert the `text size` from `dp` to `sp`, but it was inside the `MaterialShowcaseView` lib so we can't change it.

| Playstore warning  | Inside lib |
| ------------- | ------------- |
| ![Screenshot from 2024-02-14 17-23-31](https://github.com/kiwix/kiwix-android/assets/34593983/d0c965e3-1ce9-4e68-b4ff-d533b090cfe6) | ![SHowCaseViewTitleAndDismissButton](https://github.com/kiwix/kiwix-android/assets/34593983/6735fb6c-c52b-4e5a-b5da-63c43913690e) |

* Lastly Play Store shows a warning for using the 2 icons in the same place. We are showing the share icon in `actionMode` when the user selects multiple files. that are upon the default share icon. Play Store thinks it is overlapping on other views so the default share icon is not able to perform the click operation, but it is not. So here we don't need to fix this as it is only a warning. 

![Screenshot from 2024-02-14 17-25-05](https://github.com/kiwix/kiwix-android/assets/34593983/e64d8ba3-0738-4f66-8b00-27e9054a360a)

