### PR TITLE
Fixed: Speed up Automated Tests by sharing apks. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Build APK for test cases
+        run: ./gradlew assembleDebug
+
       - name: create instrumentation coverage
         uses: ReactiveCircus/android-emulator-runner@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 24, 30, 33 ]
+        api-level: [ 33 ]
       fail-fast: false
     runs-on: macos-11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 33 ]
+        api-level: [ 24, 30, 33 ]
       fail-fast: false
     runs-on: macos-11
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 24, 30, 33 ]
+        api-level: [ 33 ]
       fail-fast: false
     runs-on: macos-11
     steps:
@@ -37,9 +37,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build APK for test cases
-        run: ./gradlew assembleDebug
-
       - name: create instrumentation coverage
         uses: ReactiveCircus/android-emulator-runner@v2
         env:
@@ -50,7 +47,7 @@ jobs:
           arch: x86_64
           profile: pixel_2
           ram-size: '4096M'
-          disk-size: '14G'
+          disk-size: ${{ matrix.api-level == 33 && '18G' || '14G' }}
           sdcard-path-or-size: ${{ matrix.api-level != 33 && '1000M' || '4096M' }}
           disable-animations: false
           heap-size: ${{ matrix.api-level == 33 && '512M' || '' }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,9 @@ android {
     versionCode = generateVersionCode()
     versionName = generateVersionName()
     manifestPlaceholders["permission"] = "android.permission.MANAGE_EXTERNAL_STORAGE"
+    testInstrumentationRunnerArguments += mapOf(
+      "apk" to "$buildDir/outputs/apk/androidTest/debug/kiwix-debug-androidTest.apk"
+    )
   }
   lint {
     checkDependencies = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,9 +39,6 @@ android {
     versionCode = generateVersionCode()
     versionName = generateVersionName()
     manifestPlaceholders["permission"] = "android.permission.MANAGE_EXTERNAL_STORAGE"
-    testInstrumentationRunnerArguments += mapOf(
-      "apk" to "$buildDir/outputs/apk/androidTest/debug/kiwix-debug-androidTest.apk"
-    )
   }
   lint {
     checkDependencies = true

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -18,8 +18,9 @@
 
 package org.kiwix.kiwixmobile
 
-import android.Manifest.permission
+import android.Manifest
 import android.content.Context
+import android.os.Build
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -34,10 +35,22 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 abstract class BaseActivityTest {
   open lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
 
-  private val permissions = arrayOf(
-    permission.READ_EXTERNAL_STORAGE,
-    permission.WRITE_EXTERNAL_STORAGE
-  )
+  private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    arrayOf(
+      Manifest.permission.POST_NOTIFICATIONS,
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.NEARBY_WIFI_DEVICES,
+      Manifest.permission.ACCESS_NETWORK_STATE
+    )
+  } else {
+    arrayOf(
+      Manifest.permission.READ_EXTERNAL_STORAGE,
+      Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      Manifest.permission.ACCESS_FINE_LOCATION,
+      Manifest.permission.ACCESS_NETWORK_STATE
+    )
+  }
 
   @get:Rule
   var permissionRules: GrantPermissionRule =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
@@ -88,6 +88,7 @@ abstract class BaseRobot(
     var uiObject2: UiObject2? = null
     for (i in 0 until retryCount) {
       try {
+        uiDevice.waitForIdle()
         uiObject2 = uiDevice.wait(Until.findObject(findable.selector(this)), timeout)
         break
       } catch (noMatchingViewException: NoMatchingViewException) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
@@ -88,7 +88,7 @@ abstract class BaseRobot(
     var uiObject2: UiObject2? = null
     for (i in 0 until retryCount) {
       try {
-        uiDevice.waitForIdle(VERY_LONG_WAIT)
+        uiDevice.waitForIdle(LONG_WAIT)
         uiObject2 = uiDevice.wait(Until.findObject(findable.selector(this)), timeout)
         break
       } catch (noMatchingViewException: NoMatchingViewException) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
@@ -88,7 +88,7 @@ abstract class BaseRobot(
     var uiObject2: UiObject2? = null
     for (i in 0 until retryCount) {
       try {
-        uiDevice.waitForIdle()
+        uiDevice.waitForIdle(VERY_LONG_WAIT)
         uiObject2 = uiDevice.wait(Until.findObject(findable.selector(this)), timeout)
         break
       } catch (noMatchingViewException: NoMatchingViewException) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -89,10 +89,8 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      TestUtils.closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -119,6 +119,8 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
       )
     }
     box = boxStore.boxFor(BookmarkEntity::class.java)
+    // clear the data before running the test case
+    clearBookmarks()
 
     // add a file in fileSystem because we need to actual file path for making object of Archive.
     val loadFileStream =
@@ -139,9 +141,6 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
         }
       }
     }
-
-    // clear the data before running the test case
-    clearBookmarks()
   }
 
   @Test
@@ -310,7 +309,9 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
         .blockingFirst() as List<LibkiwixBookmarkItem>
     )
     box.removeAll()
-    zimFile.delete() // delete the temp ZIM file to free up the memory
+    if (::zimFile.isInitialized) {
+      zimFile.delete() // delete the temp ZIM file to free up the memory
+    }
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -92,7 +92,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
         TestUtils.closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -262,7 +262,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
   @Test
   fun testLargeDataMigration(): Unit = runBlocking {
     // Test large data migration for recent searches
-    val numEntities = 10000
+    val numEntities = 1000
     // Insert a large number of recent search entities into ObjectBox
     (1..numEntities)
       .asSequence()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -122,7 +123,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     // add a file in fileSystem because we need to actual file path for making object of Archive.
     val loadFileStream =
       ObjectBoxToLibkiwixMigratorTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    zimFile = File(context.cacheDir, "testzim.zim")
+    zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -125,10 +124,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     // add a file in fileSystem because we need to actual file path for making object of Archive.
     val loadFileStream =
       ObjectBoxToLibkiwixMigratorTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -122,7 +122,6 @@ class DownloadRobot : BaseRobot() {
   }
 
   private fun assertStopDownloadDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(Text("Stop download?"))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -42,8 +42,8 @@ fun downloadRobot(func: DownloadRobot.() -> Unit) =
 
 class DownloadRobot : BaseRobot() {
 
-  private var retryCountForDataToLoad = 5
-  private var retryCountForCheckDownloadStart = 5
+  private var retryCountForDataToLoad = 10
+  private var retryCountForCheckDownloadStart = 10
   private val zimFileTitle = "Off the Grid"
 
   fun clickLibraryOnBottomNav() {
@@ -67,6 +67,10 @@ class DownloadRobot : BaseRobot() {
 
   fun checkIfZimFileDownloaded() {
     isVisible(Text(zimFileTitle))
+  }
+
+  fun refreshOnlineList() {
+    refresh(R.id.librarySwipeRefresh)
   }
 
   fun downloadZimFile() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -36,13 +36,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
 
@@ -57,10 +56,8 @@ class DownloadTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -91,6 +91,7 @@ class DownloadTest : BaseActivityTest() {
       }
       downloadRobot {
         clickDownloadOnBottomNav()
+        refreshOnlineList()
         waitForDataToLoad()
         stopDownloadIfAlreadyStarted()
         downloadZimFile()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -36,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -59,7 +60,7 @@ class DownloadTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -27,7 +27,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Assert
@@ -41,7 +40,6 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
@@ -80,7 +78,6 @@ class DownloadTest : BaseActivityTest() {
 
   @Test
   fun downloadTest() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     try {
       downloadRobot {
         clickLibraryOnBottomNav()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -32,6 +32,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -49,7 +50,7 @@ class HelpFragmentTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -31,13 +31,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource
 
 class HelpFragmentTest : BaseActivityTest() {
@@ -47,10 +46,8 @@ class HelpFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -41,8 +41,8 @@ fun initialDownload(func: InitialDownloadRobot.() -> Unit) =
 
 class InitialDownloadRobot : BaseRobot() {
 
-  private var retryCountForCheckDownloadStart = 5
-  private var retryCountForCheckDataLoaded = 5
+  private var retryCountForCheckDownloadStart = 10
+  private var retryCountForCheckDataLoaded = 10
   private val zimFileTitle = "Off the Grid"
 
   fun clickLibraryOnBottomNav() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -34,6 +34,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -56,7 +57,7 @@ class InitialDownloadTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -34,14 +34,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -54,10 +53,8 @@ class InitialDownloadTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -29,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -56,7 +57,7 @@ class IntroFragmentTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -28,13 +28,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 class IntroFragmentTest : BaseActivityTest() {
 
@@ -54,10 +53,8 @@ class IntroFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -33,12 +33,11 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -65,10 +64,8 @@ class LanguageFragmentTest {
   @Before
   fun setUp() {
     UiDevice.getInstance(instrumentation).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(instrumentation.targetContext.applicationContext)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(instrumentation.targetContext.applicationContext)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(instrumentation.targetContext.applicationContext)
       .edit {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -67,7 +68,7 @@ class LanguageFragmentTest {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(instrumentation.targetContext.applicationContext)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(instrumentation.targetContext.applicationContext)
       .edit {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -20,8 +20,9 @@ package org.kiwix.kiwixmobile.language
 import android.Manifest
 import android.app.Instrumentation
 import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
-import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -45,9 +46,6 @@ class LanguageFragmentTest {
   @Rule
   @JvmField
   var retryRule = RetryRule()
-
-  @get:Rule
-  var activityScenarioRule = ActivityScenarioRule(KiwixMainActivity::class.java)
 
   private val permissions = arrayOf(
     Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -77,6 +75,9 @@ class LanguageFragmentTest {
         putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
         putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       }
+    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -38,7 +38,7 @@ fun language(func: LanguageRobot.() -> Unit) = LanguageRobot().applyWithViewHier
 
 class LanguageRobot : BaseRobot() {
 
-  private var retryCountForDataToLoad = 5
+  private var retryCountForDataToLoad = 10
 
   fun clickDownloadOnBottomNav() {
     clickOn(ViewId(R.id.downloadsFragment))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -60,27 +60,22 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   fun assertClickNearbyDeviceMessageVisible() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.click_nearby_devices_message))
   }
 
   fun clickOnGotItButton() {
-    pauseForBetterTestPerformance()
     clickOn(TextId(R.string.got_it))
   }
 
   fun assertDeviceNameMessageVisible() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.your_device_name_message))
   }
 
   fun assertNearbyDeviceListMessageVisible() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.nearby_devices_list_message))
   }
 
   fun assertTransferZimFilesListMessageVisible() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.transfer_zim_files_list_message))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -35,6 +35,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -78,7 +79,7 @@ class LocalFileTransferTest {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
         TestUtils.closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -34,8 +34,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -76,10 +76,8 @@ class LocalFileTransferTest {
   fun setup() {
     context = instrumentation.targetContext.applicationContext
     UiDevice.getInstance(instrumentation).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      TestUtils.closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -51,6 +51,7 @@ class LocalFileTransferTest {
 
   private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
     arrayOf(
+      Manifest.permission.POST_NOTIFICATIONS,
       Manifest.permission.NEARBY_WIFI_DEVICES
     )
   } else {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -29,6 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
@@ -51,7 +52,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -29,7 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
@@ -37,7 +37,6 @@ import org.kiwix.kiwixmobile.nav.destination.library.OnlineLibraryRobot
 import org.kiwix.kiwixmobile.settings.SettingsRobot
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.webserver.ZimHostRobot
 
 class TopLevelDestinationTest : BaseActivityTest() {
@@ -49,10 +48,8 @@ class TopLevelDestinationTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -73,11 +73,11 @@ class TopLevelDestinationTest : BaseActivityTest() {
     topLevel {
       clickReaderOnBottomNav {
       }
+      clickDownloadOnBottomNav(OnlineLibraryRobot::assertLibraryListDisplayed)
       clickLibraryOnBottomNav {
         assertGetZimNearbyDeviceDisplayed()
         clickFileTransferIcon(LocalFileTransferRobot::assertReceiveFileTitleVisible)
       }
-      clickDownloadOnBottomNav(OnlineLibraryRobot::assertLibraryListDisplayed)
       clickBookmarksOnNavDrawer {
         assertBookMarksDisplayed()
         clickOnTrashIcon()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -28,13 +28,12 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.libzim.Archive
 import java.io.File
 import java.io.FileOutputStream
@@ -45,10 +44,8 @@ class MimeTypeTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.mimetype
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -61,7 +62,7 @@ class MimeTypeTest : BaseActivityTest() {
   @Test
   fun testMimeType() {
     val loadFileStream = MimeTypeTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -28,6 +28,7 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -47,7 +48,7 @@ class MimeTypeTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.mimetype
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -64,10 +63,7 @@ class MimeTypeTest : BaseActivityTest() {
   @Test
   fun testMimeType() {
     val loadFileStream = MimeTypeTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogRobot.kt
@@ -37,7 +37,6 @@ fun playStoreRestriction(func: PlayStoreRestrictionDialogRobot.() -> Unit) =
 class PlayStoreRestrictionDialogRobot : BaseRobot() {
 
   fun clickLibraryOnBottomNav() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.libraryFragment))
   }
 
@@ -54,7 +53,6 @@ class PlayStoreRestrictionDialogRobot : BaseRobot() {
   }
 
   fun clickOnUnderstood() {
-    pauseForBetterTestPerformance()
     onView(withText("UNDERSTOOD"))
       .perform(click())
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -30,6 +30,7 @@ import leakcanary.LeakAssertions
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -72,7 +73,7 @@ class PlayStoreRestrictionDialogTest {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
         TestUtils.closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -46,6 +46,7 @@ class PlayStoreRestrictionDialogTest {
 
   private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
     arrayOf(
+      Manifest.permission.POST_NOTIFICATIONS,
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
       Manifest.permission.NEARBY_WIFI_DEVICES

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -30,7 +30,7 @@ import leakcanary.LeakAssertions
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -70,10 +70,8 @@ class PlayStoreRestrictionDialogTest {
   fun waitForIdle() {
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      TestUtils.closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -18,22 +18,24 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
 import org.kiwix.kiwixmobile.localFileTransfer.localFileTransfer
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -59,12 +61,18 @@ class LibraryRobot : BaseRobot() {
   }
 
   fun assertNoFilesTextDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(ViewId(R.id.file_management_no_files))
   }
 
   fun deleteZimIfExists() {
     try {
+      try {
+        onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))
+        // if this view is displaying then we do not need to run the further code.
+        return
+      } catch (e: AssertionFailedError) {
+        Log.e("DELETE_ZIM_FILE", "Zim files found in local library so we are deleting them")
+      }
       val recyclerViewId: Int = R.id.zimfilelist
       val recyclerViewItemsCount = RecyclerViewItemCount(recyclerViewId).checkRecyclerViewCount()
       // Scroll to the end of the RecyclerView to ensure all items are visible
@@ -79,7 +87,6 @@ class LibraryRobot : BaseRobot() {
       clickOnFileDeleteIcon()
       assertDeleteDialogDisplayed()
       clickOnDeleteZimFile()
-      pauseForBetterTestPerformance()
     } catch (e: Exception) {
       Log.i(
         "TEST_DELETE_ZIM",
@@ -90,7 +97,6 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnFileDeleteIcon() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.zim_file_delete_item))
   }
 
@@ -101,7 +107,6 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnDeleteZimFile() {
-    pauseForBetterTestPerformance()
     onView(withText("DELETE")).perform(click())
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -85,7 +86,7 @@ class LocalLibraryTest : BaseActivityTest() {
     // load a zim file to test, After downloading zim file library list is visible or not
     val loadFileStream =
       LocalLibraryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -30,13 +30,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -50,10 +49,8 @@ class LocalLibraryTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -88,11 +87,7 @@ class LocalLibraryTest : BaseActivityTest() {
     // load a zim file to test, After downloading zim file library list is visible or not
     val loadFileStream =
       LocalLibraryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile =
-      File(
-        ContextCompat.getExternalFilesDirs(context, null)[0],
-        "testzim.zim"
-      )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -52,7 +53,7 @@ class LocalLibraryTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.note
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -91,7 +92,7 @@ class NoteFragmentTest : BaseActivityTest() {
 
     val loadFileStream =
       NoteFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -32,15 +32,14 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -56,10 +55,8 @@ class NoteFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -58,7 +59,7 @@ class NoteFragmentTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.note
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -94,10 +93,7 @@ class NoteFragmentTest : BaseActivityTest() {
 
     val loadFileStream =
       NoteFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -66,7 +66,6 @@ class NoteRobot : BaseRobot() {
   }
 
   fun assertBackwardNavigationHistoryDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.note))
   }
 
@@ -76,7 +75,6 @@ class NoteRobot : BaseRobot() {
   }
 
   fun saveNote() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.save_note))
   }
 
@@ -95,7 +93,6 @@ class NoteRobot : BaseRobot() {
   }
 
   fun clickOnOpenNote() {
-    pauseForBetterTestPerformance()
     clickOn(Text("OPEN NOTE"))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -63,7 +63,6 @@ class BookmarksRobot : BaseRobot() {
   }
 
   fun clickOnSaveBookmarkImage() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.bottom_toolbar_bookmark))
   }
 
@@ -90,7 +89,6 @@ class BookmarksRobot : BaseRobot() {
   }
 
   fun assertBookmarkSaved() {
-    pauseForBetterTestPerformance()
     isVisible(Text("Test Zim"))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -75,7 +76,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
     }
     val loadFileStream =
       LibkiwixBookmarkTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -77,10 +76,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
     }
     val loadFileStream =
       LibkiwixBookmarkTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -31,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
@@ -55,7 +56,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
         TestUtils.closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -30,8 +30,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
@@ -53,10 +53,8 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      TestUtils.closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -35,7 +35,6 @@ fun navigationHistory(func: NavigationHistoryRobot.() -> Unit) =
 class NavigationHistoryRobot : BaseRobot() {
 
   fun checkZimFileLoadedSuccessful(readerFragment: Int) {
-    pauseForBetterTestPerformance()
     isVisible(ViewId(readerFragment))
   }
 
@@ -52,37 +51,30 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun longClickOnBackwardButton() {
-    pauseForBetterTestPerformance()
     longClickOn(ViewId(R.id.bottom_toolbar_arrow_back))
   }
 
   fun longClickOnForwardButton() {
-    pauseForBetterTestPerformance()
     longClickOn(ViewId(R.id.bottom_toolbar_arrow_forward))
   }
 
   fun assertBackwardNavigationHistoryDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.backward_history))
   }
 
   fun clickOnBackwardButton() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.bottom_toolbar_arrow_back))
   }
 
   fun assertForwardNavigationHistoryDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.forward_history))
   }
 
   fun clickOnDeleteHistory() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.menu_pages_clear))
   }
 
   fun assertDeleteDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(TextId(R.string.clear_all_history_dialog_title))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -57,7 +58,7 @@ class NavigationHistoryTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -32,14 +32,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -55,10 +54,8 @@ class NavigationHistoryTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.page.history
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -76,7 +77,7 @@ class NavigationHistoryTest : BaseActivityTest() {
     }
     val loadFileStream =
       NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.page.history
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -79,10 +78,7 @@ class NavigationHistoryTest : BaseActivityTest() {
     }
     val loadFileStream =
       NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.reader
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -75,7 +76,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     }
     val loadFileStream =
       KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -56,7 +57,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -78,10 +77,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     }
     val loadFileStream =
       KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -32,14 +32,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -54,10 +53,8 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ReaderRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ReaderRobot.kt
@@ -36,17 +36,14 @@ class ReaderRobot : BaseRobot() {
   private var retryCountForClickOnUndoButton = 5
 
   fun checkZimFileLoadedSuccessful(readerFragment: Int) {
-    pauseForBetterTestPerformance()
     isVisible(ViewId(readerFragment))
   }
 
   fun clickOnTabIcon() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.ic_tab_switcher_text))
   }
 
   fun clickOnClosedAllTabsButton() {
-    pauseForBetterTestPerformance()
     clickOn(ViewId(R.id.tab_switcher_close_all_tabs))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -17,7 +17,6 @@
  */
 package org.kiwix.kiwixmobile.search
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -217,10 +216,7 @@ class SearchFragmentTest : BaseActivityTest() {
   private fun getTestZimFile(): File {
     val loadFileStream =
       SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
-      "testzim.zim"
-    )
+    val zimFile = File(context.cacheDir, "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.search
 
+import android.content.Context
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -214,7 +215,7 @@ class SearchFragmentTest : BaseActivityTest() {
   private fun getTestZimFile(): File {
     val loadFileStream =
       SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.cacheDir, "testzim.zim")
+    val zimFile = File(context.getDir("testDir", Context.MODE_PRIVATE), "testzim.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -34,14 +34,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -64,10 +63,8 @@ class SearchFragmentTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
     uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
@@ -66,7 +67,7 @@ class SearchFragmentTest : BaseActivityTest() {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -28,6 +28,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.intro.IntroRobot
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
@@ -64,7 +65,7 @@ class KiwixSettingsFragmentTest {
           InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         )
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     UiThreadStatement.runOnUiThread {
       activityScenarioRule.scenario.onActivity {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -27,14 +27,13 @@ import leakcanary.LeakAssertions
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.intro.IntroRobot
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.utils.StandardActions
 
 class KiwixSettingsFragmentTest {
@@ -60,12 +59,10 @@ class KiwixSettingsFragmentTest {
   fun setup() {
     // Go to IntroFragment
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(
-          InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-        )
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(
+        InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+      )
+      waitForIdle(LONG_WAIT)
     }
     UiThreadStatement.runOnUiThread {
       activityScenarioRule.scenario.onActivity {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -40,6 +40,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -77,7 +78,7 @@ class KiwixSplashActivityTest {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -39,14 +39,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -75,10 +74,8 @@ class KiwixSplashActivityTest {
     Intents.init()
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -31,8 +31,6 @@ import androidx.test.core.app.canTakeScreenshot
 import androidx.test.core.app.takeScreenshot
 import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.By
-import androidx.test.uiautomator.By.textContains
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
@@ -159,13 +157,6 @@ object TestUtils {
     val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
     return targetContext.resources.getString(id)
   }
-
-  @JvmStatic
-  fun isSystemUINotRespondingDialogVisible(uiDevice: UiDevice) =
-    uiDevice.findObject(textContains("System UI isn't responding")) != null ||
-      uiDevice.findObject(textContains("Process system isn't responding")) != null ||
-      uiDevice.findObject(textContains("Launcher isn't responding")) != null ||
-      uiDevice.findObject(By.clazz("android.app.Dialog")) != null
 
   @JvmStatic
   fun closeSystemDialogs(context: Context?) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -54,7 +54,11 @@ object TestUtils {
   @JvmField var TEST_PAUSE_MS = 3000
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
-  const val RETRY_COUNT_FOR_FLAKY_TEST = 3
+
+  // Increased retry count to 5 for flaky test cases on API level 33,
+  // where failures occurred multiple times due to the heavy `google_apis`.
+  // so to address this we have increased it to 5 to properly run the test cases.
+  const val RETRY_COUNT_FOR_FLAKY_TEST = 5
 
   /*
     TEST_PAUSE_MS is used as such:

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
@@ -354,97 +354,109 @@ class FileUtilsInstrumentationTest {
 
   @Test
   fun testExtractDocumentId() {
-    val dummyDownloadUriData = arrayOf(
-      DummyUrlData(
-        null,
-        "raw:$expectedFilePath",
-        Uri.parse("${downloadDocumentUriPrefix}raw%3A%2Fstorage%2Femulated%2F0%2F$commonUri")
-      ),
-      DummyUrlData(
-        null,
-        expectedFilePath,
-        Uri.parse("$downloadDocumentUriPrefix%2Fstorage%2Femulated%2F0%2F$commonUri")
-      ),
-      DummyUrlData(
-        null,
-        "",
-        Uri.parse(downloadUriPrefix)
-      )
-    )
-
-    dummyDownloadUriData.forEach { dummyUrlData ->
-      dummyUrlData.uri?.let { uri ->
-        Assertions.assertEquals(
-          FileUtils.extractDocumentId(uri, DocumentResolverWrapper()),
-          dummyUrlData.expectedFileName
+    // We are not running this test case on Android 13 and above. In this version,
+    // numerous security updates have been included, preventing us from modifying the
+    // default behavior of ContentResolver.
+    // Therefore, we are restricting this test to API level 33 and below.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      val dummyDownloadUriData = arrayOf(
+        DummyUrlData(
+          null,
+          "raw:$expectedFilePath",
+          Uri.parse("${downloadDocumentUriPrefix}raw%3A%2Fstorage%2Femulated%2F0%2F$commonUri")
+        ),
+        DummyUrlData(
+          null,
+          expectedFilePath,
+          Uri.parse("$downloadDocumentUriPrefix%2Fstorage%2Femulated%2F0%2F$commonUri")
+        ),
+        DummyUrlData(
+          null,
+          "",
+          Uri.parse(downloadUriPrefix)
         )
-      }
-    }
+      )
 
-    // Testing with a dynamically generated URI. This URI creates at runtime,
-    // and passing it statically would result in an `IllegalArgumentException` exception.
-    // Therefore, we simulate this scenario using the `DocumentsContractWrapper`
-    // to conduct the test.
-    val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
-    val expectedDocumentId = "1000020403"
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      // Below Android 10, download URI schemes are of the content type, such as:
-      // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
-      // As a result, this method will not be called during that time. We are not testing it on
-      // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
-      val mockedUri = Uri.parse("$downloadUriPrefix$expectedDocumentId")
-      every { mockDocumentsContractWrapper.getDocumentId(mockedUri) } returns expectedDocumentId
-      val actualDocumentId = FileUtils.extractDocumentId(mockedUri, mockDocumentsContractWrapper)
-      assertEquals(expectedDocumentId, actualDocumentId)
+      dummyDownloadUriData.forEach { dummyUrlData ->
+        dummyUrlData.uri?.let { uri ->
+          Assertions.assertEquals(
+            FileUtils.extractDocumentId(uri, DocumentResolverWrapper()),
+            dummyUrlData.expectedFileName
+          )
+        }
+      }
+
+      // Testing with a dynamically generated URI. This URI creates at runtime,
+      // and passing it statically would result in an `IllegalArgumentException` exception.
+      // Therefore, we simulate this scenario using the `DocumentsContractWrapper`
+      // to conduct the test.
+      val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
+      val expectedDocumentId = "1000020403"
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        // Below Android 10, download URI schemes are of the content type, such as:
+        // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
+        // As a result, this method will not be called during that time. We are not testing it on
+        // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
+        val mockedUri = Uri.parse("$downloadUriPrefix$expectedDocumentId")
+        every { mockDocumentsContractWrapper.getDocumentId(mockedUri) } returns expectedDocumentId
+        val actualDocumentId = FileUtils.extractDocumentId(mockedUri, mockDocumentsContractWrapper)
+        assertEquals(expectedDocumentId, actualDocumentId)
+      }
     }
   }
 
   @Test
   fun testDocumentProviderContentQuery() {
-    // test to get the download uri on old device
-    testWithDownloadUri(
-      Uri.parse("${downloadDocumentUriPrefix}raw%3A%2Fstorage%2Femulated%2F0%2F$commonUri"),
-      expectedFilePath
-    )
+    // We are not running this test case on Android 13 and above. In this version,
+    // numerous security updates have been included, preventing us from modifying the
+    // default behavior of ContentResolver.
+    // Therefore, we are restricting this test to API level 33 and below.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      // test to get the download uri on old device
+      testWithDownloadUri(
+        Uri.parse("${downloadDocumentUriPrefix}raw%3A%2Fstorage%2Femulated%2F0%2F$commonUri"),
+        expectedFilePath
+      )
 
-    // test to get the download uri on new device
-    testWithDownloadUri(
-      Uri.parse("$downloadDocumentUriPrefix%2Fstorage%2Femulated%2F0%2F$commonUri"),
-      expectedFilePath
-    )
+      // test to get the download uri on new device
+      testWithDownloadUri(
+        Uri.parse("$downloadDocumentUriPrefix%2Fstorage%2Femulated%2F0%2F$commonUri"),
+        expectedFilePath
+      )
 
-    // test with all possible download uris
-    val contentUriPrefixes = arrayOf(
-      "content://downloads/public_downloads",
-      "content://downloads/my_downloads",
-      "content://downloads/all_downloads"
-    )
+      // test with all possible download uris
+      val contentUriPrefixes = arrayOf(
+        "content://downloads/public_downloads",
+        "content://downloads/my_downloads",
+        "content://downloads/all_downloads"
+      )
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      // Below Android 10, download URI schemes are of the content type, such as:
-      // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
-      // As a result, this method will not be called during that time. We are not testing it on
-      // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
-      contentUriPrefixes.forEach {
-        val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
-        val expectedDocumentId = "1000020403"
-        val mockedUri = Uri.parse("$it/$expectedDocumentId")
-        every { mockDocumentsContractWrapper.getDocumentId(mockedUri) } returns expectedDocumentId
-        every {
-          mockDocumentsContractWrapper.query(
-            context!!,
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        // Below Android 10, download URI schemes are of the content type, such as:
+        // content://com.android.chrome.FileProvider/downloads/alpinelinux_en_all_nopic_2022-12.zim
+        // As a result, this method will not be called during that time. We are not testing it on
+        // Android versions below 10, as it would result in an "IllegalArgumentException" exception.
+        contentUriPrefixes.forEach {
+          val mockDocumentsContractWrapper: DocumentResolverWrapper = mockk()
+          val expectedDocumentId = "1000020403"
+          val mockedUri = Uri.parse("$it/$expectedDocumentId")
+          every { mockDocumentsContractWrapper.getDocumentId(mockedUri) } returns expectedDocumentId
+          every {
+            mockDocumentsContractWrapper.query(
+              context!!,
+              mockedUri,
+              "_data",
+              null,
+              null,
+              null
+            )
+          } returns expectedFilePath
+          testWithDownloadUri(
             mockedUri,
-            "_data",
-            null,
-            null,
-            null
+            expectedFilePath,
+            mockDocumentsContractWrapper
           )
-        } returns expectedFilePath
-        testWithDownloadUri(
-          mockedUri,
-          expectedFilePath,
-          mockDocumentsContractWrapper
-        )
+        }
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -52,6 +52,7 @@ class ZimHostFragmentTest {
 
   private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
     arrayOf(
+      Manifest.permission.POST_NOTIFICATIONS,
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE,
       Manifest.permission.NEARBY_WIFI_DEVICES,

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -31,8 +31,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.LONG_WAIT
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -78,10 +78,8 @@ class ZimHostFragmentTest {
   fun waitForIdle() {
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
-      }
-      waitForIdle(VERY_LONG_WAIT)
+      TestUtils.closeSystemDialogs(context)
+      waitForIdle(LONG_WAIT)
     }
     context?.let {
       sharedPreferenceUtil = SharedPreferenceUtil(it).apply {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -32,6 +32,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.VERY_LONG_WAIT
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -80,7 +81,7 @@ class ZimHostFragmentTest {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
         TestUtils.closeSystemDialogs(context)
       }
-      waitForIdle()
+      waitForIdle(VERY_LONG_WAIT)
     }
     context?.let {
       sharedPreferenceUtil = SharedPreferenceUtil(it).apply {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -165,7 +165,7 @@ class ZimHostFragmentTest {
   private fun loadZimFileInApplication(zimFileName: String) {
     val loadFileStream =
       ZimHostFragmentTest::class.java.classLoader.getResourceAsStream(zimFileName)
-    val zimFile = File(sharedPreferenceUtil.prefStorage, zimFileName)
+    val zimFile = File(context?.getDir("testDir", Context.MODE_PRIVATE), zimFileName)
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -98,7 +98,9 @@ class ZimHostFragmentTest {
 
   @Test
   fun testZimHostFragment() {
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1 &&
+      Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+    ) {
       activityScenario.onActivity {
         it.navigate(R.id.libraryFragment)
       }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -82,12 +82,18 @@ class ZimHostRobot : BaseRobot() {
 
   fun stopServerIfAlreadyStarted() {
     try {
-      assertServerStarted()
-      stopServer()
+      // Check if the "START SERVER" button is visible because, in most scenarios,
+      // this button will appear when the server is already stopped.
+      // This will expedite our test case, as verifying the visibility of
+      // non-visible views takes more time due to the try mechanism needed
+      // to properly retrieve the view.
+      assertServerStopped()
     } catch (exception: Exception) {
+      // if "START SERVER" button is not visible it means server is started so close it.
+      stopServer()
       Log.i(
         "ZIM_HOST_FRAGMENT",
-        "Failed to stop the server, Probably because server is not running"
+        "Stopped the server to perform our test case since it was already running"
       )
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -26,7 +26,6 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
-import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
 import org.hamcrest.CoreMatchers
@@ -35,7 +34,6 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.RecyclerViewItemCount
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 import org.kiwix.kiwixmobile.utils.RecyclerViewSelectedCheckBoxCountAssertion
@@ -50,12 +48,10 @@ class ZimHostRobot : BaseRobot() {
   }
 
   fun refreshLibraryList() {
-    pauseForBetterTestPerformance()
     refresh(R.id.zim_swiperefresh)
   }
 
   fun assertZimFilesLoaded() {
-    pauseForBetterTestPerformance()
     isVisible(Text("Test_Zim"))
   }
 
@@ -65,7 +61,6 @@ class ZimHostRobot : BaseRobot() {
   }
 
   fun clickOnTestZim() {
-    pauseForBetterTestPerformance()
     clickOn(Text("Test_Zim"))
   }
 
@@ -78,12 +73,10 @@ class ZimHostRobot : BaseRobot() {
   }
 
   private fun assetWifiDialogDisplayed() {
-    pauseForBetterTestPerformance()
     isVisible(Text("WiFi connection detected"))
   }
 
   fun assertServerStarted() {
-    pauseForBetterTestPerformance()
     isVisible(Text("STOP SERVER"))
   }
 
@@ -149,11 +142,6 @@ class ZimHostRobot : BaseRobot() {
   }
 
   fun assertServerStopped() {
-    pauseForBetterTestPerformance()
     isVisible(Text("START SERVER"))
-  }
-
-  private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -25,6 +25,7 @@ object Config {
   const val compileSdk = 33 // SDK version used by Gradle to compile our app.
   const val minSdk = 24 // Minimum SDK (Minimum Support Device) is 24 (Android 7.0 Nougat).
   const val targetSdk = 33 // Target SDK (Maximum Support Device) is 33 (Android 13).
+  const val buildToolVersion = "33.0.1" // buildToolVersion for API level 33 (Android 13).
 
   val javaVersion = JavaVersion.VERSION_1_8
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -49,6 +49,7 @@ class AllProjectConfigurer {
       defaultConfig {
         minSdk = Config.minSdk
         setTargetSdkVersion(Config.targetSdk)
+        buildToolsVersion(Config.buildToolVersion)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
       }
 

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -4,19 +4,7 @@ adb logcat -c
 # shellcheck disable=SC2035
 adb logcat *:E -v color &
 retry=0
-
-
-PACKAGE_NAME="org.kiwix.kiwixmobile"
-
-# Function to check if the application is installed
-is_app_installed() {
-  adb shell pm list packages | grep -q "${PACKAGE_NAME}"
-}
-
-if is_app_installed; then
-  # Clear application data to properly run the test cases.
-  adb shell pm clear "${PACKAGE_NAME}"
-fi
+adb shell pm clear "org.kiwix.kiwixmobile"
 
 while [ $retry -le 3 ]; do
   if ./gradlew jacocoInstrumentationTestReport; then
@@ -29,17 +17,7 @@ while [ $retry -le 3 ]; do
     # shellcheck disable=SC2035
     adb logcat *:E -v color &
 
-    PACKAGE_NAME="org.kiwix.kiwixmobile"
-
-    # Function to check if the application is installed
-    is_app_installed() {
-      adb shell pm list packages | grep -q "${PACKAGE_NAME}"
-    }
-
-    if is_app_installed; then
-      # Clear application data to properly run the test cases.
-      adb shell pm clear "${PACKAGE_NAME}"
-    fi
+    adb shell pm clear "org.kiwix.kiwixmobile"
     ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 
-# Enable Wi-Fi on the emulator
-adb shell svc wifi enable
 adb logcat -c
 # shellcheck disable=SC2035
 adb logcat *:E -v color &
 retry=0
+
+
+PACKAGE_NAME="org.kiwix.kiwixmobile"
+
+# Function to check if the application is installed
+is_app_installed() {
+  adb shell pm list packages | grep -q "${PACKAGE_NAME}"
+}
+
+if is_app_installed; then
+  # Clear application data to properly run the test cases.
+  adb shell pm clear "${PACKAGE_NAME}"
+fi
+
 while [ $retry -le 3 ]; do
   if ./gradlew jacocoInstrumentationTestReport; then
     echo "jacocoInstrumentationTestReport succeeded" >&2
@@ -13,8 +25,6 @@ while [ $retry -le 3 ]; do
   else
     adb kill-server
     adb start-server
-    # Enable Wi-Fi on the emulator
-    adb shell svc wifi enable
     adb logcat -c
     # shellcheck disable=SC2035
     adb logcat *:E -v color &

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -44,6 +44,10 @@ object StorageDeviceUtils {
       // Therefore, we need to explicitly include the app-specific directory for scanning.
       // See https://github.com/kiwix/kiwix-android/issues/3579
       addAll(externalFilesDirsDevices(context, true))
+
+      // added test directory to show the ZIM files stored in the test directory
+      // so that we can view and delete zim files inside this directory.
+      add(testDirectory(context))
     }
     return validate(storageDevices, false)
   }
@@ -76,6 +80,9 @@ object StorageDeviceUtils {
       generalisePath(context.getExternalFilesDir("").toString(), true),
       Environment.isExternalStorageEmulated()
     )
+
+  private fun testDirectory(context: Context) =
+    StorageDevice(context.getDir("testDir", Context.MODE_PRIVATE), true)
 
   // Remove app specific path from directories so that we can search them from the top
   private fun generalisePath(path: String, writable: Boolean) =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
@@ -18,35 +18,27 @@
 
 package org.kiwix.kiwixmobile.core
 
-import android.app.Application.getProcessName
-import android.content.Context
-import android.os.Build
+import android.util.Log
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
-import android.webkit.WebView
 import androidx.webkit.ServiceWorkerClientCompat
 import androidx.webkit.ServiceWorkerControllerCompat
 import androidx.webkit.WebViewFeature
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import javax.inject.Inject
 
-class ServiceWorkerInitialiser @Inject constructor(
-  zimReaderContainer: ZimReaderContainer,
-  context: Context
-) {
+class ServiceWorkerInitialiser @Inject constructor(zimReaderContainer: ZimReaderContainer) {
   init {
     if (WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        val process = getProcessName()
-        if (context.packageName != process) {
-          WebView.setDataDirectorySuffix(process)
-        }
+      try {
+        ServiceWorkerControllerCompat.getInstance()
+          .setServiceWorkerClient(object : ServiceWorkerClientCompat() {
+            override fun shouldInterceptRequest(request: WebResourceRequest): WebResourceResponse? =
+              zimReaderContainer.load(request.url.toString(), request.requestHeaders)
+          })
+      } catch (ignore: Exception) {
+        Log.e("ServiceWorkerInitialiser", "Error setting up ServiceWorkerClient", ignore)
       }
-      ServiceWorkerControllerCompat.getInstance()
-        .setServiceWorkerClient(object : ServiceWorkerClientCompat() {
-          override fun shouldInterceptRequest(request: WebResourceRequest): WebResourceResponse? =
-            zimReaderContainer.load(request.url.toString(), request.requestHeaders)
-        })
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
@@ -18,17 +18,30 @@
 
 package org.kiwix.kiwixmobile.core
 
+import android.app.Application.getProcessName
+import android.content.Context
+import android.os.Build
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import android.webkit.WebView
 import androidx.webkit.ServiceWorkerClientCompat
 import androidx.webkit.ServiceWorkerControllerCompat
 import androidx.webkit.WebViewFeature
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import javax.inject.Inject
 
-class ServiceWorkerInitialiser @Inject constructor(zimReaderContainer: ZimReaderContainer) {
+class ServiceWorkerInitialiser @Inject constructor(
+  zimReaderContainer: ZimReaderContainer,
+  context: Context
+) {
   init {
     if (WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        val process = getProcessName()
+        if (context.packageName != process) {
+          WebView.setDataDirectorySuffix(process)
+        }
+      }
       ServiceWorkerControllerCompat.getInstance()
         .setServiceWorkerClient(object : ServiceWorkerClientCompat() {
           override fun shouldInterceptRequest(request: WebResourceRequest): WebResourceResponse? =


### PR DESCRIPTION
Fixes #2096

* Using `uiDevice.waitForIdle()` method instead of `BaristaSleepInteractions.sleep` in our test cases. Because `BaristaSleepInteractions.sleep` runs everytime even the view is displaying on the screen which takes the extra time to run the test case, but now we are using `uiDevice.waitForIdle()` method which perform the further operation if desired view is already displaying otherwise wait for that view.
* Improved the deleting of zim files in localibrary, since we already pause for a second to check if the delete dialog is displayed or not, and again we are waiting before clicking on it. The same issue for while clicking on the PlayStoreRestrictionDialogTest where we are first waiting for the dialog to visible and then waiting for clicking on it. So we have removed the second wait since this dialog is displaying in both test cases.
* Improved the TopLevelDestinationTest. Because we were testing the drawer options fragments (Settings, Bookmarks etc) from the download screen and when we pressed the back button it came to the download screen and refreshed its data due to this our next functionality had to wait to finish this. Now we are testing all the navigation screens from the LocalLibraryScreen which makes this test case faster.
* Improved `ObjectBoxToLibkiwixMigratorTest` for clearing the previously saved bookmarks.
* Refreshing the data before checking the loaded data in DownloadTest.
* Increasing the Retry count for loading data and downloading start to properly work with a low internet connection.
* Added Notification permission in our test cases for API level 33.
* Improved our `ZimHostFragmentTest` test to boost the test case speed. It was running in 2 minutes, but after this change, it now completes in 27 seconds.
* Increased retry count to 5 for flaky test cases on API level 33, where failures occurred multiple times due to the heavy `google_apis`. so to address this we have increased it to 5 to properly run the test cases.
* We are removing the `ZimHostFragment` test from the API level 33 because, most of the time, the emulator does not have WiFi service. Running this test on this emulator is not worthwhile, as we are testing this code on WiFi see https://github.com/kiwix/kiwix-android/actions/runs/8265444407/job/22611097563?pr=3747#step:6:1980.
* Improved the ObjectBoxToLibkiwixMigratorTest test case, as it occasionally crashes during testing on API level 33 due to emulator lag on google_apis. The extensive data migration exacerbates the emulator's performance issues, leading to crashes during subsequent test processes. To address this issue, we have reduced the migration volume from 10K to 1K.
* Removed the enabling wifi for adb as it is unused now because sometimes API level 33 emulator does not have the wifi, and we have introduced this for API level 33 emulator .
* Increased the disk size of the API level 33 emulator since the emulator is crashing on this API level while performing the test cases so it might require more resources to run smoothly.
* Removed the clearing app data after the first test case failed because it did not receive test cases after the first test failure  https://github.com/kiwix/kiwix-android/actions/runs/8295560144/job/22702831374?pr=3747#step:6:3057.
* Improved system path in our test cases since sometimes the emulator treats app-specific directory as `READ_ONLY_FILESYSTEM` see https://github.com/kiwix/kiwix-android/actions/runs/8308488756/job/22738768095?pr=3747#step:5:12547.
* Added timeout for waiting for the idle state of emulator https://github.com/kiwix/kiwix-android/actions/runs/8308488756/job/22738768095?pr=3747#step:5:23824 since by default it has 10 second but the API level 33 emulator is heavy and takes more time to become idle so we have increased the timeout to properly come in the idle state.
* Added the 'testDirectory' to our scanning process, as on API level 33, the app-specific path is occasionally treated as READ_ONLY. Additionally, for certain test cases where we need to load the zim file in the LocalLibraryScreen, we've included the test directory in our scanning process, as it will be automatically handled by the OS.

Before test cases were completed on API level 33(Android 13) in **18 Minutes and 57 seconds** and by doing the above changes now it is completed in **14 minutes** on the same API level so almost 5 minutes have been reduced. 