### PR TITLE
Fixed: [Bug] Diagnostic Report not doing anything.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -98,25 +98,26 @@ open class ErrorActivity : BaseActivity() {
   private fun emailIntent(): Intent {
     val emailBody = buildBody()
     return Intent(Intent.ACTION_SEND).apply {
-      type = "vnd.android.cursor.dir/email"
+      type = "text/plain"
       putExtra(
         Intent.EXTRA_EMAIL,
         arrayOf("android-crash-feedback@kiwix.org")
       )
       putExtra(Intent.EXTRA_SUBJECT, subject)
       putExtra(Intent.EXTRA_TEXT, emailBody)
-      if (activityKiwixErrorBinding?.allowLogs?.isChecked == true) {
-        val file = fileLogger.writeLogFile(this@ErrorActivity)
-        file.appendText(emailBody)
-        val path =
-          FileProvider.getUriForFile(
-            this@ErrorActivity,
-            applicationContext.packageName + ".fileprovider",
-            file
-          )
-        addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        putExtra(android.content.Intent.EXTRA_STREAM, path)
-      }
+      val file = fileLogger.writeLogFile(
+        this@ErrorActivity,
+        activityKiwixErrorBinding?.allowLogs?.isChecked == true
+      )
+      file.appendText(emailBody)
+      val path =
+        FileProvider.getUriForFile(
+          this@ErrorActivity,
+          applicationContext.packageName + ".fileprovider",
+          file
+        )
+      addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+      putExtra(android.content.Intent.EXTRA_STREAM, path)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileLogger.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileLogger.kt
@@ -31,26 +31,25 @@ import javax.inject.Singleton
 @Singleton
 class FileLogger @Inject constructor() {
 
-  fun writeLogFile(context: Context): File {
+  fun writeLogFile(context: Context, shouldWriteDeviceLogs: Boolean = true): File {
     // Create a new folder in private storage with name: logs
     val logDir = File(context.filesDir, "logs")
     val logFile = File(logDir, fileName)
 
-    Log.d("KIWIX", "Writing all logs into [" + logDir.path + "]")
+    Log.d(TAG, "Writing all logs into [" + logDir.path + "]")
 
-    if (!logDir.exists()) {
+    if (logDir.exists()) {
+      // delete the folder so the previous saved logs files will be deleted.
+      logDir.delete()
       logDir.mkdir()
-    }
-    // Delete the pre-existing file
-    if (logDir.exists() && logFile.isFile) {
-      Log.d(TAG, "writeLogFile: Deleting preExistingFile")
-      logFile.delete()
     }
 
     try {
-      logDir.createNewFile()
-      Runtime.getRuntime().exec("logcat -f $logFile")
-      Runtime.getRuntime().exec("logcat -b all -d")
+      logFile.createNewFile()
+      if (shouldWriteDeviceLogs) {
+        Runtime.getRuntime().exec("logcat -f $logFile")
+        Runtime.getRuntime().exec("logcat -b all -d")
+      }
     } catch (e: IOException) {
       Log.e("KIWIX", "Error while writing $fileName! ", e)
     }


### PR DESCRIPTION
Fixes #3751 

* Changed intent type from `vnd.android.cursor.dir/email` to `text/plain` to ensure compatibility with all applications.
* Now attaching a log file containing all details. WhatsApp has a limitation on message sharing, so if details are lengthy, they might get cut off. We ensure complete details by providing the log file attachment.
* Improved `writeLogFile` method. Now we are deleting the directory from the storage if exist which contains the previously generated logs files since we were deleting the existing file if any are present in the storage but our fileName contains the `currentTimeMillis` so this condition will never be true, and all the logs files are stored in that directory, which takes the memory in user device, so now we are removing the previously saved log files and then generating the new one.