### PR TITLE
Fixed: PlayStore showing deep linking issue for URLs schema.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,32 +74,6 @@
         <data android:pathPattern="/.*\\..*\\..*\\..*\\.zimaa" />
         <data android:host="*" />
       </intent-filter>
-      <intent-filter android:autoVerify="true">
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data android:scheme="http" />
-        <data android:host="*" />
-        <data android:pathPattern="/.*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\..*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\..*\\..*\\.zim(aa|)" />
-      </intent-filter>
-      <intent-filter android:autoVerify="true">
-        <action android:name="android.intent.action.VIEW" />
-
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data android:scheme="https" />
-        <data android:host="*" />
-        <data android:pathPattern="/.*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\..*\\.zim(aa|)" />
-        <data android:pathPattern="/.*\\..*\\..*\\..*\\.zim(aa|)" />
-      </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
 


### PR DESCRIPTION
Fixes #3808 

* Removed the URL type deep link since we are mainly using deep links for opening zim files in the application, and URLs type deep links are for downloading the content not for opening the ZIM files so we are removing these deep links from our application.
* Now user can normally download the zim files from (outside Kiwix) like other zim files.
