### PR TITLE
Upgraded the minimum SDK version to `25`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 24, 30, 33 ]
+        api-level: [ 25, 30, 33 ]
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
@@ -65,7 +65,7 @@ jobs:
           sdcard-path-or-size: 2048M
           cores: 4
           disable-animations: false
-          heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}
+          heap-size: ${{ matrix.api-level != 25 && '512M' || '' }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           channel: canary
           script: echo "Generated AVD snapshot for caching."
@@ -85,7 +85,7 @@ jobs:
           force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
-          heap-size: ${{ matrix.api-level != 24 && '512M' || '' }}
+          heap-size: ${{ matrix.api-level != 25 && '512M' || '' }}
           channel: canary
           script: bash contrib/instrumentation.sh
 
@@ -98,18 +98,18 @@ jobs:
           path: screencap.png
 
       - name: create unit coverage
-        if: ${{ matrix.api-level==24 }}
+        if: ${{ matrix.api-level==25 }}
         run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.api-level==24 }}
+        if: ${{ matrix.api-level==25 }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Coverage to GH-Actions
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.api-level==24 }}
+        if: ${{ matrix.api-level==25 }}
         with:
           name: Tests Coverage Report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           sdcard-path-or-size: 2048M
           cores: 4
           disable-animations: false
-          heap-size: ${{ matrix.api-level != 25 && '512M' || '' }}
+          heap-size: 512M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           channel: canary
           script: echo "Generated AVD snapshot for caching."
@@ -85,7 +85,7 @@ jobs:
           force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
-          heap-size: ${{ matrix.api-level != 25 && '512M' || '' }}
+          heap-size: 512M
           channel: canary
           script: bash contrib/instrumentation.sh
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ offline. This is achieved by reading the content of a file in the
 [ZIM](https://openzim.org) format, a highly compressed open format
 with additional metadata.
 
-This is the version for Android, with [support versions ranging from 7
+This is the version for Android, with [support versions ranging from 7.1
 to 13](https://github.com/kiwix/kiwix-android/blob/main/buildSrc/src/main/kotlin/Config.kt).
 
 **Important Note**: Starting from Android 11, the ZIM file picker

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -23,7 +23,7 @@ object Config {
   // Here is a list of all Android versions with their corresponding API
   // levels: https://apilevels.com/
   const val compileSdk = 33 // SDK version used by Gradle to compile our app.
-  const val minSdk = 24 // Minimum SDK (Minimum Support Device) is 24 (Android 7.0 Nougat).
+  const val minSdk = 25 // Minimum SDK (Minimum Support Device) is 25 (Android 7.1 Nougat).
   const val targetSdk = 33 // Target SDK (Maximum Support Device) is 33 (Android 13).
 
   val javaVersion = JavaVersion.VERSION_1_8

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
@@ -32,7 +32,7 @@ import android.net.ConnectivityManager
  *
  *
  * Each implementation ends with a `V<n>` suffix, identifying the minimum API version on which this implementation
- * can be used. For example, see [CompatV24].
+ * can be used. For example, see [CompatV25].
  *
  *
  * Each implementation `CompatVn` should extend the implementation `CompatVm` for the greatest m<n such that `CompatVm`

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -29,7 +29,7 @@ class CompatHelper private constructor() {
   // Note: Needs ": Compat" or the type system assumes `Compat21`
   private val compatValue: Compat = when {
     sdkVersion >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
-    else -> CompatV24()
+    else -> CompatV25()
   }
 
   companion object {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV25.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV25.kt
@@ -27,7 +27,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 
-open class CompatV24 : Compat {
+open class CompatV25 : Compat {
 
   override fun queryIntentActivities(
     packageManager: PackageManager,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV33.kt
@@ -30,7 +30,7 @@ const val API_33 = 33
 
 @TargetApi(API_33)
 open class CompatV33 : Compat {
-  private val compatV24 = CompatV24()
+  private val compatV25 = CompatV25()
   override fun queryIntentActivities(
     packageManager: PackageManager,
     intent: Intent,
@@ -48,8 +48,8 @@ open class CompatV33 : Compat {
     packageManager.getPackageInfo(packageName, PackageInfoFlags.of(flag.toLong()))
 
   override fun isNetworkAvailable(connectivity: ConnectivityManager): Boolean =
-    compatV24.isNetworkAvailable(connectivity)
+    compatV25.isNetworkAvailable(connectivity)
 
   override fun isWifi(connectivity: ConnectivityManager): Boolean =
-    compatV24.isWifi(connectivity)
+    compatV25.isWifi(connectivity)
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
@@ -41,7 +41,7 @@ class NetworkUtilsTest {
   private val networkCapabilities: NetworkCapabilities = mockk()
 
   @Test
-  fun testNetworkAvailability_CompatV24() {
+  fun testNetworkAvailability_CompatV25() {
     every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivity
     val compatV25 = CompatV25()
     val network: Network = mockk()
@@ -56,7 +56,7 @@ class NetworkUtilsTest {
   }
 
   @Test
-  fun test_isWifi_CompatV24() {
+  fun test_isWifi_CompatV25() {
     val compatV25 = CompatV25()
     val network: Network = mockk()
 
@@ -70,7 +70,7 @@ class NetworkUtilsTest {
   }
 
   @Test
-  fun testNetworkAvailability_NoNetwork_CompatV24() {
+  fun testNetworkAvailability_NoNetwork_CompatV25() {
     every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivity
     val compatV25 = CompatV25()
     val network: Network = mockk()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
@@ -31,7 +31,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.compat.CompatV24
+import org.kiwix.kiwixmobile.core.compat.CompatV25
 import java.util.regex.Pattern
 
 class NetworkUtilsTest {
@@ -43,43 +43,43 @@ class NetworkUtilsTest {
   @Test
   fun testNetworkAvailability_CompatV24() {
     every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivity
-    val compatV23 = CompatV24()
+    val compatV25 = CompatV25()
     val network: Network = mockk()
 
     every { connectivity.activeNetwork } returns network
     every { connectivity.getNetworkCapabilities(network) } returns networkCapabilities
     every { networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET) } returns true
 
-    assertTrue(compatV23.isNetworkAvailable(connectivity))
+    assertTrue(compatV25.isNetworkAvailable(connectivity))
     every { networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET) } returns false
-    assertFalse(compatV23.isNetworkAvailable(connectivity))
+    assertFalse(compatV25.isNetworkAvailable(connectivity))
   }
 
   @Test
   fun test_isWifi_CompatV24() {
-    val compatV23 = CompatV24()
+    val compatV25 = CompatV25()
     val network: Network = mockk()
 
     every { connectivity.activeNetwork } returns network
     every { connectivity.getNetworkCapabilities(network) } returns networkCapabilities
     every { networkCapabilities.hasTransport(TRANSPORT_WIFI) } returns true
 
-    assertTrue(compatV23.isWifi(connectivity))
+    assertTrue(compatV25.isWifi(connectivity))
     every { networkCapabilities.hasTransport(TRANSPORT_WIFI) } returns false
-    assertFalse(compatV23.isWifi(connectivity))
+    assertFalse(compatV25.isWifi(connectivity))
   }
 
   @Test
   fun testNetworkAvailability_NoNetwork_CompatV24() {
     every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivity
-    val compatV23 = CompatV24()
+    val compatV25 = CompatV25()
     val network: Network = mockk()
 
     every { connectivity.activeNetwork } returns network
     every { connectivity.getNetworkCapabilities(network) } returns networkCapabilities
     every { networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET) } returns false
 
-    assertFalse(compatV23.isNetworkAvailable(connectivity))
+    assertFalse(compatV25.isNetworkAvailable(connectivity))
   }
 
   @Test


### PR DESCRIPTION
Fixes #3783 

* Updated the `README.md` file for this new change.
* Removed the API level 24 from CI and added the API level 25 since now our minimum SDK version is 25.
* Renamed CompatV24 file since we have upgraded the minimum SDK version so this fileName was irrelevant.
* Added the `heap size` in the API level 25 emulator.