### PR TITLE
Fixed: Improve article search in our application.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.core.dao.entities.BookmarkEntity
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
 import org.kiwix.kiwixmobile.core.di.modules.DatabaseModule
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -96,10 +97,16 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
       onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
         it.navigate(R.id.libraryFragment)
       }
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -60,6 +60,7 @@ class DeepLinksTest : BaseActivityTest() {
         setIsPlayStoreBuildType(true)
         prefIsTest = true
         playStoreRestrictionPermissionDialog = false
+        putPrefLanguage("en")
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -37,6 +37,8 @@ import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 
 fun downloadRobot(func: DownloadRobot.() -> Unit) =
   DownloadRobot().applyWithViewHierarchyPrinting(func)
@@ -57,12 +59,15 @@ class DownloadRobot : BaseRobot() {
 
   fun waitForDataToLoad() {
     try {
-      isVisible(Text(zimFileTitle))
+      isVisible(TextId(R.string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
         retryCountForDataToLoad--
         waitForDataToLoad()
+        return
       }
+      // throw the exception when there is no more retry left.
+      throw RuntimeException("Couldn't load the online library list.\n Original exception = $e")
     }
   }
 
@@ -75,7 +80,14 @@ class DownloadRobot : BaseRobot() {
   }
 
   fun downloadZimFile() {
-    clickOn(Text(zimFileTitle))
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      onView(
+        RecyclerViewMatcher(R.id.libraryList).atPosition(
+          1
+        )
+      ).perform(click())
+    })
   }
 
   fun assertDownloadStart() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -38,6 +38,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
@@ -74,9 +75,17 @@ class DownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 
@@ -137,10 +146,10 @@ class DownloadTest : BaseActivityTest() {
         // change the application language
         topLevel {
           clickSettingsOnSideNav {
-            clickOnLanguagePreference()
+            clickLanguagePreference()
             assertLanguagePrefDialogDisplayed()
             selectDeviceDefaultLanguage()
-            clickOnLanguagePreference()
+            clickLanguagePreference()
             assertLanguagePrefDialogDisplayed()
             selectAlbanianLanguage()
           }
@@ -159,7 +168,7 @@ class DownloadTest : BaseActivityTest() {
         // select the default device language to perform other test cases.
         topLevel {
           clickSettingsOnSideNav {
-            clickOnLanguagePreference()
+            clickLanguagePreference()
             assertLanguagePrefDialogDisplayed()
             selectDeviceDefaultLanguage()
             // check if the device default language is selected or not.

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -30,6 +30,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -51,6 +52,13 @@ class HelpFragmentTest : BaseActivityTest() {
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 
@@ -113,6 +121,7 @@ class HelpFragmentTest : BaseActivityTest() {
         putPrefWifiOnly(false)
         setIsPlayStoreBuildType(showRestriction)
         prefIsTest = true
+        putPrefLanguage("en")
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -34,6 +34,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -65,9 +66,17 @@ class InitialDownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -29,6 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -60,9 +61,17 @@ class IntroFragmentTest : BaseActivityTest() {
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -75,9 +76,17 @@ class LanguageFragmentTest {
         putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
         putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
         putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+        putString(SharedPreferenceUtil.PREF_LANG, "en")
       }
     ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(instrumentation.targetContext.applicationContext)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -34,6 +34,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -86,6 +87,13 @@ class LocalFileTransferTest {
     shouldShowShowCaseFeatureToUser(false)
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
     StandardActions.closeDrawer()
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
@@ -113,6 +121,11 @@ class LocalFileTransferTest {
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
       onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
         it.navigate(R.id.libraryFragment)
       }
     }
@@ -161,6 +174,7 @@ class LocalFileTransferTest {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, shouldShowShowCase)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     if (isResetShowCaseId) {
       // To clear showCaseID to ensure the showcase view will show.

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -28,6 +28,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
@@ -61,9 +62,17 @@ class TopLevelDestinationTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -55,6 +55,7 @@ class MimeTypeTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/PlayStoreRestrictionDialogTest.kt
@@ -114,6 +114,7 @@ class PlayStoreRestrictionDialogTest {
         setIsPlayStoreBuildType(true)
         prefIsTest = true
         playStoreRestrictionPermissionDialog = showDialog
+        putPrefLanguage("en")
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -32,6 +32,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -70,9 +71,17 @@ class LocalLibraryTest : BaseActivityTest() {
       // while refreshing the content in LocalLibraryFragment.
       putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -66,9 +67,17 @@ class NoteFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -32,6 +32,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
@@ -63,9 +64,17 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -65,9 +66,17 @@ class NavigationHistoryTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -54,9 +55,17 @@ class EncodedUrlTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -63,9 +64,17 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
@@ -68,9 +69,17 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
@@ -73,9 +74,17 @@ class SearchFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -166,6 +166,23 @@ class SearchFragmentTest : BaseActivityTest() {
       // go to reader screen
       pressBack()
     }
+
+    // Added test for checking the crash scenario where the application was crashing when we
+    // frequently searched for article, and clicked on the searched item.
+    search {
+      // test by searching 10 article and clicking on them
+      searchAndClickOnArticle(searchQueryForDownloadedZimFile)
+      searchAndClickOnArticle("A Song")
+      searchAndClickOnArticle("The Ra")
+      searchAndClickOnArticle("The Ge")
+      searchAndClickOnArticle("Wish")
+      searchAndClickOnArticle("WIFI")
+      searchAndClickOnArticle("Woman")
+      searchAndClickOnArticle("Big Ba")
+      searchAndClickOnArticle("My Wor")
+      searchAndClickOnArticle("100")
+      assertArticleLoaded()
+    }
     removeTemporaryZimFilesToFreeUpDeviceStorage()
     LeakAssertions.assertNoLeaks()
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -20,26 +20,27 @@ package org.kiwix.kiwixmobile.search
 
 import android.view.KeyEvent
 import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
-import androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition
-import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.uiautomator.UiDevice
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import org.hamcrest.Matchers.allOf
+import com.adevinta.android.barista.internal.matcher.HelperMatchers.atPosition
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 fun search(func: SearchRobot.() -> Unit) = SearchRobot().applyWithViewHierarchyPrinting(func)
 
@@ -67,29 +68,24 @@ class SearchRobot : BaseRobot() {
   }
 
   fun searchWithFrequentlyTypedWords(query: String, wait: Long = 0L) {
-    val searchView = onView(withId(R.id.search_src_text))
-    for (char in query) {
-      searchView.perform(typeText(char.toString()))
-      if (wait != 0L) {
-        BaristaSleepInteractions.sleep(wait)
+    testFlakyView({
+      val searchView = onView(withId(R.id.search_src_text))
+      for (char in query) {
+        searchView.perform(typeText(char.toString()))
+        if (wait != 0L) {
+          BaristaSleepInteractions.sleep(wait)
+        }
       }
-    }
+    })
   }
 
   fun assertSearchSuccessful(searchResult: String) {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     val recyclerViewId = R.id.search_list
 
-    // Scroll to the first position in the RecyclerView
-    onView(withId(recyclerViewId)).perform(scrollToPosition<ViewHolder>(0))
-
-    // Match the view at the first position in the RecyclerView
-    onView(withText(searchResult)).check(
+    onView(withId(recyclerViewId)).check(
       matches(
-        allOf(
-          isDisplayed(),
-          isDescendantOfA(withId(recyclerViewId))
-        )
+        atPosition(0, hasDescendant(withText(searchResult)))
       )
     )
   }
@@ -105,5 +101,27 @@ class SearchRobot : BaseRobot() {
     // clear search query if any remains due to any condition not to affect any other test scenario
     val searchView = onView(withId(R.id.search_src_text))
     searchView.perform(clearText())
+  }
+
+  private fun openSearchScreen() {
+    testFlakyView({ onView(withId(R.id.menu_search)).perform(click()) })
+  }
+
+  fun searchAndClickOnArticle(searchString: String) {
+    openSearchScreen()
+    searchWithFrequentlyTypedWords(searchString)
+    clickOnSearchItemInSearchList()
+  }
+
+  fun assertArticleLoaded() {
+    testFlakyView({
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'Big Baby DRAM')]"
+          )
+        )
+    })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -28,6 +28,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.intro.IntroRobot
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
@@ -69,6 +71,11 @@ class KiwixSettingsFragmentTest {
     }
     UiThreadStatement.runOnUiThread {
       activityScenarioRule.scenario.onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(it)
+        )
         it.navigate(R.id.introFragment)
       }
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -78,7 +78,22 @@ class SettingsRobot : BaseRobot() {
   }
 
   fun clickLanguagePreference() {
-    clickRecyclerViewItems(R.string.device_default)
+    testFlakyView({
+      onView(
+        withResourceName("recycler_view")
+      ).perform(
+        actionOnItem<RecyclerView.ViewHolder>(
+          hasDescendant(
+            Matchers.anyOf(
+              withText("shqip"),
+              withText("English"),
+              withText(R.string.device_default)
+            )
+          ),
+          ViewActions.click()
+        )
+      )
+    })
   }
 
   fun assertLanguagePrefDialogDisplayed() {
@@ -126,21 +141,6 @@ class SettingsRobot : BaseRobot() {
 
   fun assertVersionTextViewPresent() {
     clickRecyclerViewItems(R.string.pref_info_version)
-  }
-
-  fun clickOnLanguagePreference() {
-    try {
-      clickRecyclerViewItems(R.string.device_default)
-    } catch (ignore: Exception) {
-      // if the device language Albanian
-      onView(
-        withResourceName("recycler_view")
-      ).perform(
-        actionOnItem<RecyclerView.ViewHolder>(
-          hasDescendant(Matchers.anyOf(withText("shqip"))), ViewActions.click()
-        )
-      )
-    }
   }
 
   fun selectAlbanianLanguage() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -31,6 +31,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
@@ -88,10 +89,18 @@ class ZimHostFragmentTest {
         setIsPlayStoreBuildType(true)
         prefIsTest = true
         playStoreRestrictionPermissionDialog = false
+        putPrefLanguage("en")
       }
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(it)
+        )
+      }
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -86,14 +86,7 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
       }
   }
 
-  fun copyReader(): ZimFileReader? = runBlocking {
-    zimFile?.let { zimFileReaderFactory.create(it) }
-      ?: assetFileDescriptor?.let { zimFileReaderFactory.create(it) }
-  }
-
   val zimFile get() = zimFileReader?.zimFile
-
-  val assetFileDescriptor get() = zimFileReader?.assetFileDescriptor
 
   /**
    * Return the zimFile path if opened from file else return the filePath of assetFileDescriptor
@@ -112,5 +105,3 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
   val favicon get() = zimFileReader?.favicon
   val language get() = zimFileReader?.language
 }
-
-data class SearchResult(val title: String?)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -285,6 +285,15 @@ class SearchFragment : BaseFragment() {
     }
 
   private suspend fun render(state: SearchState) {
+    // Check if the fragment is visible on the screen. This method called multiple times
+    // (7-14 times) when an item in the search list is clicked, which leads to unnecessary
+    // data loading and also causes a crash.
+    // The issue arises because the searchViewModel takes a moment to detach from the window,
+    // and during this time, this method is called multiple times due to the rendering process.
+    // To avoid unnecessary data loading and prevent crashes, we check if the search screen is
+    // visible to the user before proceeding. If the screen is not visible,
+    // we skip the data loading process.
+    // if (!isVisible) return
     searchMutex.withLock {
       // `cancelAndJoin` cancels the previous running job and waits for it to completely cancel.
       renderingJob?.cancelAndJoin()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -293,7 +293,7 @@ class SearchFragment : BaseFragment() {
     // To avoid unnecessary data loading and prevent crashes, we check if the search screen is
     // visible to the user before proceeding. If the screen is not visible,
     // we skip the data loading process.
-    // if (!isVisible) return
+    if (!isVisible) return
     searchMutex.withLock {
       // `cancelAndJoin` cancels the previous running job and waits for it to completely cancel.
       renderingJob?.cancelAndJoin()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -113,12 +113,10 @@ class SearchViewModel @Inject constructor(
   @Suppress("DEPRECATION")
   private fun searchResults() = filter.asFlow()
     .mapLatest {
-      val zimFileReader = zimReaderContainer.copyReader()
-      try {
-        SearchResultsWithTerm(it, searchResultGenerator.generateSearchResults(it, zimFileReader))
-      } finally {
-        zimFileReader?.dispose()
-      }
+      SearchResultsWithTerm(
+        it,
+        searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader)
+      )
     }
 
   private suspend fun actionMapper() = actions.consumeEach {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -100,7 +100,7 @@ internal class SearchViewModelTest {
     Dispatchers.setMain(testDispatcher)
     clearAllMocks()
     recentsFromDb = Channel(kotlinx.coroutines.channels.Channel.UNLIMITED)
-    every { zimReaderContainer.copyReader() } returns zimFileReader
+    every { zimReaderContainer.zimFileReader } returns zimFileReader
     coEvery {
       searchResultGenerator.generateSearchResults("", zimFileReader)
     } returns null


### PR DESCRIPTION
Fixes #3848 

* Now we are using the same `ZimFileReader` object to search the articles. It reduces the search timing and avoids unnecessary allocation of objects in memory.
* Refactored the `SearchViewModelTest` for this change.
* After this change, a few codes are become unused so we have removed that from our application.
* Fixed the test cases that were failing if `testPauseAndResumeInOtherLanguage` failed due to any reason. Because the language remains changed and other test cases will fail. Like it was failed in this PR on API level 30(https://github.com/kiwix/kiwix-android/actions/runs/9113243814/job/25054265367).
* Also, improved our `DownloadTest`, because after changing the language of the application online content will change according to the new language so now we are using a generic approach for downloading the zim file.

* Fixed the crash that playStore reported. It was due to the `render` method was called multiple times (7-14 times) when an item in the search list is clicked, which leads to unnecessary data loading and also causes a crash. The issue arises because the searchViewModel takes a moment to detach from the window, and during this time, this method is called multiple times due to the rendering process. To avoid unnecessary data loading and prevent crashes, we check if the search screen is visible to the user before proceeding. If the screen is not visible, we skip the data loading process. Below are crash logs reported by the playStore, and the same crash logs are generated by my device.

```kotlin
Cmdline: org.kiwix.kiwixmobile
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A  pid: 6773, tid: 7126, name: DefaultDispatch  >>> org.kiwix.kiwixmobile <<<
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #00 pc 0000000000230120  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #01 pc 0000000000230cb4  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (std::__ndk1::list<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> >, std::__ndk1::allocator<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> > > >::splice(std::__ndk1::__list_const_iterator<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> >, void*>, std::__ndk1::list<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> >, std::__ndk1::allocator<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> > > >&, std::__ndk1::__list_const_iterator<std::__ndk1::pair<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> >, void*>)+96)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #02 pc 000000000022f53c  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::lru_cache<unsigned int, std::__ndk1::shared_ptr<zim::Dirent const> >::get(unsigned int const&)+204)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #03 pc 000000000022ee14  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::DirectDirentAccessor::getDirent(zim::entry_index_t) const+92)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #04 pc 0000000000244e1c  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::DirentLookup<zim::FileImpl::DirentLookupConfig>::compareWithDirentAt(char, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, unsigned int) const+80)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #05 pc 0000000000244658  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::DirentLookup<zim::FileImpl::DirentLookupConfig>::findInRange(unsigned int, unsigned int, char, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&) const+308)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #06 pc 000000000023c05c  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::FastDirentLookup<zim::FileImpl::DirentLookupConfig>::find(char, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&) const+124)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #07 pc 0000000000238ca8  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::FileImpl::findx(char, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)+72)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #08 pc 0000000000238d6c  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::FileImpl::findx(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)+140)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #09 pc 0000000000215ce8  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::Archive::getEntryByPath(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&) const+564)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #10 pc 00000000002a65f0  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::SuggestionIterator::SuggestionInternalData::get_entry()+152)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #11 pc 00000000002a5390  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::SuggestionIterator::getIndexTitle() const+84)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #12 pc 00000000002a5688  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim.so (offset 0x1400000) (zim::SuggestionIterator::operator*()+168)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #13 pc 0000000000028548  /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!libzim_wrapper.so (offset 0x626000) (Java_org_kiwix_libzim_SuggestionIterator_next+500) (BuildId: eb23384a06a222c0ee4838412233ff48d1d128df)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #19 pc 00000000000074e4  /data/data/org.kiwix.kiwixmobile/code_cache/.overlay/base.apk/classes11.dex (org.kiwix.kiwixmobile.core.search.viewmodel.SearchState.getVisibleResults+0)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #24 pc 0000000000006a78  /data/data/org.kiwix.kiwixmobile/code_cache/.overlay/base.apk/classes10.dex (org.kiwix.kiwixmobile.core.search.SearchFragment$render$2$1$searchResult$1.invokeSuspend+0)
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #34 pc 00000000003562e4  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #39 pc 000000000036364c  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #44 pc 0000000000361ccc  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #49 pc 000000000035fddc  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #54 pc 000000000035ffd8  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
2024-05-17 18:04:28.835  7150-7150  DEBUG                   pid-7150                             A        #59 pc 000000000035ffac  [anon:dalvik-classes29.dex extracted in memory from /data/app/~~gt9Pp7_lZdkwP2e02Egrww==/org.kiwix.kiwixmobile-Js9e1XXFsUslmGj9kqciZA==/base.apk!classes29.dex]
```

* Added the test cases for this scenario so that we can avoid this type of errors in future.