### PR TITLE
Fixed: issue with front page of Zim on a USB stick loading.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1591,7 +1591,6 @@ abstract class CoreReaderFragment :
         // uninitialized the service worker to fix https://github.com/kiwix/kiwix-android/issues/2561
         openArticle(UNINITIALISER_ADDRESS)
         mainMenu?.onFileOpened(urlIsValid())
-        openArticle(zimFileReader.mainPage)
         setUpBookmarks(zimFileReader)
       } ?: kotlin.run {
         requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
@@ -1793,7 +1792,6 @@ abstract class CoreReaderFragment :
       if (item.shouldOpenInNewTab) {
         createNewTab()
       }
-      android.util.Log.e("OPEN_OBB", "openSearchItem: ")
       loadUrlWithCurrentWebview(zimReaderContainer?.urlSuffixToParsableUrl(it))
     }
     requireActivity().consumeObservable<SearchItemToOpen>(TAG_FILE_SEARCHED)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/ServiceWorkerUninitialiser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/ServiceWorkerUninitialiser.kt
@@ -34,7 +34,7 @@ const val UNINITIALISE_HTML = """
               $UNINITIALISER_INTERFACE.onUninitialised();
               return;
             }
-            navigator.serviceWorker.getRegistrations().then(async function (registrations) {
+            navigator.serviceWorker.getRegistrations().then((registrations) => {
               if (registrations.length) {
                 console.debug('we do have ' + registrations.length + ' registration(s)');
                 var registration = registrations[0];
@@ -80,6 +80,6 @@ class ServiceWorkerUninitialiser(val onUninitialisedAction: () -> Unit) {
 
   @JavascriptInterface
   fun onUninitialised() {
-    Handler(Looper.getMainLooper()).post { onUninitialisedAction() }
+    Handler(Looper.getMainLooper()).post { onUninitialisedAction.invoke() }
   }
 }


### PR DESCRIPTION
Fixes #3809 

* Rectified the `ServiceWorkerUninitialiser` code to appropriately uninitialize the service worker. Previously, when the uninitializing code ran from the JavaScript interface, we directly called the function, which sometimes functioned correctly but sometimes did not. To address this inconsistency, we are now invoking that function to ensure the main page loads after the service worker is uninitialized.
* Rectified the syntax error in the `ServiceWorkerUninitialiser` JavaScript code, which was causing an issue on API level 24. Consequently, the main page failed to load on this API level. We've refactored our code to ensure compatibility across all API levels.
* Now that our service is functioning correctly, there's no need to explicitly load the main page. Upon service worker uninitialization, the main page automatically loads.

![Screenshot from 2024-05-06 19-56-42](https://github.com/kiwix/kiwix-android/assets/34593983/a4666d9f-7eab-469d-837b-a3106b99d850)
