### PR TITLE
Fixed: `Content labeling` issue reported by the playstore.

### DIFF
--- a/app/src/main/res/layout/fragment_local_file_transfer.xml
+++ b/app/src/main/res/layout/fragment_local_file_transfer.xml
@@ -141,6 +141,7 @@
     android:layout_width="match_parent"
     android:layout_height="0dp"
     android:background="@android:color/transparent"
+    android:contentDescription="@string/files_for_transfer"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpFragment.kt
@@ -76,7 +76,12 @@ abstract class HelpFragment : BaseFragment() {
     val activity = requireActivity() as AppCompatActivity
     fragmentHelpBinding?.activityHelpFeedbackTextView?.setOnClickListener { sendFeedback() }
     fragmentHelpBinding?.activityHelpFeedbackImageView?.setOnClickListener { sendFeedback() }
-    fragmentHelpBinding?.diagnosticClickableArea?.setOnClickListener { sendDiagnosticReport() }
+    fragmentHelpBinding?.activityHelpDiagnosticImageView?.setOnClickListener {
+      sendDiagnosticReport()
+    }
+    fragmentHelpBinding?.activityHelpDiagnosticTextView?.setOnClickListener {
+      sendDiagnosticReport()
+    }
     fragmentHelpBinding?.activityHelpRecyclerView?.addItemDecoration(
       DividerItemDecoration(activity, DividerItemDecoration.VERTICAL)
     )

--- a/core/src/main/res/layout/fragment_help.xml
+++ b/core/src/main/res/layout/fragment_help.xml
@@ -25,6 +25,8 @@
     android:layout_height="wrap_content"
     android:drawablePadding="@dimen/activity_horizontal_margin"
     android:text="@string/send_feedback"
+    android:gravity="start|center"
+    android:minHeight="48dp"
     android:textAppearance="?android:attr/textAppearanceMedium"
     app:layout_constraintBottom_toBottomOf="@id/activity_help_feedback_image_view"
     app:layout_constraintEnd_toEndOf="parent"
@@ -42,7 +44,7 @@
     android:id="@+id/activity_help_diagnostic_image_view"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:contentDescription="@string/send_feedback"
+    android:contentDescription="@string/send_report"
     android:padding="@dimen/activity_horizontal_margin"
     android:src="@drawable/ic_feedback_orange_24dp"
     app:layout_constraintStart_toStartOf="parent"
@@ -53,20 +55,13 @@
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:drawablePadding="@dimen/activity_horizontal_margin"
+    android:gravity="start|center"
+    android:minHeight="48dp"
     android:text="@string/send_report"
     android:textAppearance="?android:attr/textAppearanceMedium"
     app:layout_constraintBottom_toBottomOf="@id/activity_help_diagnostic_image_view"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/activity_help_diagnostic_image_view"
-    app:layout_constraintTop_toTopOf="@id/activity_help_diagnostic_image_view" />
-
-  <View
-    android:id="@+id/diagnostic_clickable_area"
-    android:layout_width="0dp"
-    android:layout_height="0dp"
-    app:layout_constraintBottom_toBottomOf="@id/activity_help_diagnostic_image_view"
-    app:layout_constraintEnd_toEndOf="@id/activity_help_diagnostic_text_view"
-    app:layout_constraintStart_toStartOf="@id/activity_help_diagnostic_image_view"
     app:layout_constraintTop_toTopOf="@id/activity_help_diagnostic_image_view" />
 
   <View


### PR DESCRIPTION
Fixes #3810 

* Added the content description for the `send report` image, and fixed the sizing issues of `send feedback` and `send report` `textView` so that users can easily click on these views.
* Added content description for `File transfer list recyclerview`.
* There is only one accessibility warning left which is `Multiple items have the same description` it is because recyclerview items have the same content description and we can ignore this type of error because 2 views can have the same content description because their functionality can be same.