### PR TITLE
Fixed: Content is not displaying after opening the ZIM file from Chrome.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1478,9 +1478,13 @@ abstract class CoreReaderFragment :
   ) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
       if (file?.isFileExist() == true) {
+        // Show content if there is `Open Library` button showing
+        // and we are opening the ZIM file
+        reopenBook()
         openAndSetInContainer(file = file)
         updateTitle()
       } else if (assetFileDescriptor != null) {
+        reopenBook()
         openAndSetInContainer(
           assetFileDescriptor = assetFileDescriptor,
           filePath = filePath


### PR DESCRIPTION
Fixes #3726 

Although the ZIM file is loaded, it does not appear in the reader because the "Open Library" button is already visible, and the content view is hidden at this point. To address this, we utilized our `reopenBook()` method when loading the ZIM file in the reader, which manages the visibility of these views.

   **Before fix**


https://github.com/kiwix/kiwix-android/assets/34593983/afda9d7c-937a-4edf-952c-f18da2315952

  **After Fix**


https://github.com/kiwix/kiwix-android/assets/34593983/34f5f145-e93f-457f-9490-bdc1b296a9c0