### PR TITLE
Fixed: Security and trust issue reported by the playStore.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -57,7 +57,6 @@ class LocalFileTransferTest {
     arrayOf(
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
-      Manifest.permission.ACCESS_COARSE_LOCATION,
       Manifest.permission.ACCESS_FINE_LOCATION
     )
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -54,7 +54,6 @@ class PlayStoreRestrictionDialogTest {
     arrayOf(
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
-      Manifest.permission.ACCESS_COARSE_LOCATION,
       Manifest.permission.ACCESS_FINE_LOCATION
     )
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -60,7 +60,6 @@ class ZimHostFragmentTest {
     arrayOf(
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
-      Manifest.permission.ACCESS_COARSE_LOCATION,
       Manifest.permission.ACCESS_FINE_LOCATION,
       Manifest.permission.ACCESS_NETWORK_STATE
     )

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
 
   <uses-permission
     android:name="android.permission.ACCESS_FINE_LOCATION"
-    android:maxSdkVersion="32" />
+    android:maxSdkVersion="32"
+    tools:ignore="CoarseFineLocation" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
   <uses-permission android:name="${permission}" />
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -71,7 +71,6 @@ import org.kiwix.kiwixmobile.databinding.FragmentLocalFileTransferBinding
 import org.kiwix.kiwixmobile.localFileTransfer.WifiDirectManager.Companion.getDeviceStatus
 import org.kiwix.kiwixmobile.localFileTransfer.adapter.WifiP2pDelegate
 import org.kiwix.kiwixmobile.localFileTransfer.adapter.WifiPeerListAdapter
-import org.kiwix.kiwixmobile.core.webserver.ZimHostFragment.Companion.PERMISSION_REQUEST_CODE_COARSE_LOCATION
 import uk.co.deanwild.materialshowcaseview.MaterialShowcaseSequence
 import uk.co.deanwild.materialshowcaseview.ShowcaseConfig
 import javax.inject.Inject
@@ -489,5 +488,6 @@ class LocalFileTransferFragment :
     const val TAG = "LocalFileTransferActvty"
     private const val PERMISSION_REQUEST_FINE_LOCATION = 2
     private const val PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS = 3
+    const val PERMISSION_REQUEST_CODE_COARSE_LOCATION = 10
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -55,8 +55,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
@@ -218,6 +218,7 @@ class LocalFileTransferFragment :
     when {
       !checkFineLocationAccessPermission() ->
         true
+
       !checkExternalStorageWritePermission() ->
         true
       /* Initiate discovery */
@@ -225,10 +226,12 @@ class LocalFileTransferFragment :
         requestEnableWifiP2pServices()
         true
       }
+
       Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !isLocationServiceEnabled -> {
         requestEnableLocationServices()
         true
       }
+
       else -> {
         showPeerDiscoveryProgressBar()
         wifiDirectManager.discoverPeerDevices()
@@ -349,7 +352,7 @@ class LocalFileTransferFragment :
   private fun askNearbyWifiDevicesPermission() {
     ActivityCompat.requestPermissions(
       requireActivity(), arrayOf(Manifest.permission.NEARBY_WIFI_DEVICES),
-      PERMISSION_REQUEST_CODE_COARSE_LOCATION
+      PERMISSION_REQUEST_CODE_NEARBY_WIFI_DEVICES
     )
   }
 
@@ -399,25 +402,30 @@ class LocalFileTransferFragment :
   ) {
     if (grantResults[0] == PERMISSION_DENIED) {
       when (requestCode) {
-        PERMISSION_REQUEST_FINE_LOCATION -> {
+        PERMISSION_REQUEST_FINE_LOCATION,
+        PERMISSION_REQUEST_CODE_NEARBY_WIFI_DEVICES -> {
           Log.e(TAG, "Location permission not granted")
           toast(R.string.permission_refused_location, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
+
         PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS -> {
           Log.e(TAG, "Storage write permission not granted")
           toast(R.string.permission_refused_storage, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
+
         else ->
           super.onRequestPermissionsResult(requestCode, permissions, grantResults)
       }
     } else if (grantResults[0] == PERMISSION_GRANTED) {
       when (requestCode) {
         PERMISSION_REQUEST_FINE_LOCATION,
-        PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS -> {
+        PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS,
+        PERMISSION_REQUEST_CODE_NEARBY_WIFI_DEVICES -> {
           onSearchMenuClicked()
         }
+
         else ->
           super.onRequestPermissionsResult(requestCode, permissions, grantResults)
       }
@@ -488,6 +496,6 @@ class LocalFileTransferFragment :
     const val TAG = "LocalFileTransferActvty"
     private const val PERMISSION_REQUEST_FINE_LOCATION = 2
     private const val PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS = 3
-    const val PERMISSION_REQUEST_CODE_COARSE_LOCATION = 10
+    const val PERMISSION_REQUEST_CODE_NEARBY_WIFI_DEVICES = 10
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -64,6 +64,7 @@ import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -325,8 +326,8 @@ class LocalFileTransferFragment :
         if (!permissionGranted) {
           if (shouldShowRationale(NEARBY_WIFI_DEVICES)) {
             alertDialogShower.show(
-              KiwixDialog.NearbyWifiPermissionRationaleOnHostZimFile,
-              ::askNearbyWifiDevicesPermission
+              KiwixDialog.NearbyWifiPermissionRationale,
+              requireActivity()::navigateToAppSettings
             )
           } else {
             askNearbyWifiDevicesPermission()
@@ -339,7 +340,7 @@ class LocalFileTransferFragment :
         if (shouldShowRationale(ACCESS_FINE_LOCATION)) {
           alertDialogShower.show(
             KiwixDialog.LocationPermissionRationale,
-            ::requestLocationPermission
+            requireActivity()::navigateToAppSettings
           )
         } else {
           requestLocationPermission()
@@ -369,7 +370,7 @@ class LocalFileTransferFragment :
           if (shouldShowRationale(WRITE_EXTERNAL_STORAGE)) {
             alertDialogShower.show(
               KiwixDialog.StoragePermissionRationale,
-              ::requestStoragePermissionPermission
+              requireActivity()::navigateToAppSettings
             )
           } else {
             requestStoragePermissionPermission()

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
     android:name="android.permission.NEARBY_WIFI_DEVICES"
     android:usesPermissionFlags="neverForLocation"
     tools:targetApi="s" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <queries>
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE" />

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -49,9 +49,9 @@ sealed class KiwixDialog(
     android.R.string.cancel
   )
 
-  object NearbyWifiPermissionRationaleOnHostZimFile : KiwixDialog(
+  object NearbyWifiPermissionRationale : KiwixDialog(
     null,
-    R.string.permission_rationale_location_on_host_zim_file,
+    R.string.permission_rationale_nearby,
     android.R.string.ok,
     android.R.string.cancel
   )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -49,13 +49,6 @@ sealed class KiwixDialog(
     android.R.string.cancel
   )
 
-  object LocationPermissionRationaleOnHostZimFile : KiwixDialog(
-    null,
-    R.string.permission_rationale_location_on_host_zim_file,
-    android.R.string.ok,
-    android.R.string.cancel
-  )
-
   object NearbyWifiPermissionRationaleOnHostZimFile : KiwixDialog(
     null,
     R.string.permission_rationale_location_on_host_zim_file,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/ZimHostFragment.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.webserver
 
-import android.Manifest
 import android.Manifest.permission.POST_NOTIFICATIONS
 import android.annotation.SuppressLint
 import android.app.Dialog
@@ -26,7 +25,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -37,7 +35,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -56,7 +53,6 @@ import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.ConnectivityReporter
-import org.kiwix.kiwixmobile.core.utils.REQUEST_POST_NOTIFICATION_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.ServerUtils
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -172,17 +168,14 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
     }
 
     activityZimHostBinding?.startServerButton?.setOnClickListener {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ||
-        checkNearbyWifiDevicesPermission()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
       ) {
         if (requireActivity().hasNotificationPermission(sharedPreferenceUtil)) {
           startStopServer()
         } else {
           requestNotificationPermission()
         }
-      } else if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P ||
-        checkCoarseLocationAccessPermission()
-      ) {
+      } else {
         startStopServer()
       }
     }
@@ -201,87 +194,6 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
         requireActivity()::navigateToAppSettings
       )
     }
-  }
-
-  private fun checkCoarseLocationAccessPermission(): Boolean =
-    if (ContextCompat.checkSelfPermission(
-        requireActivity(),
-        Manifest.permission.ACCESS_COARSE_LOCATION
-      ) == PackageManager.PERMISSION_DENIED
-    ) {
-      if (ActivityCompat.shouldShowRequestPermissionRationale(
-          requireActivity(),
-          Manifest.permission.ACCESS_COARSE_LOCATION
-        )
-      ) {
-        alertDialogShower.show(
-          KiwixDialog.LocationPermissionRationaleOnHostZimFile,
-          ::askCoarseLocationPermission
-        )
-      } else {
-        askCoarseLocationPermission()
-      }
-      false
-    } else {
-      true
-    }
-
-  private fun checkNearbyWifiDevicesPermission(): Boolean =
-    if (ContextCompat.checkSelfPermission(
-        requireActivity(),
-        Manifest.permission.NEARBY_WIFI_DEVICES
-      ) == PackageManager.PERMISSION_DENIED
-    ) {
-      if (ActivityCompat.shouldShowRequestPermissionRationale(
-          requireActivity(),
-          Manifest.permission.NEARBY_WIFI_DEVICES
-        )
-      ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-          alertDialogShower.show(
-            KiwixDialog.NearbyWifiPermissionRationaleOnHostZimFile,
-            ::askNearbyWifiDevicesPermission
-          )
-        }
-      } else {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-          askNearbyWifiDevicesPermission()
-        }
-      }
-      false
-    } else {
-      true
-    }
-
-  @Suppress("DEPRECATION")
-  override fun onRequestPermissionsResult(
-    requestCode: Int,
-    permissions: Array<out String>,
-    grantResults: IntArray
-  ) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-    if (permissions.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-      if (requestCode == PERMISSION_REQUEST_CODE_COARSE_LOCATION ||
-        requestCode == REQUEST_POST_NOTIFICATION_PERMISSION
-      ) {
-        startStopServer()
-      }
-    }
-  }
-
-  private fun askCoarseLocationPermission() {
-    ActivityCompat.requestPermissions(
-      requireActivity(), arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION),
-      PERMISSION_REQUEST_CODE_COARSE_LOCATION
-    )
-  }
-
-  @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-  private fun askNearbyWifiDevicesPermission() {
-    ActivityCompat.requestPermissions(
-      requireActivity(), arrayOf(Manifest.permission.NEARBY_WIFI_DEVICES),
-      PERMISSION_REQUEST_CODE_COARSE_LOCATION
-    )
   }
 
   private fun startStopServer() {
@@ -529,6 +441,5 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   companion object {
     const val SELECTED_ZIM_PATHS_KEY = "selected_zim_paths"
     const val RESTART_SERVER = "restart_server"
-    const val PERMISSION_REQUEST_CODE_COARSE_LOCATION = 10
   }
 }

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -244,8 +244,6 @@
   <string name="severe_loss_error">خطأ شديد! حاول تعطيل/إعادة تمكين الواي فاي P2P</string>
   <string name="connection_failed">فشل الاتصال</string>
   <string name="permission_rationale_location">مطلوب إذن للموقع بواسطة أندرويد للسماح للتطبيق باكتشاف الأجهزة المقترنة</string>
-  <string name="permission_rationale_location_on_host_zim_file">مطلوب إذن للموقع بواسطة أندرويد للسماح للتطبيق باكتشاف ملفات زيم (Zim) المستضافة</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">يتطلب Android إذنًا لأجهزة wifi المجاورة للسماح للتطبيق باستضافة ملفات Zim</string>
   <string name="permission_refused_location">لا يمكن تحديد موقع الأجهزة المقترنة دون أذونات الموقع</string>
   <string name="permission_refused_storage">لا يمكن الوصول إلى ملفات زيم (ZIM) دون إذن وحدة تخزين</string>
   <string name="request_enable_location">تمكين الموقع للسماح باكتشاف الأجهزة المقترنة</string>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -238,8 +238,6 @@
   <string name="severe_loss_error">Závažná chyba! Zkuste vypnout/znovu zapnout WiFi P2P</string>
   <string name="connection_failed">Spojení selhalo</string>
   <string name="permission_rationale_location">Systém Android vyžaduje povolení polohy, aby aplikace mohla detekovat zařízení v okolí</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android vyžaduje povolení umístění, aby aplikace mohla hostovat soubory Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android vyžaduje povolení zařízení Wi-Fi v okolí, aby mohla aplikace hostovat soubory Zim</string>
   <string name="permission_refused_location">Nelze nalézt zařízení v okolí bez přístupu k poloze</string>
   <string name="permission_refused_storage">Nelze získat přístup k souborům zim bez povolení přístupu do úložiště</string>
   <string name="request_enable_location">Povolit přístup k poloze a umožnit vyhledávání zařízení</string>

--- a/core/src/main/res/values-dag/strings.xml
+++ b/core/src/main/res/values-dag/strings.xml
@@ -229,8 +229,6 @@
   <string name="severe_loss_error">Chiriŋ din mali yaa! Labi niŋ ŋmaabu labi\'niŋ WiFi P2P</string>
   <string name="connection_failed">Laɣimbu zaɣisiya</string>
   <string name="permission_rationale_location">Dooshee soli nyɛla binshɛli Android ni bora ni di tooi chɛ ka app ŋɔ tooi baŋ di taba</string>
-  <string name="permission_rationale_location_on_host_zim_file">Dooshee soli nyɛla binshɛli Android ni bora ni di tooi chɛ ka app ŋɔ gbubi Zim fasara nima</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">WiFi din miri na bimbuɣisira soli nyɛla Android ni bori shɛli ni di tooi chɛ ka app ŋɔ gbubi Zim fasara nima</string>
   <string name="permission_refused_location">Ku tooi m-bo gbaai di taba  shee di yi niŋ ka a bi ti dooshee soya</string>
   <string name="permission_refused_storage">Ku tooi nya zim fasara nima di yi niŋ ka a bi ti deei niŋ shee soli</string>
   <string name="request_enable_location">Tim dooshee soli di yɛn chɛ ka di gbaai di taba</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -259,8 +259,6 @@
   <string name="severe_loss_error">Schwerer Fehler! Versuchen Sie, Wi-Fi P2P auszuschalten und wieder einzuschalten</string>
   <string name="connection_failed">Verbindung fehlgeschlagen</string>
   <string name="permission_rationale_location">Android benötigt eine Standorterlaubnis, damit die App Peer-Geräte erkennen kann.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android benötigt eine Standorterlaubnis, damit die App Zim-Dateien hosten kann</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android erfordert die Berechtigung für WLAN-Geräte in der Nähe, damit die App Zim-Dateien hosten kann</string>
   <string name="permission_refused_location">Ohne Standortberechtigungen können Peer-Geräte nicht lokalisiert werden</string>
   <string name="permission_refused_storage">Ohne Speichererlaubnis ist kein Zugriff auf ZIM-Dateien möglich</string>
   <string name="request_enable_location">Standort aktivieren, um Peer-Geräte zu finden</string>

--- a/core/src/main/res/values-diq/strings.xml
+++ b/core/src/main/res/values-diq/strings.xml
@@ -227,7 +227,6 @@
   <string name="severe_loss_error">Xetaya gırane! Bıcerebnê ke WiFi P2P’yi dewre ra vecê/reyêna aktif kerê</string>
   <string name="connection_failed">Gıreyin nêbiya</string>
   <string name="permission_rationale_location">Cihazê takêşan ra ferq bıyayışi rê terefê Androidi ra mısadey mehali ganiyo.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Dosyayanê ZIMi darênayışê aplikasyoni rê terefê Androidi ra mısadey mehali ganiyo.</string>
   <string name="permission_refused_location">Bêmısadey mehali cihazanê takêşi nêvineyênê</string>
   <string name="permission_refused_storage">Bêmısadey depo kerdışi nêresiyeno dosyayanê ZIMi</string>
   <string name="request_enable_location">Taypêyan his kerdışi rê seba mısade dayışi mehali aktiv kerê</string>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -247,8 +247,6 @@
   <string name="severe_loss_error">¡Error grave! Prueba inhabilitando / rehabilitando WiFi punto a punto</string>
   <string name="connection_failed">Falló la conexión</string>
   <string name="permission_rationale_location">Se requieren permisos de localización en Android para detectar dispositivos participantes</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android requiere permiso de ubicación para permitir que la aplicación aloje archivos Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android permiso de los dispositivos WiFi cercanos para permitir a la aplicación alojar archivos zim.</string>
   <string name="permission_refused_location">No se pueden ubicar dispositivos de pares sin permisos de ubicación</string>
   <string name="permission_refused_storage">No se puede acceder a archivos ZIM sin permisos de almacenamiento</string>
   <string name="request_enable_location">Habilite la ubicación para permitir la detección de compañeros</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -254,8 +254,6 @@
   <string name="severe_loss_error">Erreur grave! Essayez de désactiver/réactiver l’appairage WiFi</string>
   <string name="connection_failed">La connexion a échoué</string>
   <string name="permission_rationale_location">L’autorisation de géolocalisation est requise par Android pour permettre à l’application de détecter des appareils à proximité.</string>
-  <string name="permission_rationale_location_on_host_zim_file">La permission locale est demandée par Android pour autoriser l’application à héberger des fichiers Zim.</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Une autorisation des appareils Wi-Fi à proximité est requise par Android pour permettre à l’application d’héberger des fichiers Zim.</string>
   <string name="permission_refused_location">Impossible de trouver des appareils proches sans les autorisations de géolocalisation</string>
   <string name="permission_refused_storage">Impossible d’accéder aux fichiers ZIM sans autorisation d’accès au stockage</string>
   <string name="request_enable_location">Activer la géolocalisation pour permettre la détection d’appareils proches</string>

--- a/core/src/main/res/values-ha/strings.xml
+++ b/core/src/main/res/values-ha/strings.xml
@@ -238,8 +238,6 @@
   <string name="severe_loss_error">Kuskure mai tsanani! Gwada Kashe/Sake kunna WiFi P2P</string>
   <string name="connection_failed">Haɗin ya gaza</string>
   <string name="permission_rationale_location">Android na buƙatar izinin wuri don ba da damar ƙa’idar ta gano na’urorin tsara</string>
-  <string name="permission_rationale_location_on_host_zim_file">Ana buƙatar izinin wuri ta Android don ba da damar ƙa’idar ta dauki nauyin fayilolin Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Ana buƙatar izinin na’urorin wifi kusa da Android don ba da damar ƙa’idar ta dauki nauyin fayilolin Zim</string>
   <string name="permission_refused_location">Ba za a iya gano na’urorin takwarorinsu ba tare da izinin wuri ba</string>
   <string name="permission_refused_storage">Ba za a iya samun damar yin amfani da fayilolin zim ba tare da izinin ajiya ba</string>
   <string name="request_enable_location">Kunna wurin don ba da damar gano takwarorinsu</string>

--- a/core/src/main/res/values-hi/strings.xml
+++ b/core/src/main/res/values-hi/strings.xml
@@ -242,8 +242,6 @@
   <string name="severe_loss_error">गंभीर त्रुटि! वाईफ़ाई पी2पी को अक्षम/पुन: सक्षम करने का प्रयास करें</string>
   <string name="connection_failed">कनेक्शन विफल</string>
   <string name="permission_rationale_location">ऐप को सहकर्मी उपकरणों का पता लगाने की अनुमति देने के लिए एंड्रॉइड द्वारा स्थान अनुमति की आवश्यकता होती है</string>
-  <string name="permission_rationale_location_on_host_zim_file">ऐप को ZIM फ़ाइलों को होस्ट करने की अनुमति देने के लिए एंड्रॉइड द्वारा स्थान अनुमति की आवश्यकता होती है</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">ऐप को Zim फ़ाइलों को होस्ट करने की अनुमति देने के लिए एंड्रॉइड द्वारा आस-पास के वाईफाई डिवाइस की अनुमति आवश्यक है</string>
   <string name="permission_refused_location">स्थान अनुमतियों के बिना सहकर्मी उपकरणों का पता नहीं लगाया जा सकता</string>
   <string name="permission_refused_storage">भंडारण अनुमति के बिना ZIM फ़ाइलों तक नहीं पहुंच सकते</string>
   <string name="request_enable_location">साथियों का पता लगाने की अनुमति देने के लिए स्थान सक्षम करें</string>

--- a/core/src/main/res/values-ia/strings.xml
+++ b/core/src/main/res/values-ia/strings.xml
@@ -233,8 +233,6 @@
   <string name="severe_loss_error">Error grave! Tenta disactivar/reactivar WiFi P2P</string>
   <string name="connection_failed">Connexion fallite</string>
   <string name="permission_rationale_location">Android require accesso al position geographic pro permitter al application deteger apparatos a proximitate.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android require accesso al position geographic pro permitter al application albergar files Zim.</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android require un autorisation de apparatos Wi-Fi a proximitate pro permitter al application albergar files Zim.</string>
   <string name="permission_refused_location">Non pote localisar apparatos a proximitate sin accesso al position geographic</string>
   <string name="permission_refused_storage">Non pote acceder a files Zim sin accesso al immagazinage</string>
   <string name="request_enable_location">Activa position geographic pro permitter detection de apparatos proxime</string>

--- a/core/src/main/res/values-ig/strings.xml
+++ b/core/src/main/res/values-ig/strings.xml
@@ -241,8 +241,6 @@
   <string name="severe_loss_error">siri ike\n mperi! Gbalịa gbanyụọ/nyegharịa WiFi P2P</string>
   <string name="connection_failed">Njikọ\n dara</string>
   <string name="permission_rationale_location">Ebe\n Android chọrọ ikike iji kwe ka ngwa ahụ chọpụta ngwaọrụ ndị ọgbọ</string>
-  <string name="permission_rationale_location_on_host_zim_file">Ebe\n Android chọrọ ikike iji kwe ka ngwa ahụ kwado faịlụ Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">N’akụkụ\n Android chọrọ ikike wifi ngwaọrụ iji kwe ka ngwa ahụ kwado faịlụ Zim</string>
   <string name="permission_refused_location">Enweghị ike\n chọta ngwaọrụ ndị ọgbọ na-enweghị ikike ebe</string>
   <string name="permission_refused_storage">Enweghị ike\n nweta faịlụ zim na-enweghị ikike nchekwa</string>
   <string name="request_enable_location">Gbanye ngosi ebe iji nabata nchọpụta nke otu</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -240,8 +240,6 @@
   <string name="severe_loss_error">Errore grave rilevato! Prova a disabilitare e a riabilitare Wi-Fi Direct</string>
   <string name="connection_failed">Connessione fallita</string>
   <string name="permission_rationale_location">L’accesso alla posizione è richiesto da Android per consentire all’app di rilevare i dispositivi nelle vicinanze</string>
-  <string name="permission_rationale_location_on_host_zim_file">L’accesso alla posizione è richiesto da Android per consentire all’app di ospitare file ZIM</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">L’autorizzazione dei dispositivi Wi-Fi nelle vicinanze è richiesta da Android per consentire all’app di ospitare file Zim</string>
   <string name="permission_refused_location">Impossibile cercare i dispositivi nelle vicinanze senza l’accesso alla posizione</string>
   <string name="permission_refused_storage">Impossibile accedere ai file ZIM senza l’accesso allo spazio di archiviazione</string>
   <string name="request_enable_location">Abilita la geolocalizzazione per poter cercare i dispositivi nelle vicinanze</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -242,8 +242,6 @@
   <string name="severe_loss_error">שגיאה חמורה! נא לנסות לכבות ולהדליק מחדש את ה־P2P בווייפיי</string>
   <string name="connection_failed">החיבור נכשל</string>
   <string name="permission_rationale_location">נדרשת הרשאת גישה באנדרואיד כדי לאפשר ליישום לזהות מכשירים עמיתים</string>
-  <string name="permission_rationale_location_on_host_zim_file">הרשאת גישה למיקום נדרשת על־ידי אנדרואיד כדי לאפשר ליישום לארח קובצי Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">הרשאת התקני וייפיי בקרבת מקום נדרשת על־ידי אנדרואיד כדי לאפשר ליישום לארח קובצי Zim</string>
   <string name="permission_refused_location">לא ניתן לאתר מגשירים עמיתים ללא הרשאות מיקום</string>
   <string name="permission_refused_storage">לא ניתן לגשת לקובצי zim ללא הרשאות אחסון</string>
   <string name="request_enable_location">נא להפעיל מיקום כדי לאפשר זיהוי עמיתים</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -242,7 +242,6 @@
   <string name="severe_loss_error">서버 오류! 와이파이 P2P를 비활성화/재활성화해 보십시오</string>
   <string name="connection_failed">연결 실패</string>
   <string name="permission_rationale_location">안드로이드에서 앱의 피어 장치 찾기를 허용하려면 위치 권한이 필요합니다</string>
-  <string name="permission_rationale_location_on_host_zim_file">안드로이드에서 앱의 Zim 파일 호스팅을 허용하려면 위치 권한이 필요합니다</string>
   <string name="permission_refused_location">위치 권한 없이 피어 장치를 찾을 수 없습니다</string>
   <string name="permission_refused_storage">스토리지 권한 없이 zim 파일에 접근할 수 없습니다</string>
   <string name="request_enable_location">친구를 찾기 위해 위치 접근을 활성화합니다</string>

--- a/core/src/main/res/values-ku/strings.xml
+++ b/core/src/main/res/values-ku/strings.xml
@@ -232,8 +232,6 @@
   <string name="severe_loss_error">Çewtiya dijwar! WiFi P2P-yê neçalak bike/dîsa aktîv bike</string>
   <string name="connection_failed">Girêdan têk çû</string>
   <string name="permission_rationale_location">Destûra lokasyonê lazim e ji aliyê Androîdê ve ji bo destûr bidin sepanê ku karibe cîhazên din ên wekhev tesbît bike.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Ji bo sepan karibe dosyeyên Zim-ê bihewîne destûra lokasyonê ji aliyê Androîdê ve lazim e.</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Ji bo destûr bide sepanê ku dosyeyên Zi-ê bihewîne, destûra cîhazên wîfiyê yên li nêzîkê lazim e ji aliyê Androîdê ve.</string>
   <string name="permission_refused_location">Nikare cîhazên wekhev tesbît bike bêyî destûrên lokasyonê</string>
   <string name="permission_refused_storage">Nikare bigihe pelên zim-ê bêyî destûra depoyê</string>
   <string name="request_enable_location">Lokasyonê aktîv bike ji bo destûr vidî tesbîtkirina hevcinsan</string>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -234,8 +234,6 @@
   <string name="severe_loss_error">Голема грешка! Исклучете го и пак вклучете го поврзувањето на уреди со безжичен пристап</string>
   <string name="connection_failed">Врската е прекината</string>
   <string name="permission_rationale_location">Андроид бара дозвола за местоположба за да му даде на прилогот да пронаоѓа уреди за сврзување</string>
-  <string name="permission_rationale_location_on_host_zim_file">Андроид бара дозвола за местоположба за да му даде на прилогот да вдомува ZIM-податотеки</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Андроид бара дозвола од околните безжични уреди за да му даде на прилогот да вдомува ZIM-податотеки</string>
   <string name="permission_refused_location">Не можам да пронаоѓам уреди за сврзување без дозвола за местоположба</string>
   <string name="permission_refused_storage">Не можам да дојдам до ZIM-податотеките без дозвола за складирање</string>
   <string name="request_enable_location">Овозможете местоположба за да можам да пронаоѓам уреди за сврзување</string>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -243,8 +243,6 @@
   <string name="severe_loss_error">Ernstige fout! Probeer WiFi P2P uit te schakelen en opnieuw in te schakelen</string>
   <string name="connection_failed">Verbinding mislukt</string>
   <string name="permission_rationale_location">Android vereist locatietoestemming zodat de app nabije apparaten kan detecteren</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android vereist locatietoestemming zodat de app ZIM-bestanden kan aanbieden</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android vereist toestemming voor nabije WiFi-apparaten zodat de app ZIM-bestanden kan aanbieden</string>
   <string name="permission_refused_location">Kan geen nabije apparaten vinden zonder locatierechten</string>
   <string name="permission_refused_storage">Geen toegang tot ZIM-bestanden zonder opslagrechten</string>
   <string name="request_enable_location">Schakel locatie in om detectie van nabije apparaten mogelijk te maken</string>

--- a/core/src/main/res/values-nqo/strings.xml
+++ b/core/src/main/res/values-nqo/strings.xml
@@ -233,8 +233,6 @@
   <string name="severe_loss_error">ߝߎ߬ߕߎ߲߬ߕߌ߫ ߘߍ߰ߜߍ߹ ߊ߬ ߡߊߝߍߣߍ߲߫ ߞߵߊ߬ ߓߐ߫ ߊ߬ ߟߊ߫ \\ ߥߌߝߌ ߘߊߓߍ߲-ߘߊߓߍ߲ ߠߊߞߎߣߎ߲߫ ߞߎߘߊ߫ ߘߌ߫</string>
   <string name="connection_failed">ߜߊ߲߬ߞߎ߲߬ߠߌ߲ ߓߘߊ߫ ߗߌߙߏ߲߫</string>
   <string name="permission_rationale_location">ߘߌ߲߬ߞߌߙߊ ߟߊߘߤߊ߬ߟߌ ߞߊ߬ߣߌ߲߬ߣߍ߲߫ ߦߋ߫ ߊ߲ߘߙߏߦߌߘ ߓߟߏ߫ ߛߊ߫ ߞߊ߬ ߞߙߍ߬ߝߍ߬ ߞߍߟߊ߲ ߠߎ߬ ߡߊߟߐ߲߫</string>
-  <string name="permission_rationale_location_on_host_zim_file">ߘߌ߲߬ߞߌߙߊ ߟߊ߬ߘߤߊ߬ߟߌ ߞߊ߬ߣߌ߲߬ߣߍ߲߫ ߦߋ߫ ߊ߲ߘߙߏߦߌߘ ߓߟߏ߫ ߛߊ߫ ߞߵߊ߬ ߕߏ߫ ߟߥߊ߬ߟߌ߬ߟߊ߲ ߦߋ߫ ߛߋ߫ ߖ߭ߌߡ ߞߐߕߐ߮ ߟߎ߬ ߟߊߛߣߍ߫ ߟߊ߫</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">ߞߙߍ߬ߝߍ߬ ߥߌߝߌ ߞߍߟߊ߲ ߟߊ߫ ߘߌ߬ߢߍ ߞߊ߬ߣߌ߲߬ߣߍ߲߫ ߦߋ߫ ߊ߲ߘߙߏߦߌߘ ߓߟߏ߫ ߛߊ߫ ߞߵߊ߬ ߕߏ߫ ߟߥߊ߬ߟߌ߬ߟߊ߲ ߦߋ߫ ߛߋ߫ ߖ߭ߌߡ ߞߐߕߐ߮ ߟߎ߬ ߟߊߛߣߍ߫ ߟߊ߫</string>
   <string name="permission_refused_location">ߞߙߍ߬ߝߍ߬ ߞߍߟߊ߲ ߕߍ߫ ߛߐ߲߬ ߡߊߟߐ߲߫ ߠߊ߫ ߣߌ߫ ߘߌ߲߬ߞߌߙߊ ߡߊ߫ ߟߊߘߊ߬ߤߊ߫</string>
   <string name="permission_refused_storage">ߖ߭ߌߡ ߞߐߕߐ߮ ߟߎ߬ ߕߍߣߊ߬ ߟߊߛߐ߬ߘߐ߲߬ ߠߊ߫ ߣߌ߫ ߟߊ߬ߡߙߊ߬ߦߙߐ ߡߊ߫ ߟߊߘߤߊ߬</string>
   <string name="request_enable_location">ߘߌ߲߬ߞߌߙߊ ߟߊߘߤߊ߬ ߛߊ߫ ߞߊ߬ ߞߙߍ߬ߝߍ߬ߟߊ ߟߊߛߐ߬ߘߐ߲߬</string>

--- a/core/src/main/res/values-or/strings.xml
+++ b/core/src/main/res/values-or/strings.xml
@@ -233,8 +233,6 @@
   <string name="severe_loss_error">ଗୁରୁତର ତ୍ରୁଟି! ୱାଇଫାଇ P2P ଅକ୍ଷମ / ପୁନ enable- ସକ୍ଷମ କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ |</string>
   <string name="connection_failed">ସଂଯୋଗ ବିଫଳ ହୋଇଛି</string>
   <string name="permission_rationale_location">ଆପକୁ ସାଥୀ ଉପକରଣଗୁଡ଼ିକୁ ଚିହ୍ନଟ କରିବାକୁ ଅନୁମତି ଦେବା ପାଇଁ ଆଣ୍ଡ୍ରଏଡ୍ ଦ୍ୱାରା ଅବସ୍ଥାନ ଅନୁମତି ଆବଶ୍ୟକ |</string>
-  <string name="permission_rationale_location_on_host_zim_file">ଆପକୁ ହୋଷ୍ଟ ଜିମ୍ ଫାଇଲଗୁଡିକୁ ଅନୁମତି ଦେବା ପାଇଁ ଆଣ୍ଡ୍ରଏଡ୍ ଦ୍ୱାରା ଅବସ୍ଥାନ ଅନୁମତି ଆବଶ୍ୟକ |</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">ଆପକୁ ହୋଷ୍ଟ ଜିମ୍ ଫାଇଲଗୁଡ଼ିକୁ ଅନୁମତି ଦେବା ପାଇଁ ଆଣ୍ଡ୍ରଏଡ୍ ଦ୍ୱାରା ନିକଟସ୍ଥ ୱାଇଫାଇ ଡିଭାଇସ୍ ଅନୁମତି ଆବଶ୍ୟକ |</string>
   <string name="permission_refused_location">ଅବସ୍ଥାନ ଅନୁମତି ବିନା ସାଥି ଉପକରଣଗୁଡ଼ିକୁ ଚିହ୍ନଟ କରିପାରିବ ନାହିଁ |</string>
   <string name="permission_refused_storage">ଷ୍ଟୋରେଜ୍ ଅନୁମତି ବିନା ଜିମ୍ ଫାଇଲଗୁଡିକ ପ୍ରବେଶ କରିପାରିବ ନାହିଁ |</string>
   <string name="request_enable_location">ସାଥୀମାନଙ୍କୁ ଚିହ୍ନଟ କରିବାକୁ ସ୍ଥାନ ସକ୍ଷମ କରନ୍ତୁ |</string>

--- a/core/src/main/res/values-pl/strings.xml
+++ b/core/src/main/res/values-pl/strings.xml
@@ -248,8 +248,6 @@
   <string name="severe_loss_error">Poważny błąd! Spróbuj wyłączyć/ponownie włączyć WiFi P2P</string>
   <string name="connection_failed">Połączenie nie powiodło się</string>
   <string name="permission_rationale_location">Uprawnienie lokalizacja jest wymagane przez system Android, aby umożliwić aplikacji do wykrywania urządzeń</string>
-  <string name="permission_rationale_location_on_host_zim_file">Aby aplikacja mogła hostować pliki Zim, wymagana jest zgoda na lokalizację</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Aby aplikacja mogła hostować pliki Zim, system Android wymaga pozwolenia na korzystanie z pobliskich urządzeń Wi-Fi</string>
   <string name="permission_refused_location">Nie można zlokalizować urządzeń bez uprawnień do lokalizacji</string>
   <string name="permission_refused_storage">Nie można uzyskać dostępu do plików zim bez uprawnień do przechowywania</string>
   <string name="request_enable_location">Włączyć lokalizację, aby umożliwić wykrywanie równorzędnych elementów</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -244,8 +244,6 @@
   <string name="severe_loss_error">Erro grave! Tente desativar/reativar WiFi P2P</string>
   <string name="connection_failed">Falha na conexão</string>
   <string name="permission_rationale_location">A permissão de localização é necessária pelo Android para permitir que o aplicativo detecte dispositivos de mesmo nível</string>
-  <string name="permission_rationale_location_on_host_zim_file">A permissão de localização é exigida pelo Android para permitir que o aplicativo hospede arquivos Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">A permissão de localização é exigida pelo Android para permitir que o aplicativo hospede arquivos Zim</string>
   <string name="permission_refused_location">Não é possível localizar dispositivos pares sem permissões de localização</string>
   <string name="permission_refused_storage">Não é possível acessar arquivos zim sem permissão de armazenamento</string>
   <string name="request_enable_location">Ativar local para permitir a detecção de pares</string>

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -240,8 +240,6 @@
   <string name="severe_loss_error">This is toast\'s message when a user\'s wifi P2P gets disconnected from another device.</string>
   <string name="connection_failed">This is toast\'s message when a user fails to connect to another device via wifi P2P.</string>
   <string name="permission_rationale_location">This is dialog\'s message when a user is trying to search nearby devices but the app does not have access to location permission.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Tell the user Location permission required for hosting zim file.</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">It is a dialog\'s message that tells the user that nearby wifi permission is required for hosting zim file.</string>
   <string name="permission_refused_location">It is a toast\'s message shown when a user tries to share zim files but the app does not have access to location permission.</string>
   <string name="permission_refused_storage">It is a toast\'s message shown when a user tries to share zim files but the app does not have access to storage permission.</string>
   <string name="request_enable_location">It is a dialog\'s message shown when a user tries to share zim files but location service is not enabled.</string>

--- a/core/src/main/res/values-ro/strings.xml
+++ b/core/src/main/res/values-ro/strings.xml
@@ -225,7 +225,6 @@
   <string name="severe_loss_error">Eroare majoră! Încercați Dezactivarea/Reactivarea WiFi P2P</string>
   <string name="connection_failed">Conexiune eșuată</string>
   <string name="permission_rationale_location">Android are nevoie de permisiunea de geolocalizare pentru a permite aplicației să detecteze dispozitivele din apropiere.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android necesită permisiunea de localizare pentru a permite aplicației să găzduiască fișiere Zim</string>
   <string name="permission_refused_location">Nu se pot găsi dispozitive din apropiere fără permisiuni de geolocalizare</string>
   <string name="permission_refused_storage">Nu puteți accesa fișiere zim fără permisiunea de stocare</string>
   <string name="request_enable_location">Activați geolocalizarea pentru a permite detectarea dispozitivelor din apropiere</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -259,8 +259,6 @@
   <string name="severe_loss_error">Серьёзная ошибка! Попробуйте выключить и снова включить WiFi P2P</string>
   <string name="connection_failed">Не удалось установить соединение</string>
   <string name="permission_rationale_location">Доступ к местонахождению требуется Android для поиска близлежащих устройств</string>
-  <string name="permission_rationale_location_on_host_zim_file">Доступ к местонахождению требуется Android для размещения файлов Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Разрешение на использование устройств Wi-Fi поблизости требуется системой Android, чтобы приложение могло размещать файлы Zim</string>
   <string name="permission_refused_location">Невозможно обнаружить устройства без доступа к местоположению</string>
   <string name="permission_refused_storage">Невозможно получить доступ к файлам zim без разрешения на доступ к хранилищу</string>
   <string name="request_enable_location">Разрешите доступ к местоположению, чтобы позволить поиск устройств</string>

--- a/core/src/main/res/values-sc/strings.xml
+++ b/core/src/main/res/values-sc/strings.xml
@@ -233,8 +233,6 @@
   <string name="severe_loss_error">Faddina manna! Proa a Disabilitare/Torrare a abilitare su P2P WiFi</string>
   <string name="connection_failed">Connessione fallida</string>
   <string name="permission_rationale_location">Android tenet bisòngiu de su permissu de localizatzione pro rilevare dispositivos pares (peers)</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android tenet bisòngiu de su permissu de localizatzione pro permìtere a s’aplicatzione de istrangiare documentos Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android tenet bisòngiu de su permissu de localizatzione de sos dispositivos wifi a curtzu pro permìtere a s’aplicatzione de istrangiare archìvios Zim</string>
   <string name="permission_refused_location">Impossìbile localizare dispositivos pares (peers) chene sos permissos de localizatzione</string>
   <string name="permission_refused_storage">Impossìbile tènnere atzessu a sos documentos zim chene su permissu de archiviatzione</string>
   <string name="request_enable_location">Abìlita sa localizatzione pro permìtere su rilevamentu de pares (peers)</string>

--- a/core/src/main/res/values-sk/strings.xml
+++ b/core/src/main/res/values-sk/strings.xml
@@ -227,8 +227,6 @@
   <string name="severe_loss_error">Závažná chyba! Skúste vypnúť/zapnúť WiFi P2P</string>
   <string name="connection_failed">Spojenie zlyhalo</string>
   <string name="permission_rationale_location">Aby aplikácia mohla objavovať zariadenia v okolí, systém Android vyžaduje povolenie k polohe</string>
-  <string name="permission_rationale_location_on_host_zim_file">Aby aplikácia mohla hosťovať súbory Zim, systém Android vyžaduje povolenie k polohe</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android vyžaduje povolenie pre zariadenia Wi-Fi v okolí, aby mohla aplikácia hostiť súbory Zim</string>
   <string name="permission_refused_location">Bez prístupu k polohe nie je možné lokalizovať zariadenia v okolí</string>
   <string name="permission_refused_storage">Bez prístupu na úložisko nie je možný prístup k súborom zim</string>
   <string name="request_enable_location">Pre zistenie zariadení v okolí povoľte prístup k polohe</string>

--- a/core/src/main/res/values-sl/strings.xml
+++ b/core/src/main/res/values-sl/strings.xml
@@ -242,8 +242,6 @@
   <string name="severe_loss_error">Huda napaka! Poskusite izklopiti/znova vklopiti Wi-Fi P2P</string>
   <string name="connection_failed">Povezava ni uspela</string>
   <string name="permission_rationale_location">Android zahteva dovoljenje za lokacijo, da lahko aplikaciji omogoči zaznavanje enakovrednih naprav</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android zahteva dovoljenje za lokacijo, da lahko aplikaciji omogoči gostitev datotek ZIM</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android zahteva dovoljenje za bložnje naprave Wi-Fi, da lahko aplikaciji omogoči gostovanje datotek ZIM</string>
   <string name="permission_refused_location">Enakovrednih naprav ni mogoče najti brez dovoljenj za lokacijo</string>
   <string name="permission_refused_storage">Do datotek ZIM ni mogoče dostopati brez dovoljenja za shranjevanje</string>
   <string name="request_enable_location">Omogočite lokacijo, da bo mogoče zaznavanje enakovrednih naprav</string>

--- a/core/src/main/res/values-sq/strings.xml
+++ b/core/src/main/res/values-sq/strings.xml
@@ -230,8 +230,6 @@
   <string name="severe_loss_error">Gabim shërbyesi! Provoni të Çaktivizoni/Riaktivizoni WiFi P2P</string>
   <string name="connection_failed">Lidhja dështoi</string>
   <string name="permission_rationale_location">Leja mbi vendndodhjen është e domosdoshme për Android-in që të lejojë aplikacionin të pikasë pajisje ortake</string>
-  <string name="permission_rationale_location_on_host_zim_file">Leja mbi vendndodhjen është e domosdoshme për Android-in që të lejojë aplikacionin të strehojë kartela Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Që të lejohet aplikacioni të strehojë kartela Zim, nga Android-i lypsen leje mbi pajisje wifi atypari</string>
   <string name="permission_refused_location">Pa leje mbi vendndodhjen s’mund të lokalizohen pajisje ortake</string>
   <string name="permission_refused_storage">S’mund të përdoren kartela ZIM pa leje depozite</string>
   <string name="request_enable_location">Që të lejoni pikasje ortakësh, aktivizoni vendndodhje</string>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -242,8 +242,6 @@
   <string name="severe_loss_error">Allvarligt fel! Testa att starta om WiFi P2P</string>
   <string name="connection_failed">Anslutning misslyckades</string>
   <string name="permission_rationale_location">Platsåtkomst krävs från Android för att låta appen söka efter närliggande enheter.</string>
-  <string name="permission_rationale_location_on_host_zim_file">Platsåtkomst krävs från Android för att låta appen hantera Host Zim-filer.</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android kräver behörighet till närliggande wifi-enheter för att låta appen hantera Zim-filer</string>
   <string name="permission_refused_location">Kan inte hitta närliggande enheter utan platsåtkomst.</string>
   <string name="permission_refused_storage">Kan inte komma åt zim-filer utan lagringsbehörighet</string>
   <string name="request_enable_location">Aktivera plats för att tillåta sökning efter närliggande enheter</string>

--- a/core/src/main/res/values-sw/strings.xml
+++ b/core/src/main/res/values-sw/strings.xml
@@ -215,8 +215,6 @@
   <string name="severe_loss_error">Hitilafu kubwa! Jaribu Zima/Wezesha tena WiFi P2P</string>
   <string name="connection_failed">Muunganisho haukufaulu</string>
   <string name="permission_rationale_location">Ruhusa ya eneo inahitajika na Android ili kuruhusu programu kutambua vifaa vingine</string>
-  <string name="permission_rationale_location_on_host_zim_file">Ruhusa ya mahali inahitajika na Android ili kuruhusu programu kupangisha faili za Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Ruhusa ya vifaa vya karibu vya wifi inahitajika na Android ili kuruhusu programu kupangisha faili za Zim</string>
   <string name="permission_refused_location">Haiwezi kupata vifaa vya programu zingine bila ruhusa za eneo</string>
   <string name="permission_refused_storage">Haiwezi kufikia faili za zim bila ruhusa ya kuhifadhi</string>
   <string name="request_enable_location">Wezesha eneo ili kuruhusu ugunduzi wa programu zingine</string>

--- a/core/src/main/res/values-ta/strings.xml
+++ b/core/src/main/res/values-ta/strings.xml
@@ -232,8 +232,6 @@
   <string name="severe_loss_error">கடுமையான பிழை! வைஃபை P2P ஐ முடக்க / மீண்டும் இயக்க முயற்சிக்கவும்</string>
   <string name="connection_failed">இணைப்பு தோல்வியடைந்தது</string>
   <string name="permission_rationale_location">சக சாதனங்களைக் கண்டறிவதற்கான செயலியை அனுமதிக்க ஆன்ட்ராய்டுக்கு இருப்பிட அனுமதி தேவை</string>
-  <string name="permission_rationale_location_on_host_zim_file">Zim கோப்புகளை ஹோஸ்ட் செய்வதற்கான செயலியை அனுமதிக்க ஆன்ட்ராய்டுக்கு இருப்பிட அனுமதி தேவை</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Zim கோப்புகளை ஹோஸ்ட் செய்ய ஆப்ஸை அனுமதிக்க, அருகிலுள்ள வைஃபை சாதனங்களின் அனுமதி Androidக்கு தேவை</string>
   <string name="permission_refused_location">இருப்பிட அனுமதியின்றி சக சாதனங்களைக் கண்டுபிடிக்க முடியாது</string>
   <string name="permission_refused_storage">சேமிப்பக அனுமதியின்றி zim கோப்புகளை அணுக முடியாது</string>
   <string name="request_enable_location">சகாக்களைக் கண்டறிய அனுமதிக்க இருப்பிடத்தை இயக்கவும்</string>

--- a/core/src/main/res/values-te/strings.xml
+++ b/core/src/main/res/values-te/strings.xml
@@ -238,8 +238,6 @@
   <string name="severe_loss_error">తీవ్ర లోపం! WiFi P2Pని డిసేబుల్/రీ-ఎనేబుల్ చేయడానికి ప్రయత్నించండి</string>
   <string name="connection_failed">సంధానము విఫలమైనది</string>
   <string name="permission_rationale_location">పీర్ పరికరాలను గుర్తించడానికి యాప్‌ను అనుమతించడానికి Androidకి స్థాన అనుమతి అవసరం</string>
-  <string name="permission_rationale_location_on_host_zim_file">Zim ఫైల్‌లను హోస్ట్ చేయడానికి యాప్‌ను అనుమతించడానికి Androidకి స్థాన అనుమతి అవసరం</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Zim ఫైల్‌లను హోస్ట్ చేయడానికి యాప్‌ని అనుమతించడానికి Androidకి సమీపంలోని wifi పరికరాల అనుమతి అవసరం</string>
   <string name="permission_refused_location">స్థాన అనుమతులు లేకుండా పీర్ పరికరాలను గుర్తించడం సాధ్యం కాదు</string>
   <string name="permission_refused_storage">నిల్వ అనుమతి లేకుండా జిమ్ ఫైల్‌లను యాక్సెస్ చేయలేరు</string>
   <string name="request_enable_location">సహచరులను గుర్తించడాన్ని అనుమతించడానికి స్థానాన్ని ప్రారంభించండి</string>

--- a/core/src/main/res/values-tn/strings.xml
+++ b/core/src/main/res/values-tn/strings.xml
@@ -235,8 +235,6 @@
   <string name="severe_loss_error">Phoso e e masisi! Leka go tima/go tshuba Wfi P2P</string>
   <string name="connection_failed">Go ikgolaganya go ne ga se ka ga atlega</string>
   <string name="permission_rationale_location">Tumelelo ya lefelo e tlhokiwa ke Android go letlelela app go lemoga didirisiwa tsa balekane</string>
-  <string name="permission_rationale_location_on_host_zim_file">Tumelelo ya lefelo e tlhokiwa ke Android go letlelela app go amogela difaele tsa Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Tumelelo ya didirisiwa tsa wifi tse di fa gaufi e a tlhokiwa ke Android go letlelela app go amogela difaele tsa Zim</string>
   <string name="permission_refused_location">Ga o kgone go bona didirisiwa tsa balekane ntle le go fa tetla ya lefelo</string>
   <string name="permission_refused_storage">Ga o kgone go fitlhelela difaele tsa zim ntle le tetla ya go boloka</string>
   <string name="request_enable_location">Fa tetla ya lefelo gore go kgonege go lemoga balekane</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -251,8 +251,6 @@
   <string name="severe_loss_error">Ağır hata! WiFi P2P\'yi Devre Dışı Bırak/Yeniden Etkinleştir\'i deneyin</string>
   <string name="connection_failed">Bağlantı kurulamadı</string>
   <string name="permission_rationale_location">Uygulamanın eş aygıtları algılamasına izin vermek için Android tarafından konum izni gerekir</string>
-  <string name="permission_rationale_location_on_host_zim_file">Uygulamanın Zim dosyalarını barındırmasına izin vermek için Android tarafından konum izni gereklidir</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Uygulamanın Zim dosyalarını barındırmasına izin vermek için Android tarafından yakındaki wifi cihazları izni gerekir</string>
   <string name="permission_refused_location">Konum izinleri olmadan eş aygıtlar bulunamıyor</string>
   <string name="permission_refused_storage">Depolama izni olmadan zim dosyalarına erişilemiyor</string>
   <string name="request_enable_location">Eşlerin algılanmasına izin vermek için konumu etkinleştir</string>

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -237,7 +237,6 @@
   <string name="severe_loss_error">Серйозна помилка! Попробуйте вимкнути і наново вмикнути WiFi P2P</string>
   <string name="connection_failed">З’єднання не вдалося</string>
   <string name="permission_rationale_location">Android-у потрібний дозвіл на отримання місцезнахождення для пошуку сусідніх пристроїв</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android’у потрібен локальний дозвіл на отримання місцезнахождення для розміщення файлів Zim</string>
   <string name="permission_refused_location">Неможливо знайти сусідні пристрої без дозволу на доступ до місцезнаходження</string>
   <string name="permission_refused_storage">Неможливо отримати доступ до файлів zim без дозволу на доступ до сховища</string>
   <string name="request_enable_location">Вмикнути місцезнаходження для вможливлення пошуку сусідніх пристроїв</string>

--- a/core/src/main/res/values-yo/strings.xml
+++ b/core/src/main/res/values-yo/strings.xml
@@ -239,8 +239,6 @@
   <string name="severe_loss_error">Wrong operation, try and off or connect your WiFi p2p</string>
   <string name="connection_failed">No Lock.</string>
   <string name="permission_rationale_location">Igbanilaaye ipo ni Android nilo lati gba ohun elo laaye lati ṣawari awọn ẹrọ ẹlẹgbẹ</string>
-  <string name="permission_rationale_location_on_host_zim_file">Igbanilaaye ipo ni Android nilo lati gba ohun elo naa laaye lati gbalejo awọn faili Zim</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Igbanilaaye awọn ẹrọ wifi ti o wa nitosi ni Android nilo lati gba ohun elo naa laaye lati gbalejo awọn faili Zim</string>
   <string name="permission_refused_location">Ko le wa awọn ẹrọ ẹlẹgbẹ laisi awọn igbanilaaye ipo</string>
   <string name="permission_refused_storage">Ko le wọle si awọn faili zim laisi igbanilaaye ibi ipamọ</string>
   <string name="request_enable_location">Mu ipo ṣiṣẹ lati gba wiwa awọn ẹlẹgbẹ laaye</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -244,8 +244,6 @@
   <string name="severe_loss_error">嚴重錯誤！請嘗試停用/重新啟用 WiFi P2P</string>
   <string name="connection_failed">連線失敗</string>
   <string name="permission_rationale_location">Android 需要位置權限來允許應用程式去偵測端點設備</string>
-  <string name="permission_rationale_location_on_host_zim_file">Android 需要位置權限來允許應用程式去托管 Zim 檔案</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android 需要附近的 wifi 設備權限才能允許應用程式託管 zim 檔案</string>
   <string name="permission_refused_location">沒有位置權限無法定位端點設備</string>
   <string name="permission_refused_storage">沒有儲存權限無法存取 zim 檔案</string>
   <string name="request_enable_location">啟動位置來允許偵測端點</string>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -257,8 +257,6 @@
   <string name="severe_loss_error">严重错误！请尝试禁用/重新启用 WiFi P2P</string>
   <string name="connection_failed">连接失败</string>
   <string name="permission_rationale_location">为了寻找对等设备，我们需要定位权限（这是 Android 系统的要求）</string>
-  <string name="permission_rationale_location_on_host_zim_file">要成为 ZIM 文件主机，我们需要定位权限（这是 Android 系统的要求）</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Android 需要附近的 wifi 设备权限才能允许应用托管 ZIM 文件。</string>
   <string name="permission_refused_location">在没有定位权限的情况下无法找到对等设备</string>
   <string name="permission_refused_storage">在没有存储权限的情况下无法读取 ZIM 文件</string>
   <string name="request_enable_location">开启定位服务以寻找对等设备</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -244,8 +244,7 @@
   <string name="severe_loss_error" tools:keep="@string/severe_loss_error">Severe error! Try Disable/Re-enable WiFi P2P</string>
   <string name="connection_failed" tools:keep="@string/connection_failed">Connection failed</string>
   <string name="permission_rationale_location">Location permission is required by Android to allow the app to detect peer devices</string>
-  <string name="permission_rationale_location_on_host_zim_file">Location permission is required by Android to allow the app to Host Zim files</string>
-  <string name="permission_rationale_nearby_device_on_host_zim_file">Nearby wifi devices permission is required by Android to allow the app to Host Zim files</string>
+  <string name="permission_rationale_nearby">Nearby devices permission is required by Android to allow the app to detect peer devices</string>
   <string name="permission_refused_location" tools:keep="@string/permission_refused_location">Cannot locate peer devices without location permissions</string>
   <string name="permission_refused_storage" tools:keep="@string/permission_refused_storage">Cannot access zim files without storage permission</string>
   <string name="request_enable_location">Enable location to allow detection of peers</string>


### PR DESCRIPTION
Fixes #3708 

* Removed the `ACCESS_COARSE_LOCATION` from the application as it is unnecessary in the project. This permission was used in the ZimHostFragment to host the ZIM files on the server, but this permission is not required for this feature. Hence, we have removed this permission from the project.
* Removed this permission from test cases.
* Removed the unused code from the project related to this permission.


https://github.com/kiwix/kiwix-android/assets/34593983/869ac542-f36a-47d6-801e-bfe4a3e8c416


https://github.com/kiwix/kiwix-android/assets/34593983/7762a601-1667-4422-835e-b725667f4692


https://github.com/kiwix/kiwix-android/assets/34593983/7b3b79b9-c6d6-4b17-a6e4-023a391d0094

* Resolved the issue where discovering peers did not automatically start after granting the `NEARBY_WIFI_DEVICES` permission on Android 13 like it starts after giving the `ACCESS_FINE_LOCATION` on below Android 13.
* Fixed an issue where if we disallow the location/nearby or storage permission twice, we can't discover the peers for sending/receiving ZIM files.
  **Before fix**
  

https://github.com/kiwix/kiwix-android/assets/34593983/bae132d3-16b6-49d6-b8a7-745b26127670

**After Fix**



https://github.com/kiwix/kiwix-android/assets/34593983/dc76a4f8-2def-4d05-a5d8-04f21fda7af7






