### PR TITLE
Added test cases for the search functionality.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -48,8 +48,8 @@ import java.net.URI
 
 class SearchFragmentTest : BaseActivityTest() {
 
-  private val stackExchangeZimFileUrl =
-    "https://download.kiwix.org/zim/stack_exchange/academia.stackexchange.com_en_all_2023-05.zim"
+  private val rayCharlesZimFileUrl =
+    "https://dev.kiwix.org/kiwix-android/test/wikipedia_en_ray_charles_maxi_2023-12.zim"
 
   @Rule
   @JvmField
@@ -196,7 +196,7 @@ class SearchFragmentTest : BaseActivityTest() {
 
   private fun downloadRequest() =
     Request.Builder()
-      .url(URI.create(stackExchangeZimFileUrl).toURL())
+      .url(URI.create(rayCharlesZimFileUrl).toURL())
       .build()
 
   private fun openSearchWithQuery(query: String = "", zimFile: File) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -18,13 +18,23 @@
 
 package org.kiwix.kiwixmobile.search
 
+import android.view.KeyEvent
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.UiDevice
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import org.hamcrest.Matchers.allOf
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.core.R
@@ -33,6 +43,11 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 fun search(func: SearchRobot.() -> Unit) = SearchRobot().applyWithViewHierarchyPrinting(func)
 
 class SearchRobot : BaseRobot() {
+
+  val searchUnitTestingQuery = "Unit testing"
+  val searchUnitTestResult = "Unit testing - Wikipedia"
+  val searchQueryForDownloadedZimFile = "A Statem"
+  val searchResultForDownloadedZimFile = "A Statement in a Thesis Proposal"
 
   fun clickOnSearchItemInSearchList() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
@@ -48,5 +63,42 @@ class SearchRobot : BaseRobot() {
   fun checkZimFileSearchSuccessful(readerFragment: Int) {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     isVisible(ViewId(readerFragment))
+  }
+
+  fun searchWithFrequentlyTypedWords(query: String, wait: Long = 0L) {
+    val searchView = onView(withId(R.id.search_src_text))
+    for (char in query) {
+      searchView.perform(typeText(char.toString()))
+      if (wait != 0L) {
+        BaristaSleepInteractions.sleep(wait)
+      }
+    }
+  }
+
+  fun assertSearchSuccessful(searchResult: String) {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
+    val recyclerViewId = R.id.search_list
+
+    // Scroll to the first position in the RecyclerView
+    onView(withId(recyclerViewId)).perform(scrollToPosition<ViewHolder>(0))
+
+    // Match the view at the first position in the RecyclerView
+    onView(withText(searchResult)).check(
+      matches(
+        allOf(
+          isDisplayed(),
+          isDescendantOfA(withId(recyclerViewId))
+        )
+      )
+    )
+  }
+
+  fun deleteSearchedQueryFrequently(textToDelete: String, uiDevice: UiDevice, wait: Long = 0L) {
+    for (i in textToDelete.indices) {
+      uiDevice.pressKeyCode(KeyEvent.KEYCODE_DEL)
+      if (wait != 0L) {
+        BaristaSleepInteractions.sleep(wait)
+      }
+    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -46,8 +46,8 @@ class SearchRobot : BaseRobot() {
 
   val searchUnitTestingQuery = "Unit testing"
   val searchUnitTestResult = "Unit testing - Wikipedia"
-  val searchQueryForDownloadedZimFile = "A Statem"
-  val searchResultForDownloadedZimFile = "A Statement in a Thesis Proposal"
+  val searchQueryForDownloadedZimFile = "A Fool"
+  val searchResultForDownloadedZimFile = "A Fool for You"
 
   fun clickOnSearchItemInSearchList() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())


### PR DESCRIPTION
Fixes #3596 

* In this updated test case, we have addressed scenarios involving fast typing/deleting for search queries. Additionally, we implemented a test case where the user types with both short and long delays to ensure the following:
   **Short delay:** Properly tests the cancellation of the previously searching task.
   **Long delay:** Properly executes the search query letter by letter and ensures that there is no crash during the search.
* We are downloading the "stack exchange" ZIM file in our test case because this ZIM file yields many search results. Therefore, we download and perform all search operations on this file to simulate a real-world scenario, as our test ZIM file only contains three search results.
* The temporary ZIM file is deleted after performing the test to free up device storage.