### PR TITLE
Fixed: Tabs are not restoring if we accidentally click twice on the Close all tabs button.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -704,6 +704,7 @@ abstract class CoreReaderFragment :
     closeAllTabsButton?.setToolTipWithContentDescription(
       resources.getString(R.string.close_all_tabs)
     )
+    setIsCloseAllTabButtonClickable(true)
     // Set a negative top margin to the web views to remove
     // the unwanted blank space caused by the toolbar.
     setTopMarginToWebViews(-requireActivity().getToolbarHeight())
@@ -1631,7 +1632,10 @@ abstract class CoreReaderFragment :
   @OnClick(R2.id.tab_switcher_close_all_tabs)
   fun closeAllTabs() {
     onReadAloudStop()
-    closeAllTabsButton?.rotate()
+    closeAllTabsButton?.apply {
+      rotate()
+      setIsCloseAllTabButtonClickable(false)
+    }
     tempZimFileForUndo = zimReaderContainer?.zimFile
     tempWebViewListForUndo.apply {
       clear()
@@ -1644,11 +1648,17 @@ abstract class CoreReaderFragment :
       root.bringToFront()
       Snackbar.make(root, R.string.tabs_closed, Snackbar.LENGTH_LONG).apply {
         setAction(R.string.undo) {
+          it.isEnabled = false // to prevent multiple clicks on this button
+          setIsCloseAllTabButtonClickable(true)
           restoreDeletedTabs()
         }
         show()
       }
     }
+  }
+
+  private fun setIsCloseAllTabButtonClickable(isClickable: Boolean) {
+    closeAllTabsButton?.isClickable = isClickable
   }
 
   private fun restoreDeletedTabs() {


### PR DESCRIPTION
Fixes #3792 

* This issue occurred because when the Close all tabs button was first clicked, it closed all tabs and stored them into the temp list, emptying the main list. However, if the button was immediately clicked again, it would attempt to copy the main list to the temp list, which was already empty. To address this issue, we have disabled the button after the first click to prevent such situations, as they can occur due to accidental clicks.
* Enhanced the behavior of the "Tabs closed" snackBar. Now, when the user clicks the "UNDO" button to restore a tab, we disable the snackBar's "UNDO" button to prevent subsequent clicks. This prevents the addition of multiple tabs if the "UNDO" button is clicked multiple times, as such restored tabs can lead to unexpected behavior.

| Before FIx  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/0e310dbb-7714-4464-8c1a-b81b002d119e">  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/c547caca-1549-4e0c-9b29-4e45027da687">  |