### PR TITLE
Room introduction & migration of recent search

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+
+@RunWith(AndroidJUnit4::class)
+class KiwixRoomDatabaseTest {
+  private lateinit var recentSearchRoomDao: RecentSearchRoomDao
+  private lateinit var db: KiwixRoomDatabase
+
+  @After
+  fun teardown() {
+    db.close()
+  }
+
+  @Test
+  fun testRecentSearchRoomDao() = runBlocking {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    db = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    val zimId = "34388L"
+    val searchTerm = "title 1"
+    val searchTerm2 = "title 2"
+    val url = ""
+    recentSearchRoomDao = db.recentSearchRoomDao()
+    val recentSearch = RecentSearchRoomEntity(zimId = zimId, searchTerm = searchTerm, url = url)
+    val recentSearch1 = RecentSearchRoomEntity(zimId = zimId, searchTerm = searchTerm2, url = url)
+
+    // test inserting into recent search database
+    recentSearchRoomDao.saveSearch(recentSearch.searchTerm, recentSearch.zimId, url = url)
+    var recentSearches = recentSearchRoomDao.search(zimId).first()
+    assertEquals(recentSearches.size, 1)
+    assertEquals(recentSearch.searchTerm, recentSearches.first().searchTerm)
+    assertEquals(recentSearch.zimId, recentSearches.first().zimId)
+
+    // test deleting recent search
+    recentSearchRoomDao.deleteSearchString(searchTerm)
+    recentSearches = recentSearchRoomDao.search(searchTerm).first()
+    assertEquals(recentSearches.size, 0)
+
+    // test deleting all recent search history
+    recentSearchRoomDao.saveSearch(recentSearch.searchTerm, recentSearch.zimId, url = url)
+    recentSearchRoomDao.saveSearch(recentSearch1.searchTerm, recentSearch1.zimId, url = url)
+    recentSearches = recentSearchRoomDao.search(zimId).first()
+    assertEquals(recentSearches.size, 2)
+    recentSearchRoomDao.deleteSearchHistory()
+    recentSearches = recentSearchRoomDao.search(searchTerm).first()
+    assertEquals(recentSearches.size, 0)
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -102,7 +102,7 @@ class ObjectBoxToRoomMigratorTest {
     // Migrate data into Room database
     objectBoxToRoomMigrator.migrateRecentSearch(box)
     val actualDataAfterMigration = kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
-    assertEquals(1, actual.size)
+    assertEquals(2, actualDataAfterMigration.size)
     val existingItem =
       actualDataAfterMigration.find {
         it.searchTerm == existingSearchTerm && it.zimId == existingZimId
@@ -138,14 +138,12 @@ class ObjectBoxToRoomMigratorTest {
     assertTrue(actualDataAfterInvalidMigration.isEmpty())
 
     // Test large data migration for recent searches
-    val numEntities = 1000
+    val numEntities = 5000
     // Insert a large number of recent search entities into ObjectBox
     for (i in 1..numEntities) {
       val searchTerm = "search_$i"
       val zimId = "$i"
-      val recentSearchEntity =
-        RecentSearchEntity(searchTerm = searchTerm, zimId = zimId, url = "$expectedUrl$i")
-      box.put(recentSearchEntity)
+      box.put(RecentSearchEntity(searchTerm = searchTerm, zimId = zimId, url = "$expectedUrl$i"))
     }
     val startTime = System.currentTimeMillis()
     // Migrate data into Room database
@@ -157,7 +155,7 @@ class ObjectBoxToRoomMigratorTest {
       kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
     assertEquals(numEntities, actualDataAfterLargeMigration.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 5000)
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 10000)
   }
 
   private fun clearRecentSearchDatabases(box: Box<RecentSearchEntity>) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.objectbox.Box
+import io.objectbox.BoxStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
+import org.kiwix.kiwixmobile.core.di.modules.DatabaseModule
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+
+@RunWith(AndroidJUnit4::class)
+class ObjectBoxToRoomMigratorTest {
+  private lateinit var context: Context
+  private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
+  private lateinit var boxStore: BoxStore
+  private lateinit var objectBoxToRoomMigrator: ObjectBoxToRoomMigrator
+
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+    kiwixRoomDatabase = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    boxStore = DatabaseModule.boxStore!!
+    objectBoxToRoomMigrator = ObjectBoxToRoomMigrator()
+    objectBoxToRoomMigrator.kiwixRoomDatabase = kiwixRoomDatabase
+    objectBoxToRoomMigrator.boxStore = boxStore
+    objectBoxToRoomMigrator.sharedPreferenceUtil = SharedPreferenceUtil(context)
+  }
+
+  @After
+  fun cleanup() {
+    kiwixRoomDatabase.close()
+    boxStore.close()
+  }
+
+  @Test
+  fun migrateRecentSearch_shouldInsertDataIntoRoomDatabase() = runBlocking {
+    val box = boxStore.boxFor(RecentSearchEntity::class.java)
+    // clear both databases for recent searches to test more edge cases
+    clearRecentSearchDatabases(box)
+    val expectedSearchTerm = "test search"
+    val expectedZimId = "8812214350305159407L"
+    val expectedUrl = "http://kiwix.app/mainPage"
+    val recentSearchEntity =
+      RecentSearchEntity(searchTerm = expectedSearchTerm, zimId = expectedZimId, url = expectedUrl)
+    // insert into object box
+    box.put(recentSearchEntity)
+    // migrate data into room database
+    objectBoxToRoomMigrator.migrateRecentSearch(box)
+    // check if data successfully migrated to room
+    val actual = kiwixRoomDatabase.recentSearchRoomDao().search(expectedZimId).first()
+    assertEquals(actual.size, 1)
+    assertEquals(actual[0].searchTerm, expectedSearchTerm)
+    assertEquals(actual[0].zimId, expectedZimId)
+
+    // clear both databases for recent searches to test more edge cases
+    clearRecentSearchDatabases(box)
+
+    // Migrate data from empty ObjectBox database
+    objectBoxToRoomMigrator.migrateRecentSearch(box)
+    val actualData = kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
+    assertTrue(actualData.isEmpty())
+
+    // Test if data successfully migrated to Room and existing data is preserved
+    val existingSearchTerm = "existing search"
+    val existingZimId = "8812214350305159407L"
+    kiwixRoomDatabase.recentSearchRoomDao()
+      .saveSearch(existingSearchTerm, existingZimId, "$expectedUrl/1")
+    box.put(recentSearchEntity)
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateRecentSearch(box)
+    val actualDataAfterMigration = kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
+    assertEquals(1, actual.size)
+    val existingItem =
+      actualDataAfterMigration.find {
+        it.searchTerm == existingSearchTerm && it.zimId == existingZimId
+      }
+    assertNotNull(existingItem)
+    val newItem =
+      actualDataAfterMigration.find {
+        it.searchTerm == expectedSearchTerm && it.zimId == expectedZimId
+      }
+    assertNotNull(newItem)
+
+    clearRecentSearchDatabases(box)
+
+    // Test migration if ObjectBox has null values
+    lateinit var undefinedSearchTerm: String
+    lateinit var undefinedZimId: String
+    lateinit var undefinedUrl: String
+    try {
+      val invalidSearchEntity =
+        RecentSearchEntity(
+          searchTerm = undefinedSearchTerm,
+          zimId = undefinedZimId,
+          url = undefinedUrl
+        )
+      box.put(invalidSearchEntity)
+      // Migrate data into Room database
+      objectBoxToRoomMigrator.migrateRecentSearch(box)
+    } catch (_: Exception) {
+    }
+    // Ensure Room database remains empty or unaffected by the invalid data
+    val actualDataAfterInvalidMigration =
+      kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
+    assertTrue(actualDataAfterInvalidMigration.isEmpty())
+
+    // Test large data migration for recent searches
+    val numEntities = 1000
+    // Insert a large number of recent search entities into ObjectBox
+    for (i in 1..numEntities) {
+      val searchTerm = "search_$i"
+      val zimId = "$i"
+      val recentSearchEntity =
+        RecentSearchEntity(searchTerm = searchTerm, zimId = zimId, url = "$expectedUrl$i")
+      box.put(recentSearchEntity)
+    }
+    val startTime = System.currentTimeMillis()
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateRecentSearch(box)
+    val endTime = System.currentTimeMillis()
+    val migrationTime = endTime - startTime
+    // Check if data successfully migrated to Room
+    val actualDataAfterLargeMigration =
+      kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
+    assertEquals(numEntities, actualDataAfterLargeMigration.size)
+    // Assert that the migration completes within a reasonable time frame
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 5000)
+  }
+
+  private fun clearRecentSearchDatabases(box: Box<RecentSearchEntity>) {
+    // delete history for testing other edge cases
+    kiwixRoomDatabase.recentSearchRoomDao().deleteSearchHistory()
+    box.removeAll()
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/RecentSearchRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/RecentSearchRoomDaoTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+
+@RunWith(AndroidJUnit4::class)
+class RecentSearchRoomDaoTest {
+
+  private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
+  private lateinit var recentSearchRoomDao: RecentSearchRoomDao
+
+  @After
+  fun tearDown() {
+    kiwixRoomDatabase.close()
+  }
+
+  @Test
+  fun testRecentSearchRoomDao() = runBlocking {
+    val zimId = "8812214350305159407L"
+    val url = "http://kiwix.app/mainPage"
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    kiwixRoomDatabase = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java).build()
+    recentSearchRoomDao = kiwixRoomDatabase.recentSearchRoomDao()
+    // Save a recent search entity
+    val query =
+      "This is a long search term to test whether it will be saved into the room database."
+    recentSearchRoomDao.saveSearch(query, zimId, url)
+    // Search for recent search entities with a matching zimId
+    val result = getRecentSearchByZimId(zimId)
+    // Verify that the result contains the saved entity
+    assertThat(result.size, equalTo(1))
+    assertThat(result[0].searchTerm, equalTo(query))
+    assertThat(result[0].zimId, equalTo(zimId))
+
+    // Delete the saved entity by search term
+    recentSearchRoomDao.deleteSearchString(query)
+    // Verify that the result does not contain the deleted entity
+    assertThat(getRecentSearchByZimId(zimId).size, equalTo(0))
+
+    // Testing deleting all recent searched history
+    // Save two recent search entities
+    recentSearchRoomDao.saveSearch(query, zimId, url)
+    recentSearchRoomDao.saveSearch("query 2", zimId, url)
+    // Delete all recent search entities
+    recentSearchRoomDao.deleteSearchHistory()
+    // Verify that the result is empty
+    assertThat(getRecentSearchByZimId(zimId).size, equalTo(0))
+
+    // test to save empty values for recent search
+    val emptyQuery = ""
+    recentSearchRoomDao.saveSearch(emptyQuery, zimId, url)
+    // verify that the result is not empty
+    assertThat(getRecentSearchByZimId(zimId).size, equalTo(1))
+
+    // we are not saving undefined or null values into database.
+    // test to save undefined value for recent search.
+    lateinit var undefinedQuery: String
+    try {
+      recentSearchRoomDao.saveSearch(undefinedQuery, zimId, url)
+      assertThat(
+        "Undefined value was saved into database",
+        false
+      )
+    } catch (e: Exception) {
+      assertThat("Undefined value was not saved, as expected.", true)
+    }
+
+    // Delete all recent search entities for testing unicodes values
+    recentSearchRoomDao.deleteSearchHistory()
+
+    // save unicode values into database
+    val unicodeQuery = "title \u03A3" // Unicode character for Greek capital letter Sigma
+    recentSearchRoomDao.saveSearch(unicodeQuery, zimId, url)
+    assertThat(getRecentSearchByZimId(zimId)[0].searchTerm, equalTo("title Σ"))
+  }
+
+  private suspend fun getRecentSearchByZimId(zimId: String) =
+    recentSearchRoomDao.search(zimId).first()
+}

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -351,4 +351,8 @@ object Libs {
    */
   const val material_show_case_view: String =
     "com.github.deano2390:MaterialShowcaseView:" + Versions.material_show_case_view
+
+  const val roomKtx = "androidx.room:room-ktx:" + Versions.roomVersion
+
+  const val roomCompiler = "androidx.room:room-compiler:" + Versions.roomVersion
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -103,6 +103,8 @@ object Versions {
   const val junit: String = "1.1.5"
 
   const val material_show_case_view: String = "1.3.7"
+
+  const val roomVersion = "2.5.0"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -206,6 +206,8 @@ class AllProjectConfigurer {
       implementation(Libs.rxjava)
       implementation(Libs.preference_ktx)
       implementation(Libs.material_show_case_view)
+      implementation(Libs.roomKtx)
+      kapt(Libs.roomCompiler)
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/RecentSearchRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/RecentSearchRoomDao.kt
@@ -1,0 +1,98 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import io.objectbox.Box
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
+import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
+
+@Dao
+abstract class RecentSearchRoomDao {
+
+  @Query(
+    "SELECT * FROM RecentSearchRoomEntity WHERE zimId LIKE :zimId ORDER BY" +
+      " RecentSearchRoomEntity.id DESC"
+  )
+  abstract fun search(zimId: String?): Flow<List<RecentSearchRoomEntity>>
+
+  @Query(
+    "SELECT * FROM RecentSearchRoomEntity"
+  )
+  abstract fun fullSearch(): Flow<List<RecentSearchRoomEntity>>
+
+  fun recentSearches(zimId: String? = ""): Flow<List<SearchListItem.RecentSearchListItem>> {
+    return if (zimId != "") {
+      search(zimId).map { searchEntities ->
+        searchEntities.distinctBy(RecentSearchRoomEntity::searchTerm).take(NUM_RECENT_RESULTS)
+          .map { searchEntity ->
+            SearchListItem.RecentSearchListItem(
+              searchEntity.searchTerm,
+              searchEntity.url
+            )
+          }
+      }
+    } else {
+      return fullSearch().map { searchEntities ->
+        searchEntities.distinctBy(RecentSearchRoomEntity::searchTerm)
+          .take(NUM_RECENT_RESULTS)
+          .map { searchEntity ->
+            SearchListItem.RecentSearchListItem(
+              searchEntity.searchTerm,
+              searchEntity.url
+            )
+          }
+      }
+    }
+  }
+
+  @Query(
+    "INSERT INTO RecentSearchRoomEntity(searchTerm, zimId, url) VALUES (:title , :zimId, :url)"
+  )
+  abstract fun saveSearch(title: String, zimId: String, url: String?)
+
+  @Query("DELETE FROM RecentSearchRoomEntity WHERE searchTerm=:searchTerm")
+  abstract fun deleteSearchString(searchTerm: String)
+
+  @Query("DELETE FROM RecentSearchRoomEntity")
+  abstract fun deleteSearchHistory()
+
+  fun migrationToRoomInsert(
+    box: Box<RecentSearchEntity>
+  ) {
+    val searchRoomEntityList = box.all
+    searchRoomEntityList.forEachIndexed { _, recentSearchEntity ->
+      CoroutineScope(Dispatchers.IO).launch {
+        saveSearch(recentSearchEntity.searchTerm, recentSearchEntity.zimId, recentSearchEntity.url)
+        // Todo Should we remove object store data now?
+      }
+    }
+  }
+
+  companion object {
+    private const val NUM_RECENT_RESULTS = 100
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/RecentSearchRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/RecentSearchRoomDao.kt
@@ -20,13 +20,8 @@ package org.kiwix.kiwixmobile.core.dao
 
 import androidx.room.Dao
 import androidx.room.Query
-import io.objectbox.Box
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 
@@ -79,18 +74,6 @@ abstract class RecentSearchRoomDao {
 
   @Query("DELETE FROM RecentSearchRoomEntity")
   abstract fun deleteSearchHistory()
-
-  fun migrationToRoomInsert(
-    box: Box<RecentSearchEntity>
-  ) {
-    val searchRoomEntityList = box.all
-    searchRoomEntityList.forEachIndexed { _, recentSearchEntity ->
-      CoroutineScope(Dispatchers.IO).launch {
-        saveSearch(recentSearchEntity.searchTerm, recentSearchEntity.zimId, recentSearchEntity.url)
-        // Todo Should we remove object store data now?
-      }
-    }
-  }
 
   companion object {
     private const val NUM_RECENT_RESULTS = 100

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/RecentSearchEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/RecentSearchEntity.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.core.dao.entities
 import io.objectbox.annotation.Entity
 import io.objectbox.annotation.Id
 
-@Deprecated(message = "Replaced with Room")
 @Entity
 data class RecentSearchEntity(
   @Id var id: Long = 0L,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/RecentSearchRoomEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/RecentSearchRoomEntity.kt
@@ -1,6 +1,6 @@
 /*
  * Kiwix Android
- * Copyright (c) 2019 Kiwix <android.kiwix.org>
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -15,15 +15,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 package org.kiwix.kiwixmobile.core.dao.entities
 
-import io.objectbox.annotation.Entity
-import io.objectbox.annotation.Id
+import androidx.room.PrimaryKey
 
-@Deprecated(message = "Replaced with Room")
-@Entity
-data class RecentSearchEntity(
-  @Id var id: Long = 0L,
+@androidx.room.Entity
+data class RecentSearchRoomEntity(
+  @PrimaryKey var id: Long = 0L,
   val searchTerm: String,
   val zimId: String,
   val url: String?

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -1,0 +1,78 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.data
+
+import android.content.Context
+import android.util.Log
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import io.objectbox.BoxStore
+import io.objectbox.kotlin.boxFor
+import org.kiwix.kiwixmobile.core.BuildConfig
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
+
+@Suppress("UnnecessaryAbstractClass")
+@Database(entities = [RecentSearchRoomEntity::class], version = 1)
+abstract class KiwixRoomDatabase : RoomDatabase() {
+  abstract fun recentSearchRoomDao(): RecentSearchRoomDao
+
+  companion object {
+    private var db: KiwixRoomDatabase? = null
+    fun getInstance(context: Context, boxStore: BoxStore): KiwixRoomDatabase {
+      return db ?: synchronized(KiwixRoomDatabase::class) {
+        return@getInstance db
+          ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, "KiwixRoom.db")
+            // We have already database name called kiwix.db in order to avoid complexity we named as
+            // kiwixRoom.db
+            .addCallback(object : RoomDatabase.Callback() {
+              override fun onCreate(db: SupportSQLiteDatabase) {
+                super.onCreate(db)
+                Log.d("gouri", "onCreate")
+              }
+
+              override fun onOpen(db: SupportSQLiteDatabase) {
+                super.onOpen(db)
+                Log.d("gouri", "onOpen")
+              }
+
+              override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
+                super.onDestructiveMigration(db)
+                Log.d("gouri", "onDestructiveMigration")
+              }
+            })
+            .build().also {
+              if (!BuildConfig.BUILD_TYPE.contentEquals("fdroid")) {
+                it.migrateRecentSearch(boxStore)
+              }
+            }
+      }
+    }
+
+    fun destroyInstance() {
+      db = null
+    }
+  }
+
+  fun migrateRecentSearch(boxStore: BoxStore) {
+    recentSearchRoomDao().migrationToRoomInsert(boxStore.boxFor())
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -19,14 +19,9 @@
 package org.kiwix.kiwixmobile.core.data
 
 import android.content.Context
-import android.util.Log
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import androidx.sqlite.db.SupportSQLiteDatabase
-import io.objectbox.BoxStore
-import io.objectbox.kotlin.boxFor
-import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 
@@ -37,42 +32,18 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
 
   companion object {
     private var db: KiwixRoomDatabase? = null
-    fun getInstance(context: Context, boxStore: BoxStore): KiwixRoomDatabase {
+    fun getInstance(context: Context): KiwixRoomDatabase {
       return db ?: synchronized(KiwixRoomDatabase::class) {
         return@getInstance db
           ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, "KiwixRoom.db")
-            // We have already database name called kiwix.db in order to avoid complexity we named as
-            // kiwixRoom.db
-            .addCallback(object : RoomDatabase.Callback() {
-              override fun onCreate(db: SupportSQLiteDatabase) {
-                super.onCreate(db)
-                Log.d("gouri", "onCreate")
-              }
-
-              override fun onOpen(db: SupportSQLiteDatabase) {
-                super.onOpen(db)
-                Log.d("gouri", "onOpen")
-              }
-
-              override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
-                super.onDestructiveMigration(db)
-                Log.d("gouri", "onDestructiveMigration")
-              }
-            })
-            .build().also {
-              if (!BuildConfig.BUILD_TYPE.contentEquals("fdroid")) {
-                it.migrateRecentSearch(boxStore)
-              }
-            }
+            // We have already database name called kiwix.db in order to avoid complexity we named
+            // as kiwixRoom.db
+            .build()
       }
     }
 
     fun destroyInstance() {
       db = null
     }
-  }
-
-  fun migrateRecentSearch(boxStore: BoxStore) {
-    recentSearchRoomDao().migrationToRoomInsert(boxStore.boxFor())
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -27,7 +27,7 @@ import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
 import org.kiwix.kiwixmobile.core.dao.NewNoteDao
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.di.qualifiers.IO
 import org.kiwix.kiwixmobile.core.di.qualifiers.MainThread
 import org.kiwix.kiwixmobile.core.extensions.HeaderizableList
@@ -57,7 +57,7 @@ class Repository @Inject internal constructor(
   private val historyDao: HistoryDao,
   private val notesDao: NewNoteDao,
   private val languageDao: NewLanguagesDao,
-  private val recentSearchDao: NewRecentSearchDao,
+  private val recentSearchRoomDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer
 ) : DataSource {
 
@@ -101,8 +101,8 @@ class Repository @Inject internal constructor(
 
   override fun clearHistory() = Completable.fromAction {
     historyDao.deleteAllHistory()
-    recentSearchDao.deleteSearchHistory()
-  }
+    recentSearchRoomDao.deleteSearchHistory()
+  }.subscribeOn(io)
 
   override fun getBookmarks() =
     libkiwixBookmarks.bookmarks() as Flowable<List<LibkiwixBookmarkItem>>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
@@ -21,9 +21,6 @@ package org.kiwix.kiwixmobile.core.data.remote
 import io.objectbox.Box
 import io.objectbox.BoxStore
 import io.objectbox.kotlin.boxFor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
@@ -35,25 +32,23 @@ class ObjectBoxToRoomMigrator {
   @Inject lateinit var boxStore: BoxStore
   @Inject lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
-  fun migrateObjectBoxDataToRoom() {
+  suspend fun migrateObjectBoxDataToRoom() {
     CoreApp.coreComponent.inject(this)
     migrateRecentSearch(boxStore.boxFor())
     // TODO we will migrate here for other entities
   }
 
-  fun migrateRecentSearch(box: Box<RecentSearchEntity>) {
+  suspend fun migrateRecentSearch(box: Box<RecentSearchEntity>) {
     val searchRoomEntityList = box.all
     searchRoomEntityList.forEachIndexed { _, recentSearchEntity ->
-      CoroutineScope(Dispatchers.IO).launch {
-        kiwixRoomDatabase.recentSearchRoomDao()
-          .saveSearch(
-            recentSearchEntity.searchTerm,
-            recentSearchEntity.zimId,
-            recentSearchEntity.url
-          )
-        // removing the single entity from the object box after migration.
-        box.remove(recentSearchEntity.id)
-      }
+      kiwixRoomDatabase.recentSearchRoomDao()
+        .saveSearch(
+          recentSearchEntity.searchTerm,
+          recentSearchEntity.zimId,
+          recentSearchEntity.url
+        )
+      // removing the single entity from the object box after migration.
+      box.remove(recentSearchEntity.id)
     }
     sharedPreferenceUtil.putPrefRecentSearchMigrated(true)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
@@ -1,0 +1,60 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.data.remote
+
+import io.objectbox.Box
+import io.objectbox.BoxStore
+import io.objectbox.kotlin.boxFor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.CoreApp
+import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import javax.inject.Inject
+
+class ObjectBoxToRoomMigrator {
+  @Inject lateinit var kiwixRoomDatabase: KiwixRoomDatabase
+  @Inject lateinit var boxStore: BoxStore
+  @Inject lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+
+  fun migrateObjectBoxDataToRoom() {
+    CoreApp.coreComponent.inject(this)
+    migrateRecentSearch(boxStore.boxFor())
+    // TODO we will migrate here for other entities
+  }
+
+  fun migrateRecentSearch(box: Box<RecentSearchEntity>) {
+    val searchRoomEntityList = box.all
+    searchRoomEntityList.forEachIndexed { _, recentSearchEntity ->
+      CoroutineScope(Dispatchers.IO).launch {
+        kiwixRoomDatabase.recentSearchRoomDao()
+          .saveSearch(
+            recentSearchEntity.searchTerm,
+            recentSearchEntity.zimId,
+            recentSearchEntity.url
+          )
+        // removing the single entity from the object box after migration.
+        box.remove(recentSearchEntity.id)
+      }
+    }
+    sharedPreferenceUtil.putPrefRecentSearchMigrated(true)
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -35,6 +35,7 @@ import org.kiwix.kiwixmobile.core.dao.NewBookmarksDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
 import org.kiwix.kiwixmobile.core.dao.NewNoteDao
 import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.data.DataModule
 import org.kiwix.kiwixmobile.core.data.DataSource
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
@@ -97,6 +98,7 @@ interface CoreComponent {
   fun wifiManager(): WifiManager
   fun objectBoxToLibkiwixMigrator(): ObjectBoxToLibkiwixMigrator
   fun libkiwixBookmarks(): LibkiwixBookmarks
+  fun recentSearchRoomDao(): RecentSearchRoomDao
   fun context(): Context
   fun downloader(): Downloader
   fun notificationManager(): NotificationManager

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -40,6 +40,7 @@ import org.kiwix.kiwixmobile.core.data.DataModule
 import org.kiwix.kiwixmobile.core.data.DataSource
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
+import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.modules.ApplicationModule
 import org.kiwix.kiwixmobile.core.di.modules.CoreViewModelModule
 import org.kiwix.kiwixmobile.core.di.modules.JNIModule
@@ -99,6 +100,7 @@ interface CoreComponent {
   fun objectBoxToLibkiwixMigrator(): ObjectBoxToLibkiwixMigrator
   fun libkiwixBookmarks(): LibkiwixBookmarks
   fun recentSearchRoomDao(): RecentSearchRoomDao
+  fun objectBoxToRoomMigrator(): ObjectBoxToRoomMigrator
   fun context(): Context
   fun downloader(): Downloader
   fun notificationManager(): NotificationManager
@@ -111,6 +113,7 @@ interface CoreComponent {
   fun inject(errorActivity: ErrorActivity)
   fun inject(searchFragment: SearchFragment)
   fun inject(objectBoxToLibkiwixMigrator: ObjectBoxToLibkiwixMigrator)
+  fun inject(objectBoxToRoomMigrator: ObjectBoxToRoomMigrator)
 
   fun inject(settingsFragment: CoreSettingsFragment)
   fun coreServiceComponent(): CoreServiceComponent.Builder

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/ApplicationModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/ApplicationModule.kt
@@ -31,6 +31,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
+import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.qualifiers.Computation
 import org.kiwix.kiwixmobile.core.di.qualifiers.IO
 import org.kiwix.kiwixmobile.core.di.qualifiers.MainThread
@@ -70,6 +71,10 @@ class ApplicationModule {
   @Provides
   @Singleton
   fun provideObjectBoxToLibkiwixMigrator() = ObjectBoxToLibkiwixMigrator()
+
+  @Provides
+  @Singleton
+  fun provideObjectBoxToRoomMigrator() = ObjectBoxToRoomMigrator()
 
   @IO
   @Provides

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -82,8 +82,7 @@ open class DatabaseModule {
     boxStore: BoxStore
   ) =
     KiwixRoomDatabase.getInstance(
-      context = context,
-      boxStore
+      context = context
     ) // The reason we can construct a database for the repo
 
   @Singleton

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -31,6 +31,7 @@ import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
 import org.kiwix.kiwixmobile.core.dao.NewNoteDao
 import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
 import org.kiwix.kiwixmobile.core.dao.entities.MyObjectBox
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import javax.inject.Singleton
 
 @Module
@@ -73,4 +74,19 @@ open class DatabaseModule {
     newBookDao: NewBookDao
   ): FetchDownloadDao =
     FetchDownloadDao(boxStore.boxFor(), newBookDao)
+
+  @Singleton
+  @Provides
+  fun provideYourDatabase(
+    context: Context,
+    boxStore: BoxStore
+  ) =
+    KiwixRoomDatabase.getInstance(
+      context = context,
+      boxStore
+    ) // The reason we can construct a database for the repo
+
+  @Singleton
+  @Provides
+  fun provideNewRecentSearchRoomDao(db: KiwixRoomDatabase) = db.recentSearchRoomDao()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -122,7 +122,10 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       }
     }
     if (!sharedPreferenceUtil.prefIsRecentSearchMigrated) {
-      objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
+      // run the migration on background thread to avoid any UI related issues.
+      CoroutineScope(Dispatchers.IO).launch {
+        objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
+      }
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -47,6 +47,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
+import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.error.ErrorActivity
 import org.kiwix.kiwixmobile.core.extensions.browserIntent
@@ -92,6 +93,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   abstract val navHostContainer: FragmentContainerView
   abstract val mainActivity: AppCompatActivity
   @Inject lateinit var objectBoxToLibkiwixMigrator: ObjectBoxToLibkiwixMigrator
+  @Inject lateinit var objectBoxToRoomMigrator: ObjectBoxToRoomMigrator
 
   override fun onCreate(savedInstanceState: Bundle?) {
     setTheme(R.style.KiwixTheme)
@@ -118,6 +120,9 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       CoroutineScope(Dispatchers.IO).launch {
         objectBoxToLibkiwixMigrator.migrateBookmarksToLibkiwix()
       }
+    }
+    if (!sharedPreferenceUtil.prefIsRecentSearchMigrated) {
+      objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -67,7 +67,7 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModel @Inject constructor(
-  private val recentSearchDao: RecentSearchRoomDao,
+  private val recentSearchRoomDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer,
   private val searchResultGenerator: SearchResultGenerator
 ) : ViewModel() {
@@ -99,7 +99,7 @@ class SearchViewModel @Inject constructor(
     combine(
       filter.asFlow(),
       searchResults(),
-      recentSearchDao.recentSearches(zimReaderContainer.id),
+      recentSearchRoomDao.recentSearches(zimReaderContainer.id),
       searchOrigin.asFlow()
     ) { searchTerm, searchResultsWithTerm, recentResults, searchOrigin ->
       SearchState(
@@ -155,7 +155,7 @@ class SearchViewModel @Inject constructor(
     _effects.trySend(
       DeleteRecentSearch(
         it.searchListItem,
-        recentSearchDao,
+        recentSearchRoomDao,
         viewModelScope
       )
     ).isSuccess
@@ -172,7 +172,7 @@ class SearchViewModel @Inject constructor(
   private fun saveSearchAndOpenItem(searchListItem: SearchListItem, openInNewTab: Boolean) {
     _effects.trySend(
       SaveSearchToRecents(
-        recentSearchDao,
+        recentSearchRoomDao,
         searchListItem,
         zimReaderContainer.id,
         viewModelScope

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ActivityResultReceived
@@ -67,7 +67,7 @@ import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModel @Inject constructor(
-  private val recentSearchDao: NewRecentSearchDao,
+  private val recentSearchDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer,
   private val searchResultGenerator: SearchResultGenerator
 ) : ViewModel() {
@@ -152,7 +152,13 @@ class SearchViewModel @Inject constructor(
   }
 
   private fun deleteItemAndShowToast(it: ConfirmedDelete) {
-    _effects.trySend(DeleteRecentSearch(it.searchListItem, recentSearchDao)).isSuccess
+    _effects.trySend(
+      DeleteRecentSearch(
+        it.searchListItem,
+        recentSearchDao,
+        viewModelScope
+      )
+    ).isSuccess
     _effects.trySend(ShowToast(R.string.delete_specific_search_toast)).isSuccess
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearch.kt
@@ -19,15 +19,21 @@
 package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 
 data class DeleteRecentSearch(
   private val searchListItem: SearchListItem,
-  private val recentSearchDao: NewRecentSearchDao
+  private val recentSearchRoomDao: RecentSearchRoomDao,
+  private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    recentSearchDao.deleteSearchString(searchListItem.value)
+    viewModelScope.launch(Dispatchers.IO) {
+      recentSearchRoomDao.deleteSearchString(searchListItem.value)
+    }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecents.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecents.kt
@@ -23,12 +23,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.reader.addContentPrefix
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 
 data class SaveSearchToRecents(
-  private val recentSearchDao: NewRecentSearchDao,
+  private val recentSearchRoomDao: RecentSearchRoomDao,
   private val searchListItem: SearchListItem,
   private val id: String?,
   private val viewModelScope: CoroutineScope
@@ -36,7 +36,7 @@ data class SaveSearchToRecents(
   override fun invokeWith(activity: AppCompatActivity) {
     id?.let {
       viewModelScope.launch(Dispatchers.IO) {
-        recentSearchDao.saveSearch(
+        recentSearchRoomDao.saveSearch(
           searchListItem.value,
           it,
           searchListItem.url?.addContentPrefix

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -93,6 +93,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsBookmarksMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_BOOKMARKS_MIGRATED, false)
 
+  val prefIsRecentSearchMigrated: Boolean
+    get() = sharedPreferences.getBoolean(PREF_RECENT_SEARCH_MIGRATED, false)
+
   val prefStorage: String
     get() {
       val storage = sharedPreferences.getString(PREF_STORAGE, null)
@@ -101,9 +104,11 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
           putPrefStorage(it)
           putStoragePosition(0)
         }
+
         !File(storage).isFileExist() -> getPublicDirectoryPath(defaultStorage()).also {
           putStoragePosition(0)
         }
+
         else -> storage
       }
     }
@@ -120,6 +125,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun putPrefBookMarkMigrated(isMigrated: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_BOOKMARKS_MIGRATED, isMigrated) }
+
+  fun putPrefRecentSearchMigrated(isMigrated: Boolean) =
+    sharedPreferences.edit { putBoolean(PREF_RECENT_SEARCH_MIGRATED, isMigrated) }
 
   fun putPrefLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_LANG, language) }
@@ -280,5 +288,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val IS_PLAY_STORE_BUILD = "is_play_store_build"
     const val PREF_PLAY_STORE_RESTRICTION = "pref_play_store_restriction"
     const val PREF_BOOKMARKS_MIGRATED = "pref_bookmarks_migrated"
+    const val PREF_RECENT_SEARCH_MIGRATED = "pref_recent_search_migrated"
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchListItem
@@ -79,7 +79,7 @@ import org.kiwix.libzim.SuggestionSearch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class SearchViewModelTest {
-  private val recentSearchDao: NewRecentSearchDao = mockk()
+  private val recentSearchRoomDao: RecentSearchRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val searchResultGenerator: SearchResultGenerator = mockk()
   private val zimFileReader: ZimFileReader = mockk()
@@ -105,8 +105,8 @@ internal class SearchViewModelTest {
       searchResultGenerator.generateSearchResults("", zimFileReader)
     } returns null
     every { zimReaderContainer.id } returns "id"
-    every { recentSearchDao.recentSearches("id") } returns recentsFromDb.consumeAsFlow()
-    viewModel = SearchViewModel(recentSearchDao, zimReaderContainer, searchResultGenerator)
+    every { recentSearchRoomDao.recentSearches("id") } returns recentsFromDb.consumeAsFlow()
+    viewModel = SearchViewModel(recentSearchRoomDao, zimReaderContainer, searchResultGenerator)
   }
 
   @Nested
@@ -158,7 +158,10 @@ internal class SearchViewModelTest {
       val searchListItem = RecentSearchListItem("", "")
       actionResultsInEffects(
         OnItemClick(searchListItem),
-        SaveSearchToRecents(recentSearchDao, searchListItem, "id", viewModel.viewModelScope),
+        SaveSearchToRecents(
+          recentSearchRoomDao, searchListItem, "id",
+          viewModel.viewModelScope
+        ),
         OpenSearchItem(searchListItem, false)
       )
     }
@@ -168,7 +171,10 @@ internal class SearchViewModelTest {
       val searchListItem = RecentSearchListItem("", "")
       actionResultsInEffects(
         OnOpenInNewTabClick(searchListItem),
-        SaveSearchToRecents(recentSearchDao, searchListItem, "id", viewModel.viewModelScope),
+        SaveSearchToRecents(
+          recentSearchRoomDao, searchListItem, "id",
+          viewModel.viewModelScope
+        ),
         OpenSearchItem(searchListItem, true)
       )
     }
@@ -192,7 +198,7 @@ internal class SearchViewModelTest {
       val searchListItem = RecentSearchListItem("", "")
       actionResultsInEffects(
         ConfirmedDelete(searchListItem),
-        DeleteRecentSearch(searchListItem, recentSearchDao),
+        DeleteRecentSearch(searchListItem, recentSearchRoomDao, viewModel.viewModelScope),
         ShowToast(R.string.delete_specific_search_toast)
       )
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
@@ -21,8 +21,10 @@ package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.Test
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchListItem
 
@@ -31,9 +33,14 @@ internal class DeleteRecentSearchTest {
   @Test
   fun `invoke with deletes a search`() {
     val searchListItem: SearchListItem = RecentSearchListItem("", "")
-    val recentSearchDao: NewRecentSearchDao = mockk()
+    val recentSearchDao: RecentSearchRoomDao = mockk()
     val activity: AppCompatActivity = mockk()
-    DeleteRecentSearch(searchListItem, recentSearchDao).invokeWith(activity)
+    val viewModelScope = CoroutineScope(Dispatchers.IO)
+    DeleteRecentSearch(
+      searchListItem = searchListItem,
+      recentSearchRoomDao = recentSearchDao,
+      viewModelScope = viewModelScope
+    ).invokeWith(activity)
     verify { recentSearchDao.deleteSearchString(searchListItem.value) }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
@@ -53,7 +53,7 @@ internal class SaveSearchToRecentsTest {
 
   @Test
   fun `invoke with non null Id saves search`() = runBlocking {
-    val id = "id"
+    val id = "8812214350305159407L"
     SaveSearchToRecents(
       newRecentSearchDao,
       searchListItem,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
@@ -26,13 +26,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
-import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchListItem
 
 internal class SaveSearchToRecentsTest {
 
-  private val newRecentSearchDao: NewRecentSearchDao = mockk()
+  private val newRecentSearchDao: RecentSearchRoomDao = mockk()
   private val searchListItem = RecentSearchListItem("", ZimFileReader.CONTENT_PREFIX)
 
   private val activity: AppCompatActivity = mockk()


### PR DESCRIPTION
Fixes #3111 

* Introduced the `Room` database in our project.
* Now all the new recent searches will be saved in the room database instead of `objectbox`.
* We have added the migration code for previously saved `recent searches` from `objectbox` to `room`.  This will ensure that the previously saved `recent searches` will be shown to the user.
* Added the test cases for testing the migration with different scenarios, and with large data sets. Also, added the test cases for `RecentSearchRoomDaoTest`, and `KiwixRoomDatabaseTest` to test that it can save the different types of data.