### PR TITLE
Fixed: Unable to restart download after pausing.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.download
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -31,9 +30,11 @@ import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
@@ -127,11 +128,16 @@ class DownloadRobot : BaseRobot() {
 
   private fun assertStopDownloadDialogDisplayed() {
     pauseForBetterTestPerformance()
-    isVisible(Text("Stop download?"))
+    isVisible(TextId(R.string.confirm_stop_download_title))
   }
 
   private fun clickOnYesButton() {
-    onView(withText("YES")).perform(click())
+    try {
+      onView(withText("YES")).perform(click())
+    } catch (ignore: Exception) {
+      // stop the downloading for Albanian language
+      onView(withText("PO")).perform(click())
+    }
   }
 
   fun stopDownloadIfAlreadyStarted() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -20,14 +20,18 @@ package org.kiwix.kiwixmobile.settings
 
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.anything
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
@@ -122,6 +126,35 @@ class SettingsRobot : BaseRobot() {
 
   fun assertVersionTextViewPresent() {
     clickRecyclerViewItems(R.string.pref_info_version)
+  }
+
+  fun clickOnLanguagePreference() {
+    try {
+      clickRecyclerViewItems(R.string.device_default)
+    } catch (ignore: Exception) {
+      // if the device language Albanian
+      onView(
+        withResourceName("recycler_view")
+      ).perform(
+        actionOnItem<RecyclerView.ViewHolder>(
+          hasDescendant(Matchers.anyOf(withText("shqip"))), ViewActions.click()
+        )
+      )
+    }
+  }
+
+  fun selectAlbanianLanguage() {
+    testFlakyView({
+      onData(anything()).inAdapterView(withId(R.id.select_dialog_listview)).atPosition(2)
+        .perform(click())
+    })
+  }
+
+  fun selectDeviceDefaultLanguage() {
+    testFlakyView({
+      onData(anything()).inAdapterView(withId(R.id.select_dialog_listview)).atPosition(0)
+        .perform(click())
+    })
   }
 
   fun dismissDialog() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -136,7 +136,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           context?.let { context ->
             downloader.pauseResumeDownload(
               it.downloadId,
-              it.downloadState.toReadableState(context) == "Paused"
+              it.downloadState.toReadableState(context) == getString(R.string.paused_state)
             )
           }
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -117,11 +117,12 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       }
       itemDownloadBinding.downloadState.text =
         item.downloadState.toReadableState(containerView.context).also {
-          val pauseResumeIconId = if (it == "Paused") {
-            R.drawable.ic_play_24dp
-          } else {
-            R.drawable.ic_pause_24dp
-          }
+          val pauseResumeIconId =
+            if (it == itemDownloadBinding.root.context.getString(R.string.paused_state)) {
+              R.drawable.ic_play_24dp
+            } else {
+              R.drawable.ic_pause_24dp
+            }
           itemDownloadBinding.pauseResume.setImageDrawableCompat(pauseResumeIconId)
         }
       if (item.currentDownloadState == Status.FAILED) {


### PR DESCRIPTION
Fixes #3666 

* It was due to we were using the hardcoded string for checking the pause state of downloading so pausing and resuming are working fine in the English version and do not work in other languages.
* Added test cases for checking this scenario so that we can avoid this type of error in the future.

Credit goes to @artar94 for finding the real issue.