### PR TITLE
Fixed: Spurious message: "Error: Loading article (Url: https://uploadwikimedia.org/wikipedia/commons/6/65/Lock-green.svg"

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -2037,8 +2037,7 @@ abstract class CoreReaderFragment :
 
   override fun webViewFailedLoading(url: String) {
     if (isAdded) {
-      val error = String.format(getString(R.string.error_article_url_not_found), url)
-      Toast.makeText(requireActivity(), error, Toast.LENGTH_SHORT).show()
+      Log.d(TAG_KIWIX, String.format(getString(R.string.error_article_url_not_found), url))
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -149,7 +149,13 @@ open class CoreWebViewClient(
     return if (url.startsWith(ZimFileReader.CONTENT_PREFIX)) {
       zimReaderContainer.load(url, request.requestHeaders)
     } else {
-      super.shouldInterceptRequest(view, request)
+      // Return an empty WebResourceResponse for the external resource to prevent
+      // it from being loaded. Passing null would trigger an attempt to load the resource.
+      WebResourceResponse(
+        "text/css",
+        Charsets.UTF_8.name(),
+        null
+      )
     }
   }
 


### PR DESCRIPTION
Fixes #3647 

* The error toast message is no longer displayed if a URL fails to load. Instead, a debug error message is logged.
* Restricted the loading of external resources when rendering the pages.


| Before Fix  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/bd96889e-7636-4271-855d-029e05781601">  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/6bea7a08-a40b-4c81-bf3b-300211c88be6">  |

