### PR TITLE
Fixed: The Delete icon is showing wrong content description on the notes and history screen.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -91,12 +91,14 @@ class NoteRobot : BaseRobot() {
   }
 
   fun clickOnSavedNote() {
-    onView(withId(R.id.recycler_view)).perform(
-      actionOnItemAtPosition<RecyclerView.ViewHolder>(
-        0,
-        click()
+    testFlakyView({
+      onView(withId(R.id.recycler_view)).perform(
+        actionOnItemAtPosition<RecyclerView.ViewHolder>(
+          0,
+          click()
+        )
       )
-    )
+    })
   }
 
   fun clickOnOpenNote() {
@@ -114,7 +116,7 @@ class NoteRobot : BaseRobot() {
   }
 
   fun clickOnTrashIcon() {
-    clickOn(ContentDesc(R.string.pref_clear_all_bookmarks_title))
+    clickOn(ContentDesc(R.string.pref_clear_notes))
   }
 
   fun assertDeleteNoteDialogDisplayed() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
@@ -35,7 +35,7 @@ class HistoryRobot : BaseRobot() {
   }
 
   fun clickOnTrashIcon() {
-    clickOn(ContentDesc(R.string.pref_clear_all_bookmarks_title))
+    clickOn(ContentDesc(R.string.pref_clear_all_history_title))
   }
 
   fun assertDeleteHistoryDialogDisplayed() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -71,6 +71,7 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
   abstract val searchQueryHint: String
   abstract val pageAdapter: PageAdapter
   abstract val switchIsChecked: Boolean
+  abstract val deleteIconTitle: String
   private var fragmentPageBinding: FragmentPageBinding? = null
   override val fragmentToolbar: Toolbar? by lazy {
     fragmentPageBinding?.root?.findViewById(R.id.toolbar)
@@ -116,6 +117,7 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
               }
             )
           }
+          menu.findItem(R.id.menu_pages_clear).title = deleteIconTitle // Bug fix #3825
         }
 
         @Suppress("ReturnCount")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarksFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarksFragment.kt
@@ -19,6 +19,9 @@ class BookmarksFragment : PageFragment() {
   override val screenTitle: String by lazy { getString(R.string.bookmarks) }
   override val noItemsString: String by lazy { getString(R.string.no_bookmarks) }
   override val switchString: String by lazy { getString(R.string.bookmarks_from_current_book) }
+  override val deleteIconTitle: String by lazy {
+    getString(R.string.pref_clear_all_bookmarks_title)
+  }
   override val switchIsChecked: Boolean by lazy { sharedPreferenceUtil.showBookmarksAllBooks }
 
   override fun inject(baseActivity: BaseActivity) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryFragment.kt
@@ -22,6 +22,9 @@ class HistoryFragment : PageFragment() {
   override val noItemsString: String by lazy { getString(R.string.no_history) }
   override val switchString: String by lazy { getString(R.string.history_from_current_book) }
   override val screenTitle: String by lazy { getString(R.string.history) }
+  override val deleteIconTitle: String by lazy {
+    getString(R.string.pref_clear_all_history_title)
+  }
   override val switchIsChecked: Boolean by lazy { sharedPreferenceUtil.showHistoryAllBooks }
 
   override fun inject(baseActivity: BaseActivity) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesFragment.kt
@@ -39,6 +39,9 @@ class NotesFragment : PageFragment() {
 
   override val noItemsString: String by lazy { getString(R.string.no_notes) }
   override val switchString: String by lazy { getString(R.string.notes_from_all_books) }
+  override val deleteIconTitle: String by lazy {
+    getString(R.string.pref_clear_notes)
+  }
   override val switchIsChecked: Boolean by lazy { sharedPreferenceUtil.showNotesAllBooks }
 
   override fun inject(baseActivity: BaseActivity) {

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -269,6 +269,7 @@
   <string name="status" tools:keep="@string/status">Status</string>
   <string name="pref_clear_all_notes_summary">Clears all notes on all articles</string>
   <string name="pref_clear_all_notes_title">Clear all notes</string>
+  <string name="pref_clear_notes">Clear notes</string>
   <string name="pref_allow_to_read_or_write_zim_files_on_sd_card">Allow to read and write ZIM files on SD card</string>
   <string name="pref_text_zoom_summary">Change text size with 25\% increments.</string>
   <string name="tag_pic">Pic</string>


### PR DESCRIPTION
Fixes #3825 

* Added correct description to `delete` button on `HistoryFragment`, and `NotesFragment`.

| Notes screen  | History screen |
| ------------- | ------------- |
| ![ClearNotesFixed](https://github.com/kiwix/kiwix-android/assets/34593983/cda84236-6bcb-48ec-9074-a51e950ed39f) | ![ClearHistoryFix](https://github.com/kiwix/kiwix-android/assets/34593983/f2214f0a-7417-4286-893a-7f46724d6958) |

* Refactored the test case according to this new change.
* Sometimes `actionOnItemAtPosition` method gives an internal error, and does not perform the desired operation and fails the `NoteFragmentTest`. So we have moved it inside the `testFlakyView` method so that if there is any internal error occurs it retries this action.

```kotlin
org.kiwix.kiwixmobile.note.NoteFragmentTest > testUserCanSeeNotesForDeletedFiles[Pixel_6a_API_24(AVD) - 7.0] FAILED 
        androidx.test.espresso.PerformException: Error performing 'androidx.test.espresso.contrib.RecyclerViewActions$ActionOnItemAtPositionViewAction@1987abf' on view 'view.getId() is <2131296807/org.kiwix.kiwixmobile:id/recycler_view>'.
        at androidx.test.espresso.PerformException$Builder.build(PerformException.java:1)
```

