### PR TITLE
Fixed: The wrong message appears while committing the code, if Lint/Static analysis has failed.

### DIFF
--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -14,8 +14,8 @@ else
     echo 1>&2 "Static analysis found violations and attempted to autofix, please commit these autoformat changes"
     echo "
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------
-    If the build failed with '.../.gradle/daemon/5.6.1/custom/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK8
-    Please make sure JAVA_HOME is set to JDK8
+    If the build failed with '.../.gradle/daemon/8.0/custom/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK11
+    Please make sure JAVA_HOME is set to JDK11
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------"
 
     exit 1


### PR DESCRIPTION
Fixes #3779 

Refactored the error message to show the correct information to the developers, since our project needs `JDK11` to run so we have added this JDK version to the error message. Also, corrected the gradle wrapper version in this message.