### PR TITLE
Fixed: Selected files count is not showing initially in LocalLibrary screen.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -112,6 +112,7 @@ class LocalLibraryFragment : BaseFragment() {
   private val disposable = CompositeDisposable()
   private var fragmentDestinationLibraryBinding: FragmentDestinationLibraryBinding? = null
   private var permissionDeniedLayoutShowing = false
+  private var fileSelectListState: FileSelectListState? = null
 
   private val zimManageViewModel by lazy {
     requireActivity().viewModel<ZimManageViewModel>(viewModelFactory)
@@ -457,6 +458,7 @@ class LocalLibraryFragment : BaseFragment() {
         val effectResult = it.invokeWith(requireActivity() as AppCompatActivity)
         if (effectResult is ActionMode) {
           actionMode = effectResult
+          fileSelectListState?.selectedBooks?.size?.let(::setActionModeTitle)
         }
       }, Throwable::printStackTrace
     )
@@ -479,6 +481,7 @@ class LocalLibraryFragment : BaseFragment() {
   }
 
   private fun render(state: FileSelectListState) {
+    fileSelectListState = state
     val items: List<BooksOnDiskListItem> = state.bookOnDiskListItems
     bookDelegate.selectionMode = state.selectionMode
     booksOnDiskAdapter.items = items
@@ -486,7 +489,7 @@ class LocalLibraryFragment : BaseFragment() {
       actionMode?.finish()
       actionMode = null
     }
-    actionMode?.title = String.format("%d", state.selectedBooks.size)
+    setActionModeTitle(state.selectedBooks.size)
     fragmentDestinationLibraryBinding?.apply {
       if (items.isEmpty()) {
         fileManagementNoFiles.text = requireActivity().resources.getString(R.string.no_files_here)
@@ -502,6 +505,10 @@ class LocalLibraryFragment : BaseFragment() {
         zimfilelist.visibility = View.VISIBLE
       }
     }
+  }
+
+  private fun setActionModeTitle(selectedBookCount: Int) {
+    actionMode?.title = String.format("%d", selectedBookCount)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
Fixes #3715 

Initially `ActionMode` is null when we are selecting ZIM files because the `ActionMode` is in the creation process that's why it is not showing the selected book count in the ActionMode title. So to fix this we are setting the value when the actionMode is created.

**Before Fix**

https://github.com/kiwix/kiwix-android/assets/34593983/c8f49a92-dd15-4013-9e9a-c55162f823b3

**After Fix**


https://github.com/kiwix/kiwix-android/assets/34593983/090a2ee4-6caa-4e0b-983d-08c1df157bc5

