### PR TITLE
Fixed: Sometimes all the test cases crash on first time and some fail due to the navigation drawer being visible on the window. (Android 13).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,17 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'google_apis' }}
+          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
           arch: x86_64
           profile: pixel_2
-          ram-size: '4096M'
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
+          ram-size: ${{ matrix.api-level == 33 && '6144M' || '4096M' }}
+          cores: ${{ matrix.api-level == 33 && 4 || 2 }}
           disk-size: '14G'
           sdcard-path-or-size: ${{ matrix.api-level != 33 && '1000M' || '4096M' }}
           disable-animations: true
           heap-size: ${{ matrix.api-level == 33 && '512M' || '' }}
+          channel: canary
           script: bash contrib/instrumentation.sh
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
-          ram-size: ${{ matrix.api-level == 33 && '6144M' || '4096M' }}
-          cores: ${{ matrix.api-level == 33 && 4 || 2 }}
-          disk-size: '14G'
+          ram-size: ${{ matrix.api-level != 24 && '6144M' || '4096M' }}
+          cores: ${{ matrix.api-level != 24 && 4 || 2 }}
+          disk-size: ${{ matrix.api-level != 24 && '20G' || '14G' }}
           sdcard-path-or-size: ${{ matrix.api-level != 33 && '1000M' || '4096M' }}
           disable-animations: true
-          heap-size: ${{ matrix.api-level == 33 && '512M' || '' }}
+          heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}
           channel: canary
           script: bash contrib/instrumentation.sh
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -305,9 +305,6 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
   @After
   fun finish() {
     IdlingRegistry.getInstance().unregister(KiwixIdlingResource.getInstance())
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, true)
-    }
   }
 
   companion object {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -87,7 +87,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -60,7 +60,7 @@ class DownloadTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -90,6 +90,7 @@ class DownloadTest : BaseActivityTest() {
       // delete all the ZIM files showing in the LocalLibrary
       // screen to properly test the scenario.
       library {
+        waitUntilZimFilesRefreshing()
         deleteZimIfExists()
         assertNoFilesTextDisplayed()
       }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -92,7 +92,6 @@ class DownloadTest : BaseActivityTest() {
       library {
         waitUntilZimFilesRefreshing()
         deleteZimIfExists()
-        assertNoFilesTextDisplayed()
       }
       downloadRobot {
         clickDownloadOnBottomNav()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -47,7 +47,7 @@ class HelpFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -82,6 +82,7 @@ class InitialDownloadTest : BaseActivityTest() {
     // delete all the ZIM files showing in the LocalLibrary
     // screen to properly test the scenario.
     library {
+      waitUntilZimFilesRefreshing()
       deleteZimIfExists()
       assertNoFilesTextDisplayed()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -84,7 +84,6 @@ class InitialDownloadTest : BaseActivityTest() {
     library {
       waitUntilZimFilesRefreshing()
       deleteZimIfExists()
-      assertNoFilesTextDisplayed()
     }
     initialDownload {
       clickDownloadOnBottomNav()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -55,7 +55,7 @@ class InitialDownloadTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -54,7 +54,7 @@ class IntroFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -66,7 +66,7 @@ class LanguageFragmentTest {
   fun setUp() {
     UiDevice.getInstance(instrumentation).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(instrumentation.targetContext.applicationContext)
+        closeSystemDialogs(instrumentation.targetContext.applicationContext, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -38,6 +38,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.utils.StandardActions
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -82,6 +83,7 @@ class LanguageFragmentTest {
 
   @Test
   fun testLanguageFragment() {
+    StandardActions.closeDrawer() // close the drawer if open before running the test cases.
     language {
       clickDownloadOnBottomNav()
       waitForDataToLoad()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -78,6 +78,8 @@ class LanguageRobot : BaseRobot() {
   }
 
   fun checkIsLanguageSelected() {
+    // Wait for a second to properly visible the searched language on top.
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     onView(
       RecyclerViewMatcher(R.id.language_recycler_view).atPositionOnView(
         1,
@@ -89,6 +91,8 @@ class LanguageRobot : BaseRobot() {
   }
 
   fun deSelectLanguageIfAlreadySelected() {
+    // Wait for a second to properly visible the searched language on top.
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     try {
       onView(
         RecyclerViewMatcher(R.id.language_recycler_view).atPositionOnView(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -40,6 +40,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.utils.StandardActions
 
 class LocalFileTransferTest {
   @Rule
@@ -87,6 +88,7 @@ class LocalFileTransferTest {
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
     }
+    StandardActions.closeDrawer()
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
         it.navigate(R.id.libraryFragment)
@@ -115,6 +117,7 @@ class LocalFileTransferTest {
         it.navigate(R.id.libraryFragment)
       }
     }
+    StandardActions.closeDrawer()
     library {
       assertGetZimNearbyDeviceDisplayed()
       clickFileTransferIcon {
@@ -142,6 +145,7 @@ class LocalFileTransferTest {
         it.navigate(R.id.libraryFragment)
       }
     }
+    StandardActions.closeDrawer()
     library {
       // test show case view show once.
       clickFileTransferIcon(LocalFileTransferRobot::assertClickNearbyDeviceMessageNotVisible)
@@ -170,6 +174,12 @@ class LocalFileTransferTest {
     if (isResetShowCaseId) {
       // To clear showCaseID to ensure the showcase view will show.
       uk.co.deanwild.materialshowcaseview.PrefsManager.resetAll(context)
+    } else {
+      // set that Show Case is showed, because sometimes its change the
+      // order of test case on API level 33 and our test case fails.
+      val internal =
+        context.getSharedPreferences("material_showcaseview_prefs", Context.MODE_PRIVATE)
+      internal.edit().putInt("status_$SHOWCASE_ID", -1).apply()
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -76,7 +76,7 @@ class LocalFileTransferTest {
     context = instrumentation.targetContext.applicationContext
     UiDevice.getInstance(instrumentation).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -49,7 +49,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -54,7 +54,6 @@ class MimeTypeTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
-      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -46,7 +46,7 @@ class MimeTypeTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -69,7 +69,7 @@ class PlayStoreRestrictionDialogTest {
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -31,7 +31,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
+import org.hamcrest.Matchers.not
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
@@ -65,10 +67,21 @@ class LibraryRobot : BaseRobot() {
     isVisible(ViewId(R.id.file_management_no_files))
   }
 
+  fun refreshList() {
+    refresh(R.id.zim_swiperefresh)
+  }
+
+  fun waitUntilZimFilesRefreshing() {
+    try {
+      onView(withId(R.id.scanning_progress_view)).check(matches(not(isDisplayed())))
+    } catch (ignore: AssertionFailedError) {
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+      Log.i("LOCAL_LIBRARY", "Scanning of storage to find ZIM files in progress")
+      waitUntilZimFilesRefreshing()
+    }
+  }
+
   fun deleteZimIfExists() {
-    // pause for a second to load the ZIM files if any contains
-    // in the storage to not affect the test case.
-    pauseForBetterTestPerformance()
     try {
       try {
         onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -66,6 +66,9 @@ class LibraryRobot : BaseRobot() {
   }
 
   fun deleteZimIfExists() {
+    // pause for a second to load the ZIM files if any contains
+    // in the storage to not affect the test case.
+    pauseForBetterTestPerformance()
     try {
       try {
         onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -130,6 +130,7 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnDeleteZimFile() {
+    pauseForBetterTestPerformance()
     onView(withText("DELETE")).perform(click())
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -48,6 +48,7 @@ fun library(func: LibraryRobot.() -> Unit) = LibraryRobot().applyWithViewHierarc
 class LibraryRobot : BaseRobot() {
 
   private val zimFileTitle = "Test_Zim"
+  private var retryCountForRefreshingZimFiles = 5
 
   fun assertGetZimNearbyDeviceDisplayed() {
     isVisible(ViewId(R.id.get_zim_nearby_device))
@@ -77,7 +78,10 @@ class LibraryRobot : BaseRobot() {
     } catch (ignore: AssertionFailedError) {
       BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
       Log.i("LOCAL_LIBRARY", "Scanning of storage to find ZIM files in progress")
-      waitUntilZimFilesRefreshing()
+      if (retryCountForRefreshingZimFiles > 0) {
+        retryCountForRefreshingZimFiles--
+        waitUntilZimFilesRefreshing()
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -86,7 +86,6 @@ class LocalLibraryTest : BaseActivityTest() {
       refreshList()
       waitUntilZimFilesRefreshing()
       deleteZimIfExists()
-      assertNoFilesTextDisplayed()
     }
     // load a zim file to test, After downloading zim file library list is visible or not
     val loadFileStream =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -26,6 +26,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
+import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -82,6 +83,8 @@ class LocalLibraryTest : BaseActivityTest() {
       it.navigate(R.id.libraryFragment)
     }
     library {
+      refreshList()
+      waitUntilZimFilesRefreshing()
       deleteZimIfExists()
       assertNoFilesTextDisplayed()
     }
@@ -107,6 +110,7 @@ class LocalLibraryTest : BaseActivityTest() {
     }
     refresh(R.id.zim_swiperefresh)
     library(LibraryRobot::assertLibraryListDisplayed)
+    LeakAssertions.assertNoLeaks()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -51,7 +51,7 @@ class LocalLibraryTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -144,6 +144,7 @@ class NoteFragmentTest : BaseActivityTest() {
     note(NoteRobot::refreshList)
 
     library {
+      waitUntilZimFilesRefreshing()
       deleteZimIfExists()
       assertNoFilesTextDisplayed()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -41,6 +41,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.utils.StandardActions
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -116,7 +117,7 @@ class NoteFragmentTest : BaseActivityTest() {
           .apply { zimFileUri = zimFile.toUri().toString() }
       )
     }
-
+    StandardActions.closeDrawer() // close the drawer if open before running the test cases.
     note {
       clickOnNoteMenuItem(context)
       assertBackwardNavigationHistoryDialogDisplayed()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -58,7 +58,7 @@ class NoteFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -146,7 +146,6 @@ class NoteFragmentTest : BaseActivityTest() {
     library {
       waitUntilZimFilesRefreshing()
       deleteZimIfExists()
-      assertNoFilesTextDisplayed()
     }
 
     note {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -54,7 +54,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.page.history
 
+import android.util.Log
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
@@ -37,6 +38,19 @@ class NavigationHistoryRobot : BaseRobot() {
   fun checkZimFileLoadedSuccessful(readerFragment: Int) {
     pauseForBetterTestPerformance()
     isVisible(ViewId(readerFragment))
+  }
+
+  fun closeTabSwitcherIfVisible() {
+    try {
+      pauseForBetterTestPerformance()
+      isVisible(ViewId(R.id.tab_switcher_close_all_tabs))
+      pressBack()
+    } catch (ignore: Exception) {
+      Log.i(
+        "NAVIGATION_HISTORY_TEST",
+        "Couldn't found tab switcher, probably it is not visible"
+      )
+    }
   }
 
   fun clickOnAndroidArticle() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
@@ -34,6 +35,10 @@ fun navigationHistory(func: NavigationHistoryRobot.() -> Unit) =
   NavigationHistoryRobot().applyWithViewHierarchyPrinting(func)
 
 class NavigationHistoryRobot : BaseRobot() {
+
+  private var retryCountForClearNavigationHistory = 5
+  private var retryCountForBackwardNavigationHistory = 5
+  private var retryCountForForwardNavigationHistory = 5
 
   fun checkZimFileLoadedSuccessful(readerFragment: Int) {
     pauseForBetterTestPerformance()
@@ -76,8 +81,15 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun assertBackwardNavigationHistoryDialogDisplayed() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    isVisible(TextId(R.string.backward_history))
+    try {
+      isVisible(TextId(R.string.backward_history))
+    } catch (ignore: AssertionFailedError) {
+      pauseForBetterTestPerformance()
+      if (retryCountForBackwardNavigationHistory > 0) {
+        retryCountForBackwardNavigationHistory--
+        assertBackwardNavigationHistoryDialogDisplayed()
+      }
+    }
   }
 
   fun clickOnBackwardButton() {
@@ -86,8 +98,15 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun assertForwardNavigationHistoryDialogDisplayed() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    isVisible(TextId(R.string.forward_history))
+    try {
+      isVisible(TextId(R.string.forward_history))
+    } catch (ignore: AssertionFailedError) {
+      pauseForBetterTestPerformance()
+      if (retryCountForForwardNavigationHistory > 0) {
+        retryCountForForwardNavigationHistory--
+        assertForwardNavigationHistoryDialogDisplayed()
+      }
+    }
   }
 
   fun clickOnDeleteHistory() {
@@ -96,8 +115,15 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun assertDeleteDialogDisplayed() {
-    pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.clear_all_history_dialog_title))
+    try {
+      isVisible(TextId(R.string.clear_all_history_dialog_title))
+    } catch (ignore: AssertionFailedError) {
+      pauseForBetterTestPerformance()
+      if (retryCountForClearNavigationHistory > 0) {
+        retryCountForClearNavigationHistory--
+        assertDeleteDialogDisplayed()
+      }
+    }
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -76,7 +76,7 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun assertBackwardNavigationHistoryDialogDisplayed() {
-    pauseForBetterTestPerformance()
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     isVisible(TextId(R.string.backward_history))
   }
 
@@ -86,7 +86,7 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun assertForwardNavigationHistoryDialogDisplayed() {
-    pauseForBetterTestPerformance()
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     isVisible(TextId(R.string.forward_history))
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -56,7 +56,7 @@ class NavigationHistoryTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -104,8 +104,8 @@ class NavigationHistoryTest : BaseActivityTest() {
     }
     StandardActions.closeDrawer() // close the drawer if open before running the test cases.
     navigationHistory {
-      checkZimFileLoadedSuccessful(R.id.readerFragment)
       closeTabSwitcherIfVisible()
+      checkZimFileLoadedSuccessful(R.id.readerFragment)
       clickOnAndroidArticle()
       longClickOnBackwardButton()
       assertBackwardNavigationHistoryDialogDisplayed()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -40,6 +40,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirecti
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.utils.StandardActions
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -101,8 +102,10 @@ class NavigationHistoryTest : BaseActivityTest() {
           .apply { zimFileUri = zimFile.toUri().toString() }
       )
     }
+    StandardActions.closeDrawer() // close the drawer if open before running the test cases.
     navigationHistory {
       checkZimFileLoadedSuccessful(R.id.readerFragment)
+      closeTabSwitcherIfVisible()
       clickOnAndroidArticle()
       longClickOnBackwardButton()
       assertBackwardNavigationHistoryDialogDisplayed()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -53,7 +53,6 @@ class EncodedUrlTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
-      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -45,7 +45,7 @@ class EncodedUrlTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -55,7 +55,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -65,7 +65,7 @@ class SearchFragmentTest : BaseActivityTest() {
   override fun waitForIdle() {
     uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -61,7 +61,8 @@ class KiwixSettingsFragmentTest {
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
         closeSystemDialogs(
-          InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+          InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+          this
         )
       }
       waitForIdle()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -75,7 +75,7 @@ class KiwixSplashActivityTest {
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context)
+        closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaDialogInteractions
+import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.closeDrawerWithGravity
 import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawerWithGravity
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.R
@@ -41,6 +42,11 @@ object StandardActions {
   fun openDrawer() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
     openDrawerWithGravity(R.id.navigation_container, GravityCompat.START)
+  }
+
+  fun closeDrawer() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    closeDrawerWithGravity(R.id.navigation_container, GravityCompat.START)
   }
 
   @JvmStatic

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -37,6 +37,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.utils.StandardActions
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -103,12 +104,13 @@ class ZimHostFragmentTest {
       activityScenario.onActivity {
         it.navigate(R.id.libraryFragment)
       }
+      StandardActions.closeDrawer() // close the drawer if open before running the test cases.
       zimHost(ZimHostRobot::refreshLibraryList)
       // delete all the ZIM files showing in the LocalLibrary
       // screen to properly test the scenario.
       library {
+        waitUntilZimFilesRefreshing()
         deleteZimIfExists()
-        assertNoFilesTextDisplayed()
       }
       loadZimFileInApplication("testzim.zim")
       loadZimFileInApplication("small.zim")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -77,7 +77,7 @@ class ZimHostFragmentTest {
     context = InstrumentationRegistry.getInstrumentation().targetContext
     UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
       if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context)
+        TestUtils.closeSystemDialogs(context, this)
       }
       waitForIdle()
     }

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -5,6 +5,17 @@ adb shell svc wifi enable
 adb logcat -c
 # shellcheck disable=SC2035
 adb logcat *:E -v color &
+
+PACKAGE_NAME="org.kiwix.kiwixmobile"
+# Function to check if the application is installed
+is_app_installed() {
+  adb shell pm list packages | grep -q "${PACKAGE_NAME}"
+}
+
+if is_app_installed; then
+  # Clear application data to properly run the test cases.
+  adb shell pm clear "${PACKAGE_NAME}"
+fi
 retry=0
 while [ $retry -le 3 ]; do
   if ./gradlew jacocoInstrumentationTestReport; then
@@ -18,13 +29,6 @@ while [ $retry -le 3 ]; do
     adb logcat -c
     # shellcheck disable=SC2035
     adb logcat *:E -v color &
-
-    PACKAGE_NAME="org.kiwix.kiwixmobile"
-
-    # Function to check if the application is installed
-    is_app_installed() {
-      adb shell pm list packages | grep -q "${PACKAGE_NAME}"
-    }
 
     if is_app_installed; then
       # Clear application data to properly run the test cases.


### PR DESCRIPTION
Fixes #3781 
* We are clearing the data of the application on the 2nd and 3rd run, and the test cases are running normally so now we are clearing the application data on the first run as well.
* Improved the `instrumentation.sh` script to clear the application data.
* Additionally, we've implemented drawer closure in `LanguageFragmentTest`, `LocalFileTransferTest`, `NavigationHistoryTest`, `ZimHostFragmentTest`, and `NoteFragmentTest`. These tests sometimes encountered an open navigation drawer due to test failures or process crashes.
* Enhancements have been made to the `testShowCaseFeatureShowOnce` test case. It's now independent of other test cases, ensuring it remains unaffected in the event of a test process crash or failure.
* Improved the `closeSystemDialogs` method since it was not closing the system dialogs on Android 11 and above. So we have improved this method to close the system dialogs on Android 11 and above by clicking on dialog's button instead of sending the broadcast to the system.
* Waiting until the scanning process is running before deleting the ZIM files in the local library screen since it takes a few seconds to load the ZIM files that are available in storage.
* Waiting until the scanning process is running before deleting the ZIM files in the local library screen since it takes a few seconds to load the ZIM files that are available in storage.
* Closing the tabs if visible in `NavigationHistoryTest`, since sometimes tabs are visible in this test case, and the test case does not find the views and fails. https://github.com/kiwix/kiwix-android/actions/runs/8553991850/job/23440408783?pr=3782#step:5:3805
* Added `emulator-options` to exclude the back camera in the emulator. The previous default `emulator-options` are `-no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim`.
* Improved the `LanguageFragmentTest` slightly to wait for the searched language to appear at the top of the list.
* Now running the test cases on the `aosp_atd` system image instead of `google_apis` since `google_apis` is very heavy and most of the time they show the system dialog when running the test cases which leads to test failures. Also, `google_apis` uses more resources like more RAM and CPU usage so the emulator on this `target` lags or starts showing `Launcher not responding`, and other system dialog. So we now start using the `aops_atd` system image which is lightweight as compared to `google_apis`. This system image takes less time to boot the emulator e.g. `google_apis` takes almost 32 minutes to boot and prepare the test cases to run, and `aops_atd` takes 17 minutes to boot and prepare the test cases to run. So almost 15 minutes have been already reduced in running the test cases. Now our CI is very fast as compared to the previous CI.
e.g. previous CI completed the test case on API level 33 in almost 2 hours and 15 minutes (if passed), and now it passes in 46-58 minutes.
See these workflows of API level 33 (ignore the other API level, I was trying some experiments on that):-
     1. https://github.com/kiwix/kiwix-android/actions/runs/8614306925/job/23607452034
     2. https://github.com/kiwix/kiwix-android/actions/runs/8615291157/job/23610514287
     3. https://github.com/kiwix/kiwix-android/actions/runs/8617211930/job/23616630740
* Increased `ram`, `cores`, and `heap-size` for API level 30 emulator for better test performance.
* Improved test performance.
* Fixed a few flaky test cases which sometimes fail on CI.