### PR TITLE
Fixed: If restoring the tabs fails it shows the message in English language even if you are using the application in other languages.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -2194,7 +2194,7 @@ abstract class CoreReaderFragment :
       }
     } catch (e: JSONException) {
       Log.w(TAG_KIWIX, "Kiwix shared preferences corrupted", e)
-      activity.toast("Could not restore tabs.", Toast.LENGTH_LONG)
+      activity.toast(R.string.could_not_restore_tabs, Toast.LENGTH_LONG)
     }
   }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -215,6 +215,7 @@
   <string name="switch_tabs">Switch tabs</string>
   <string name="close_all_tabs">Close all tabs</string>
   <string name="close_tab">Close tab</string>
+  <string name="could_not_restore_tabs">Could not restore tabs.</string>
   <string name="pending_state">Pending</string>
   <string name="running_state">In Progress</string>
   <string name="complete">Complete</string>


### PR DESCRIPTION
Fixes #3774 

Fixed a static toast which is showing when there is an error in restoring the tabs. We have moved this static error message to our string file so that it will be translated in every language and user will see the error message in their own language.
