### PR TITLE
Fixed allocate_buffer_size on CI.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -121,10 +121,6 @@ class DownloadTest : BaseActivityTest() {
   @After
   fun finish() {
     IdlingRegistry.getInstance().unregister(getInstance())
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, false)
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 
   companion object {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -18,9 +18,7 @@
 package org.kiwix.kiwixmobile.help
 
 import android.os.Build
-import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
-import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
@@ -122,9 +120,5 @@ class HelpFragmentTest : BaseActivityTest() {
   @After
   fun finish() {
     IdlingRegistry.getInstance().unregister(KiwixIdlingResource.getInstance())
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, false)
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.initial.download
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -34,15 +33,14 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 fun initialDownload(func: InitialDownloadRobot.() -> Unit) =
   InitialDownloadRobot().applyWithViewHierarchyPrinting(func)
 
 class InitialDownloadRobot : BaseRobot() {
-
-  private var retryCountForCheckDownloadStart = 10
-  private var retryCountForCheckDataLoaded = 10
   private val zimFileTitle = "Off the Grid"
 
   fun clickDownloadOnBottomNav() {
@@ -67,14 +65,7 @@ class InitialDownloadRobot : BaseRobot() {
   }
 
   fun waitForDataToLoad() {
-    try {
-      isVisible(Text(zimFileTitle))
-    } catch (e: RuntimeException) {
-      if (retryCountForCheckDataLoaded > 0) {
-        retryCountForCheckDataLoaded--
-        waitForDataToLoad()
-      }
-    }
+    testFlakyView({ isVisible(Text(zimFileTitle)) }, 10)
   }
 
   fun downloadZimFile() {
@@ -82,26 +73,19 @@ class InitialDownloadRobot : BaseRobot() {
   }
 
   fun assertStorageConfigureDialogDisplayed() {
-    isVisible(Text("Download book to internal storage?"))
+    testFlakyView({ isVisible(Text("Download book to internal storage?")) })
   }
 
   fun assertStopDownloadDialogDisplayed() {
-    isVisible(Text("Stop download?"))
+    testFlakyView({ isVisible(Text("Stop download?")) })
   }
 
   fun clickOnYesToConfirm() {
-    onView(withText("YES")).perform(click())
+    testFlakyView({ onView(withText("YES")).perform(click()) })
   }
 
   fun assertDownloadStart() {
-    try {
-      isVisible(ViewId(R.id.stop))
-    } catch (e: RuntimeException) {
-      if (retryCountForCheckDownloadStart > 0) {
-        retryCountForCheckDownloadStart--
-        assertDownloadStart()
-      }
-    }
+    testFlakyView({ isVisible(ViewId(R.id.stop)) }, 10)
   }
 
   fun stopDownload() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -28,7 +28,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -101,14 +100,5 @@ class InitialDownloadTest : BaseActivityTest() {
       assertDownloadStop()
     }
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun setPrefStorageOption() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
-      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, false)
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -20,8 +20,8 @@ package org.kiwix.kiwixmobile.language
 import android.Manifest
 import android.app.Instrumentation
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
 import androidx.lifecycle.Lifecycle
+import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -32,6 +32,7 @@ import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 
 fun language(func: LanguageRobot.() -> Unit) = LanguageRobot().applyWithViewHierarchyPrinting(func)
@@ -70,7 +71,7 @@ class LanguageRobot : BaseRobot() {
   }
 
   fun selectLanguage(matchLanguage: String) {
-    clickOn(Text(matchLanguage))
+    testFlakyView({ clickOn(Text(matchLanguage)) })
   }
 
   fun clickOnSaveLanguageIcon() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -18,8 +18,11 @@
 
 package org.kiwix.kiwixmobile.localFileTransfer
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
@@ -28,6 +31,7 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 /**
  * Authored by Ayush Shrivastava on 29/10/20
@@ -52,7 +56,22 @@ class LocalFileTransferRobot : BaseRobot() {
 
   fun assertLocalFileTransferScreenVisible() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+    closeEnableWifiP2PDialogIfVisible()
     assertReceiveFileTitleVisible()
+  }
+
+  private fun closeEnableWifiP2PDialogIfVisible() {
+    try {
+      testFlakyView({
+        onView(withText(R.string.request_enable_wifi)).check(matches(isDisplayed()))
+        pressBack()
+      })
+    } catch (ignore: Throwable) {
+      Log.i(
+        "LOCAL_FILE_TRANSFER_TEST",
+        "Couldn't found WIFI P2P dialog, probably this is not exist"
+      )
+    }
   }
 
   fun assertLocalLibraryVisible() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -30,7 +30,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -149,14 +148,6 @@ class LocalFileTransferTest {
     library {
       // test show case view show once.
       clickFileTransferIcon(LocalFileTransferRobot::assertClickNearbyDeviceMessageNotVisible)
-    }
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, true)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
@@ -38,6 +38,7 @@ import org.kiwix.kiwixmobile.page.history.history
 import org.kiwix.kiwixmobile.settings.SettingsRobot
 import org.kiwix.kiwixmobile.settings.settingsRobo
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.StandardActions.openDrawer
 import org.kiwix.kiwixmobile.webserver.ZimHostRobot
 import org.kiwix.kiwixmobile.webserver.zimHost
@@ -115,6 +116,6 @@ class TopLevelDestinationRobot : BaseRobot() {
   }
 
   fun assertExternalLinkDialogDisplayed() {
-    isVisible(TextId(R.string.external_link_popup_dialog_title))
+    testFlakyView({ isVisible(TextId(R.string.external_link_popup_dialog_title)) })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -24,7 +24,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,13 +95,5 @@ class TopLevelDestinationTest : BaseActivityTest() {
       pressBack()
     }
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, true)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -41,6 +41,7 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
 import org.kiwix.kiwixmobile.localFileTransfer.localFileTransfer
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewItemCount
 
 fun library(func: LibraryRobot.() -> Unit) = LibraryRobot().applyWithViewHierarchyPrinting(func)
@@ -49,7 +50,6 @@ class LibraryRobot : BaseRobot() {
 
   private val zimFileTitle = "Test_Zim"
   private var retryCountForRefreshingZimFiles = 5
-  private var retryCountForDeletingZimFiles = 5
 
   fun assertGetZimNearbyDeviceDisplayed() {
     isVisible(ViewId(R.id.get_zim_nearby_device))
@@ -66,7 +66,7 @@ class LibraryRobot : BaseRobot() {
 
   private fun assertNoFilesTextDisplayed() {
     pauseForBetterTestPerformance()
-    isVisible(ViewId(R.id.file_management_no_files))
+    testFlakyView({ isVisible(ViewId(R.id.file_management_no_files)) })
   }
 
   fun refreshList() {
@@ -121,25 +121,13 @@ class LibraryRobot : BaseRobot() {
 
   private fun clickOnFileDeleteIcon() {
     pauseForBetterTestPerformance()
-    clickOn(ViewId(R.id.zim_file_delete_item))
+    testFlakyView({ clickOn(ViewId(R.id.zim_file_delete_item)) })
   }
 
   private fun clickOnDeleteZimFile() {
     // This code is flaky since the DELETE button is inside the dialog, and sometimes it visible
-    // but not on window but espresso unable to find it so we are adding a retrying mechanism here.
-    try {
-      onView(withText("DELETE")).inRoot(isDialog()).perform(click())
-    } catch (ignore: AssertionFailedError) {
-      pauseForBetterTestPerformance()
-      Log.i(
-        "LOCAL_LIBRARY",
-        "Couldn't found the DELETE button, so we are trying again to find the DELETE button"
-      )
-      if (retryCountForDeletingZimFiles > 0) {
-        retryCountForDeletingZimFiles--
-        clickOnDeleteZimFile()
-      }
-    }
+    // on window but espresso unable to find it so we are adding a retrying mechanism here.
+    testFlakyView({ onView(withText("DELETE")).inRoot(isDialog()).perform(click()) })
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -27,7 +27,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -110,14 +109,5 @@ class LocalLibraryTest : BaseActivityTest() {
     refresh(R.id.zim_swiperefresh)
     library(LibraryRobot::assertLibraryListDisplayed)
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun finish() {
-    PreferenceManager.getDefaultSharedPreferences(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, true)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -28,7 +28,6 @@ import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -158,12 +157,5 @@ class NoteFragmentTest : BaseActivityTest() {
       pressBack()
     }
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -36,12 +36,12 @@ import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.StandardActions.openDrawer
 
 fun note(func: NoteRobot.() -> Unit) = NoteRobot().apply(func)
 
 class NoteRobot : BaseRobot() {
-
   private val noteText = "Test Note"
   private val editTextId = R.id.add_note_edit_text
 
@@ -95,12 +95,13 @@ class NoteRobot : BaseRobot() {
   }
 
   fun clickOnOpenNote() {
-    pauseForBetterTestPerformance()
-    clickOn(Text("OPEN NOTE"))
+    testFlakyView({ clickOn(Text("OPEN NOTE")) })
   }
 
   fun assertNoteSaved() {
-    isVisible(Text(noteText))
+    // This is flaky since it is shown in a dialog and sometimes
+    // UIDevice does not found the view immediately due to rendering process.
+    testFlakyView({ isVisible(Text(noteText)) })
   }
 
   fun refreshList() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -32,6 +32,7 @@ import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import java.util.concurrent.TimeUnit
 
 fun bookmarks(func: BookmarksRobot.() -> Unit) =
@@ -50,16 +51,16 @@ class BookmarksRobot : BaseRobot() {
   }
 
   fun assertDeleteBookmarksDialogDisplayed() {
-    isVisible(TextId(R.string.delete_bookmarks))
+    testFlakyView({ isVisible(TextId(R.string.delete_bookmarks)) })
   }
 
   fun clickOnDeleteButton() {
     pauseForBetterTestPerformance()
-    onView(withText("DELETE")).perform(click())
+    testFlakyView({ onView(withText("DELETE")).perform(click()) })
   }
 
   fun assertNoBookMarkTextDisplayed() {
-    isVisible(TextId(R.string.no_bookmarks))
+    testFlakyView({ isVisible(TextId(R.string.no_bookmarks)) })
   }
 
   fun clickOnSaveBookmarkImage() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
@@ -24,6 +24,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 fun history(func: HistoryRobot.() -> Unit) = HistoryRobot().applyWithViewHierarchyPrinting(func)
 
@@ -38,6 +39,6 @@ class HistoryRobot : BaseRobot() {
   }
 
   fun assertDeleteHistoryDialogDisplayed() {
-    isVisible(TextId(R.string.delete_history))
+    testFlakyView({ isVisible(TextId(R.string.delete_history)) })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -28,7 +28,6 @@ import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -119,12 +118,5 @@ class NavigationHistoryTest : BaseActivityTest() {
       pressBack()
     }
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -28,7 +28,6 @@ import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -110,12 +109,5 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       checkZimFileLoadedSuccessful(R.id.readerFragment)
     }
     LeakAssertions.assertNoLeaks()
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -30,7 +30,6 @@ import leakcanary.LeakAssertions
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -235,12 +234,5 @@ class SearchFragmentTest : BaseActivityTest() {
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     return zimFile
-  }
-
-  @After
-  fun setIsTestPreference() {
-    PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, false)
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -32,6 +32,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 /**
  * Authored by Ayush Shrivastava on 25/8/20
@@ -111,7 +112,8 @@ class SettingsRobot : BaseRobot() {
   }
 
   fun assertContributorsDialogDisplayed() {
-    isVisible(Text("OK"))
+    // this is inside the dialog and dialog takes a bit to show on the screen.
+    testFlakyView({ isVisible(Text("OK")) })
   }
 
   fun assertZoomTextViewPresent() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -46,6 +46,7 @@ import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
@@ -54,9 +55,6 @@ class KiwixSplashActivityTest {
   @Rule
   @JvmField
   var retryRule = RetryRule()
-
-  private val activityScenario: ActivityScenario<KiwixMainActivity> =
-    ActivityScenario.launch(KiwixMainActivity::class.java)
 
   private val permissions = arrayOf(
     Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -84,12 +82,13 @@ class KiwixSplashActivityTest {
   @Test
   fun testFirstRun() {
     shouldShowIntro(true)
-    activityScenario.recreate()
-    activityScenario.onActivity {
+    ActivityScenario.launch(KiwixMainActivity::class.java).onActivity {
     }
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    Espresso.onView(ViewMatchers.withId(R.id.get_started))
-      .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    testFlakyView({
+      Espresso.onView(ViewMatchers.withId(R.id.get_started))
+        .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+    }, 10)
 
     // Verify that the value of the "intro shown" boolean inside
     // the SharedPreferences Database is not changed until

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -193,4 +193,20 @@ object TestUtils {
       .map { uiDevice.findObject(UiSelector().textContains(it)) }
       .firstOrNull(UiObject::exists)
   }
+
+  @JvmStatic
+  fun testFlakyView(
+    action: () -> Unit,
+    retryCount: Int = 5
+  ) {
+    try {
+      action()
+    } catch (ignore: Throwable) {
+      if (retryCount > 0) {
+        testFlakyView(action, retryCount - 1)
+      } else {
+        throw ignore // No more retries, rethrow the exception
+      }
+    }
+  }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -162,6 +162,10 @@ object TestUtils {
     uiDevice.findObject(textContains("System UI isn't responding")) != null ||
       uiDevice.findObject(textContains("Process system isn't responding")) != null ||
       uiDevice.findObject(textContains("Launcher isn't responding")) != null ||
+      uiDevice.findObject(textContains("Wait")) != null ||
+      uiDevice.findObject(textContains("WAIT")) != null ||
+      uiDevice.findObject(textContains("OK")) != null ||
+      uiDevice.findObject(textContains("Ok")) != null ||
       uiDevice.findObject(By.clazz("android.app.Dialog")) != null
 
   @JvmStatic

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -27,7 +27,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import leakcanary.LeakAssertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -179,14 +178,6 @@ class ZimHostFragmentTest {
           it.write(buffer, 0, length)
         }
       }
-    }
-  }
-
-  @After
-  fun setIsTestPreference() {
-    sharedPreferenceUtil.apply {
-      setIsPlayStoreBuildType(false)
-      prefIsTest = false
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.webserver
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -35,7 +34,9 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewItemCount
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 import org.kiwix.kiwixmobile.utils.RecyclerViewSelectedCheckBoxCountAssertion
@@ -74,17 +75,18 @@ class ZimHostRobot : BaseRobot() {
     stopServerIfAlreadyStarted()
     clickOn(ViewId(R.id.startServerButton))
     assetWifiDialogDisplayed()
-    onView(withText("PROCEED")).perform(click())
+    testFlakyView({ onView(withText("PROCEED")).perform(click()) })
   }
 
   private fun assetWifiDialogDisplayed() {
-    pauseForBetterTestPerformance()
-    isVisible(Text("WiFi connection detected"))
+    testFlakyView({ isVisible(Text("WiFi connection detected")) })
   }
 
   fun assertServerStarted() {
     pauseForBetterTestPerformance()
-    isVisible(Text("STOP SERVER"))
+    // starting server takes a bit so sometimes it fails to find this view.
+    // which makes this view flaky so we are testing this with FlakyView.
+    testFlakyView({ isVisible(Text("STOP SERVER")) })
   }
 
   fun stopServerIfAlreadyStarted() {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
@@ -22,26 +22,24 @@ import androidx.appcompat.app.AppCompatActivity
 import io.mockk.Called
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchListItem
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class SaveSearchToRecentsTest {
 
   private val newRecentSearchDao: NewRecentSearchDao = mockk()
   private val searchListItem = RecentSearchListItem("", ZimFileReader.CONTENT_PREFIX)
 
   private val activity: AppCompatActivity = mockk()
-  private val testDispatcher = TestScope()
+  private val testDispatcher = CoroutineScope(Dispatchers.IO)
 
   @Test
-  fun `invoke with null Id does nothing`() {
+  fun `invoke with null Id does nothing`() = runBlocking {
     SaveSearchToRecents(
       newRecentSearchDao,
       searchListItem,
@@ -54,7 +52,7 @@ internal class SaveSearchToRecentsTest {
   }
 
   @Test
-  fun `invoke with non null Id saves search`() = testDispatcher.runTest {
+  fun `invoke with non null Id saves search`() = runBlocking {
     val id = "id"
     SaveSearchToRecents(
       newRecentSearchDao,
@@ -62,7 +60,6 @@ internal class SaveSearchToRecentsTest {
       id,
       testDispatcher
     ).invokeWith(activity)
-    testDispatcher.advanceUntilIdle()
     verify { newRecentSearchDao.saveSearch(searchListItem.value, id, ZimFileReader.CONTENT_PREFIX) }
   }
 }


### PR DESCRIPTION
The last CI failed in https://github.com/kiwix/kiwix-android/pull/3738 due to buffer size exceeding https://github.com/kiwix/kiwix-android/actions/runs/8643117644/job/23695477416?pr=3738#step:5:8087, so in this PR, we are fixing that issue.

* The allocated buffer size was exceeded due to the retry policy of our test cases. When we retry a test, more objects are allocated to memory, causing this issue.
* When retrying a test case that failed initially, the "MANAGE_EXTERNAL_STORAGE" permission dialog appears on the window due to clearing the preferences in our test case. Therefore, we have removed that code from our test cases.
* Enhanced the test code to detect the views inside the dialogs since our test cases fail due to these dialog's views, which take a moment to appear on the window, making our test cases flaky on CI. This is also the reason for allocating more objects in memory when we retry the test case.
* Improved the `LocalFileTransferTest` as it sometimes fails on API level 33 due to the unavailability of WIFI. When WIFI is not available, the "Enable WIFI P2P" dialog appears on the window, causing our test case to fail. Subsequently, our RetryRule attempts to run this test case again, leading to the allocation of more objects in memory.
* Created a `testFlakyView` function this function helps test the flakyViews.
* Improved the system dialog checking method, Last CI failed due to a system dialog being visible but with a different title so closing the system dialog code does not work in this situation So we have improved a bit this method, because most of the system dialog contains the "WAIT", "Wait", "OK" or "Ok" buttons. https://github.com/kiwix/kiwix-android/actions/runs/8661447460/job/23751364304?pr=3785
* Improved ZimHostFragmentTest which is sometimes unable to find the "PROCEED" button.