### PR TITLE
Fixed: PlayStore reported IndexOutOfBoundsException, when we are selecting the item from rightDrawer.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -678,14 +678,25 @@ abstract class CoreReaderFragment :
       }
 
       override fun onSectionClick(view: View?, position: Int) {
-        loadUrlWithCurrentWebview(
-          "javascript:document.getElementById('" +
-            documentSections?.get(position)?.id?.replace("'", "\\'") +
-            "').scrollIntoView();"
-        )
+        if (hasItemForPositionInDocumentSectionsList(position)) { // Bug Fix #3796
+          loadUrlWithCurrentWebview(
+            "javascript:document.getElementById('" +
+              documentSections?.get(position)?.id?.replace("'", "\\'") +
+              "').scrollIntoView();"
+          )
+        }
         drawerLayout?.closeDrawers()
       }
     })
+  }
+
+  private fun hasItemForPositionInDocumentSectionsList(position: Int): Boolean {
+    val documentListSize = documentSections?.size ?: return false
+    return when {
+      position < 0 -> false
+      position >= documentListSize -> false
+      else -> true
+    }
   }
 
   private fun showTabSwitcher() {


### PR DESCRIPTION
Fixes #3796 

The error is not reproducible on my device and emulators too. But playStore reported this error so somehow this error is occurring. So to fix this issue we are now only performing the click action when the item is available in the `DocumentSectionsList`. This will avoid this type of error.
