### PR TITLE
Fixed: Addressed the touch target size issue reported by the Play Store.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
+import org.kiwix.kiwixmobile.core.extensions.setUpSearchView
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.SimpleTextListener
@@ -125,12 +126,15 @@ class LanguageFragment : BaseFragment() {
       object : MenuProvider {
         override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
           menuInflater.inflate(R.menu.menu_language, menu)
-          val search = menu.findItem(R.id.menu_language_search)
-          (search.actionView as SearchView).setOnQueryTextListener(
-            SimpleTextListener { query, _ ->
-              languageViewModel.actions.offer(Filter(query))
-            }
-          )
+          val search = menu.findItem(R.id.menu_language_search).actionView as SearchView
+          search.apply {
+            setUpSearchView(requireActivity())
+            setOnQueryTextListener(
+              SimpleTextListener { query, _ ->
+                languageViewModel.actions.offer(Filter(query))
+              }
+            )
+          }
         }
 
         override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
@@ -140,6 +144,7 @@ class LanguageFragment : BaseFragment() {
               closeKeyboard()
               true
             }
+
             else -> false
           }
         }
@@ -160,6 +165,7 @@ class LanguageFragment : BaseFragment() {
       activityLanguageBinding?.languageProgressbar?.hide()
       languageAdapter.items = state.viewItems
     }
+
     Saving -> Unit
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -67,6 +67,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
 import org.kiwix.kiwixmobile.core.extensions.setBottomMarginToFragmentContainerView
+import org.kiwix.kiwixmobile.core.extensions.setUpSearchView
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -219,11 +220,14 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           val getZimItem = menu.findItem(R.id.get_zim_nearby_device)
           getZimItem?.isVisible = false
 
-          (searchItem?.actionView as? SearchView)?.setOnQueryTextListener(
-            SimpleTextListener { query, _ ->
-              zimManageViewModel.requestFiltering.onNext(query)
-            }
-          )
+          (searchItem?.actionView as? SearchView)?.apply {
+            setUpSearchView(requireActivity())
+            setOnQueryTextListener(
+              SimpleTextListener { query, _ ->
+                zimManageViewModel.requestFiltering.onNext(query)
+              }
+            )
+          }
           zimManageViewModel.requestFiltering.onNext("")
         }
 
@@ -307,9 +311,11 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           hideRecyclerviewAndShowSwipeDownForLibraryErrorText()
         }
       }
+
       NetworkState.NOT_CONNECTED -> {
         showNoInternetConnectionError()
       }
+
       else -> {}
     }
   }
@@ -519,6 +525,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
             noInternetSnackbar()
             return
           }
+
           noWifiWithWifiOnlyPreferenceSet -> {
             dialogShower.show(WifiOnly, {
               sharedPreferenceUtil.putPrefWifiOnly(false)
@@ -526,6 +533,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
             })
             return
           }
+
           else -> if (sharedPreferenceUtil.showStorageOption) {
             showStorageConfigureDialog()
           } else if (!requireActivity().isManageExternalStoragePermissionGranted(

--- a/app/src/main/res/layout/item_download.xml
+++ b/app/src/main/res/layout/item_download.xml
@@ -95,6 +95,7 @@
         android:layout_marginStart="@dimen/stop_horizontal_margin"
         android:layout_marginEnd="@dimen/stop_horizontal_margin"
         android:layout_weight="0.5"
+        android:padding="7dp"
         android:minWidth="@dimen/stop_min_width"
         android:minHeight="@dimen/stop_min_height"
         android:src="@drawable/ic_pause_24dp" />
@@ -107,6 +108,7 @@
         android:layout_marginStart="@dimen/stop_horizontal_margin"
         android:layout_marginEnd="@dimen/stop_horizontal_margin"
         android:layout_weight="0.5"
+        android:padding="7dp"
         android:minWidth="@dimen/stop_min_width"
         android:minHeight="@dimen/stop_min_height"
         android:src="@drawable/ic_stop_24dp" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,11 +20,11 @@
 <resources>
   <dimen name="download_progress_padding">1dp</dimen>
   <dimen name="favicon_width">48dp</dimen>
-  <dimen name="stop_min_height">35dp</dimen>
-  <dimen name="stop_min_width">35dp</dimen>
+  <dimen name="stop_min_height">48dp</dimen>
+  <dimen name="stop_min_width">48dp</dimen>
   <dimen name="favicon_margin_right">8dp</dimen>
   <dimen name="item_library_margin_top">8dp</dimen>
-  <dimen name="stop_horizontal_margin">8dp</dimen>
+  <dimen name="stop_horizontal_margin">2dp</dimen>
   <dimen name="material_design_appbar_size">48dp</dimen>
 
 </resources>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/SearchViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/SearchViewExtensions.kt
@@ -1,0 +1,56 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import android.content.Context
+import android.widget.ImageView
+import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.TooltipCompat
+import androidx.core.view.setPadding
+import org.kiwix.kiwixmobile.core.R
+
+const val CLOSE_ICON_PADDING = 30
+
+fun SearchView.setUpSearchView(context: Context) {
+  val heightAndWidth = context.resources.getDimensionPixelSize(
+    R.dimen.material_minimum_height_and_width
+  )
+  val closeImageButton = findViewById<ImageView>(R.id.search_close_btn)
+  // set the tooltip on close button to show the description if user long clicks on it.
+  TooltipCompat.setTooltipText(
+    closeImageButton,
+    context.getString(R.string.abc_searchview_description_clear)
+  )
+  // override the default width of close image button.
+  // by default it is 40dp, and the default accessibility width is 48dp
+  setWidthWithPadding(
+    closeImageButton,
+    heightAndWidth,
+    CLOSE_ICON_PADDING
+  )
+}
+
+fun setWidthWithPadding(imageView: ImageView, width: Int, padding: Int) {
+  imageView.apply {
+    val params = layoutParams
+    params?.width = width
+    setPadding(padding)
+    requestLayout()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
@@ -64,7 +64,7 @@ class TabsAdapter internal constructor(
     val context = parent.context
     val margin16 = context.resources.getDimensionPixelSize(R.dimen.activity_horizontal_margin)
     val closeImageWidthAndHeight =
-      context.resources.getDimensionPixelSize(R.dimen.material_minimum_height_and_width)
+      context.resources.getDimensionPixelSize(R.dimen.close_tab_button_size)
     val close = ImageView(context)
       .apply {
         id = R.id.tabsAdapterCloseImageView

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
@@ -63,6 +63,8 @@ class TabsAdapter internal constructor(
   ): ViewHolder {
     val context = parent.context
     val margin16 = context.resources.getDimensionPixelSize(R.dimen.activity_horizontal_margin)
+    val closeImageWidthAndHeight =
+      context.resources.getDimensionPixelSize(R.dimen.material_minimum_height_and_width)
     val close = ImageView(context)
       .apply {
         id = R.id.tabsAdapterCloseImageView
@@ -94,7 +96,10 @@ class TabsAdapter internal constructor(
             -activity.getToolbarHeight() / 2 + activity.getWindowHeight() / 2
           )
         )
-        addView(close, ConstraintLayout.LayoutParams(margin16, margin16))
+        addView(
+          close,
+          ConstraintLayout.LayoutParams(closeImageWidthAndHeight, closeImageWidthAndHeight)
+        )
         layoutParams = RecyclerView.LayoutParams(
           RecyclerView.LayoutParams.WRAP_CONTENT,
           RecyclerView.LayoutParams.MATCH_PARENT

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -46,6 +46,7 @@ import org.kiwix.kiwixmobile.core.databinding.FragmentPageBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
+import org.kiwix.kiwixmobile.core.extensions.setUpSearchView
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.page.adapter.OnItemClickListener
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -106,12 +107,15 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
         override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
           menuInflater.inflate(R.menu.menu_page, menu)
           val search = menu.findItem(R.id.menu_page_search).actionView as SearchView
-          search.queryHint = searchQueryHint
-          search.setOnQueryTextListener(
-            SimpleTextListener { query, _ ->
-              pageViewModel.actions.offer(Action.Filter(query))
-            }
-          )
+          search.apply {
+            setUpSearchView(requireActivity())
+            queryHint = searchQueryHint
+            setOnQueryTextListener(
+              SimpleTextListener { query, _ ->
+                pageViewModel.actions.offer(Action.Filter(query))
+              }
+            )
+          }
         }
 
         @Suppress("ReturnCount")
@@ -121,6 +125,7 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
               pageViewModel.actions.offer(Action.Exit)
               return true
             }
+
             R.id.menu_pages_clear -> {
               pageViewModel.actions.offer(Action.UserClickedDeleteButton)
               return true

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -54,6 +54,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.databinding.FragmentSearchBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
+import org.kiwix.kiwixmobile.core.extensions.setUpSearchView
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.search.adapter.SearchAdapter
@@ -220,21 +221,25 @@ class SearchFragment : BaseFragment() {
           val searchMenuItem = menu.findItem(R.id.menu_search)
           searchMenuItem.expandActionView()
           searchView = searchMenuItem.actionView as SearchView
-          searchView?.setOnQueryTextListener(
-            SimpleTextListener { query, isSubmit ->
-              if (query.isNotEmpty()) {
-                when {
-                  isSubmit -> {
-                    // if user press the search/enter button on keyboard,
-                    // try to open the article if present
-                    getSearchListItemForQuery(query)?.let(::onItemClick)
-                  }
+          searchView?.apply {
+            setUpSearchView(requireActivity())
+            searchView?.setOnQueryTextListener(
+              SimpleTextListener { query, isSubmit ->
+                if (query.isNotEmpty()) {
+                  when {
+                    isSubmit -> {
+                      // if user press the search/enter button on keyboard,
+                      // try to open the article if present
+                      getSearchListItemForQuery(query)?.let(::onItemClick)
+                    }
 
-                  else -> searchViewModel.actions.trySend(Filter(query)).isSuccess
+                    else -> searchViewModel.actions.trySend(Filter(query)).isSuccess
+                  }
                 }
               }
-            }
-          )
+            )
+          }
+
           searchMenuItem.setOnActionExpandListener(object : OnActionExpandListener {
             override fun onMenuItemActionExpand(item: MenuItem) = false
 

--- a/core/src/main/res/layout/reader_fragment_content.xml
+++ b/core/src/main/res/layout/reader_fragment_content.xml
@@ -128,9 +128,10 @@
     android:src="@drawable/fullscreen_exit"
     android:tint="?colorSurface"
     android:visibility="gone"
+    android:minWidth="@dimen/material_minimum_height_and_width"
+    android:minHeight="@dimen/material_minimum_height_and_width"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:visibility="visible" />
+    app:layout_constraintTop_toTopOf="parent" />
 
 
   <androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -22,4 +22,5 @@
   <dimen name="material_design_appbar_size">48dp</dimen>
   <dimen name="hamburger_icon_size">36dp</dimen>
   <dimen name="material_minimum_height_and_width">48dp</dimen>
+  <dimen name="close_tab_button_size">24dp</dimen>
 </resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -21,4 +21,5 @@
 
   <dimen name="material_design_appbar_size">48dp</dimen>
   <dimen name="hamburger_icon_size">36dp</dimen>
+  <dimen name="material_minimum_height_and_width">48dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #3701
Child Issue #3680

* Increased the height and width of the views to align with Play Store policies, while ensuring no impact on the UI (as illustrated in the images below).

| Before fix  | After fix |
| ------------- | ------------- |
| ![BeforeIncreasingHeighOfPauseStop](https://github.com/kiwix/kiwix-android/assets/34593983/810e94d9-2f23-4a1d-ab8b-80d6b4b2c71e)  | ![AfterincreasingheightPauseAndStop](https://github.com/kiwix/kiwix-android/assets/34593983/3cca9d5f-efeb-4a98-a616-de9c3925361e)  |
| ![Closeimagebefore](https://github.com/kiwix/kiwix-android/assets/34593983/15aaeca5-5921-49e5-a2bf-ac86687650a9)  | ![Closeimageafter](https://github.com/kiwix/kiwix-android/assets/34593983/52614f6d-c2d0-48e1-817e-b0d2a0f16401)  |

* For the tab switcher touch target issue we already placed a fix in https://github.com/kiwix/kiwix-android/pull/3705
* Increased the touch size for the `close full screen` button to make it easily clickable. It increased its background a bit. Also removed the duplicate `visibility` attribute set on this view.

| Before fix  | After fix |
| ------------- | ------------- |
| ![beforefullscreenbutton](https://github.com/kiwix/kiwix-android/assets/34593983/536bd4af-fce3-42cf-8e6c-cc2ccd210a6d) | ![AfterFullScreenButton](https://github.com/kiwix/kiwix-android/assets/34593983/35ed366d-5a7c-4a70-a887-fd56989a6580) |

* Changed search's view close icon image width and added the `toolTipText` for showing the description if a user long click on this. So for this, We created an extension function to set up the SearchView. It now configures the toolTipText and width for the close icon of the SearchView. With this extension function, we have applied these properties to every SearchView used in the application, such as in LanguageFragment, SearchFragment, (History/Bookmark/Notes), and OnlineLibraryFragment.
  
| Before fix  | After fix | Showing description when long click on the close image |
| ------------- | ------------- | ------------- |
| ![beforecloseinage](https://github.com/kiwix/kiwix-android/assets/34593983/8cf16253-d732-4240-a7df-3eff252910c2) | ![aftercloseimage](https://github.com/kiwix/kiwix-android/assets/34593983/361fdfbc-0572-473b-a62b-356052c1035a) | ![clearquery1](https://github.com/kiwix/kiwix-android/assets/34593983/e9bb7af9-a29c-4ac9-b520-2d45cbf8a6d0) |
