### PR TITLE
Fixed: Sometimes setting the `org.kiwix.libzim.Archive.setNativeArchive` crashes the application.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.libzim.Archive
+import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -79,12 +80,14 @@ class MimeTypeTest : BaseActivityTest() {
         }
       }
     }
+    val archive = Archive(zimFile.canonicalPath)
     val zimFileReader = ZimFileReader(
       zimFile,
       null,
       null,
-      Archive(zimFile.canonicalPath),
-      NightModeConfig(SharedPreferenceUtil(context), context)
+      archive,
+      NightModeConfig(SharedPreferenceUtil(context), context),
+      SuggestionSearcher(archive)
     )
     zimFileReader.getRandomArticleUrl()?.let {
       val mimeType = zimFileReader.getMimeTypeFromUrl(it)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -27,10 +27,15 @@ import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.Locator
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
@@ -65,7 +70,7 @@ class NoteRobot : BaseRobot() {
     clickOn(Text("Note"))
   }
 
-  fun assertBackwardNavigationHistoryDialogDisplayed() {
+  fun assertNoteDialogDisplayed() {
     pauseForBetterTestPerformance()
     isVisible(TextId(R.string.note))
   }
@@ -106,6 +111,36 @@ class NoteRobot : BaseRobot() {
 
   fun refreshList() {
     refresh(org.kiwix.kiwixmobile.R.id.zim_swiperefresh)
+  }
+
+  fun clickOnTrashIcon() {
+    clickOn(ContentDesc(R.string.pref_clear_all_bookmarks_title))
+  }
+
+  fun assertDeleteNoteDialogDisplayed() {
+    testFlakyView({ isVisible(TextId(R.string.delete_notes_confirmation_msg)) })
+  }
+
+  fun clickOnDeleteButton() {
+    pauseForBetterTestPerformance()
+    testFlakyView({ onView(ViewMatchers.withText("DELETE")).perform(click()) })
+  }
+
+  fun assertNoNotesTextDisplayed() {
+    testFlakyView({ isVisible(TextId(R.string.no_notes)) })
+  }
+
+  fun assertHomePageIsLoadedOfTestZimFile() {
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'Android_(operating_system)')]"
+          )
+        )
+    })
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -35,6 +35,7 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.libzim.Archive
+import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -79,12 +80,14 @@ class EncodedUrlTest : BaseActivityTest() {
         }
       }
     }
+    val archive = Archive(zimFile.canonicalPath)
     val zimFileReader = ZimFileReader(
       zimFile,
       null,
       null,
-      Archive(zimFile.canonicalPath),
-      NightModeConfig(SharedPreferenceUtil(context), context)
+      archive,
+      NightModeConfig(SharedPreferenceUtil(context), context),
+      SuggestionSearcher(archive)
     )
     val encodedUrls = arrayOf(
       EncodedUrl(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -56,6 +56,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -402,13 +403,15 @@ class LocalLibraryFragment : BaseFragment() {
       // local library screen. Since our application is already aware of this opened ZIM file,
       // we can directly add it to the database.
       // See https://github.com/kiwix/kiwix-android/issues/3650
-      zimReaderFactory.create(file)
-        ?.let { zimFileReader ->
-          BookOnDisk(file, zimFileReader).also {
-            mainRepositoryActions.saveBook(it)
-            zimFileReader.dispose()
+      runBlocking {
+        zimReaderFactory.create(file)
+          ?.let { zimFileReader ->
+            BookOnDisk(file, zimFileReader).also {
+              mainRepositoryActions.saveBook(it)
+              zimFileReader.dispose()
+            }
           }
-        }
+      }
       activity?.navigate(
         LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
           .apply { zimFileUri = file.toUri().toString() }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -130,19 +130,6 @@ class KiwixReaderFragment : CoreReaderFragment() {
     tableDrawerRightContainer = requireActivity().findViewById(R.id.reader_drawer_nav_view)
   }
 
-  private fun exitBook() {
-    showNoBookOpenViews()
-    bottomToolbar?.visibility = GONE
-    actionBar?.title = getString(R.string.reader)
-    contentFrame?.visibility = GONE
-    mainMenu?.hideBookSpecificMenuItems()
-    closeZimBook()
-  }
-
-  private fun closeZimBook() {
-    zimReaderContainer?.setZimFile(null)
-  }
-
   override fun openHomeScreen() {
     Handler(Looper.getMainLooper()).postDelayed({
       if (webViewList.size == 0) {
@@ -246,6 +233,8 @@ class KiwixReaderFragment : CoreReaderFragment() {
       }
     } else {
       getCurrentWebView()?.snack(R.string.zim_not_opened)
+      exitBook() // hide the options for zim file to avoid unexpected UI behavior
+      return // book not found so don't need to restore the tabs for this file
     }
     restoreTabs(zimArticles, zimPositions, currentTab)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core
 import io.reactivex.Flowable
 import io.reactivex.functions.BiFunction
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadModel
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
@@ -53,7 +54,8 @@ class StorageObserver @Inject constructor(
   private fun fileHasNoMatchingDownload(downloads: List<DownloadModel>, file: File) =
     downloads.firstOrNull { file.absolutePath.endsWith(it.fileNameFromUrl) } == null
 
-  private fun convertToBookOnDisk(file: File) =
+  private fun convertToBookOnDisk(file: File) = runBlocking {
     zimReaderFactory.create(file)
       ?.let { zimFileReader -> BookOnDisk(file, zimFileReader).also { zimFileReader.dispose() } }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowOpenNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowOpenNoteDialog.kt
@@ -20,13 +20,20 @@ package org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
+import org.json.JSONArray
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.OpenNote
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.OpenPage
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Companion.CONTENT_PREFIX
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_ARTICLES
+import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE
+import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_POSITIONS
+import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_TAB
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.ShowNoteDialog
 import java.io.File
@@ -49,8 +56,28 @@ data class ShowOpenNoteDialog(
         // For custom apps, we are currently using fileDescriptor, and they only have a single file in them,
         // which is already set in zimReaderContainer, so there's no need to set it again.
         item.zimFilePath?.let {
+          val currentZimFilePath = zimReaderContainer.zimCanonicalPath
           val file = File(it)
           zimReaderContainer.setZimFile(file)
+          if (zimReaderContainer.zimCanonicalPath != currentZimFilePath) {
+            // if current zim file is not the same set the main page of that zim file
+            // so that when we go back it properly loads the article, and do nothing if the
+            // zim file is same because there might be multiple tabs opened.
+            val settings = activity.getSharedPreferences(
+              SharedPreferenceUtil.PREF_KIWIX_MOBILE,
+              0
+            )
+            val editor = settings.edit()
+            val urls = JSONArray()
+            val positions = JSONArray()
+            urls.put(CONTENT_PREFIX + zimReaderContainer.mainPage)
+            positions.put(0)
+            editor.putString(TAG_CURRENT_FILE, zimReaderContainer.zimCanonicalPath)
+            editor.putString(TAG_CURRENT_ARTICLES, "$urls")
+            editor.putString(TAG_CURRENT_POSITIONS, "$positions")
+            editor.putInt(TAG_CURRENT_TAB, 0)
+            editor.apply()
+          }
         }
         effects.offer(OpenNote(item.noteFilePath, item.zimUrl, item.title))
       }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -70,7 +71,7 @@ class StorageObserverTest {
     every { sharedPreferenceUtil.prefStorage } returns "a"
     every { fileSearch.scan(scanningProgressListener) } returns files
     every { downloadDao.downloads() } returns downloads
-    every { readerFactory.create(file) } returns zimFileReader
+    every { runBlocking { readerFactory.create(file) } } returns zimFileReader
     storageObserver = StorageObserver(downloadDao, fileSearch, readerFactory)
   }
 

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -30,6 +30,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.fragment.findNavController
+import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.extensions.getResizedDrawable
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
@@ -41,7 +42,6 @@ import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getDemoFilePathForCustom
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
 import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.R
-import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import java.io.File
 import java.util.Locale


### PR DESCRIPTION
Fixes #3805 

* We are now creating the ZimFileReader object on the background thread to not block the UI thread which sometimes causes the ANR because sometimes UI was frozen due to the creation of ZimFileReader with a large file.
* Refactored our functionality to support this new change.
* Refactored the test cases according to this functionality.
* Added the test cases, for testing the scenario where the zim file was not properly loading after opening the note on the notes screen to ensure that this functionality should work properly.