### PR TITLE
Fixed: Play Store reported a crash error when closing the tabs.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1215,7 +1215,10 @@ abstract class CoreReaderFragment :
     snackBarRoot?.let {
       it.bringToFront()
       Snackbar.make(it, R.string.tab_closed, Snackbar.LENGTH_LONG)
-        .setAction(R.string.undo) { restoreDeletedTab(index) }.show()
+        .setAction(R.string.undo) { undoButton ->
+          undoButton.isEnabled = false
+          restoreDeletedTab(index)
+        }.show()
     }
     openHomeScreen()
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1198,6 +1198,10 @@ abstract class CoreReaderFragment :
     if (currentTtsWebViewIndex == index) {
       onReadAloudStop()
     }
+    // Check if the index is valid; RecyclerView gives the index -1 for already removed views.
+    // Address those issues when the user frequently clicks on the close icon of the same tab.
+    // See https://github.com/kiwix/kiwix-android/issues/3790 for more details.
+    if (index == RecyclerView.NO_POSITION) return
     tempZimFileForUndo = zimReaderContainer?.zimFile
     tempWebViewForUndo = webViewList[index]
     webViewList.removeAt(index)


### PR DESCRIPTION
Fixes #3790 

This error was occurring due to the user frequently clicking the close icon of the same tab, in this situation first click closes the tab, and the second immediate click again triggers the `closeTab` function but recyclerView does not have the valid view for this position because it is in removing process so this makes this view invalid and recyclerView returns the `-1` index for invalid views. So this was the reason for this issue, to address this issue we have added a check in our `closeTab` method if the incoming index is `-1` then it will not execute the further code.

| Issue  | Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/898873c4-9bf0-4201-9b27-6b528b3db7b8">  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/4ed0468b-713d-4b58-853c-33604fd9ec61">  |

* Enhanced the `Tab closed` snackBar behavior. Now, when the user clicks the `UNDO` button to restore a tab, we disable the snackBar's "UNDO" button to prevent subsequent clicks. This prevents the addition of multiple tabs if the `UNDO` button is clicked multiple times, as this type of restored tab leads to unexpected behavior see below video.

https://github.com/kiwix/kiwix-android/assets/34593983/dca5aeb5-7127-457d-8bed-ca088f9cf76f

