### PR TITLE
Fixed: Migration of bookmarks is not working with recent versions of custom apps.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToLibkiwixMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToLibkiwixMigrator.kt
@@ -55,15 +55,22 @@ class ObjectBoxToLibkiwixMigrator {
         try {
           // for saving book to library, otherwise it does not save the
           // favicon and zimFilePath in library.
-          val archive = Archive(bookmarkEntity.zimFilePath)
-          val libkiwixBook = Book().apply {
-            update(archive)
+          var archive: Archive? = null
+          val libkiwixBook = bookmarkEntity.zimFilePath?.let {
+            archive = Archive(bookmarkEntity.zimFilePath)
+            Book().apply {
+              update(archive)
+            }
+          } ?: kotlin.run {
+            // for migrating bookmarks for recent custom apps since in recent version of
+            // custom app we are using the `assetFileDescriptor` which does not have the filePath.
+            null
           }
           libkiwixBookmarks.saveBookmark(
             LibkiwixBookmarkItem(bookmarkEntity, libkiwixBook),
             shouldWriteBookmarkToFile = index == bookMarksList.size - 1
           )
-          archive.dispose()
+          archive?.dispose()
           // TODO should we remove data from objectBox?
           // removing the single entity from the object box after migration.
           // box.query {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/LibkiwixBookmarkItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/LibkiwixBookmarkItem.kt
@@ -68,7 +68,7 @@ data class LibkiwixBookmarkItem(
 
   constructor(
     bookmarkEntity: BookmarkEntity,
-    libkiwixBook: Book
+    libkiwixBook: Book?
   ) : this(
     zimId = bookmarkEntity.zimId,
     zimFilePath = bookmarkEntity.zimFilePath,


### PR DESCRIPTION
Fixes #3756 

Recent version of custom apps usages the `assetFileDescriptor` which does not have any path that's why migration is not working in these versions of custom apps. However, with apk version of custom apps migration is working fine. So to address this issue we have adjusted our code to work with assetFileDescriptor as well.