### PR TITLE
Fixed: PlayStore reported `UninitializedPropertyAccessException` when launching the `KiwixMainActivity`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -37,7 +37,6 @@ import org.kiwix.kiwixmobile.BuildConfig
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
-import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.downloader.fetch.DOWNLOAD_NOTIFICATION_TITLE
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
@@ -93,9 +92,6 @@ class KiwixMainActivity : CoreMainActivity() {
   private lateinit var activityKiwixMainBinding: ActivityKiwixMainBinding
 
   private var isIntroScreenVisible: Boolean = false
-  override fun injection(coreComponent: CoreComponent) {
-    cachedComponent.inject(this)
-  }
 
   private val finishActionModeOnDestinationChange =
     NavController.OnDestinationChangedListener { _, _, _ ->
@@ -103,6 +99,7 @@ class KiwixMainActivity : CoreMainActivity() {
     }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    cachedComponent.inject(this)
     super.onCreate(savedInstanceState)
     activityKiwixMainBinding = ActivityKiwixMainBinding.inflate(layoutInflater)
     setContentView(activityKiwixMainBinding.root)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
@@ -22,23 +22,18 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import butterknife.ButterKnife
 import butterknife.Unbinder
-import org.kiwix.kiwixmobile.core.CoreApp
-import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
 
-abstract class BaseActivity : AppCompatActivity() {
+open class BaseActivity : AppCompatActivity() {
 
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
   private var unbinder: Unbinder? = null
 
-  protected abstract fun injection(coreComponent: CoreComponent)
-
   override fun onCreate(savedInstanceState: Bundle?) {
-    injection(CoreApp.coreComponent)
     super.onCreate(savedInstanceState)
     LanguageUtils.handleLocaleChange(this, sharedPreferenceUtil)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -25,12 +25,12 @@ import android.os.Process
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInformation
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.databinding.ActivityKiwixErrorBinding
-import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
 import org.kiwix.kiwixmobile.core.utils.files.FileLogger
@@ -61,6 +61,7 @@ open class ErrorActivity : BaseActivity() {
   var activityKiwixErrorBinding: ActivityKiwixErrorBinding? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    coreComponent.inject(this)
     super.onCreate(savedInstanceState)
     activityKiwixErrorBinding = ActivityKiwixErrorBinding.inflate(layoutInflater)
     setContentView(activityKiwixErrorBinding?.root)
@@ -221,10 +222,6 @@ open class ErrorActivity : BaseActivity() {
     startActivity(restartAppIntent)
     finish()
     killCurrentProcess()
-  }
-
-  override fun injection(coreComponent: CoreComponent) {
-    coreComponent.inject(this)
   }
 
   companion object {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -27,7 +27,6 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.navigation.NavigationView
-import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.extensions.browserIntent
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.custom.BuildConfig
@@ -74,11 +73,8 @@ class CustomMainActivity : CoreMainActivity() {
 
   private lateinit var activityCustomMainBinding: ActivityCustomMainBinding
 
-  override fun injection(coreComponent: CoreComponent) {
-    customActivityComponent.inject(this)
-  }
-
   override fun onCreate(savedInstanceState: Bundle?) {
+    customActivityComponent.inject(this)
     super.onCreate(savedInstanceState)
     activityCustomMainBinding = ActivityCustomMainBinding.inflate(layoutInflater)
     setContentView(activityCustomMainBinding.root)


### PR DESCRIPTION
Fixes #3794 

* This error was not reproducible on my device and emulators too. But playstore reported this error, and there are 8 occurrences in the last 60 days. So I have check the code and found that code is causing the error that is unused for `KiwixMainActivity`.
* The error was occurring when launching the `KiwixMainActivity`. At this moment, `coreComponent` was in creation process so it is not initialized at this moment, and we are passing this component in our `KiwixMainActivity` through interface for injection of this activity. But we are not using `coreComponent` object in our `KiwixMainActivity` so passing it to the activity is unused because we are injecting this activity through `cachedComponent`, and this unused object causing the error. So we have removed this interface from our `BaseActivity` and directly injecting `KiwixMainActivity` in via `cachedComponent`.
* This interface was used in `KiwixMainActivity`, `CustomMainActivity`, and `ErrorActivity`. In `KiwixMainActivity` and `CustomMainActivity` this interface was unused since we are not using `CoreComponent` to inject these activities. For the `ErrorActivity`, we are now directly using the `CoreComponent` to inject this activity.
