### PR TITLE
Changing runner to `ubuntu-latest`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         api-level: [ 24, 30, 33 ]
       fail-fast: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           key: avd-${{ matrix.api-level }}
 
       - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+        # if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -82,6 +82,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
+          force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
     strategy:
       matrix:
         api-level: [ 24, 30, 33 ]
-      fail-fast: false
-    runs-on: macos-11
+      fail-fast: true
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11
@@ -37,8 +37,41 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          arch: x86_64
+          profile: pixel_2
+          ram-size: 4096M
+          force-avd-creation: false
+          sdcard-path-or-size: 2048M
+          cores: 4
+          disable-animations: false
+          heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          channel: canary
+          script: echo "Generated AVD snapshot for caching."
+
       - name: create instrumentation coverage
-        uses: ReactiveCircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2
         env:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
@@ -46,11 +79,10 @@ jobs:
           target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none
-          ram-size: ${{ matrix.api-level != 24 && '6144M' || '4096M' }}
-          cores: ${{ matrix.api-level != 24 && 4 || 2 }}
-          disk-size: ${{ matrix.api-level != 24 && '20G' || '14G' }}
-          sdcard-path-or-size: ${{ matrix.api-level != 33 && '1000M' || '4096M' }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          ram-size: 4096M
+          cores: 4
+          sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}
           channel: canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           key: avd-${{ matrix.api-level }}
 
       - name: Create AVD and generate snapshot for caching
-        # if: steps.avd-cache.outputs.cache-hit != 'true'
+        if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}


### PR DESCRIPTION
Fixes #3784 

* Changed the runner of CI to `ubuntu-22.04` to boost the performance.
*  Enabled the `fail-fast` option in CI, if any of the jobs fail on any emulator then it will cancel all jobs running on other emulators in the current process so that other PRs do not need to wait to finish this job. Also, this will reduce the running timing on CI since if a job fails on any emulator we need to fix that so running other jobs does not make sense. So we are canceling those jobs if any fail.
* Introducing caching for AVD to run test cases faster. It reduced the emulator's boot time. [More details]( https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#usage--examples)
* Removed the 'disk-size' option since it was throwing an error, causing the emulator not to boot. Also, reduced the SD card size to 2GB from 4GB.


After moving to `ubuntu` runner our CI has now started completing in 20-22 minutes https://github.com/kiwix/kiwix-android/actions/runs/8686630570/job/23818493032. We have introduced the avd cache mechanism that reduces the CI times by 4-5 minutes see https://github.com/kiwix/kiwix-android/actions/runs/8687288698/job/23820501975?pr=3786. The CI is now completing 15-20 minutes.

| API level  | Before time | After time |
| ------------- | ------------- | ------------- |
| 24 | 33-40 Minutes | 14-16 Minutes |
| 30  | 44-55Minutes  | 17-20Minutes |
| 33 | 40-45 Minutes | 13-16 Minutes |