### PR TITLE
Fixed: `Low contrast` issues reported by the playstore.

### DIFF
--- a/app/src/main/res/layout/fragment_intro.xml
+++ b/app/src/main/res/layout/fragment_intro.xml
@@ -4,6 +4,8 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="?colorSurface"
+  tools:ignore="Overdraw"
   tools:context=".intro.IntroFragment">
 
   <org.kiwix.kiwixmobile.intro.CustomViewPager

--- a/app/src/main/res/layout/item_intro_1.xml
+++ b/app/src/main/res/layout/item_intro_1.xml
@@ -3,6 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="?colorSurface"
   android:padding="24dp">
 
   <ImageView

--- a/app/src/main/res/layout/item_intro_2.xml
+++ b/app/src/main/res/layout/item_intro_2.xml
@@ -3,6 +3,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="?colorSurface"
   android:padding="24dp">
 
   <ImageView

--- a/app/src/main/res/layout/item_language.xml
+++ b/app/src/main/res/layout/item_language.xml
@@ -3,7 +3,8 @@
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="64dp">
+  android:layout_height="wrap_content"
+  android:minHeight="64dp">
 
   <CheckBox
     android:id="@+id/item_language_checkbox"

--- a/app/src/main/res/layout/item_language.xml
+++ b/app/src/main/res/layout/item_language.xml
@@ -56,7 +56,11 @@
 
   <View
     android:id="@+id/item_language_clickable_area"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?selectableItemBackground" />
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    android:background="?selectableItemBackground"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/src/main/res/drawable/ic_feedback_orange_24dp.xml
+++ b/core/src/main/res/drawable/ic_feedback_orange_24dp.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
   android:height="24dp"
-  android:tint="#FF9800"
+  android:tint="#D17D00"
   android:viewportHeight="24.0"
   android:viewportWidth="24.0"
   android:width="24dp">

--- a/core/src/main/res/layout/activity_kiwix_error.xml
+++ b/core/src/main/res/layout/activity_kiwix_error.xml
@@ -4,7 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@android:color/holo_blue_dark"
+  android:background="@color/error_activity_background"
   tools:context=".error.ErrorActivity"
   tools:ignore="Overdraw">
 
@@ -17,7 +17,7 @@
     android:layout_marginEnd="8dp"
     android:text="@string/crash_description"
     android:textAlignment="center"
-    android:textColor="@color/alabaster_white"
+    android:textColor="@color/white"
     android:textSize="14sp"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -30,8 +30,8 @@
     android:layout_marginStart="8dp"
     android:layout_marginEnd="8dp"
     android:layout_marginBottom="32dp"
-    android:singleLine="true"
     android:maxLines="1"
+    android:singleLine="true"
     android:text="@string/crash_button_confirm"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@+id/restartButton"
@@ -99,9 +99,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_language"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
 
       <CheckBox
         android:id="@+id/allowLogs"
@@ -110,9 +111,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_logs"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
 
       <CheckBox
         android:id="@+id/allowCrash"
@@ -121,9 +123,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_exception"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
 
       <CheckBox
         android:id="@+id/allowZims"
@@ -132,9 +135,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_zimfiles"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
 
       <CheckBox
         android:id="@+id/allowDeviceDetails"
@@ -143,9 +147,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_device"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
 
       <CheckBox
         android:id="@+id/allowFileSystemDetails"
@@ -154,9 +159,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="100dp"
         android:layout_marginTop="8dp"
+        android:buttonTint="@color/denim_blue200"
         android:checked="true"
         android:text="@string/crash_checkbox_file_system"
-        android:textColor="@color/alabaster_white" />
+        android:textColor="@color/white" />
     </LinearLayout>
   </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -18,4 +18,5 @@
   <color name="monza_red">#b00020</color>
   <color name="startServerGreen">#2e7d31</color>
   <color name="stopServerRed">#c62728</color>
+  <color name="error_activity_background">#007EA8</color>
 </resources>


### PR DESCRIPTION
Fixes #3813 

* Changed the background color of `ErrorActivity` and the checkbox to resolve the issue.

| Before (Night mode)  | Before (Light mode)  | After (Night mode) | After (Light mode)  | 
| ------------- | ------------- | ------------- | ------------- |
| ![BeforeNightMode](https://github.com/kiwix/kiwix-android/assets/34593983/068098da-db15-4184-a3a8-ecc7b606b16d)  | ![BeforeLightMode](https://github.com/kiwix/kiwix-android/assets/34593983/c386b198-14e1-4b68-ac6c-ad30bcb39843)  | ![AfterNightMode](https://github.com/kiwix/kiwix-android/assets/34593983/593a2118-7a46-4acf-b0c2-e9a830021481) | ![AfterLightMode](https://github.com/kiwix/kiwix-android/assets/34593983/81805258-79dc-41f4-8444-3af6a57e59fe) |

* Added the background color in `IntroFragment` to resolve the issue, it is the same design as the previous one.
* Changed the tint color of the `ic_feedback_orange_24dp` image to resolve the low contrast issue.

| Before | After  |
| ------------- | ------------- |
| ![BeforeHelpScreen](https://github.com/kiwix/kiwix-android/assets/34593983/a434e1f9-11a3-4944-a92f-29e565ede788)  | ![HelpScreenAfter](https://github.com/kiwix/kiwix-android/assets/34593983/2540e10e-bc28-441c-ba6e-6c3a22c85918) | 

* Changed the height of the `item_language` item to wrap content instead of a fixed height which prevents the expansion of the layout if there is more content.


Apart from these issues, other `Low contrast` issues are just because they are behind something. For example, see the below screens.
| Screenshot | Screenshot  | Screenshot |
| ------------- | ------------- | ------------- |
| ![Screenshot from 2024-05-07 16-59-04](https://github.com/kiwix/kiwix-android/assets/34593983/e5603239-3226-4769-8fc6-691fff938f66) | ![Screenshot from 2024-05-07 16-59-26](https://github.com/kiwix/kiwix-android/assets/34593983/61af307a-a3a2-4d2c-94be-d0232fddd595) | ![Screenshot from 2024-05-07 16-59-16](https://github.com/kiwix/kiwix-android/assets/34593983/ab15349e-b42b-4bcb-a553-b7c9aadd7a80) |
