### PR TITLE
Fixed: PlayStore reported an error for Encyclopédie médicale WikiMed app.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -214,7 +214,10 @@ open class ErrorActivity : BaseActivity() {
     }.toString()
 
   open fun restartApp() {
-    startActivity(packageManager.getLaunchIntentForPackage(packageName))
+    val restartAppIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    }
+    startActivity(restartAppIntent)
     finish()
     killCurrentProcess()
   }


### PR DESCRIPTION
Fixes #3734 

* For the issue `Caused by java.lang.ClassNotFoundException: org.chromium.base.JniAndroid$UncaughtExceptionException
` it is related to the `org.chromium` lib and we recently upgraded our webview dependency in https://github.com/kiwix/kiwix-android/issues/3644.
* Fixed where restarting the app was not working on Android 11 and above.

| Before Fix  | After Fix |
| ------------- | ------------- |
|  <video src="https://github.com/kiwix/kiwix-android/assets/34593983/d7bc39d2-1fff-42e1-9164-c97fb6b6fa3b"> | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/843d9ab4-5f72-43e4-8525-58c4a2b2b169">  |