### PR TITLE
Fixed: ZIM file is not deleting from LocalLibraryFragment if we do not have the storage permission in non-playstore variant, which is fine but it should ask permission.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -152,7 +152,13 @@ class LocalLibraryFragment : BaseFragment() {
           offerAction(RequestNavigateTo(it))
         }
       },
-      { offerAction(RequestMultiSelection(it)) },
+      {
+        if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
+          showManageExternalStoragePermissionDialog()
+        } else {
+          offerAction(RequestMultiSelection(it))
+        }
+      },
       { offerAction(RequestSelect(it)) }
     )
   }


### PR DESCRIPTION
Fixes #3746 

* Added permission check when selecting the ZIM file to delete or share, which fixes this problem.


https://github.com/kiwix/kiwix-android/assets/34593983/4105d2a1-33f4-48c1-a0e4-cbfbda540fac

