### PR TITLE
Fixed: Test cases are frequently failing on API level 33.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -122,7 +123,10 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     // add a file in fileSystem because we need to actual file path for making object of Archive.
     val loadFileStream =
       ObjectBoxToLibkiwixMigratorTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    zimFile = File(context.cacheDir, "testzim.zim")
+    zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->
@@ -306,6 +310,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
         .blockingFirst() as List<LibkiwixBookmarkItem>
     )
     box.removeAll()
+    zimFile.delete() // delete the temp ZIM file to free up the memory
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -54,47 +54,6 @@ class DownloadRobot : BaseRobot() {
     clickOn(ViewId(R.id.downloadsFragment))
   }
 
-  private fun longClickOnZimFile() {
-    longClickOn(Text(zimFileTitle))
-  }
-
-  private fun clickOnFileDeleteIcon() {
-    clickOn(ViewId(R.id.zim_file_delete_item))
-  }
-
-  private fun assertDeleteDialogDisplayed() {
-    pauseForBetterTestPerformance()
-    onView(withText("DELETE")).check(matches(isDisplayed()))
-  }
-
-  private fun clickOnDeleteZimFile() {
-    pauseForBetterTestPerformance()
-    onView(withText("DELETE")).perform(click())
-  }
-
-  fun deleteZimIfExists(shouldDeleteZimFile: Boolean) {
-    try {
-      longClickOnZimFile()
-      clickOnFileDeleteIcon()
-      assertDeleteDialogDisplayed()
-      clickOnDeleteZimFile()
-      pauseForBetterTestPerformance()
-    } catch (e: Exception) {
-      if (shouldDeleteZimFile) {
-        throw Exception(
-          "$zimFileTitle downloaded successfully. " +
-            "But failed to delete $zimFileTitle file " +
-            "Actual exception ${e.localizedMessage}"
-        )
-      }
-      Log.i(
-        "TEST_DELETE_ZIM",
-        "Failed to delete ZIM file with title [" + zimFileTitle + "]... " +
-          "Probably because it doesn't exist"
-      )
-    }
-  }
-
   fun waitForDataToLoad() {
     try {
       isVisible(Text(zimFileTitle))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -28,11 +28,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 fun downloadRobot(func: DownloadRobot.() -> Unit) =
@@ -183,6 +185,15 @@ class DownloadRobot : BaseRobot() {
         "Failed to stop download with title [" + zimFileTitle + "]... " +
           "Probably because it doesn't download the zim file"
       )
+    }
+  }
+
+  fun refreshLocalLibraryData() {
+    try {
+      refresh(R.id.zim_swiperefresh)
+      pauseForBetterTestPerformance()
+    } catch (e: RuntimeException) {
+      Log.w(KIWIX_DOWNLOAD_TEST, "Failed to refresh ZIM list: " + e.localizedMessage)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.download
 
-import android.util.Log
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -29,7 +28,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Assert
@@ -39,7 +37,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -86,6 +83,7 @@ class DownloadTest : BaseActivityTest() {
     try {
       downloadRobot {
         clickLibraryOnBottomNav()
+        refreshLocalLibraryData()
         deleteZimIfExists(false)
         clickDownloadOnBottomNav()
         waitForDataToLoad()
@@ -98,18 +96,16 @@ class DownloadTest : BaseActivityTest() {
         assertDownloadResumed()
         waitUntilDownloadComplete()
         clickLibraryOnBottomNav()
+        // refresh the local library list to show the downloaded zim file
+        refreshLocalLibraryData()
         checkIfZimFileDownloaded()
         deleteZimIfExists(true)
+        refreshLocalLibraryData()
       }
     } catch (e: Exception) {
       Assert.fail(
         "Couldn't find downloaded file ' Off the Grid ' Original Exception: ${e.message}"
       )
-    }
-    try {
-      refresh(R.id.zim_swiperefresh)
-    } catch (e: RuntimeException) {
-      Log.w(KIWIX_DOWNLOAD_TEST, "Failed to refresh ZIM list: " + e.localizedMessage)
     }
     LeakAssertions.assertNoLeaks()
   }
@@ -124,7 +120,7 @@ class DownloadTest : BaseActivityTest() {
   }
 
   companion object {
-    private const val KIWIX_DOWNLOAD_TEST = "kiwixDownloadTest"
+    const val KIWIX_DOWNLOAD_TEST = "kiwixDownloadTest"
 
     @BeforeClass
     fun beforeClass() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
@@ -84,7 +85,14 @@ class DownloadTest : BaseActivityTest() {
       downloadRobot {
         clickLibraryOnBottomNav()
         refreshLocalLibraryData()
-        deleteZimIfExists(false)
+      }
+      // delete all the ZIM files showing in the LocalLibrary
+      // screen to properly test the scenario.
+      library {
+        deleteZimIfExists()
+        assertNoFilesTextDisplayed()
+      }
+      downloadRobot {
         clickDownloadOnBottomNav()
         waitForDataToLoad()
         stopDownloadIfAlreadyStarted()
@@ -99,8 +107,6 @@ class DownloadTest : BaseActivityTest() {
         // refresh the local library list to show the downloaded zim file
         refreshLocalLibraryData()
         checkIfZimFileDownloaded()
-        deleteZimIfExists(true)
-        refreshLocalLibraryData()
       }
     } catch (e: Exception) {
       Assert.fail(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -91,8 +91,17 @@ class InitialDownloadRobot : BaseRobot() {
     }
   }
 
-  fun refreshList() {
+  fun refreshOnlineList() {
     refresh(R.id.librarySwipeRefresh)
+  }
+
+  fun refreshLocalLibraryData() {
+    try {
+      refresh(R.id.zim_swiperefresh)
+      pauseForBetterTestPerformance()
+    } catch (e: RuntimeException) {
+      Log.w("InitialDownloadTest", "Failed to refresh ZIM list: " + e.localizedMessage)
+    }
   }
 
   fun waitForDataToLoad() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -57,40 +57,6 @@ class InitialDownloadRobot : BaseRobot() {
     isVisible(ViewId(R.id.libraryList))
   }
 
-  private fun longClickOnZimFile() {
-    longClickOn(Text(zimFileTitle))
-  }
-
-  private fun clickOnFileDeleteIcon() {
-    clickOn(ViewId(R.id.zim_file_delete_item))
-  }
-
-  private fun assertDeleteDialogDisplayed() {
-    pauseForBetterTestPerformance()
-    onView(withText("DELETE")).check(matches(isDisplayed()))
-  }
-
-  private fun clickOnDeleteZimFile() {
-    pauseForBetterTestPerformance()
-    onView(withText("DELETE")).perform(click())
-  }
-
-  fun deleteZimIfExists() {
-    try {
-      longClickOnZimFile()
-      clickOnFileDeleteIcon()
-      assertDeleteDialogDisplayed()
-      clickOnDeleteZimFile()
-      pauseForBetterTestPerformance()
-    } catch (e: Exception) {
-      Log.i(
-        "TEST_DELETE_ZIM",
-        "Failed to delete ZIM file with title [" + zimFileTitle + "]... " +
-          "Probably because it doesn't exist"
-      )
-    }
-  }
-
   fun refreshOnlineList() {
     refresh(R.id.librarySwipeRefresh)
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -75,11 +75,12 @@ class InitialDownloadTest : BaseActivityTest() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     initialDownload {
       clickLibraryOnBottomNav()
+      refreshLocalLibraryData()
       // This is for if download test fails for some reason after downloading the zim file
       deleteZimIfExists()
       clickDownloadOnBottomNav()
       assertLibraryListDisplayed()
-      refreshList()
+      refreshOnlineList()
       waitForDataToLoad()
       stopDownloadIfAlreadyStarted()
       downloadZimFile()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
@@ -76,8 +77,14 @@ class InitialDownloadTest : BaseActivityTest() {
     initialDownload {
       clickLibraryOnBottomNav()
       refreshLocalLibraryData()
-      // This is for if download test fails for some reason after downloading the zim file
+    }
+    // delete all the ZIM files showing in the LocalLibrary
+    // screen to properly test the scenario.
+    library {
       deleteZimIfExists()
+      assertNoFilesTextDisplayed()
+    }
+    initialDownload {
       clickDownloadOnBottomNav()
       assertLibraryListDisplayed()
       refreshOnlineList()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.mimetype
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -63,7 +64,10 @@ class MimeTypeTest : BaseActivityTest() {
   @Test
   fun testMimeType() {
     val loadFileStream = MimeTypeTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -27,7 +27,6 @@ import androidx.test.uiautomator.UiDevice
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.kiwix.libzim.Archive
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
@@ -35,6 +34,7 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.libzim.Archive
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -52,6 +52,7 @@ class MimeTypeTest : BaseActivityTest() {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -34,7 +34,6 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
-import org.kiwix.kiwixmobile.search.SearchFragmentTest
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
@@ -88,7 +87,7 @@ class LocalLibraryTest : BaseActivityTest() {
     }
     // load a zim file to test, After downloading zim file library list is visible or not
     val loadFileStream =
-      SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+      LocalLibraryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile =
       File(
         ContextCompat.getExternalFilesDirs(context, null)[0],

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.note
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -93,7 +94,10 @@ class NoteFragmentTest : BaseActivityTest() {
 
     val loadFileStream =
       NoteFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -58,6 +58,9 @@ class NoteRobot : BaseRobot() {
   }
 
   fun clickOnNoteMenuItem(context: Context) {
+    // wait a bit to properly load the readerFragment and setting up the
+    // overFlowOptionMenu so that we can easily click on it.
+    pauseForBetterTestPerformance()
     openActionBarOverflowOrOptionsMenu(context)
     clickOn(Text("Note"))
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -53,6 +53,15 @@ class BookmarksRobot : BaseRobot() {
     isVisible(TextId(R.string.delete_bookmarks))
   }
 
+  fun clickOnDeleteButton() {
+    pauseForBetterTestPerformance()
+    onView(withText("DELETE")).perform(click())
+  }
+
+  fun assertNoBookMarkTextDisplayed() {
+    isVisible(TextId(R.string.no_bookmarks))
+  }
+
   fun clickOnSaveBookmarkImage() {
     pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.bottom_toolbar_bookmark))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -34,6 +34,7 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -124,9 +125,8 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
 
   @Test
   fun testBookmarkRemainsSavedOrNot() {
-    bookmarks {
-      longClickOnSaveBookmarkImage()
-      assertBookmarkSaved()
+    topLevel {
+      clickBookmarksOnNavDrawer(BookmarksRobot::assertBookmarkSaved)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -75,7 +76,10 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
     }
     val loadFileStream =
       LibkiwixBookmarkTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->
@@ -96,6 +100,13 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       )
     }
     bookmarks {
+      // delete any bookmark if already saved to properly perform this test case.
+      longClickOnSaveBookmarkImage()
+      clickOnTrashIcon()
+      assertDeleteBookmarksDialogDisplayed()
+      clickOnDeleteButton()
+      assertNoBookMarkTextDisplayed()
+      pressBack()
       // Test saving bookmark
       clickOnSaveBookmarkImage()
       clickOnOpenSavedBookmarkButton()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -60,6 +60,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.page.history
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -78,7 +79,10 @@ class NavigationHistoryTest : BaseActivityTest() {
     }
     val loadFileStream =
       NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.reader
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -77,7 +78,10 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     }
     val loadFileStream =
       KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.search
 
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -216,7 +217,10 @@ class SearchFragmentTest : BaseActivityTest() {
   private fun getTestZimFile(): File {
     val loadFileStream =
       SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -122,6 +122,7 @@ class SearchFragmentTest : BaseActivityTest() {
       pressBack()
     }
 
+    UiThreadStatement.runOnUiThread { kiwixMainActivity.navigate(R.id.libraryFragment) }
     // test with a large ZIM file to properly test the scenario
     downloadingZimFile = getDownloadingZimFile()
     OkHttpClient().newCall(downloadRequest()).execute().use { response ->
@@ -136,7 +137,6 @@ class SearchFragmentTest : BaseActivityTest() {
         )
       }
     }
-    UiThreadStatement.runOnUiThread { kiwixMainActivity.navigate(R.id.libraryFragment) }
     openKiwixReaderFragmentWithFile(downloadingZimFile)
     openSearchWithQuery(zimFile = downloadingZimFile)
     search {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -44,7 +44,7 @@ fun search(func: SearchRobot.() -> Unit) = SearchRobot().applyWithViewHierarchyP
 
 class SearchRobot : BaseRobot() {
 
-  val searchUnitTestingQuery = "Unit testing"
+  val searchUnitTestingQuery = "Unit testi"
   val searchUnitTestResult = "Unit testing - Wikipedia"
   val searchQueryForDownloadedZimFile = "A Fool"
   val searchResultForDownloadedZimFile = "A Fool for You"

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -22,6 +22,7 @@ import android.view.KeyEvent
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -100,5 +101,9 @@ class SearchRobot : BaseRobot() {
         BaristaSleepInteractions.sleep(wait)
       }
     }
+
+    // clear search query if any remains due to any condition not to affect any other test scenario
+    val searchView = onView(withId(R.id.search_src_text))
+    searchView.perform(clearText())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -31,6 +31,7 @@ import androidx.test.core.app.canTakeScreenshot
 import androidx.test.core.app.takeScreenshot
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.textContains
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
@@ -159,7 +160,8 @@ object TestUtils {
   fun isSystemUINotRespondingDialogVisible(uiDevice: UiDevice) =
     uiDevice.findObject(textContains("System UI isn't responding")) != null ||
       uiDevice.findObject(textContains("Process system isn't responding")) != null ||
-      uiDevice.findObject(textContains("Launcher isn't responding")) != null
+      uiDevice.findObject(textContains("Launcher isn't responding")) != null ||
+      uiDevice.findObject(By.clazz("android.app.Dialog")) != null
 
   @JvmStatic
   fun closeSystemDialogs(context: Context?) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -152,6 +152,9 @@ class ZimHostFragmentTest {
 
         // Check that only one ZIM file is hosted on the server after unselecting
         assertItemHostedOnServer(1)
+
+        // finally close the server at the end of test case
+        stopServer()
       }
       LeakAssertions.assertNoLeaks()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -34,6 +34,7 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import java.io.File
@@ -99,6 +100,13 @@ class ZimHostFragmentTest {
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
         it.navigate(R.id.libraryFragment)
+      }
+      zimHost(ZimHostRobot::refreshLibraryList)
+      // delete all the ZIM files showing in the LocalLibrary
+      // screen to properly test the scenario.
+      library {
+        deleteZimIfExists()
+        assertNoFilesTextDisplayed()
       }
       loadZimFileInApplication("testzim.zim")
       loadZimFileInApplication("small.zim")

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -6,8 +6,7 @@ adb logcat -c
 # shellcheck disable=SC2035
 adb logcat *:E -v color &
 retry=0
-while [ $retry -le 3 ]
-do
+while [ $retry -le 3 ]; do
   if ./gradlew jacocoInstrumentationTestReport; then
     echo "jacocoInstrumentationTestReport succeeded" >&2
     break
@@ -19,6 +18,18 @@ do
     adb logcat -c
     # shellcheck disable=SC2035
     adb logcat *:E -v color &
+
+    PACKAGE_NAME="org.kiwix.kiwixmobile"
+
+    # Function to check if the application is installed
+    is_app_installed() {
+      adb shell pm list packages | grep -q "${PACKAGE_NAME}"
+    }
+
+    if is_app_installed; then
+      # Clear application data to properly run the test cases.
+      adb shell pm clear "${PACKAGE_NAME}"
+    fi
     ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then


### PR DESCRIPTION
Fixes #3732 

* Refreshed the ZIM files list before deleting/checking for downloaded ZIM files in `DownloadTest` and `InitialDownloadTest` because sometimes data doesn't show on the `LocalLibraryScreen` after downloading the ZIM file, leading to test failures.
* Hiding the `Storage Restriction` dialog in `LibkiwixBookTest` and `MimeTypeTest` to not show this dialog in these test cases.
* Improved the temporary ZIM file path in `NoteFragmentTest` to properly display the ZIM file in the LocalLibrary screen so that it can be deleted in our test case.
* Enhanced the loading of ZIM files in `LocalLibraryTest`.
* Improved SearchFragmentTest that is sometimes failing on API level 30.
* Improved the ZIM file path in many scenarios so that the created ZIM file will show in the LocalLibraryScreen and we can delete it so that we can free up the memory.
* Improved the LibkiwixBookmarkTest. In this, before performing the test case we are removing the existing bookmarks if any so that the saved bookmark will not go outside the screen(We faced an occurrence of this type locally).
* Improved our `instrumentation.sh` bash script, if our test fails then after restarting the emulator if our application is installed we clear its cache data so that test cases will perform properly. We have made this change to fix a scenario that comes locally after testing so many times where downloading is stuck due to the lag of the emulator.
* Improved the `LibkiwixBookmarkTest`, we are now opening the Bookmark screen via the navigation drawer instead of long clicking on the `bottom_toolbar_bookmark` button because sometimes the screen scrolls down and this button hides and our test case fails on API level 33.
* Improved the NoteFragmentTest. Sometimes it didn't find the `overFlowOptionMenu` since we immediately clicked on that menu while opening the readerFragment, and sometimes this menu was not shown, because it was preparing its data to show.
* Added a condition for checking if any system dialog is visible then close it.