### PR TITLE
Fixed: Bookmarks should show in new version of kiwix(`3.10.0`) even the bookmarks related files exist or not in fileSystem.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -142,21 +142,6 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
 
   @Test
   fun testSingleDataMigration(): Unit = runBlocking {
-    val expectedZimName = "Alpine_Linux"
-    val expectedZimId = "60094d1e-1c9a-a60b-2011-4fb02f8db6c3"
-    val expectedZimFilePath = zimFile.canonicalPath
-    val expectedTitle = "Installing"
-    val expectedBookmarkUrl = "https://alpine_linux/InstallingPage"
-    val expectedFavicon = ""
-    val bookmarkEntity = BookmarkEntity(
-      0,
-      expectedZimId,
-      expectedZimName,
-      expectedZimFilePath,
-      expectedBookmarkUrl,
-      expectedTitle,
-      expectedFavicon
-    )
     box.put(bookmarkEntity)
     // migrate data into room database
     objectBoxToLibkiwixMigrator.migrateBookMarks(box)
@@ -168,6 +153,8 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     assertEquals(actualDataAfterMigration[0].zimId, expectedZimId)
     assertEquals(actualDataAfterMigration[0].title, expectedTitle)
     assertEquals(actualDataAfterMigration[0].url, expectedBookmarkUrl)
+    // Clear the bookmarks list from device to not affect the other test cases.
+    clearBookmarks()
   }
 
   @Test
@@ -177,6 +164,8 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     val actualDataAfterMigration =
       objectBoxToLibkiwixMigrator.libkiwixBookmarks.bookmarks().blockingFirst()
     assertTrue(actualDataAfterMigration.isEmpty())
+    // Clear the bookmarks list from device to not affect the other test cases.
+    clearBookmarks()
   }
 
   @Test
@@ -216,6 +205,8 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
         it.url == expectedBookmarkUrl && it.title == expectedTitle
       }
     assertNotNull(newItem)
+    // Clear the bookmarks list from device to not affect the other test cases.
+    clearBookmarks()
   }
 
   @Test
@@ -240,6 +231,61 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     val actualDataAfterMigration =
       objectBoxToLibkiwixMigrator.libkiwixBookmarks.bookmarks().blockingFirst()
     assertEquals(1000, actualDataAfterMigration.size)
+    // Clear the bookmarks list from device to not affect the other test cases.
+    clearBookmarks()
+  }
+
+  @Test
+  fun testMigrationForNewCustomApps(): Unit = runBlocking {
+    val expectedZimId = "60094d1e-1c9a-a60b-2011"
+    val bookmarkEntity = BookmarkEntity(
+      0,
+      expectedZimId,
+      expectedZimName,
+      null,
+      expectedBookmarkUrl,
+      expectedTitle,
+      expectedFavicon
+    )
+    box.put(bookmarkEntity)
+    // migrate data into room database
+    objectBoxToLibkiwixMigrator.migrateBookMarks(box)
+    // check if data successfully migrated to room
+    val actualDataAfterMigration =
+      objectBoxToLibkiwixMigrator.libkiwixBookmarks.bookmarks().blockingFirst()
+    assertEquals(1, actualDataAfterMigration.size)
+    assertEquals(actualDataAfterMigration[0].zimFilePath, null)
+    assertEquals(actualDataAfterMigration[0].zimId, expectedZimId)
+    assertEquals(actualDataAfterMigration[0].title, expectedTitle)
+    assertEquals(actualDataAfterMigration[0].url, expectedBookmarkUrl)
+    // Clear the bookmarks list from device to not affect the other test cases.
+    clearBookmarks()
+  }
+
+  @Test
+  fun testMigrationForNonExistingFiles(): Unit = runBlocking {
+    val expectedZimId = "60094d1e-1c9a-a60b-2011-a60b"
+    val nonExistingPath = "storage/Download/demo/demo.zim"
+    val bookmarkEntity = BookmarkEntity(
+      0,
+      expectedZimId,
+      expectedZimName,
+      nonExistingPath,
+      expectedBookmarkUrl,
+      expectedTitle,
+      expectedFavicon
+    )
+    box.put(bookmarkEntity)
+    // migrate data into room database
+    objectBoxToLibkiwixMigrator.migrateBookMarks(box)
+    // check if data successfully migrated to room
+    val actualDataAfterMigration =
+      objectBoxToLibkiwixMigrator.libkiwixBookmarks.bookmarks().blockingFirst()
+    assertEquals(1, actualDataAfterMigration.size)
+    assertEquals(actualDataAfterMigration[0].zimFilePath, null)
+    assertEquals(actualDataAfterMigration[0].zimId, expectedZimId)
+    assertEquals(actualDataAfterMigration[0].title, expectedTitle)
+    assertEquals(actualDataAfterMigration[0].url, expectedBookmarkUrl)
     // Clear the bookmarks list from device to not affect the other test cases.
     clearBookmarks()
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToLibkiwixMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToLibkiwixMigrator.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.data.remote
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import io.objectbox.Box
 import io.objectbox.BoxStore
 import io.objectbox.kotlin.boxFor
@@ -29,8 +28,10 @@ import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.entities.BookmarkEntity
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.libkiwix.Book
 import org.kiwix.libzim.Archive
+import java.io.File
 import javax.inject.Inject
 
 class ObjectBoxToLibkiwixMigrator {
@@ -57,9 +58,15 @@ class ObjectBoxToLibkiwixMigrator {
           // favicon and zimFilePath in library.
           var archive: Archive? = null
           val libkiwixBook = bookmarkEntity.zimFilePath?.let {
-            archive = Archive(bookmarkEntity.zimFilePath)
-            Book().apply {
-              update(archive)
+            if (File(it).exists()) {
+              archive = Archive(bookmarkEntity.zimFilePath)
+              Book().apply {
+                update(archive)
+              }
+            } else {
+              // Migrate bookmarks even if the file does not exist in the file system,
+              // to display them on the bookmark screen.
+              null
             }
           } ?: kotlin.run {
             // for migrating bookmarks for recent custom apps since in recent version of


### PR DESCRIPTION
Fixes #3765 

* Adding the bookmarks in libkiwix even if the bookmark-related files exist or not in fileSystem. This will ensure all the bookmarks will show on the bookmark screen, and it will improve the user experience.
* Implemented test cases to verify this functionality and to test the migration for new custom apps.