### PR TITLE
Fixed: Ci is continuously failing.

### DIFF
--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -7,14 +7,20 @@ adb logcat -c
 adb logcat *:E -v color &
 
 PACKAGE_NAME="org.kiwix.kiwixmobile"
+TEST_PACKAGE_NAME="${PACKAGE_NAME}.test"
 # Function to check if the application is installed
 is_app_installed() {
-  adb shell pm list packages | grep -q "${PACKAGE_NAME}"
+  adb shell pm list packages | grep -q "$1"
 }
 
-if is_app_installed; then
+if is_app_installed "$PACKAGE_NAME"; then
   # Delete the application to properly run the test cases.
   adb uninstall "${PACKAGE_NAME}"
+fi
+
+if is_app_installed "$TEST_PACKAGE_NAME"; then
+  # Delete the test application to properly run the test cases.
+  adb uninstall "${TEST_PACKAGE_NAME}"
 fi
 retry=0
 while [ $retry -le 3 ]; do
@@ -30,9 +36,13 @@ while [ $retry -le 3 ]; do
     # shellcheck disable=SC2035
     adb logcat *:E -v color &
 
-    if is_app_installed; then
+    if is_app_installed "$PACKAGE_NAME"; then
       # Delete the application to properly run the test cases.
       adb uninstall "${PACKAGE_NAME}"
+    fi
+    if is_app_installed "$TEST_PACKAGE_NAME"; then
+      # Delete the test application to properly run the test cases.
+      adb uninstall "${TEST_PACKAGE_NAME}"
     fi
     ./gradlew clean
     retry=$(( retry + 1 ))

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -13,8 +13,8 @@ is_app_installed() {
 }
 
 if is_app_installed; then
-  # Clear application data to properly run the test cases.
-  adb shell pm clear "${PACKAGE_NAME}"
+  # Delete the application to properly run the test cases.
+  adb uninstall "${PACKAGE_NAME}"
 fi
 retry=0
 while [ $retry -le 3 ]; do
@@ -31,8 +31,8 @@ while [ $retry -le 3 ]; do
     adb logcat *:E -v color &
 
     if is_app_installed; then
-      # Clear application data to properly run the test cases.
-      adb shell pm clear "${PACKAGE_NAME}"
+      # Delete the application to properly run the test cases.
+      adb uninstall "${PACKAGE_NAME}"
     fi
     ./gradlew clean
     retry=$(( retry + 1 ))


### PR DESCRIPTION
Fixes #3819 

* Modified the `instrumentation.sh` script to delete the (app, test app) if already installed in the device before running the test cases.

