### PR TITLE
Uploading nightly APK with released signature.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,15 +22,21 @@ jobs:
           java-version: 11
           distribution: temurin
 
-      - name: build debug
-        run: ./gradlew assembleNightly
-
       - name: Decrypt files
         env:
-          ssh_key: ${{ secrets.ssh_key }}
+          KEYSTORE: ${{ secrets.keystore }}
+          SSH_KEY: ${{ secrets.ssh_key }}
         run: |
-          echo "$ssh_key" | base64 -d > ssh_key
+          echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
+          echo "$SSH_KEY" | base64 -d > ssh_key
           chmod 600 ssh_key
+          
+      - name: build debug
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+        run: ./gradlew assembleNightly
 
       - name: Set date variable
         run: echo "DATE=$(echo $(date +%Y-%m-%d))" >> $GITHUB_ENV

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,8 @@ android {
     create("nightly") {
       initWith(getByName("debug"))
       matchingFallbacks += "debug"
+      // Build the nightly APK with the released keyStore to make the APK updatable. See #3838
+      signingConfig = signingConfigs.getByName("releaseSigningConfig")
     }
   }
   bundle {


### PR DESCRIPTION
Fixes #3838 

* Uploading nightly APK with a released signature so that APK can update, if a user downloads the new version of nightly like our released APK.
* Modified the nightly CI for this change.