### PR TITLE
Upgraded many dependencies of our project.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -46,7 +46,7 @@ class LocalFileTransferTest {
   @JvmField
   var retryRule = RetryRule()
 
-  private var context: Context? = null
+  private lateinit var context: Context
   private lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
 
   private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -67,7 +67,7 @@ class KiwixSplashActivityTest {
   @JvmField
   var permissionRules: GrantPermissionRule =
     GrantPermissionRule.grant(*permissions)
-  private var context: Context? = null
+  private lateinit var context: Context
 
   @Before
   fun setUp() {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   }
   implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.20.0")
   implementation("com.googlecode.json-simple:json-simple:1.1")
-  implementation("com.squareup.okhttp3:okhttp:4.9.0")
+  implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
   implementation(gradleApi())
   implementation(localGroovy())

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,7 +20,7 @@ object Versions {
 
   const val com_squareup_retrofit2: String = "2.9.0"
 
-  const val com_squareup_okhttp3: String = "4.9.0"
+  const val com_squareup_okhttp3: String = "4.10.0"
 
   const val org_jetbrains_kotlin: String = "1.7.0"
 
@@ -32,7 +32,7 @@ object Versions {
 
   const val com_jakewharton: String = "10.2.3"
 
-  const val androidx_test: String = "1.5.1"
+  const val androidx_test: String = "1.5.2"
 
   const val androidx_test_core: String = "1.5.0"
 
@@ -40,7 +40,7 @@ object Versions {
 
   const val io_objectbox: String = "3.5.0"
 
-  const val io_mockk: String = "1.13.5"
+  const val io_mockk: String = "1.13.7"
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
@@ -52,25 +52,25 @@ object Versions {
 
   const val javax_annotation_api: String = "1.3.2"
 
-  const val leakcanary_android: String = "2.9.1"
+  const val leakcanary_android: String = "2.13"
 
-  const val constraintlayout: String = "2.0.4"
+  const val constraintlayout: String = "2.1.4"
 
   const val swipe_refresh_layout: String = "1.1.0"
 
   const val collection_ktx: String = "1.1.0"
 
-  const val preference_ktx: String = "1.1.1"
+  const val preference_ktx: String = "1.2.0"
 
-  const val junit_jupiter: String = "5.9.1"
+  const val junit_jupiter: String = "5.10.2"
 
-  const val assertj_core: String = "3.18.1"
+  const val assertj_core: String = "3.25.3"
 
-  const val core_testing: String = "2.1.0"
+  const val core_testing: String = "2.2.0"
 
   const val fragment_ktx: String = "1.2.5"
 
-  const val testing_ktx: String = "1.2.0"
+  const val testing_ktx: String = "1.3.0"
 
   const val threetenabp: String = "1.3.0"
 
@@ -80,15 +80,15 @@ object Versions {
 
   const val simple_xml: String = "2.7.1"
 
-  const val appcompat: String = "1.2.0"
+  const val appcompat: String = "1.6.1"
 
   const val rxandroid: String = "2.1.1"
 
-  const val core_ktx: String = "1.3.2"
+  const val core_ktx: String = "1.9.0"
 
   const val libkiwix: String = "2.0.0"
 
-  const val material: String = "1.2.1"
+  const val material: String = "1.8.0"
 
   const val multidex: String = "2.0.1"
 
@@ -96,11 +96,11 @@ object Versions {
 
   const val fetch: String = "3.1.6"
 
-  const val rxjava: String = "2.2.20"
+  const val rxjava: String = "2.2.21"
 
   const val webkit: String = "1.7.0"
 
-  const val junit: String = "1.1.4"
+  const val junit: String = "1.1.5"
 
   const val material_show_case_view: String = "1.3.7"
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -120,13 +120,13 @@ abstract class CorePrefsFragment :
   override fun onResume() {
     super.onResume()
     preferenceScreen.sharedPreferences
-      .registerOnSharedPreferenceChangeListener(this)
+      ?.registerOnSharedPreferenceChangeListener(this)
   }
 
   override fun onPause() {
     super.onPause()
     preferenceScreen.sharedPreferences
-      .unregisterOnSharedPreferenceChangeListener(this)
+      ?.unregisterOnSharedPreferenceChangeListener(this)
   }
 
   override fun onDestroyView() {

--- a/core/src/main/res/layout/reader_fragment_content.xml
+++ b/core/src/main/res/layout/reader_fragment_content.xml
@@ -126,7 +126,7 @@
     android:background="?colorOnSurface"
     android:contentDescription="@string/menu_exit_full_screen"
     android:src="@drawable/fullscreen_exit"
-    android:tint="?colorSurface"
+    app:tint="?colorSurface"
     android:visibility="gone"
     android:minWidth="@dimen/material_minimum_height_and_width"
     android:minHeight="@dimen/material_minimum_height_and_width"

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -290,7 +290,7 @@ class TestObserver<T>(
   }
 
   fun assertValue(value: (T) -> Boolean): TestObserver<T> {
-    assertThat(values.last()).satisfies { value(it) }
+    assertThat(values.last()).satisfies({ value(it) })
     return this
   }
 }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomPrefsFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomPrefsFragment.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.custom.settings
 
 import android.os.Bundle
+import androidx.preference.Preference
 import org.kiwix.kiwixmobile.core.settings.CorePrefsFragment
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil.Companion.PREF_LANG
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil.Companion.PREF_WIFI_ONLY
@@ -33,7 +34,7 @@ class CustomPrefsFragment : CorePrefsFragment() {
     if (BuildConfig.ENFORCED_LANG.isEmpty()) {
       setUpLanguageChooser(PREF_LANG)
     } else {
-      preferenceScreen.removePreference(findPreference("pref_language"))
+      findPreference<Preference>("pref_language")?.let(preferenceScreen::removePreference)
     }
     preferenceScreen.removePreferenceRecursively(PREF_WIFI_ONLY)
   }
@@ -50,6 +51,6 @@ class CustomPrefsFragment : CorePrefsFragment() {
   }
 
   override fun setStorage() {
-    preferenceScreen.removePreference(findPreference("pref_storage"))
+    findPreference<Preference>("pref_storage")?.let(preferenceScreen::removePreference)
   }
 }


### PR DESCRIPTION
Fixes #3730 

* Upgraded test cases and project dependencies.
* Refactor test cases and project code according to the new changes in dependencies.

| Dependency  | From | To |
| ------------- | ------------- | ------------- |
| androidx.test.ext:junit  | 1.1.4 | 1.1.5 |
| org.junit.jupiter:junit-jupiter  | 5.9.1 | 5.10.2 |
| androidx.test:runner | 1.5.1 | 1.5.2 |
| com.squareup.okhttp3:mockwebserver | 4.9.0 | 4.10.0 |
| com.squareup.okhttp3:logging-interceptor | 4.9.0 | 4.10.0 |
| com.squareup.okhttp3:okhttp | 4.9.0 | 4.10.0 |
| io.mockk:mockk-android | 1.13.5 | 1.13.7 |
| io.mockk:mockk | 1.13.5 | 1.13.7 |
| org.assertj:assertj-core | 3.18.1 | 3.25..3 |
| com.squareup.leakcanary:leakcanary-android | 2.9.1 | 2.13 |
| com.squareup.leakcanary:leakcanary-android-instrumentation | 2.9.1| 2.13 |
| androidx.appcompat:appcompat | 1.2.0 | 1.6.1 |
| com.google.android.material:material | 1.2.1 | 1.8.0 |
| androidx.constraintlayout:constraintlayout | 2.0.4 | 2.1.4 |
| io.reactivex.rxjava2:rxjava | 2.2.20 | 2.2.21 |
| androidx.core:core-ktx | 1.3.2 | 1.9.0 |
| androidx.preference:preference-ktx | 1.1.1 | 1.2.0 |
| androidx.arch.core:core-testing | 2.1.0 | 2.2.0 |
| com.jraska.livedata:testing-ktx | 1.2.0 | 1.3.0 |

