### PR TITLE
Fixed: Opening ZIM file from history that does not exist in fileSystem leads to execpected UI behavior (When already a ZIM file opened in the reader).

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -113,6 +113,12 @@ class KiwixReaderFragment : CoreReaderFragment() {
     )
 
     if (filePath == null || !File(filePath).isFileExist()) {
+      // Close the previously opened book in the reader. Since this file is not found,
+      // it will not be set in the zimFileReader. The previously opened ZIM file
+      // will be saved when we move between fragments. If we return to the reader again,
+      // it will attempt to open the last opened ZIM file with the last loaded URL,
+      // which is inside the non-existing ZIM file. This leads to unexpected behavior.
+      exitBook()
       activity.toast(R.string.error_file_not_found)
       return
     }


### PR DESCRIPTION
Fixes #3762 

* The issue occurs because we are not opening the zim file in the reader because it does not exist in the fileSystem but we are [loading the saved URL in webView](https://github.com/kiwix/kiwix-android/blob/d26c1d7daf3bb4dea40b24cf2ab5d0fd24a3ad60/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt#L99) of that file which does not exist. So when we are switching between fragments then we are opening the previously saved zim file but with the wrong URL which leads to this unexpected behavior. So to fix this we are closing the previously opened book if the new zim file does not exist in the fileSystem.


| Before fix  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/61d8e6bf-be71-4837-a7e0-82614314437d">  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/c6033968-3729-4b19-9b2e-58dc4c41ee65">  |
