### PR TITLE
Fixed: application was crashing when starting the `kiwix server`.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/KiwixServer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/webserver/KiwixServer.kt
@@ -23,7 +23,6 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getDemoFilePathForCustomApp
 import org.kiwix.libkiwix.Book
-import org.kiwix.libkiwix.JNIKiwixException
 import org.kiwix.libkiwix.Library
 import org.kiwix.libkiwix.Server
 import org.kiwix.libzim.Archive
@@ -67,8 +66,13 @@ class KiwixServer @Inject constructor(
             update(archive)
           }
           kiwixLibrary.addBook(book)
-        } catch (e: JNIKiwixException) {
-          Log.v(TAG, "Couldn't add book with path:{ $path }")
+        } catch (ignore: Exception) {
+          // Catch the other exceptions as well. e.g. while hosting the split zim files.
+          // we have an issue with split zim files, see #3827
+          Log.v(
+            TAG,
+            "Couldn't add book with path:{ $path }.\n Original Exception = $ignore"
+          )
         }
       }
       return KiwixServer(kiwixLibrary, Server(kiwixLibrary))


### PR DESCRIPTION
Fixes #3845 

* Added a check for checking the `MANAGE_EXTERNAL_STORAGE` permission when starting the server in the non-playStore variant. If there is no permission, then it asks for permission to avoid the crash due to permission lack for file.
* Improved the permission asking when the user tries to start the server in all variants and all versions of Android so that it will ask storage(read/write) permission for below Android 13 in non-playStore variant. Also, ask for the `MANAGE_EXTERNAL_STORAGE` permission in Android 11 and above. This check ensures that without the storage and `MANAGE_EXTERNAL_PERMISSION` user can not start the server. Because if the application does not have storage permission then it crashes when creating the `Archive` object.
* Fixed: application crashing when hosting the split zim files on the server, since we have an issue with split zim files of `zim-tools` #3827. Due to this issue, there is a crash reported on the playStore. Because we have full access to files in the playStore variant since all the files are located in the `app-specific` directory.

| Crash scenario | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/65c27966-0608-43bd-99d0-388a2d712f1d" /> | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/d0d2a268-d506-45e7-a427-ce65076766e4" />  |

* Improved the log for showing the actual error if there is something goes wrong while adding the book in `Library`.