### PR TITLE
Fixed: Content labeling issue reported by the playstore.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -26,6 +26,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
@@ -35,10 +36,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
+import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.SimpleTextListener
@@ -78,13 +82,18 @@ class LanguageFragment : BaseFragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     val activity = requireActivity() as CoreMainActivity
-    activity.setSupportActionBar(view.findViewById(R.id.toolbar))
+    val toolbar: Toolbar = view.findViewById(R.id.toolbar)
+    activity.setSupportActionBar(toolbar)
 
     activity.supportActionBar?.let {
       it.setDisplayHomeAsUpEnabled(true)
       it.setHomeAsUpIndicator(R.drawable.ic_clear_white_24dp)
       it.setTitle(R.string.select_languages)
     }
+    // set the contentDescription to navigation back button
+    toolbar.getToolbarNavigationIcon()?.setToolTipWithContentDescription(
+      getString(string.toolbar_back_button_content_description)
+    )
     activityLanguageBinding?.languageRecyclerView?.run {
       adapter = languageAdapter
       layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)

--- a/app/src/main/java/org/kiwix/kiwixmobile/language/adapter/LanguageListViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/adapter/LanguageListViewHolder.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.language.adapter
 import android.view.View
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.databinding.HeaderDateBinding
 import org.kiwix.kiwixmobile.databinding.ItemLanguageBinding
 import org.kiwix.kiwixmobile.language.adapter.LanguageListItem.HeaderItem
@@ -48,8 +49,18 @@ sealed class LanguageListViewHolder<in T : LanguageListItem>(override val contai
       itemLanguageBinding.itemLanguageLocalizedName.text = language.languageLocalized
       itemLanguageBinding.itemLanguageBooksCount.text = containerView.context
         .getString(R.string.books_count, language.occurencesOfLanguage)
-      itemLanguageBinding.itemLanguageCheckbox.isChecked = language.active
-      itemLanguageBinding.itemLanguageClickableArea.setOnClickListener { clickAction(item) }
+      itemLanguageBinding.itemLanguageCheckbox.apply {
+        setToolTipWithContentDescription(
+          containerView.context.getString(R.string.select_language_content_description)
+        )
+        isChecked = language.active
+      }
+      itemLanguageBinding.itemLanguageClickableArea.apply {
+        setToolTipWithContentDescription(
+          containerView.context.getString(R.string.select_language_content_description)
+        )
+        setOnClickListener { clickAction(item) }
+      }
     }
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -59,6 +59,7 @@ import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -139,6 +140,9 @@ class LocalFileTransferFragment :
     wifiDirectManager.callbacks = this
     wifiDirectManager.lifecycleCoroutineScope = lifecycleScope
     wifiDirectManager.startWifiDirectManager(filesForTransfer)
+    fragmentLocalFileTransferBinding
+      ?.textViewDeviceName
+      ?.setToolTipWithContentDescription(getString(R.string.your_device))
   }
 
   private fun setupMenu() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -55,10 +55,12 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
+import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -245,12 +247,18 @@ class LocalFileTransferFragment :
 
   private fun setupToolbar(view: View, activity: CoreMainActivity, isReceiver: Boolean) {
     val toolbar: Toolbar = view.findViewById(R.id.toolbar)
-    activity.setSupportActionBar(toolbar)
-    toolbar.title =
-      if (isReceiver) getString(R.string.receive_files_title)
-      else getString(R.string.send_files_title)
-    toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp)
-    toolbar.setNavigationOnClickListener { activity.popNavigationBackstack() }
+    toolbar.apply {
+      activity.setSupportActionBar(this)
+      title =
+        if (isReceiver) getString(R.string.receive_files_title)
+        else getString(R.string.send_files_title)
+      setNavigationIcon(R.drawable.ic_close_white_24dp)
+      // set the contentDescription to navigation back button
+      getToolbarNavigationIcon()?.setToolTipWithContentDescription(
+        getString(string.toolbar_back_button_content_description)
+      )
+      setNavigationOnClickListener { activity.popNavigationBackstack() }
+    }
   }
 
   private fun getFilesForTransfer() =

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -26,6 +26,7 @@ import org.kiwix.kiwixmobile.core.downloader.model.Base64String
 import org.kiwix.kiwixmobile.core.extensions.setBitmap
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
 import org.kiwix.kiwixmobile.core.extensions.setTextAndVisibility
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.zim_manager.KiloByte
@@ -101,9 +102,18 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       itemDownloadBinding.libraryDownloadTitle.text = item.title
       itemDownloadBinding.libraryDownloadDescription.text = item.description
       itemDownloadBinding.downloadProgress.progress = item.progress
-      itemDownloadBinding.stop.setOnClickListener { clickAction.invoke(item) }
-      itemDownloadBinding.pauseResume.setOnClickListener {
-        pauseResumeClickAction.invoke(item)
+      itemDownloadBinding.stop.apply {
+        setToolTipWithContentDescription(itemDownloadBinding.root.context.getString(R.string.stop))
+        setOnClickListener { clickAction.invoke(item) }
+      }
+      itemDownloadBinding.pauseResume.apply {
+        val context = itemDownloadBinding.root.context
+        val description =
+          "${context.getString(R.string.tts_pause)}/${context.getString(R.string.tts_resume)}"
+        setToolTipWithContentDescription(description)
+        setOnClickListener {
+          pauseResumeClickAction.invoke(item)
+        }
       }
       itemDownloadBinding.downloadState.text =
         item.downloadState.toReadableState(containerView.context).also {

--- a/app/src/main/res/layout/activity_language.xml
+++ b/app/src/main/res/layout/activity_language.xml
@@ -14,6 +14,7 @@
     android:layout_width="0dp"
     android:layout_height="0dp"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    android:contentDescription="@string/pref_language_title"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_destination_download.xml
+++ b/app/src/main/res/layout/fragment_destination_download.xml
@@ -48,6 +48,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
+        android:contentDescription="@string/library"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:listitem="@layout/item_download" />
 

--- a/app/src/main/res/layout/fragment_destination_library.xml
+++ b/app/src/main/res/layout/fragment_destination_library.xml
@@ -55,6 +55,7 @@
           android:id="@+id/zimfilelist"
           android:layout_width="0dp"
           android:layout_height="match_parent"
+          android:contentDescription="@string/crash_checkbox_zimfiles"
           app:layout_constraintBottom_toBottomOf="parent"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_library.xml
+++ b/app/src/main/res/layout/item_library.xml
@@ -113,6 +113,7 @@
       android:layout_width="0dp"
       android:layout_height="0dp"
       android:alpha=".5"
+      android:contentDescription="@string/detecting_file_system"
       android:background="@color/pure_gray"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintEnd_toEndOf="parent"

--- a/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageViewHolder.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageViewHolder.kt
@@ -23,6 +23,7 @@ import eu.mhutti1.utils.storage.StorageDevice
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
 import org.kiwix.kiwixmobile.core.databinding.DeviceItemBinding
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
@@ -45,8 +46,15 @@ internal class StorageViewHolder(
     }
     deviceItemBinding.fileSize.text = storageCalculator.calculateAvailableSpace(item.file) + " / " +
       storageCalculator.calculateTotalSpace(item.file) + "  "
-    deviceItemBinding.clickOverlay.setOnClickListener {
-      onClickAction.invoke(item)
+    deviceItemBinding.clickOverlay.apply {
+      setToolTipWithContentDescription(
+        deviceItemBinding.root.context.getString(
+          R.string.storage_selection_dialog_accessibility_description
+        )
+      )
+      setOnClickListener {
+        onClickAction.invoke(item)
+      }
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseFragment.kt
@@ -24,6 +24,9 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 
 /**
  * All fragments should inherit from this fragment.
@@ -55,6 +58,10 @@ abstract class BaseFragment : Fragment() {
         it.supportActionBar?.let { actionBar ->
           actionBar.setDisplayHomeAsUpEnabled(true)
           title = fragmentTitle
+          // set the navigation back button contentDescription
+          getToolbarNavigationIcon()?.setToolTipWithContentDescription(
+            getString(R.string.toolbar_back_button_content_description)
+          )
         }
       }
       setNavigationOnClickListener {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ToolbarExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ToolbarExtensions.kt
@@ -1,0 +1,43 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import android.text.TextUtils
+import android.view.View
+import androidx.appcompat.widget.Toolbar
+
+fun Toolbar.getToolbarNavigationIcon(): View? {
+  // check if contentDescription previously was set
+  val hadContentDescription = !TextUtils.isEmpty(navigationContentDescription)
+  val contentDescription =
+    if (hadContentDescription) navigationContentDescription else "navigationIcon"
+  // set the contentDescription on toolbar's navigationIcon
+  navigationContentDescription = contentDescription
+  val potentialViews = arrayListOf<View>()
+  // find the view based on it's content description,
+  // set programmatically or with android:contentDescription
+  findViewsWithText(potentialViews, contentDescription, View.FIND_VIEWS_WITH_CONTENT_DESCRIPTION)
+  // Clear content description if not previously present
+  if (!hadContentDescription) {
+    navigationContentDescription = null
+  }
+  // Nav icon is always instantiated at this point because calling
+  // setNavigationContentDescription ensures its existence
+  return potentialViews.firstOrNull()
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.extensions
 import android.annotation.SuppressLint
 import android.view.View
 import androidx.annotation.ColorInt
+import androidx.appcompat.widget.TooltipCompat
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 
@@ -68,4 +69,15 @@ fun View.snack(
       }
     })
   }.show()
+}
+
+/**
+ * Sets the content description to address an accessibility issue reported by the Play Store.
+ * Additionally, sets a tooltip for displaying hints to the user when they long-click on the view.
+ *
+ * @param description The content description and tooltip text to be set.
+ */
+fun View.setToolTipWithContentDescription(description: String) {
+  contentDescription = description
+  TooltipCompat.setTooltipText(this, description)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -50,6 +50,8 @@ import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.error.ErrorActivity
 import org.kiwix.kiwixmobile.core.extensions.browserIntent
+import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.search.NAV_ARG_SEARCH_STRING
 import org.kiwix.kiwixmobile.core.utils.EXTRA_IS_WIDGET_VOICE
@@ -197,6 +199,14 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     navController.navigateUp() || super.onSupportNavigateUp()
 
   open fun setupDrawerToggle(toolbar: Toolbar) {
+    // Set the initial contentDescription to the hamburger icon.
+    // This method is called from various locations after modifying the navigationIcon.
+    // For example, we previously changed this icon/contentDescription to the "+" button
+    // when opening the tabSwitcher. After closing the tabSwitcher, we reset the
+    // contentDescription to the default hamburger icon.
+    toolbar.getToolbarNavigationIcon()?.setToolTipWithContentDescription(
+      getString(R.string.open_drawer)
+    )
     drawerToggle =
       ActionBarDrawerToggle(
         this,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -65,7 +65,6 @@ import androidx.annotation.AnimRes
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.appcompat.widget.TooltipCompat
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.Group
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -115,6 +114,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigatio
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.findFirstTextView
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.DocumentParser.SectionsListener
@@ -694,13 +694,8 @@ abstract class CoreReaderFragment :
       )
       setDisplayShowTitleEnabled(false)
     }
-    // contentDescription is not working as expected, so use TooltipCompat.setTooltipText
-    // method instead of toolTipText, for backward compatibility
     closeAllTabsButton?.let {
-      TooltipCompat.setTooltipText(
-        it,
-        resources.getString(R.string.close_all_tabs)
-      )
+      it.setToolTipWithContentDescription(resources.getString(R.string.close_all_tabs))
     }
     // Set a negative top margin to the web views to remove
     // the unwanted blank space caused by the toolbar.

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -113,6 +113,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationP
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.findFirstTextView
+import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.snack
@@ -692,11 +693,15 @@ abstract class CoreReaderFragment :
       setHomeAsUpIndicator(
         ContextCompat.getDrawable(requireActivity(), R.drawable.ic_round_add_white_36dp)
       )
+      // set the contentDescription to UpIndicator icon.
+      toolbar?.getToolbarNavigationIcon()?.setToolTipWithContentDescription(
+        getString(R.string.search_open_in_new_tab)
+      )
       setDisplayShowTitleEnabled(false)
     }
-    closeAllTabsButton?.let {
-      it.setToolTipWithContentDescription(resources.getString(R.string.close_all_tabs))
-    }
+    closeAllTabsButton?.setToolTipWithContentDescription(
+      resources.getString(R.string.close_all_tabs)
+    )
     // Set a negative top margin to the web views to remove
     // the unwanted blank space caused by the toolbar.
     setTopMarginToWebViews(-requireActivity().getToolbarHeight())

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainMenu.kt
@@ -22,9 +22,9 @@ import android.content.res.Configuration
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
-import androidx.appcompat.widget.TooltipCompat
 import androidx.core.view.isVisible
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 
 const val REQUEST_FILE_SEARCH = 1236
@@ -101,12 +101,7 @@ class MainMenu(
     )
     tabSwitcher?.actionView?.apply {
       setOnClickListener { menuClickListener.onTabMenuClicked() }
-      // contentDescription is not working as expected, so use TooltipCompat.setTooltipText
-      // method instead of toolTipText, for backward compatibility
-      TooltipCompat.setTooltipText(
-        this,
-        resources.getString(R.string.switch_tabs)
-      )
+      setToolTipWithContentDescription(resources.getString(R.string.switch_tabs))
     }
     addNote.menuItemClickListener { menuClickListener.onAddNoteMenuClicked() }
     randomArticle.menuItemClickListener { menuClickListener.onRandomArticleMenuClicked() }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
@@ -26,7 +26,6 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.TooltipCompat
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
@@ -39,6 +38,7 @@ import com.google.android.material.card.MaterialCardView
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.tint
 import org.kiwix.kiwixmobile.core.utils.DimenUtils.getToolbarHeight
 import org.kiwix.kiwixmobile.core.utils.DimenUtils.getWindowHeight
@@ -67,12 +67,7 @@ class TabsAdapter internal constructor(
       .apply {
         id = R.id.tabsAdapterCloseImageView
         setImageDrawableCompat(R.drawable.ic_clear_white_24dp)
-        // contentDescription is not working as expected, so use TooltipCompat.setTooltipText
-        // method instead of toolTipText, for backward compatibility
-        TooltipCompat.setTooltipText(
-          this,
-          resources.getString(R.string.close_tab)
-        )
+        setToolTipWithContentDescription(resources.getString(R.string.close_tab))
         val outValue = TypedValue()
         context.theme.resolveAttribute(android.R.attr.actionBarItemBackground, outValue, true)
         setBackgroundResource(outValue.resourceId)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -45,6 +45,7 @@ import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.databinding.FragmentPageBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
+import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.page.adapter.OnItemClickListener
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -137,9 +138,12 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
     super.onViewCreated(view, savedInstanceState)
     setupMenu()
     val activity = requireActivity() as CoreMainActivity
-    fragmentPageBinding?.recyclerView?.layoutManager =
-      LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
-    fragmentPageBinding?.recyclerView?.adapter = pageAdapter
+    fragmentPageBinding?.recyclerView?.apply {
+      layoutManager =
+        LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
+      adapter = pageAdapter
+      fragmentTitle?.let(::setToolTipWithContentDescription)
+    }
     fragmentPageBinding?.noPage?.text = noItemsString
 
     fragmentPageBinding?.pageSwitch?.apply {

--- a/core/src/main/res/layout/activity_zim_host.xml
+++ b/core/src/main/res/layout/activity_zim_host.xml
@@ -60,6 +60,7 @@
     android:layout_height="0dp"
     android:layout_marginTop="16dp"
     android:layout_marginBottom="8dp"
+    android:contentDescription="@string/menu_wifi_hotspot"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
     app:layout_constraintBottom_toTopOf="@+id/startServerButton"
     app:layout_constraintEnd_toEndOf="parent"

--- a/core/src/main/res/layout/item_book.xml
+++ b/core/src/main/res/layout/item_book.xml
@@ -119,6 +119,7 @@
       android:layout_height="0dp"
       android:background="?android:attr/selectableItemBackground"
       app:layout_constraintBottom_toBottomOf="parent"
+      android:contentDescription="@string/zim_file_content_description"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -352,4 +352,7 @@
   <string name="your_device_name_message">Your device name will appear here.</string>
   <string name="nearby_devices_list_message">Here, you\'ll find a list of nearby devices. Tap on a device\'s name to initiate file transfer.</string>
   <string name="transfer_zim_files_list_message">Here, you\’ll find the list of available ZIM files for transfer.</string>
+  <string name="storage_selection_dialog_accessibility_description">Select storage for downloading ZIM files.</string>
+  <string name="zim_file_content_description">ZIM file which has the reading content</string>
+  <string name="select_language_content_description">Selecting this language will prioritize displaying downloadable books in that language at the top.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -355,4 +355,5 @@
   <string name="storage_selection_dialog_accessibility_description">Select storage for downloading ZIM files.</string>
   <string name="zim_file_content_description">ZIM file which has the reading content</string>
   <string name="select_language_content_description">Selecting this language will prioritize displaying downloadable books in that language at the top.</string>
+  <string name="toolbar_back_button_content_description">Goto previous screen</string>
 </resources>


### PR DESCRIPTION
Fixes #3700 
Child Issue https://github.com/kiwix/kiwix-android/issues/3680

* Added content descriptions for all views reported by the Play Store, including RecyclerView, dialog's itemView, pause/resume/stop buttons, and many more.
* Created an extension function to handle both setting the content description to address Play Store accessibility issues and displaying hints to the user using ToolTipText. This function consolidates these tasks in one place, eliminating code duplication.
* Added a few new `contentDescription` for views, which are shown in the below images, if you have any better suggestions for these `contentDescripton`, it would be welcome.

![LanguageSelection](https://github.com/kiwix/kiwix-android/assets/34593983/ebab75f7-f08d-4315-b751-cb512d779996)
![PauseButton](https://github.com/kiwix/kiwix-android/assets/34593983/29ed49b8-8940-4514-888d-f1a28107c34d)
![Stopabutton](https://github.com/kiwix/kiwix-android/assets/34593983/f86f0438-fc78-4dbb-8b52-c7a4ce989cc7)
![StorageSelectionDialog](https://github.com/kiwix/kiwix-android/assets/34593983/a2fe5549-4594-4f7f-802a-86d92c0c7e63)


* For the below change we do not have any direct function to get the `navigationIcon` from toolbar. So we make a helper function to get that view. Please read the code comments as this change has some conditions after closing some screens. For example, we previously changed this icon/contentDescription to the "+" button when opening the tabSwitcher. After closing the tabSwitcher, we reset the contentDescription to the default hamburger icon. To properly understand all the changes we have added appropriate comments on methods.

| Back button descripton | Back button descripton  | Back button descripton | Back button descripton | Back button description |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| ![Screenshot_20240216-123341](https://github.com/kiwix/kiwix-android/assets/34593983/dfee7af4-96d2-4f6a-8c18-2839def999e0)  | ![Screenshot_20240216-123346](https://github.com/kiwix/kiwix-android/assets/34593983/0b90bc57-8ee5-43e2-9dd2-f7f97ba2ef73) | ![Screenshot_20240216-123404](https://github.com/kiwix/kiwix-android/assets/34593983/8889839e-9aa3-4c19-b009-b3550b3795af)  | ![Screenshot_20240216-123417](https://github.com/kiwix/kiwix-android/assets/34593983/0c73d570-9637-4012-98b5-be43e7ad70cc)  | ![Screenshot_20240216-123421](https://github.com/kiwix/kiwix-android/assets/34593983/14fa93d2-aed3-4403-891c-4e5066ed0ae4) |
| ![Screenshot_20240216-123426](https://github.com/kiwix/kiwix-android/assets/34593983/9826289e-af54-4d9e-8783-a179cd681d37) | ![Screenshot_20240216-123430](https://github.com/kiwix/kiwix-android/assets/34593983/5c951b19-30b3-4872-888f-5d1032b11312) | ![Screenshot_20240216-123435](https://github.com/kiwix/kiwix-android/assets/34593983/008f2387-1637-4754-bf2b-bd9399f545cc) | ![Screenshot_20240216-123452](https://github.com/kiwix/kiwix-android/assets/34593983/cb615d39-8916-48c5-adf2-4e46e39b183b) | ![Screenshot_20240216-124930](https://github.com/kiwix/kiwix-android/assets/34593983/16f54dc2-37c3-48ea-a84c-b4a0df38d6c2) |

* For the `ActionMode` back button, there is no way I found yet to get the view so the description is not set for that (Might be that's why Play Store does not report for this view.). `ActionMode` activates, when you select one or more things(Zim files, history, etc) to delete. If you have any suggestions it would be welcome.
* When SearchView is activated then it overrides the default behavior of `navigationBackButton` means it removes the `contentDecripton` from the `navigationBackButton` so it does not show when the searchView is activated but after searchView is closed it starts working normally. You can see this behavior in the `Bookmarks` screen, just a long click on the backButton when initially launching the screen you will see the description, after that click on the search icon and again try to long click on the back button you will not see the description. SearchView does not have its own backButton it internally overrides the behaviour of `navigationBackButton`.