### PR TITLE
Fixed: If there is a zim file loaded in the reader that has the service worker in it so we can't exit the application with a back Button.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -108,6 +108,8 @@ class SearchRobot : BaseRobot() {
   }
 
   fun searchAndClickOnArticle(searchString: String) {
+    // wait a bit to properly load the ZIM file in the reader
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     openSearchScreen()
     searchWithFrequentlyTypedWords(searchString)
     clickOnSearchItemInSearchList()


### PR DESCRIPTION
Fixes #3854 

*  The issue was caused by a service worker URL being loaded in the WebView. When the back button was pressed, the callback redirected to the mainPage, causing an infinite loop. To address this, we clear the WebView history if the URL is the main page URL, as WebView cannot clear the history for the current page. If the current URL is a service worker URL and we clear the history, it will not remove the service worker from the history, so it will remain. Therefore, we clear the history when the main page is loaded for the first time.
* Also, fixed the back button problem with service worker ZIM files.
* Improved the showing of `bottomToolbar` visibility code, the null check was placed on the wrong views.
* Preventing saving the Service worker url in history.
* Added necessary comments on the method why we are placing the conditions.
* Fixed flaky `SearchFragmentTest` that occasionally fails due to the `search_src_text` not found error.

| Before fix  | After fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/699594ec-77e8-40a6-b412-1fe92c22752c"/> |  <video src="https://github.com/kiwix/kiwix-android/assets/34593983/8636d0a0-580f-4a22-a666-c39994607c2f"/> |


https://github.com/kiwix/kiwix-android/assets/34593983/34455acf-e984-43c0-a6c4-69a6a871c544

