### PR TITLE
Fixed `Implementation` issue reported by the playstore.

### DIFF
--- a/core/src/main/res/layout/ic_tab_switcher.xml
+++ b/core/src/main/res/layout/ic_tab_switcher.xml
@@ -12,13 +12,15 @@
 
   <TextView
     android:id="@+id/ic_tab_switcher_text"
-    android:layout_width="20dp"
-    android:layout_height="20dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:background="@drawable/border_tab_switcher"
     android:gravity="center"
     android:textColor="@android:color/white"
     android:textSize="12sp"
     android:textStyle="bold"
+    android:minHeight="20dp"
+    android:minWidth="20dp"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes #3812 

* Changed the width and height of `ic_tab_switcher_text` to  `wrapContent`  instead of fixed width and height which prevents to expansion of the view if there is more content to display.
* To maintain the current design we have added the `minHeight` and `minWidth` for textView otherwise the background was showing very odd.
* For other issues that are showing in the below screenshots, we can not place a fix for these issues, since these are inside the library and there are no methods for setting the `textSize`. However, the issue is we need to change the `textSize` from `dp` to `sp`, and it is only show once when this feature is first time used.
![Screenshot from 2024-04-30 18-34-39](https://github.com/kiwix/kiwix-android/assets/34593983/32caa37c-7d2f-4634-a00d-9b3e5aca3854)
![Screenshot from 2024-04-30 18-34-34](https://github.com/kiwix/kiwix-android/assets/34593983/3cb307fe-171d-44c4-a9cb-16aa4b6962ae)
