### PR TITLE
Fixed: Broken fullscreen mode with `3.10`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -203,7 +203,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     ) {
       exitBook()
     }
-    if (isFullScreenVideo) {
+    if (isFullScreenVideo || isInFullScreenMode()) {
       hideNavBar()
     }
   }
@@ -275,7 +275,11 @@ class KiwixReaderFragment : CoreReaderFragment() {
   }
 
   private fun showNavBar() {
-    requireActivity().findViewById<BottomNavigationView>(R.id.bottom_nav_view).visibility = VISIBLE
+    // show the navBar if fullScreenMode is not active.
+    if (!isInFullScreenMode()) {
+      requireActivity().findViewById<BottomNavigationView>(R.id.bottom_nav_view).visibility =
+        VISIBLE
+    }
   }
 
   override fun createNewTab() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -109,7 +109,7 @@ fun View.closeFullScreenMode(window: Window) {
   WindowCompat.setDecorFitsSystemWindows(window, true)
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
     WindowInsetsControllerCompat(window, window.decorView).apply {
-      show(WindowInsetsCompat.Type.systemBars())
+      show(WindowInsetsCompat.Type.statusBars())
       show(WindowInsetsCompat.Type.displayCutout())
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ViewExtensions.kt
@@ -19,9 +19,15 @@
 package org.kiwix.kiwixmobile.core.extensions
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.view.View
+import android.view.Window
+import android.view.WindowManager
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 
@@ -80,4 +86,36 @@ fun View.snack(
 fun View.setToolTipWithContentDescription(description: String) {
   contentDescription = description
   TooltipCompat.setTooltipText(this, description)
+}
+
+fun View.showFullScreenMode(window: Window) {
+  WindowCompat.setDecorFitsSystemWindows(window, false)
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    WindowInsetsControllerCompat(window, window.decorView).apply {
+      hide(WindowInsetsCompat.Type.statusBars())
+      hide(WindowInsetsCompat.Type.displayCutout())
+      systemBarsBehavior =
+        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
+  }
+  @Suppress("Deprecation")
+  window.apply {
+    addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+    clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+  }
+}
+
+fun View.closeFullScreenMode(window: Window) {
+  WindowCompat.setDecorFitsSystemWindows(window, true)
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    WindowInsetsControllerCompat(window, window.decorView).apply {
+      show(WindowInsetsCompat.Type.systemBars())
+      show(WindowInsetsCompat.Type.displayCutout())
+    }
+  }
+  @Suppress("DEPRECATION")
+  window.apply {
+    addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN)
+    clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -73,9 +73,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Lifecycle
@@ -113,9 +110,11 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationP
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.findFirstTextView
+import org.kiwix.kiwixmobile.core.extensions.closeFullScreenMode
 import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
+import org.kiwix.kiwixmobile.core.extensions.showFullScreenMode
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.DocumentParser.SectionsListener
@@ -1483,12 +1482,7 @@ abstract class CoreReaderFragment :
     exitFullscreenButton?.visibility = View.VISIBLE
     exitFullscreenButton?.background?.alpha = 153
     val window = requireActivity().window
-    WindowCompat.setDecorFitsSystemWindows(window, true)
-    WindowInsetsControllerCompat(window, window.decorView.rootView).apply {
-      hide(WindowInsetsCompat.Type.systemBars())
-      systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-      window.decorView.rootView.requestLayout()
-    }
+    window.decorView.showFullScreenMode(window)
     getCurrentWebView()?.apply {
       requestLayout()
       translationY = 0f
@@ -1499,18 +1493,14 @@ abstract class CoreReaderFragment :
   @Suppress("MagicNumber")
   @OnClick(R2.id.activity_main_fullscreen_button)
   open fun closeFullScreen() {
+    sharedPreferenceUtil?.putPrefFullScreen(false)
     toolbarContainer?.visibility = View.VISIBLE
     updateBottomToolbarVisibility()
     exitFullscreenButton?.visibility = View.GONE
     exitFullscreenButton?.background?.alpha = 255
     val window = requireActivity().window
-    WindowCompat.setDecorFitsSystemWindows(window, true)
-    WindowInsetsControllerCompat(window, window.decorView.rootView).apply {
-      show(WindowInsetsCompat.Type.systemBars())
-      window.decorView.rootView.requestLayout()
-    }
+    window.decorView.closeFullScreenMode(window)
     getCurrentWebView()?.requestLayout()
-    sharedPreferenceUtil?.putPrefFullScreen(false)
   }
 
   override fun openExternalUrl(intent: Intent) {
@@ -1771,12 +1761,12 @@ abstract class CoreReaderFragment :
     }
   }
 
-  private fun isInFullScreenMode(): Boolean = sharedPreferenceUtil?.prefFullScreen == true
+  protected fun isInFullScreenMode(): Boolean = sharedPreferenceUtil?.prefFullScreen == true
 
   private fun updateBottomToolbarVisibility() {
     bottomToolbar?.let {
       if (urlIsValid() &&
-        tabSwitcherRoot?.visibility != View.VISIBLE
+        tabSwitcherRoot?.visibility != View.VISIBLE && !isInFullScreenMode()
       ) {
         it.visibility = View.VISIBLE
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -67,7 +67,9 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
     (context as Activity).window.apply {
       if (isFullScreen) {
         showFullScreenMode(this)
-      } else {
+      } else if (!sharedPreferenceUtil.prefFullScreen) {
+        // close the fullScreenMode if application is not running in the fullScreenMode.
+        // when closing the video's fullScreenMode, otherwise no need to close the fullScreenMode.
         closeFullScreenMode(this)
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -24,23 +24,22 @@ import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.util.AttributeSet
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import android.view.ContextMenu
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.closeFullScreenMode
+import org.kiwix.kiwixmobile.core.extensions.showFullScreenMode
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.videowebview.VideoEnabledWebChromeClient.ToggledFullscreenCallback
 import org.kiwix.videowebview.VideoEnabledWebView
 import javax.inject.Inject
@@ -65,16 +64,11 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
   private val compositeDisposable = CompositeDisposable()
 
   private fun setWindowVisibility(isFullScreen: Boolean) {
-    val window = (context as Activity).window
-    WindowCompat.setDecorFitsSystemWindows(window, !isFullScreen)
-    WindowInsetsControllerCompat(window, window.decorView.rootView).apply {
+    (context as Activity).window.apply {
       if (isFullScreen) {
-        hide(WindowInsetsCompat.Type.systemBars())
-        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        window.decorView.rootView.requestLayout()
+        showFullScreenMode(this)
       } else {
-        show(WindowInsetsCompat.Type.systemBars())
-        window.decorView.rootView.requestLayout()
+        closeFullScreenMode(this)
       }
     }
   }


### PR DESCRIPTION
Fixes #3851 

* Fixed the fullScreen mode not properly working on Android 11 and above(It was showing the blue line on the top), and also not showing the navigation options so that the user can close the `fullScreenMode` while pressing the back button in the navigation. Now it started showing the `fullScreenMode` like in earlier version of kiwix.
* Also improved the `fullScreenMode` for lower versions of Android. We have created an extension function so that we can easily reuse the code when we open/close the `fullScreenMode` for a video.
* Fixed the BottomToolbar's options was showing when the application is in the background in `fullScreenMode` and the user opens again the application.
* When the application is running in the `fullScreenmode` and we close the `fullScreenMode` of a video so at that time BottomToolbar's option was showing. So we have fixed that.


| Before Android 11  | After Android 11 |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/130740f9-0a7b-4fa4-a807-968508c33a3c"> | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/4d6d5cf9-bb7a-4328-a011-63617cf02537">  |