### PR TITLE
Add test cases for getLocalFilePathByUri() method.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
@@ -267,25 +267,28 @@ class FileUtilsInstrumentationTest {
         }
       }
     }
-    val commonUri = "Download/beer.stackexchange.com_en_all_2023-05.zim"
-    val sdCardPath = context!!.getExternalFilesDirs("")[1].path.substringBefore("/Android")
+    val commonPath = "Download/beer.stackexchange.com_en_all_2023-05.zim"
+    val commonUri = "Download%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+    // get the SD card path
+    val sdCardPath = context?.getExternalFilesDirs("")
+      ?.get(1)?.path?.substringBefore("/Android")
     val dummyUriData = listOf(
       // test the download uri on older devices
       DummyUrlData(
         null,
-        "${Environment.getExternalStorageDirectory()}/$commonUri",
+        "${Environment.getExternalStorageDirectory()}/$commonPath",
         Uri.parse(
           "content://com.android.providers.downloads.documents/document/" +
-            "raw%3A%2Fstorage%2Femulated%2F0%2FDownload%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+            "raw%3A%2Fstorage%2Femulated%2F0%2F$commonUri"
         )
       ),
       // test the download uri with new version of android
       DummyUrlData(
         null,
-        "${Environment.getExternalStorageDirectory()}/$commonUri",
+        "${Environment.getExternalStorageDirectory()}/$commonPath",
         Uri.parse(
           "content://com.android.providers.downloads.documents/document/" +
-            "%2Fstorage%2Femulated%2F0%2FDownload%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+            "%2Fstorage%2Femulated%2F0%2F$commonUri"
         )
       ),
       // test with file scheme
@@ -297,29 +300,29 @@ class FileUtilsInstrumentationTest {
       // test with internal storage uri
       DummyUrlData(
         null,
-        "${Environment.getExternalStorageDirectory()}/$commonUri",
+        "${Environment.getExternalStorageDirectory()}/$commonPath",
         Uri.parse(
           "content://com.android.externalstorage.documents/document/" +
-            "primary%3ADownload%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+            "primary%3A$commonUri"
         )
       ),
       // test with SD card uri
       DummyUrlData(
         null,
-        "$sdCardPath/$commonUri",
+        "$sdCardPath/$commonPath",
         Uri.parse(
           "content://com.android.externalstorage.documents/document/" +
-            sdCardPath.substringAfter("storage/") +
-            "%3ADownload%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+            sdCardPath?.substringAfter("storage/") +
+            "%3A$commonUri"
         )
       ),
       // test with USB stick uri
       DummyUrlData(
         null,
-        "/mnt/media_rw/USB/$commonUri",
+        "/mnt/media_rw/USB/$commonPath",
         Uri.parse(
           "content://com.android.externalstorage.documents/document/" +
-            "USB%3ADownload%2Fbeer.stackexchange.com_en_all_2023-05.zim"
+            "USB%3A$commonUri"
         )
       ),
       // test with invalid uri

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
@@ -388,6 +388,10 @@ class FileUtilsInstrumentationTest {
     val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
     val expectedDocumentId = "1000020403"
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      // Below Android 10, download URI schemes are of the content type, such as:
+      // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
+      // As a result, this method will not be called during that time. We are not testing it on
+      // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
       val mockedUri = Uri.parse("$downloadUriPrefix$expectedDocumentId")
       every { mockDocumentsContractWrapper.getDocumentId(mockedUri) } returns expectedDocumentId
       val actualDocumentId = FileUtils.extractDocumentId(mockedUri, mockDocumentsContractWrapper)
@@ -417,6 +421,10 @@ class FileUtilsInstrumentationTest {
     )
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      // Below Android 10, download URI schemes are of the content type, such as:
+      // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
+      // As a result, this method will not be called during that time. We are not testing it on
+      // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
       contentUriPrefixes.forEach {
         val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
         val expectedDocumentId = "1000020403"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/DocumentResolverWrapper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/DocumentResolverWrapper.kt
@@ -1,0 +1,53 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils.files
+
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import org.kiwix.kiwixmobile.core.extensions.get
+
+/**
+ * Wrapper class created for `DocumentsContract` and `ContentResolver` methods.
+ * This class facilitates the usage of these methods in test cases where direct
+ * mocking is not feasible.
+ */
+class DocumentResolverWrapper {
+  fun getDocumentId(uri: Uri): String = DocumentsContract.getDocumentId(uri)
+
+  @Suppress("LongParameterList")
+  fun query(
+    context: Context,
+    uri: Uri,
+    columnName: String,
+    selection: String?,
+    selectionArgs: Array<String>?,
+    sortOrder: String?
+  ): String? = context.contentResolver.query(
+    uri,
+    arrayOf(columnName),
+    selection,
+    selectionArgs,
+    sortOrder
+  )?.use {
+    return@query if (it.moveToFirst() && it.getColumnIndex(columnName) != -1) {
+      it[columnName]
+    } else null
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -46,7 +46,6 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
-import java.lang.NumberFormatException
 
 object FileUtils {
 
@@ -117,7 +116,6 @@ object FileUtils {
     context: Context,
     uri: Uri
   ): String? {
-    Log.e("DOWNLOAD_URI", "getLocalFilePathByUri: $uri")
     if (DocumentsContract.isDocumentUri(context, uri)) {
       if ("com.android.externalstorage.documents" == uri.authority) {
         val documentId = DocumentsContract.getDocumentId(uri)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -228,6 +228,9 @@ object FileUtils {
       null
     } catch (ignore: UnsupportedOperationException) {
       null
+    } catch (ignore: IllegalStateException) {
+      // to handle the scenario if the given uri is UNKNOWN
+      null
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -205,8 +205,8 @@ object FileUtils {
       }
     } catch (ignore: Exception) {
       Log.e(
-        "kiwix", "Error in getting path for documentId = $documentId \n" +
-          "Exception = $ignore"
+        "kiwix",
+        "Error in getting path for documentId = $documentId \nException = $ignore"
       )
     }
 
@@ -221,8 +221,8 @@ object FileUtils {
       return documentsContractWrapper.getDocumentId(uri)
     } catch (ignore: Exception) {
       Log.e(
-        "kiwix", "Unable to get documentId for uri = $uri \n" +
-          "Exception = $ignore"
+        "kiwix",
+        "Unable to get documentId for uri = $uri \nException = $ignore"
       )
     }
     return ""
@@ -245,8 +245,8 @@ object FileUtils {
       )
     } catch (ignore: Exception) {
       Log.e(
-        "kiwix", "Could not get path for uri = $uri \n" +
-          "Exception = $ignore"
+        "kiwix",
+        "Could not get path for uri = $uri \nException = $ignore"
       )
       null
     }


### PR DESCRIPTION
Fixes #3710 

* Enhanced the queryForActualPath() method to retrieve the actual path for a URI. Users faced a `java.lang.UnsupportedOperationException: Unknown URI` exception when querying the contentResolver with an invalid URI. A check has been added to prevent such errors.

* On older devices, the download URI contains the full file path, causing the `documentProviderContentQuery` to fail in retrieving the path, leading to unexpected behavior (failure to open the ZIM file). The code has been improved to handle this scenario.
* In certain devices, the content URI prefix may differ, and using only `public_downloads` to obtain the actual path from the URI might not work if the device has a different URI prefix. The code has been enhanced to consider every possible content prefix when retrieving the actual path.
* This test ensures that every URI will return the expected file path. e.g. for download uri, older device compatibility, internal/external/USB-STICK URI, and if an invalid URI is given then it will return the null.
* Added code to handle the exception when the provided download URI is invalid, as we encountered this issue in the test case for API level 24. https://github.com/kiwix/kiwix-android/actions/runs/7963507455/job/21739230714#step:5:1725