### PR TITLE
Fixed: Bookmark screen title is set as "Kiwix" if we open the Bookmarks screen from Widget

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseFragment.kt
@@ -57,7 +57,7 @@ abstract class BaseFragment : Fragment() {
         it.setSupportActionBar(this)
         it.supportActionBar?.let { actionBar ->
           actionBar.setDisplayHomeAsUpEnabled(true)
-          title = fragmentTitle
+          actionBar.title = fragmentTitle
           // set the navigation back button contentDescription
           getToolbarNavigationIcon()?.setToolTipWithContentDescription(
             getString(R.string.toolbar_back_button_content_description)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.core.main
 
-import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
@@ -47,7 +46,6 @@ abstract class CoreSearchWidget : AppWidgetProvider() {
     }
   }
 
-  @SuppressLint("UnspecifiedImmutableFlag")
   private fun pendingIntent(context: Context, action: String) =
     PendingIntent.getActivity(
       context,


### PR DESCRIPTION
Fixes #3718 

* The issue happened because we were setting the title directly on the toolbar. When quickly opening the bookmark screen from the widget, the toolbar was getting updates, but they weren't happening smoothly, leading to the title not showing up correctly. To fix this, we set the title on the `actionBar` instead of the toolbar. The `actionBar` handles titles and updates the toolbar in a more synchronized way, especially during fast transitions like opening the bookmark screen from the widget. Switching to `actionBar.title` makes sure the title updates reliably, solving the problem we faced during quick navigation.
* Removed the unnecessary `UnspecifiedImmutableFlag` lint suppression from CoreSearchWidget.


**Before Fix**

https://github.com/kiwix/kiwix-android/assets/34593983/f233f9cf-c744-4553-ba1c-91eedc960fdf



**After Fix**


https://github.com/kiwix/kiwix-android/assets/34593983/13f4cf95-16b9-4d93-aa1b-c05e6162c068

