### PR TITLE
Fixed: Not able to upload 512MB+ custom apps anymore.  

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -84,7 +84,7 @@ class MimeTypeTest : BaseActivityTest() {
     val archive = Archive(zimFile.canonicalPath)
     val zimFileReader = ZimFileReader(
       zimFile,
-      null,
+      emptyList(),
       null,
       archive,
       NightModeConfig(SharedPreferenceUtil(context), context),

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -92,7 +92,7 @@ class EncodedUrlTest : BaseActivityTest() {
     val archive = Archive(zimFile.canonicalPath)
     val zimFileReader = ZimFileReader(
       zimFile,
-      null,
+      emptyList(),
       null,
       archive,
       NightModeConfig(SharedPreferenceUtil(context), context),

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -121,7 +121,7 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
       val archive = Archive(zimFile.canonicalPath)
       val zimFileReader = ZimFileReader(
         zimFile,
-        null,
+        emptyList(),
         null,
         archive,
         NightModeConfig(SharedPreferenceUtil(context), context),

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -199,7 +199,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
   override fun onResume() {
     super.onResume()
     if (zimReaderContainer?.zimFile == null &&
-      zimReaderContainer?.zimFileReader?.assetFileDescriptor == null
+      zimReaderContainer?.zimFileReader?.assetFileDescriptorList?.isEmpty() == true
     ) {
       exitBook()
     }

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -48,8 +48,6 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       buildConfigField("String", "ENFORCED_LANG", "\"${customApp.enforcedLanguage}\"")
       buildConfigField("String", "ABOUT_APP_URL", "\"${customApp.aboutAppUrl}\"")
       buildConfigField("String", "SUPPORT_URL", "\"${customApp.supportUrl}\"")
-      // Add asset file name in buildConfig file, we will use later to receive the zim file.
-      buildConfigField("String", "PLAY_ASSET_FILE", "\"${customApp.name}.zim\"")
       buildConfigField("Boolean", "DISABLE_SIDEBAR", "${customApp.disableSideBar}")
       buildConfigField("Boolean", "DISABLE_TABS", "${customApp.disableTabs}")
       buildConfigField("Boolean", "DISABLE_READ_ALOUD", "${customApp.disableReadAloud}")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1624,10 +1624,12 @@ abstract class CoreReaderFragment :
 
       val zimFileReader = zimReaderContainer.zimFileReader
       zimFileReader?.let { zimFileReader ->
-        // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
-        openArticle(UNINITIALISER_ADDRESS)
-        mainMenu?.onFileOpened(urlIsValid())
-        setUpBookmarks(zimFileReader)
+        Handler(Looper.getMainLooper()).post {
+          // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
+          openArticle(UNINITIALISER_ADDRESS)
+          mainMenu?.onFileOpened(urlIsValid())
+          setUpBookmarks(zimFileReader)
+        }
       } ?: kotlin.run {
         requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1554,7 +1554,7 @@ abstract class CoreReaderFragment :
   protected fun openZimFile(
     file: File?,
     isCustomApp: Boolean = false,
-    assetFileDescriptor: AssetFileDescriptor? = null,
+    assetFileDescriptorList: List<AssetFileDescriptor> = emptyList(),
     filePath: String? = null
   ) {
     if (hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE) || isCustomApp) {
@@ -1564,10 +1564,10 @@ abstract class CoreReaderFragment :
         reopenBook()
         openAndSetInContainer(file = file)
         updateTitle()
-      } else if (assetFileDescriptor != null) {
+      } else if (assetFileDescriptorList.isNotEmpty()) {
         reopenBook()
         openAndSetInContainer(
-          assetFileDescriptor = assetFileDescriptor,
+          assetFileDescriptorList = assetFileDescriptorList,
           filePath = filePath
         )
         updateTitle()
@@ -1602,7 +1602,7 @@ abstract class CoreReaderFragment :
 
   private fun openAndSetInContainer(
     file: File? = null,
-    assetFileDescriptor: AssetFileDescriptor? = null,
+    assetFileDescriptorList: List<AssetFileDescriptor> = emptyList(),
     filePath: String? = null
   ) {
     try {
@@ -1613,9 +1613,9 @@ abstract class CoreReaderFragment :
       e.printStackTrace()
     }
     zimReaderContainer?.let { zimReaderContainer ->
-      if (assetFileDescriptor != null) {
+      if (assetFileDescriptorList.isNotEmpty()) {
         zimReaderContainer.setZimFileDescriptor(
-          assetFileDescriptor,
+          assetFileDescriptorList,
           filePath = filePath
         )
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -156,8 +156,8 @@ import org.kiwix.kiwixmobile.core.utils.TAG_FILE_SEARCHED_NEW_TAB
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.UpdateUtils.reformatProviderUrl
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
-import org.kiwix.kiwixmobile.core.utils.dialog.UnsupportedMimeTypeHandler
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
+import org.kiwix.kiwixmobile.core.utils.dialog.UnsupportedMimeTypeHandler
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.deleteCachedFiles
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.readFile
 import org.kiwix.kiwixmobile.core.utils.files.Log
@@ -1624,12 +1624,10 @@ abstract class CoreReaderFragment :
 
       val zimFileReader = zimReaderContainer.zimFileReader
       zimFileReader?.let { zimFileReader ->
-        Handler(Looper.getMainLooper()).post {
-          // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
-          openArticle(UNINITIALISER_ADDRESS)
-          mainMenu?.onFileOpened(urlIsValid())
-          setUpBookmarks(zimFileReader)
-        }
+        // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
+        openArticle(UNINITIALISER_ADDRESS)
+        mainMenu?.onFileOpened(urlIsValid())
+        setUpBookmarks(zimFileReader)
       } ?: kotlin.run {
         requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -46,12 +46,14 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
   }
 
   fun setZimFileDescriptor(
-    assetFileDescriptor: AssetFileDescriptor,
+    assetFileDescriptorList: List<AssetFileDescriptor>,
     filePath: String? = null
   ) {
     zimFileReader = runBlocking {
-      if (assetFileDescriptor.parcelFileDescriptor.dup().fileDescriptor.valid())
-        zimFileReaderFactory.create(assetFileDescriptor, filePath)
+      if (assetFileDescriptorList.isNotEmpty() &&
+        assetFileDescriptorList[0].parcelFileDescriptor.dup().fileDescriptor.valid()
+      )
+        zimFileReaderFactory.create(assetFileDescriptorList, filePath)
       else null
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/KiwixServer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/KiwixServer.kt
@@ -51,7 +51,8 @@ class KiwixServer @Inject constructor(
             // Determine whether to create an Archive from an asset or a file path
             val archive = if (path == getDemoFilePathForCustomApp(context)) {
               // For custom apps using a demo file, create an Archive with FileDescriptor
-              val assetFileDescriptor = zimReaderContainer.zimFileReader?.assetFileDescriptor
+              val assetFileDescriptor =
+                zimReaderContainer.zimFileReader?.assetFileDescriptorList?.get(0)
               val startOffset = assetFileDescriptor?.startOffset ?: 0L
               val size = assetFileDescriptor?.length ?: 0L
               Archive(

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -181,8 +181,8 @@ class CustomReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            if (it.assetFileDescriptor != null) {
-              openZimFile(null, true, it.assetFileDescriptor)
+            if (it.assetFileDescriptorList.isNotEmpty()) {
+              openZimFile(null, true, it.assetFileDescriptorList)
             } else {
               openZimFile(it.file, true)
             }


### PR DESCRIPTION
Fixes #3511 

* Introduced the splitting zim file with 500MB for custom apps. Since the bundle has a limit for a file to upload it uses the play asset delivery mode, and for new custom apps, playStore does not allow to upload the apk (with apk we can upload more than 1GB file). So to address this issue we have introduced a feature in libzim where we can load the zim files via the fd list.
* We have modified our code to upload the files with 500MB chunks in the asset folder, and later we are accessing these files from the asset folder and creating the archive object with the help of the new libzim feature.
* Currently CI will fail because we are using the new libzim feature in this PR. But currently new binding of `java-libkiwix` is not released once the new binding is released and we start using that then this error will resolve.
