### PR TITLE
Migrated history to room database

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -24,6 +24,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -94,24 +96,24 @@ class KiwixRoomDatabaseTest {
     // delete the previous saved data from history to run the test cases properly.
     historyRoomDao.deleteAllHistory()
     val historyItem = getHistoryItem(
-      "Main Page",
-      "https://kiwix.app/A/MainPage",
-      "30 May 2024",
-      1
+      title = "Main Page",
+      historyUrl = "https://kiwix.app/A/MainPage",
+      databaseId = 1
     )
 
     // test inserting into history database
     historyRoomDao.saveHistory(historyItem)
     var historyList = historyRoomDao.historyRoomEntity().first()
-    assertEquals(historyList.size, 1)
-    assertEquals(historyItem.title, historyList.first().historyTitle)
-    assertEquals(historyItem.zimId, historyList.first().zimId)
-    assertEquals(historyItem.zimName, historyList.first().zimName)
-    assertEquals(historyItem.historyUrl, historyList.first().historyUrl)
-    assertEquals(historyItem.zimFilePath, historyList.first().zimFilePath)
-    assertEquals(historyItem.favicon, historyList.first().favicon)
-    assertEquals(historyItem.dateString, historyList.first().dateString)
-    assertEquals(historyItem.timeStamp, historyList.first().timeStamp)
+    with(historyList.first()) {
+      assertThat(historyTitle, equalTo(historyItem.title))
+      assertThat(zimId, equalTo(historyItem.zimId))
+      assertThat(zimName, equalTo(historyItem.zimName))
+      assertThat(historyUrl, equalTo(historyItem.historyUrl))
+      assertThat(zimFilePath, equalTo(historyItem.zimFilePath))
+      assertThat(favicon, equalTo(historyItem.favicon))
+      assertThat(dateString, equalTo(historyItem.dateString))
+      assertThat(timeStamp, equalTo(historyItem.timeStamp))
+    }
 
     // test deleting the history
     historyRoomDao.deleteHistory(listOf(historyItem))
@@ -121,12 +123,7 @@ class KiwixRoomDatabaseTest {
     // test deleting all history
     historyRoomDao.saveHistory(historyItem)
     historyRoomDao.saveHistory(
-      getHistoryItem(
-        "Installation",
-        "https://kiwix.app/A/Installation",
-        "30 May 2024",
-        2
-      )
+      getHistoryItem(databaseId = 2)
     )
     historyList = historyRoomDao.historyRoomEntity().first()
     assertEquals(historyList.size, 2)
@@ -135,21 +132,27 @@ class KiwixRoomDatabaseTest {
     assertEquals(historyList.size, 0)
   }
 
-  private fun getHistoryItem(
-    title: String,
-    historyUrl: String,
-    dateString: String,
-    databaseId: Long
-  ): HistoryListItem.HistoryItem =
-    HistoryListItem.HistoryItem(
-      databaseId = databaseId,
-      zimId = "1f88ab6f-c265-b-3ff-8f49-b7f4429503800",
-      zimName = "alpinelinux_en_all",
-      historyUrl = historyUrl,
-      title = title,
-      zimFilePath = "/storage/emulated/0/Download/alpinelinux_en_all_maxi_2023-01.zim",
-      favicon = null,
-      dateString = dateString,
-      timeStamp = System.currentTimeMillis()
-    )
+  companion object {
+    fun getHistoryItem(
+      title: String = "Installation",
+      historyUrl: String = "https://kiwix.app/A/Installation",
+      dateString: String = "30 May 2024",
+      databaseId: Long,
+      zimId: String = "1f88ab6f-c265-b-3ff-8f49-b7f4429503800",
+      zimName: String = "alpinelinux_en_all",
+      zimFilePath: String = "/storage/emulated/0/Download/alpinelinux_en_all_maxi_2023-01.zim",
+      timeStamp: Long = System.currentTimeMillis()
+    ): HistoryListItem.HistoryItem =
+      HistoryListItem.HistoryItem(
+        databaseId = databaseId,
+        zimId = zimId,
+        zimName = zimName,
+        historyUrl = historyUrl,
+        title = title,
+        zimFilePath = zimFilePath,
+        favicon = null,
+        dateString = dateString,
+        timeStamp = timeStamp
+      )
+  }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -137,7 +137,7 @@ class KiwixRoomDatabaseTest {
       title: String = "Installation",
       historyUrl: String = "https://kiwix.app/A/Installation",
       dateString: String = "30 May 2024",
-      databaseId: Long,
+      databaseId: Long = 0L,
       zimId: String = "1f88ab6f-c265-b-3ff-8f49-b7f4429503800",
       zimName: String = "alpinelinux_en_all",
       zimFilePath: String = "/storage/emulated/0/Download/alpinelinux_en_all_maxi_2023-01.zim",

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -26,6 +26,8 @@ import io.objectbox.Box
 import io.objectbox.BoxStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -33,6 +35,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.KiwixRoomDatabaseTest.Companion.getHistoryItem
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryEntity
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
@@ -69,7 +73,7 @@ class ObjectBoxToRoomMigratorTest {
   fun migrateRecentSearch_shouldInsertDataIntoRoomDatabase() = runBlocking {
     val box = boxStore.boxFor(RecentSearchEntity::class.java)
     // clear both databases for recent searches to test more edge cases
-    clearRecentSearchDatabases(box)
+    clearRoomAndBoxStoreDatabases(box)
     val expectedSearchTerm = "test search"
     val expectedZimId = "8812214350305159407L"
     val expectedUrl = "http://kiwix.app/mainPage"
@@ -86,7 +90,7 @@ class ObjectBoxToRoomMigratorTest {
     assertEquals(actual[0].zimId, expectedZimId)
 
     // clear both databases for recent searches to test more edge cases
-    clearRecentSearchDatabases(box)
+    clearRoomAndBoxStoreDatabases(box)
 
     // Migrate data from empty ObjectBox database
     objectBoxToRoomMigrator.migrateRecentSearch(box)
@@ -114,7 +118,7 @@ class ObjectBoxToRoomMigratorTest {
       }
     assertNotNull(newItem)
 
-    clearRecentSearchDatabases(box)
+    clearRoomAndBoxStoreDatabases(box)
 
     // Test migration if ObjectBox has null values
     lateinit var undefinedSearchTerm: String
@@ -158,9 +162,112 @@ class ObjectBoxToRoomMigratorTest {
     assertTrue("Migration took too long: $migrationTime ms", migrationTime < 10000)
   }
 
-  private fun clearRecentSearchDatabases(box: Box<RecentSearchEntity>) {
+  private fun <T> clearRoomAndBoxStoreDatabases(box: Box<T>) {
     // delete history for testing other edge cases
     kiwixRoomDatabase.recentSearchRoomDao().deleteSearchHistory()
+    kiwixRoomDatabase.historyRoomDao().deleteAllHistory()
     box.removeAll()
+  }
+
+  @Test
+  fun migrateHistory_shouldInsertDataIntoRoomDatabase() = runBlocking {
+    val box = boxStore.boxFor(HistoryEntity::class.java)
+    // clear both databases for history to test more edge cases
+    clearRoomAndBoxStoreDatabases(box)
+
+    val historyItem = getHistoryItem()
+    val historyItem2 = getHistoryItem(
+      title = "Main Page",
+      historyUrl = "https://kiwix.app/A/MainPage"
+    )
+    val historyItem3 = getHistoryItem(databaseId = 1)
+    // insert into object box
+    box.put(HistoryEntity(historyItem))
+    // migrate data into room database
+    objectBoxToRoomMigrator.migrateHistory(box)
+    // check if data successfully migrated to room
+    val actual = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    with(actual.first()) {
+      assertThat(historyTitle, equalTo(historyItem.title))
+      assertThat(zimId, equalTo(historyItem.zimId))
+      assertThat(zimName, equalTo(historyItem.zimName))
+      assertThat(historyUrl, equalTo(historyItem.historyUrl))
+      assertThat(zimFilePath, equalTo(historyItem.zimFilePath))
+      assertThat(favicon, equalTo(historyItem.favicon))
+      assertThat(dateString, equalTo(historyItem.dateString))
+      assertThat(timeStamp, equalTo(historyItem.timeStamp))
+    }
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Migrate data from empty ObjectBox database
+    objectBoxToRoomMigrator.migrateHistory(box)
+    var actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    assertTrue(actualData.isEmpty())
+
+    // Test if data successfully migrated to Room and existing data is preserved
+    kiwixRoomDatabase.historyRoomDao().saveHistory(historyItem3)
+    box.put(HistoryEntity(historyItem2))
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateHistory(box)
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    assertEquals(2, actualData.size)
+    val existingItem =
+      actualData.find {
+        it.historyUrl == historyItem.historyUrl && it.historyTitle == historyItem.title
+      }
+    assertNotNull(existingItem)
+    val newItem =
+      actualData.find {
+        it.historyUrl == historyItem2.historyUrl && it.historyTitle == historyItem2.title
+      }
+    assertNotNull(newItem)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Test room will not migrate the already exiting data in the database.
+    kiwixRoomDatabase.historyRoomDao().saveHistory(historyItem)
+    box.put(HistoryEntity(historyItem))
+    objectBoxToRoomMigrator.migrateHistory(box)
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    assertEquals(1, actualData.size)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Test migration if ObjectBox has null values
+    try {
+      lateinit var invalidHistoryEntity: HistoryEntity
+      box.put(invalidHistoryEntity)
+      // Migrate data into Room database
+      objectBoxToRoomMigrator.migrateHistory(box)
+    } catch (_: Exception) {
+    }
+    // Ensure Room database remains empty or unaffected by the invalid data
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    assertTrue(actualData.isEmpty())
+
+    // Test large data migration for recent searches
+    val numEntities = 5000
+    // Insert a large number of recent search entities into ObjectBox
+    for (i in 1..numEntities) {
+      box.put(
+        HistoryEntity(
+          getHistoryItem(
+            title = "Installation$i",
+            historyUrl = "https://kiwix.app/A/Installation$i"
+          )
+        )
+      )
+    }
+    val startTime = System.currentTimeMillis()
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateHistory(box)
+    val endTime = System.currentTimeMillis()
+    val migrationTime = endTime - startTime
+    // Check if data successfully migrated to Room
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    assertEquals(numEntities, actualData.size)
+    // Assert that the migration completes within a reasonable time frame
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 10000)
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -159,7 +159,7 @@ class ObjectBoxToRoomMigratorTest {
       kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
     assertEquals(numEntities, actualDataAfterLargeMigration.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 10000)
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
   }
 
   private fun <T> clearRoomAndBoxStoreDatabases(box: Box<T>) {
@@ -268,6 +268,6 @@ class ObjectBoxToRoomMigratorTest {
     actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
     assertEquals(numEntities, actualData.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 10000)
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.roomDao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.KiwixRoomDatabaseTest.Companion.getHistoryItem
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
+
+@RunWith(AndroidJUnit4::class)
+class HistoryRoomDaoTest {
+  private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
+  private lateinit var historyRoomDao: HistoryRoomDao
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    kiwixRoomDatabase = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java).build()
+    historyRoomDao = kiwixRoomDatabase.historyRoomDao()
+  }
+
+  @After
+  fun tearDown() {
+    kiwixRoomDatabase.close()
+  }
+
+  @Test
+  fun testHistoryRoomDao() = runBlocking {
+    // delete all the history from database to properly run the test cases.
+    historyRoomDao.deleteAllHistory()
+    val historyItem = getHistoryItem(
+      title = "Main Page",
+      historyUrl = "https://kiwix.app/A/MainPage",
+      databaseId = 1
+    )
+
+    // Save and retrieve a history item
+    historyRoomDao.saveHistory(historyItem)
+    var historyList = historyRoomDao.historyRoomEntity().first()
+    with(historyList.first()) {
+      assertThat(historyTitle, equalTo(historyItem.title))
+      assertThat(zimId, equalTo(historyItem.zimId))
+      assertThat(zimName, equalTo(historyItem.zimName))
+      assertThat(historyUrl, equalTo(historyItem.historyUrl))
+      assertThat(zimFilePath, equalTo(historyItem.zimFilePath))
+      assertThat(favicon, equalTo(historyItem.favicon))
+      assertThat(dateString, equalTo(historyItem.dateString))
+      assertThat(timeStamp, equalTo(historyItem.timeStamp))
+    }
+
+    // Test to update the same day history for url
+    historyRoomDao.saveHistory(historyItem)
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertEquals(historyList.size, 1)
+
+    // Delete the saved history item
+    historyRoomDao.deleteHistory(listOf(historyItem))
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertEquals(historyList.size, 0)
+
+    // Save and delete all history items
+    historyRoomDao.saveHistory(historyItem)
+    historyRoomDao.saveHistory(getHistoryItem(databaseId = 2, dateString = "31 May 2024"))
+    historyRoomDao.deleteAllHistory()
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertThat(historyList.size, equalTo(0))
+
+    // Save history item with empty fields
+    val emptyHistoryUrl = ""
+    val emptyTitle = ""
+    historyRoomDao.saveHistory(getHistoryItem(emptyTitle, emptyHistoryUrl, databaseId = 1))
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertThat(historyList.size, equalTo(1))
+    historyRoomDao.deleteAllHistory()
+
+    // Attempt to save undefined history item
+    lateinit var undefinedHistoryItem: HistoryListItem.HistoryItem
+    try {
+      historyRoomDao.saveHistory(undefinedHistoryItem)
+      assertThat(
+        "Undefined value was saved into database",
+        false
+      )
+    } catch (e: Exception) {
+      assertThat("Undefined value was not saved, as expected.", true)
+    }
+
+    // Save history item with Unicode values
+    val unicodeTitle = "title \u03A3" // Unicode character for Greek capital letter Sigma
+    val historyItem2 = getHistoryItem(title = unicodeTitle, databaseId = 2)
+    historyRoomDao.saveHistory(historyItem2)
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertThat(historyList.first().historyTitle, equalTo("title Σ"))
+
+    // Test deletePages function
+    historyRoomDao.saveHistory(historyItem)
+    historyRoomDao.deletePages(listOf(historyItem, historyItem2))
+    historyList = historyRoomDao.historyRoomEntity().first()
+    assertThat(historyList.size, equalTo(0))
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/RecentSearchRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/RecentSearchRoomDaoTest.kt
@@ -16,7 +16,7 @@
  *
  */
 
-package org.kiwix.kiwixmobile
+package org.kiwix.kiwixmobile.roomDao
 
 import android.content.Context
 import androidx.room.Room

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -27,6 +27,12 @@ object Libs {
     Versions.org_jetbrains_kotlinx_kotlinx_coroutines
 
   /**
+   * https://github.com/Kotlin/kotlinx.coroutines
+   */
+  const val kotlinx_coroutines_rx2: String = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:" +
+    Versions.org_jetbrains_kotlinx_kotlinx_coroutines
+
+  /**
    * https://developer.android.com/testing
    */
   const val espresso_contrib: String = "androidx.test.espresso:espresso-contrib:" +

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -355,4 +355,6 @@ object Libs {
   const val roomKtx = "androidx.room:room-ktx:" + Versions.roomVersion
 
   const val roomCompiler = "androidx.room:room-compiler:" + Versions.roomVersion
+
+  const val roomRuntime = "androidx.room:room-runtime:" + Versions.roomVersion
 }

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -207,6 +207,8 @@ class AllProjectConfigurer {
       implementation(Libs.preference_ktx)
       implementation(Libs.material_show_case_view)
       implementation(Libs.roomKtx)
+      annotationProcessor(Libs.roomCompiler)
+      implementation(Libs.roomRuntime)
       kapt(Libs.roomCompiler)
     }
   }

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -204,6 +204,7 @@ class AllProjectConfigurer {
       implementation(Libs.fetch)
       implementation(Libs.rxandroid)
       implementation(Libs.rxjava)
+      implementation(Libs.kotlinx_coroutines_rx2)
       implementation(Libs.preference_ktx)
       implementation(Libs.material_show_case_view)
       implementation(Libs.roomKtx)

--- a/buildSrc/src/main/kotlin/plugin/ConvenienceExtensions.kt
+++ b/buildSrc/src/main/kotlin/plugin/ConvenienceExtensions.kt
@@ -54,5 +54,8 @@ internal fun DependencyHandlerScope.testImplementation(dependency: String) =
 internal fun DependencyHandlerScope.implementation(dependency: String) =
   addDependency("implementation", dependency)
 
+internal fun DependencyHandlerScope.annotationProcessor(dependency: String) =
+  addDependency("annotationProcessor", dependency)
+
 private fun DependencyHandlerScope.addDependency(configurationName: String, dependency: String) =
   add(configurationName, dependency)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
@@ -1,0 +1,91 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.TypeConverter
+import androidx.room.Update
+import io.objectbox.Box
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryEntity
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryRoomEntity
+import org.kiwix.kiwixmobile.core.page.adapter.Page
+import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
+
+@Dao
+abstract class HistoryRoomDao : BasePageDao {
+  @Query("SELECT * FROM HistoryRoomEntity ORDER BY HistoryRoomEntity.timeStamp DESC")
+  abstract fun historyRoomEntity(): Flow<List<HistoryRoomEntity>>
+
+  fun history(): Flow<List<Page>> = historyRoomEntity().map {
+    it.map(HistoryListItem::HistoryItem)
+  }
+
+  override fun pages() = history()
+  override fun deletePages(pagesToDelete: List<Page>) =
+    deleteHistory(pagesToDelete as List<HistoryListItem.HistoryItem>)
+
+  @Query("SELECT * FROM HistoryRoomEntity WHERE historyUrl LIKE :url AND dateString LIKE :date")
+  abstract fun getHistoryItem(url: String, date: String): HistoryListItem.HistoryItem
+
+  fun getHistoryItem(historyItem: HistoryListItem.HistoryItem): HistoryListItem.HistoryItem =
+    getHistoryItem(historyItem.historyUrl, historyItem.dateString)
+
+  @Update
+  abstract fun updateHistoryItem(historyItem: HistoryListItem.HistoryItem)
+
+  fun saveHistory(historyItem: HistoryListItem.HistoryItem) {
+    val item = getHistoryItem(historyItem)
+    updateHistoryItem(item)
+  }
+
+  @Delete
+  abstract fun deleteHistory(historyList: List<HistoryListItem.HistoryItem>)
+
+  @Query("DELETE FROM HistoryRoomEntity")
+  abstract fun deleteAllHistory()
+
+  fun migrationToRoomHistory(
+    box: Box<HistoryEntity>
+  ) {
+    val historyEntityList = box.all
+    historyEntityList.forEachIndexed { _, item ->
+      CoroutineScope(Dispatchers.IO).launch {
+        // saveHistory(HistoryListItem.HistoryItem(item))
+        // Todo Should we remove object store data now?
+      }
+    }
+  }
+}
+
+class HistoryRoomDaoCoverts {
+  @TypeConverter
+  fun fromHistoryRoomEntity(historyRoomEntity: HistoryRoomEntity): HistoryListItem =
+    HistoryListItem.HistoryItem(historyRoomEntity)
+
+  @TypeConverter
+  fun historyItemToHistoryListItem(historyItem: HistoryListItem.HistoryItem): HistoryRoomEntity =
+    HistoryRoomEntity(historyItem)
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
@@ -56,7 +56,16 @@ abstract class HistoryRoomDao : PageRoomDao {
     getHistoryRoomEntity(
       historyItem.historyUrl,
       historyItem.dateString
-    )?.let(::updateHistoryItem) ?: run {
+    )?.let {
+      it.apply {
+        // update the exiting entity
+        historyUrl = historyItem.historyUrl
+        historyTitle = historyItem.title
+        timeStamp = historyItem.timeStamp
+        dateString = historyItem.dateString
+      }
+      updateHistoryItem(it)
+    } ?: run {
       insertHistoryItem(HistoryRoomEntity(historyItem))
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
@@ -19,9 +19,18 @@
 package org.kiwix.kiwixmobile.core.dao
 
 import io.reactivex.Flowable
+import kotlinx.coroutines.flow.Flow
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 
-interface PageDao {
-  fun pages(): Flowable<List<Page>>
+interface PageDao : BasePageDao {
+  override fun pages(): Flowable<List<Page>>
+}
+
+interface PageRoomDao : BasePageDao {
+  override fun pages(): Flow<List<Page>>
+}
+
+interface BasePageDao {
+  fun pages(): Any
   fun deletePages(pagesToDelete: List<Page>)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
@@ -29,10 +29,10 @@ data class HistoryRoomEntity(
   val zimName: String,
   val zimFilePath: String,
   val favicon: String?,
-  val historyUrl: String,
-  val historyTitle: String,
-  val dateString: String,
-  val timeStamp: Long
+  var historyUrl: String,
+  var historyTitle: String,
+  var dateString: String,
+  var timeStamp: Long
 ) {
   constructor(historyItem: HistoryItem) : this(
     historyItem.databaseId,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
@@ -24,7 +24,7 @@ import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryIt
 
 @Entity
 data class HistoryRoomEntity(
-  @PrimaryKey var id: Long = 0L,
+  @PrimaryKey(autoGenerate = true) var id: Long = 0L,
   val zimId: String,
   val zimName: String,
   val zimFilePath: String,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/HistoryRoomEntity.kt
@@ -1,0 +1,48 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.dao.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem
+
+@Entity
+data class HistoryRoomEntity(
+  @PrimaryKey var id: Long = 0L,
+  val zimId: String,
+  val zimName: String,
+  val zimFilePath: String,
+  val favicon: String?,
+  val historyUrl: String,
+  val historyTitle: String,
+  val dateString: String,
+  val timeStamp: Long
+) {
+  constructor(historyItem: HistoryItem) : this(
+    historyItem.databaseId,
+    historyItem.zimId,
+    historyItem.zimName,
+    historyItem.zimFilePath,
+    historyItem.favicon,
+    historyItem.historyUrl,
+    historyItem.title,
+    historyItem.dateString,
+    historyItem.timeStamp
+  )
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -23,6 +23,9 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDaoCoverts
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.HistoryRoomEntity
@@ -33,6 +36,7 @@ import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 @TypeConverters(HistoryRoomDaoCoverts::class)
 abstract class KiwixRoomDatabase : RoomDatabase() {
   abstract fun recentSearchRoomDao(): RecentSearchRoomDao
+  abstract fun historyRoomDao(): HistoryRoomDao
 
   companion object {
     private var db: KiwixRoomDatabase? = null
@@ -42,7 +46,13 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
           ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, "KiwixRoom.db")
             // We have already database name called kiwix.db in order to avoid complexity we named
             // as kiwixRoom.db
+            // .addMigrations(MIGRATION_1_2)
             .build()
+      }
+    }
+
+    private val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+      override fun migrate(database: SupportSQLiteDatabase) {
       }
     }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -57,7 +57,7 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
           """
             CREATE TABLE IF NOT EXISTS `HistoryRoomEntity`(
             `id` INTEGER NOT NULL,
-            `timeStamp` LONG NOT NULL,
+            `timeStamp` INTEGER NOT NULL,
             `zimId` TEXT NOT NULL,
             `historyUrl` TEXT NOT NULL,
             `zimName` TEXT NOT NULL,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -46,13 +46,29 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
           ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, "KiwixRoom.db")
             // We have already database name called kiwix.db in order to avoid complexity we named
             // as kiwixRoom.db
-            // .addMigrations(MIGRATION_1_2)
+            .addMigrations(MIGRATION_1_2)
             .build()
       }
     }
 
     private val MIGRATION_1_2: Migration = object : Migration(1, 2) {
       override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+          """
+            CREATE TABLE IF NOT EXISTS `HistoryRoomEntity`(
+            `id` INTEGER NOT NULL,
+            `timeStamp` LONG NOT NULL,
+            `zimId` TEXT NOT NULL,
+            `historyUrl` TEXT NOT NULL,
+            `zimName` TEXT NOT NULL,
+            `favicon` TEXT,
+            `historyTitle` TEXT NOT NULL,
+            `dateString` TEXT NOT NULL,
+            `zimFilePath` TEXT NOT NULL,
+            PRIMARY KEY (`id`)
+          )
+          """
+        )
       }
     }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -22,11 +22,15 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDaoCoverts
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryRoomEntity
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 
 @Suppress("UnnecessaryAbstractClass")
-@Database(entities = [RecentSearchRoomEntity::class], version = 1)
+@Database(entities = [RecentSearchRoomEntity::class, HistoryRoomEntity::class], version = 2)
+@TypeConverters(HistoryRoomDaoCoverts::class)
 abstract class KiwixRoomDatabase : RoomDatabase() {
   abstract fun recentSearchRoomDao(): RecentSearchRoomDao
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -22,7 +22,7 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Scheduler
 import io.reactivex.Single
-import org.kiwix.kiwixmobile.core.dao.HistoryDao
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
@@ -54,7 +54,7 @@ class Repository @Inject internal constructor(
   @param:MainThread private val mainThread: Scheduler,
   private val bookDao: NewBookDao,
   private val libkiwixBookmarks: LibkiwixBookmarks,
-  private val historyDao: HistoryDao,
+  private val historyRoomDao: HistoryRoomDao,
   private val notesDao: NewNoteDao,
   private val languageDao: NewLanguagesDao,
   private val recentSearchRoomDao: RecentSearchRoomDao,
@@ -90,17 +90,17 @@ class Repository @Inject internal constructor(
       .subscribeOn(io)
 
   override fun saveHistory(history: HistoryItem) =
-    Completable.fromAction { historyDao.saveHistory(history) }
+    Completable.fromAction { historyRoomDao.saveHistory(history) }
       .subscribeOn(io)
 
   override fun deleteHistory(historyList: List<HistoryListItem>) =
     Completable.fromAction {
-      historyDao.deleteHistory(historyList.filterIsInstance(HistoryItem::class.java))
+      historyRoomDao.deleteHistory(historyList.filterIsInstance(HistoryItem::class.java))
     }
       .subscribeOn(io)
 
   override fun clearHistory() = Completable.fromAction {
-    historyDao.deleteAllHistory()
+    historyRoomDao.deleteAllHistory()
     recentSearchRoomDao.deleteSearchHistory()
   }.subscribeOn(io)
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/ObjectBoxToRoomMigrator.kt
@@ -22,8 +22,10 @@ import io.objectbox.Box
 import io.objectbox.BoxStore
 import io.objectbox.kotlin.boxFor
 import org.kiwix.kiwixmobile.core.CoreApp
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryEntity
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
 
@@ -34,7 +36,12 @@ class ObjectBoxToRoomMigrator {
 
   suspend fun migrateObjectBoxDataToRoom() {
     CoreApp.coreComponent.inject(this)
-    migrateRecentSearch(boxStore.boxFor())
+    if (!sharedPreferenceUtil.prefIsRecentSearchMigrated) {
+      migrateRecentSearch(boxStore.boxFor())
+    }
+    if (!sharedPreferenceUtil.prefIsHistoryMigrated) {
+      migrateHistory(boxStore.boxFor())
+    }
     // TODO we will migrate here for other entities
   }
 
@@ -51,5 +58,16 @@ class ObjectBoxToRoomMigrator {
       box.remove(recentSearchEntity.id)
     }
     sharedPreferenceUtil.putPrefRecentSearchMigrated(true)
+  }
+
+  suspend fun migrateHistory(box: Box<HistoryEntity>) {
+    val historyEntityList = box.all
+    historyEntityList.forEachIndexed { _, historyEntity ->
+      kiwixRoomDatabase.historyRoomDao()
+        .saveHistory(HistoryListItem.HistoryItem(historyEntity))
+      // removing the single entity from the object box after migration.
+      box.remove(historyEntity.id)
+    }
+    sharedPreferenceUtil.putPrefHistoryMigrated(true)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -29,6 +29,7 @@ import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
 import org.kiwix.kiwixmobile.core.dao.HistoryDao
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewBookmarksDao
@@ -100,6 +101,7 @@ interface CoreComponent {
   fun objectBoxToLibkiwixMigrator(): ObjectBoxToLibkiwixMigrator
   fun libkiwixBookmarks(): LibkiwixBookmarks
   fun recentSearchRoomDao(): RecentSearchRoomDao
+  fun historyRoomDao(): HistoryRoomDao
   fun objectBoxToRoomMigrator(): ObjectBoxToRoomMigrator
   fun context(): Context
   fun downloader(): Downloader

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -88,4 +88,8 @@ open class DatabaseModule {
   @Singleton
   @Provides
   fun provideNewRecentSearchRoomDao(db: KiwixRoomDatabase) = db.recentSearchRoomDao()
+
+  @Provides
+  @Singleton
+  fun provideHistoryDao(db: KiwixRoomDatabase) = db.historyRoomDao()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -121,11 +121,9 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
         objectBoxToLibkiwixMigrator.migrateBookmarksToLibkiwix()
       }
     }
-    if (!sharedPreferenceUtil.prefIsRecentSearchMigrated) {
-      // run the migration on background thread to avoid any UI related issues.
-      CoroutineScope(Dispatchers.IO).launch {
-        objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
-      }
+    // run the migration on background thread to avoid any UI related issues.
+    CoroutineScope(Dispatchers.IO).launch {
+      objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1941,7 +1941,6 @@ abstract class CoreReaderFragment :
 
   @OnClick(R2.id.bottom_toolbar_home)
   fun openMainPage() {
-    Log.e("ZIMFILEREADER1", "openMainPage ")
     val articleUrl = zimReaderContainer?.mainPage
     openArticle(articleUrl)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -65,7 +65,7 @@ class BookmarkViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: BookmarkState) =
-    ShowDeleteBookmarksDialog(effects, state, pageDao)
+    ShowDeleteBookmarksDialog(effects, state, basePageDao)
 
   override fun copyWithNewItems(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel
 
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects.ShowDeleteBookmarksDialog
@@ -64,8 +65,8 @@ class BookmarkViewModel @Inject constructor(
   override fun deselectAllPages(state: BookmarkState): BookmarkState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
-  override fun createDeletePageDialogEffect(state: BookmarkState) =
-    ShowDeleteBookmarksDialog(effects, state, basePageDao)
+  override fun createDeletePageDialogEffect(state: BookmarkState, viewModelScope: CoroutineScope) =
+    ShowDeleteBookmarksDialog(effects, state, basePageDao, viewModelScope)
 
   override fun copyWithNewItems(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
@@ -34,14 +35,15 @@ import javax.inject.Inject
 data class ShowDeleteBookmarksDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: PageState<LibkiwixBookmarkItem>,
-  private val basePageDao: BasePageDao
+  private val basePageDao: BasePageDao,
+  private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
     activity.cachedComponent.inject(this)
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedBookmarks else DeleteAllBookmarks,
-      { effects.offer(DeletePageItems(state, basePageDao)) }
+      { effects.offer(DeletePageItems(state, basePageDao, viewModelScope)) }
     )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
@@ -34,14 +35,14 @@ import javax.inject.Inject
 data class ShowDeleteBookmarksDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: PageState<LibkiwixBookmarkItem>,
-  private val pageDao: PageDao
+  private val basePageDao: BasePageDao
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
     activity.cachedComponent.inject(this)
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedBookmarks else DeleteAllBookmarks,
-      { effects.offer(DeletePageItems(state, pageDao)) }
+      { effects.offer(DeletePageItems(state, basePageDao)) }
     )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
-import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/adapter/HistoryListItem.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.page.history.adapter
 
 import org.kiwix.kiwixmobile.core.dao.entities.HistoryEntity
+import org.kiwix.kiwixmobile.core.dao.entities.HistoryRoomEntity
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.adapter.PageRelated
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
@@ -68,6 +69,19 @@ sealed class HistoryListItem : PageRelated {
       historyEntity.historyTitle,
       historyEntity.dateString,
       historyEntity.timeStamp,
+      false
+    )
+
+    constructor(historyRoomEntity: HistoryRoomEntity) : this(
+      historyRoomEntity.id,
+      historyRoomEntity.zimId,
+      historyRoomEntity.zimName,
+      historyRoomEntity.zimFilePath,
+      historyRoomEntity.favicon,
+      historyRoomEntity.historyUrl,
+      historyRoomEntity.historyTitle,
+      historyRoomEntity.dateString,
+      historyRoomEntity.timeStamp,
       false
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.page.history.viewmodel
 
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.ShowDeleteHistoryDialog
@@ -57,8 +58,11 @@ class HistoryViewModel @Inject constructor(
     return state.copy(showAll = action.isChecked)
   }
 
-  override fun createDeletePageDialogEffect(state: HistoryState) =
-    ShowDeleteHistoryDialog(effects, state, basePageDao)
+  override fun createDeletePageDialogEffect(
+    state: HistoryState,
+    viewModelScope: CoroutineScope
+  ) =
+    ShowDeleteHistoryDialog(effects, state, basePageDao, viewModelScope)
 
   override fun deselectAllPages(state: HistoryState): HistoryState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.page.history.viewmodel
 
 import org.kiwix.kiwixmobile.core.dao.HistoryDao
+import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.ShowDeleteHistoryDialog
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.UpdateAllHistoryPreference
@@ -29,10 +30,10 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
 
 class HistoryViewModel @Inject constructor(
-  historyDao: HistoryDao,
+  historyRoomDao: HistoryRoomDao,
   zimReaderContainer: ZimReaderContainer,
   sharedPrefs: SharedPreferenceUtil
-) : PageViewModel<HistoryItem, HistoryState>(historyDao, sharedPrefs, zimReaderContainer) {
+) : PageViewModel<HistoryItem, HistoryState>(historyRoomDao, sharedPrefs, zimReaderContainer) {
 
   override fun initialState(): HistoryState =
     HistoryState(emptyList(), sharedPreferenceUtil.showHistoryAllBooks, zimReaderContainer.id)
@@ -58,7 +59,7 @@ class HistoryViewModel @Inject constructor(
   }
 
   override fun createDeletePageDialogEffect(state: HistoryState) =
-    ShowDeleteHistoryDialog(effects, state, pageDao)
+    ShowDeleteHistoryDialog(effects, state, basePageDao)
 
   override fun deselectAllPages(state: HistoryState): HistoryState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.page.history.viewmodel
 
-import org.kiwix.kiwixmobile.core.dao.HistoryDao
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem.HistoryItem
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.ShowDeleteHistoryDialog

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
-import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.HistoryState
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.page.history.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
@@ -33,13 +34,14 @@ import javax.inject.Inject
 data class ShowDeleteHistoryDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: HistoryState,
-  private val basePageDao: BasePageDao
+  private val basePageDao: BasePageDao,
+  private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
     activity.cachedComponent.inject(this)
     dialogShower.show(if (state.isInSelectionState) DeleteSelectedHistory else DeleteAllHistory, {
-      effects.offer(DeletePageItems(state, basePageDao))
+      effects.offer(DeletePageItems(state, basePageDao, viewModelScope))
     })
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.page.history.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.HistoryState
@@ -33,13 +34,13 @@ import javax.inject.Inject
 data class ShowDeleteHistoryDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: HistoryState,
-  private val pageDao: PageDao
+  private val basePageDao: BasePageDao
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
     activity.cachedComponent.inject(this)
     dialogShower.show(if (state.isInSelectionState) DeleteSelectedHistory else DeleteAllHistory, {
-      effects.offer(DeletePageItems(state, pageDao))
+      effects.offer(DeletePageItems(state, basePageDao))
     })
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.page.notes.viewmodel
 
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.dao.NewNoteDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
@@ -65,8 +66,8 @@ class NotesViewModel @Inject constructor(
   override fun deselectAllPages(state: NotesState): NotesState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
-  override fun createDeletePageDialogEffect(state: NotesState) =
-    ShowDeleteNotesDialog(effects, state, basePageDao)
+  override fun createDeletePageDialogEffect(state: NotesState, viewModelScope: CoroutineScope) =
+    ShowDeleteNotesDialog(effects, state, basePageDao, viewModelScope)
 
   override fun onItemClick(page: Page) =
     ShowOpenNoteDialog(effects, page, zimReaderContainer)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -66,7 +66,7 @@ class NotesViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: NotesState) =
-    ShowDeleteNotesDialog(effects, state, pageDao)
+    ShowDeleteNotesDialog(effects, state, basePageDao)
 
   override fun onItemClick(page: Page) =
     ShowOpenNoteDialog(effects, page, zimReaderContainer)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
@@ -18,18 +18,17 @@ package org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects
  *
  */
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
-import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.notes.viewmodel.NotesState
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteAllNotes
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteSelectedNotes
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import javax.inject.Inject
 
 data class ShowDeleteNotesDialog(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
@@ -22,6 +22,7 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.notes.viewmodel.NotesState
@@ -34,7 +35,7 @@ import javax.inject.Inject
 data class ShowDeleteNotesDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: NotesState,
-  private val pageDao: PageDao
+  private val basePageDao: BasePageDao
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
@@ -43,7 +44,7 @@ data class ShowDeleteNotesDialog(
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedNotes else DeleteAllNotes,
       {
-        effects.offer(DeletePageItems(state, pageDao))
+        effects.offer(DeletePageItems(state, basePageDao))
       }
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
@@ -34,7 +35,8 @@ import javax.inject.Inject
 data class ShowDeleteNotesDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: NotesState,
-  private val basePageDao: BasePageDao
+  private val basePageDao: BasePageDao,
+  private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
@@ -43,7 +45,7 @@ data class ShowDeleteNotesDialog(
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedNotes else DeleteAllNotes,
       {
-        effects.offer(DeletePageItems(state, basePageDao))
+        effects.offer(DeletePageItems(state, basePageDao, viewModelScope))
       }
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -20,12 +20,16 @@ package org.kiwix.kiwixmobile.core.page.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.dao.PageDao
+import org.kiwix.kiwixmobile.core.dao.PageRoomDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.Exit
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.ExitActionModeMenu
@@ -42,7 +46,7 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.PopFragmentBackstack
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
 abstract class PageViewModel<T : Page, S : PageState<T>>(
-  protected val pageDao: PageDao,
+  protected val basePageDao: BasePageDao,
   val sharedPreferenceUtil: SharedPreferenceUtil,
   val zimReaderContainer: ZimReaderContainer
 ) : ViewModel() {
@@ -70,11 +74,25 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
       .subscribe(state::postValue, Throwable::printStackTrace)
 
   protected fun addDisposablesToCompositeDisposable() {
-    compositeDisposable.addAll(
-      viewStateReducer(),
-      pageDao.pages().subscribeOn(Schedulers.io())
-        .subscribe({ actions.offer(UpdatePages(it)) }, Throwable::printStackTrace)
-    )
+    when (basePageDao) {
+      is PageDao -> {
+        compositeDisposable.addAll(
+          viewStateReducer(),
+          basePageDao.pages().subscribeOn(Schedulers.io())
+            .subscribe({ actions.offer(UpdatePages(it)) }, Throwable::printStackTrace)
+        )
+      }
+
+      is PageRoomDao -> {
+        viewModelScope.launch {
+          try {
+            // basePageDao.pages().collect(::UpdatePages)
+          } catch (exception: Exception) {
+            exception.printStackTrace()
+          }
+        }
+      }
+    }
   }
 
   private fun reduce(action: Action, state: S): S = when (action) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -87,8 +87,8 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
         viewModelScope.launch {
           try {
             // basePageDao.pages().collect(::UpdatePages)
-          } catch (exception: Exception) {
-            exception.printStackTrace()
+          } catch (ignore: Exception) {
+            ignore.printStackTrace()
           }
         }
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -20,10 +20,12 @@ package org.kiwix.kiwixmobile.core.page.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.rx2.asFlowable
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
@@ -113,7 +115,7 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
   ): S
 
   private fun offerShowDeleteDialog(state: S): S {
-    effects.offer(createDeletePageDialogEffect(state))
+    effects.offer(createDeletePageDialogEffect(state, viewModelScope = viewModelScope))
     return state
   }
 
@@ -150,5 +152,5 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
     super.onCleared()
   }
 
-  abstract fun createDeletePageDialogEffect(state: S): SideEffect<*>
+  abstract fun createDeletePageDialogEffect(state: S, viewModelScope: CoroutineScope): SideEffect<*>
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
-import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -20,19 +20,20 @@ package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
 
 data class DeletePageItems(
   private val state: PageState<*>,
-  private val pageDao: PageDao
+  private val basePageDao: BasePageDao
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     if (state.isInSelectionState) {
-      pageDao.deletePages(state.pageItems.filter(Page::isSelected))
+      basePageDao.deletePages(state.pageItems.filter(Page::isSelected))
     } else {
-      pageDao.deletePages(state.pageItems)
+      basePageDao.deletePages(state.pageItems)
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -19,6 +19,9 @@
 package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.BasePageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -26,13 +29,16 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
 
 data class DeletePageItems(
   private val state: PageState<*>,
-  private val basePageDao: BasePageDao
+  private val basePageDao: BasePageDao,
+  private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    if (state.isInSelectionState) {
-      basePageDao.deletePages(state.pageItems.filter(Page::isSelected))
-    } else {
-      basePageDao.deletePages(state.pageItems)
+    viewModelScope.launch(Dispatchers.IO) {
+      if (state.isInSelectionState) {
+        basePageDao.deletePages(state.pageItems.filter(Page::isSelected))
+      } else {
+        basePageDao.deletePages(state.pageItems)
+      }
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -96,6 +96,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsRecentSearchMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_RECENT_SEARCH_MIGRATED, false)
 
+  val prefIsHistoryMigrated: Boolean
+    get() = sharedPreferences.getBoolean(PREF_HISTORY_MIGRATED, false)
+
   val prefStorage: String
     get() {
       val storage = sharedPreferences.getString(PREF_STORAGE, null)
@@ -128,6 +131,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun putPrefRecentSearchMigrated(isMigrated: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_RECENT_SEARCH_MIGRATED, isMigrated) }
+
+  fun putPrefHistoryMigrated(isMigrated: Boolean) =
+    sharedPreferences.edit { putBoolean(PREF_HISTORY_MIGRATED, isMigrated) }
 
   fun putPrefLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_LANG, language) }
@@ -289,5 +295,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_PLAY_STORE_RESTRICTION = "pref_play_store_restriction"
     const val PREF_BOOKMARKS_MIGRATED = "pref_bookmarks_migrated"
     const val PREF_RECENT_SEARCH_MIGRATED = "pref_recent_search_migrated"
+    const val PREF_HISTORY_MIGRATED = "pref_history_migrated"
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -24,6 +24,9 @@ import io.mockk.mockk
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -47,6 +50,7 @@ internal class BookmarkViewModelTest {
   private val libkiwixBookMarks: LibkiwixBookmarks = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val sharedPreferenceUtil: SharedPreferenceUtil = mockk()
+  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   private lateinit var viewModel: BookmarkViewModel
 
@@ -128,11 +132,16 @@ internal class BookmarkViewModelTest {
   }
 
   @Test
-  internal fun `createDeletePageDialogEffect returns correct dialog`() {
+  internal fun `createDeletePageDialogEffect returns correct dialog`() = runTest {
     assertThat(
-      viewModel.createDeletePageDialogEffect(bookmarkState())
+      viewModel.createDeletePageDialogEffect(bookmarkState(), viewModelScope)
     ).isEqualTo(
-      ShowDeleteBookmarksDialog(viewModel.effects, bookmarkState(), libkiwixBookMarks)
+      ShowDeleteBookmarksDialog(
+        viewModel.effects,
+        bookmarkState(),
+        libkiwixBookMarks,
+        viewModelScope
+      )
     )
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialogTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialogTest.kt
@@ -5,6 +5,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.reactivex.processors.PublishProcessor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.HistoryDao
@@ -21,30 +24,33 @@ internal class ShowDeleteHistoryDialogTest {
   private val historyDao = mockk<HistoryDao>()
   val activity = mockk<CoreMainActivity>()
   private val dialogShower = mockk<DialogShower>(relaxed = true)
+  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   @Test
-  fun `invoke with shows dialog that offers ConfirmDelete action`() {
+  fun `invoke with shows dialog that offers ConfirmDelete action`() = runBlocking {
     val showDeleteHistoryDialog =
       ShowDeleteHistoryDialog(
         effects,
         historyState(),
-        historyDao
+        historyDao,
+        viewModelScope
       )
     mockkActivityInjection(showDeleteHistoryDialog)
     val lambdaSlot = slot<() -> Unit>()
     showDeleteHistoryDialog.invokeWith(activity)
     verify { dialogShower.show(any(), capture(lambdaSlot)) }
     lambdaSlot.captured.invoke()
-    verify { effects.offer(DeletePageItems(historyState(), historyDao)) }
+    verify { effects.offer(DeletePageItems(historyState(), historyDao, viewModelScope)) }
   }
 
   @Test
-  fun `invoke with selected item shows dialog with delete selected items title`() {
+  fun `invoke with selected item shows dialog with delete selected items title`() = runBlocking {
     val showDeleteHistoryDialog =
       ShowDeleteHistoryDialog(
         effects,
         historyState(listOf(historyItem(isSelected = true))),
-        historyDao
+        historyDao,
+        viewModelScope
       )
     mockkActivityInjection(showDeleteHistoryDialog)
     showDeleteHistoryDialog.invokeWith(activity)
@@ -52,12 +58,13 @@ internal class ShowDeleteHistoryDialogTest {
   }
 
   @Test
-  fun `invoke with no selected items shows dialog with delete all items title`() {
+  fun `invoke with no selected items shows dialog with delete all items title`() = runBlocking {
     val showDeleteHistoryDialog =
       ShowDeleteHistoryDialog(
         effects,
         historyState(),
-        historyDao
+        historyDao,
+        viewModelScope
       )
     mockkActivityInjection(showDeleteHistoryDialog)
     showDeleteHistoryDialog.invokeWith(activity)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/TestablePageClasses.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/TestablePageClasses.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.page.viewmodel
 
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -61,7 +62,10 @@ class TestablePageViewModel(
   override fun deselectAllPages(state: TestablePageState): TestablePageState =
     state.copy(searchTerm = "deselectAllPagesCalled")
 
-  override fun createDeletePageDialogEffect(state: TestablePageState): SideEffect<*> {
+  override fun createDeletePageDialogEffect(
+    state: TestablePageState,
+    viewModelScope: CoroutineScope
+  ): SideEffect<*> {
     createDeletePageDialogEffectCalled = true
     return mockk()
   }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -21,6 +21,9 @@ package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.historyItem
@@ -31,18 +34,27 @@ internal class DeletePageItemsTest {
   val activity: AppCompatActivity = mockk()
   private val item1 = historyItem()
   private val item2 = historyItem()
+  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   @Test
-  fun `delete with selected items only deletes the selected items`() {
+  fun `delete with selected items only deletes the selected items`() = runBlocking {
     item1.isSelected = true
-    DeletePageItems(historyState(listOf(item1, item2)), pageDao).invokeWith(activity)
+    DeletePageItems(
+      historyState(listOf(item1, item2)),
+      pageDao,
+      viewModelScope
+    ).invokeWith(activity)
     verify { pageDao.deletePages(listOf(item1)) }
   }
 
   @Test
-  fun `delete with no selected items deletes all items`() {
+  fun `delete with no selected items deletes all items`() = runBlocking {
     item1.isSelected = false
-    DeletePageItems(historyState(listOf(item1, item2)), pageDao).invokeWith(activity)
+    DeletePageItems(
+      historyState(listOf(item1, item2)),
+      pageDao,
+      viewModelScope
+    ).invokeWith(activity)
     verify { pageDao.deletePages(listOf(item1, item2)) }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
@@ -23,6 +23,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
@@ -31,7 +32,7 @@ import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchList
 internal class DeleteRecentSearchTest {
 
   @Test
-  fun `invoke with deletes a search`() {
+  fun `invoke with deletes a search`() = runBlocking {
     val searchListItem: SearchListItem = RecentSearchListItem("", "")
     val recentSearchDao: RecentSearchRoomDao = mockk()
     val activity: AppCompatActivity = mockk()


### PR DESCRIPTION
Fixes #3107

* Now all the new history will be saved in the room database instead of `objectbox`
* We have added the migration code for previously saved history from `objectbox to `room`. This will ensure that the previously saved history will be shown to the user.
* Added the test cases for testing the migration with different scenarios, and with large data sets. Also, added the test cases for `HistoryRoomDaoTest`, and `KiwixRoomDatabaseTest` to test that it can save the different types of data.
* Refactored the existing test cases to adapt to this new change.
