### PR TITLE
Migrated Notes to room database.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -106,7 +106,7 @@ class KiwixRoomDatabaseTest {
 
     // test inserting into history database
     historyRoomDao.saveHistory(historyItem)
-    var historyList = historyRoomDao.historyRoomEntity().first()
+    var historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     with(historyList.first()) {
       assertThat(historyTitle, equalTo(historyItem.title))
       assertThat(zimId, equalTo(historyItem.zimId))
@@ -120,7 +120,7 @@ class KiwixRoomDatabaseTest {
 
     // test deleting the history
     historyRoomDao.deleteHistory(listOf(historyItem))
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertEquals(historyList.size, 0)
 
     // test deleting all history
@@ -128,10 +128,10 @@ class KiwixRoomDatabaseTest {
     historyRoomDao.saveHistory(
       getHistoryItem(databaseId = 2)
     )
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertEquals(historyList.size, 2)
     historyRoomDao.deleteAllHistory()
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertEquals(historyList.size, 0)
   }
 
@@ -139,7 +139,7 @@ class KiwixRoomDatabaseTest {
   fun testNoteRoomDao() = runBlocking {
     notesRoomDao = db.notesRoomDao()
     // delete all the notes from database to properly run the test cases.
-    notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
+    notesRoomDao.deleteNotes(notesRoomDao.notes().blockingFirst() as List<NoteListItem>)
     val noteItem = getNoteListItem(
       zimUrl = "http://kiwix.app/MainPage",
       noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/MainPage.txt"
@@ -147,7 +147,7 @@ class KiwixRoomDatabaseTest {
 
     // Save and retrieve a notes item
     notesRoomDao.saveNote(noteItem)
-    var notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    var notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     with(notesList.first()) {
       assertThat(zimId, equalTo(noteItem.zimId))
       assertThat(zimUrl, equalTo(noteItem.zimUrl))
@@ -160,7 +160,7 @@ class KiwixRoomDatabaseTest {
 
     // test deleting the history
     notesRoomDao.deleteNotes(listOf(noteItem))
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 0)
 
     // test deleting all notes
@@ -171,10 +171,10 @@ class KiwixRoomDatabaseTest {
         zimUrl = "http://kiwix.app/Installing"
       )
     )
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 2)
-    notesRoomDao.deletePages(notesRoomDao.notes().first())
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesRoomDao.deletePages(notesRoomDao.notes().blockingFirst())
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 0)
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
+import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 
 @RunWith(AndroidJUnit4::class)
 class KiwixRoomDatabaseTest {
@@ -154,5 +155,23 @@ class KiwixRoomDatabaseTest {
         dateString = dateString,
         timeStamp = timeStamp
       )
+
+    fun getNoteListItem(
+      databaseId: Long = 0L,
+      zimId: String = "1f88ab6f-c265-b-3ff-8f49-b7f4429503800",
+      title: String = "A",
+      zimFilePath: String = "/storage/emulated/0/Download/alpinelinux_en_all_maxi_2023-01.zim",
+      zimUrl: String,
+      noteFilePath: String = "/storage/emulated/0/Download/Notes/Alpine linux/AlpineNote.txt"
+    ): NoteListItem = NoteListItem(
+      databaseId = databaseId,
+      zimId = zimId,
+      title = title,
+      zimFilePath = zimFilePath,
+      zimUrl = zimUrl,
+      noteFilePath = noteFilePath,
+      null,
+      false
+    )
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -169,7 +169,8 @@ class ObjectBoxToRoomMigratorTest {
     // delete history for testing other edge cases
     kiwixRoomDatabase.recentSearchRoomDao().deleteSearchHistory()
     kiwixRoomDatabase.historyRoomDao().deleteAllHistory()
-    kiwixRoomDatabase.notesRoomDao().deletePages(kiwixRoomDatabase.notesRoomDao().notes().first())
+    kiwixRoomDatabase.notesRoomDao()
+      .deletePages(kiwixRoomDatabase.notesRoomDao().notes().blockingFirst())
     box.removeAll()
   }
 
@@ -190,7 +191,7 @@ class ObjectBoxToRoomMigratorTest {
     // migrate data into room database
     objectBoxToRoomMigrator.migrateHistory(box)
     // check if data successfully migrated to room
-    val actual = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    val actual = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     with(actual.first()) {
       assertThat(historyTitle, equalTo(historyItem.title))
       assertThat(zimId, equalTo(historyItem.zimId))
@@ -206,7 +207,7 @@ class ObjectBoxToRoomMigratorTest {
 
     // Migrate data from empty ObjectBox database
     objectBoxToRoomMigrator.migrateHistory(box)
-    var actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    var actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertTrue(actualData.isEmpty())
 
     // Test if data successfully migrated to Room and existing data is preserved
@@ -214,7 +215,7 @@ class ObjectBoxToRoomMigratorTest {
     box.put(HistoryEntity(historyItem2))
     // Migrate data into Room database
     objectBoxToRoomMigrator.migrateHistory(box)
-    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertEquals(2, actualData.size)
     val existingItem =
       actualData.find {
@@ -233,7 +234,7 @@ class ObjectBoxToRoomMigratorTest {
     kiwixRoomDatabase.historyRoomDao().saveHistory(historyItem)
     box.put(HistoryEntity(historyItem))
     objectBoxToRoomMigrator.migrateHistory(box)
-    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertEquals(1, actualData.size)
 
     clearRoomAndBoxStoreDatabases(box)
@@ -247,7 +248,7 @@ class ObjectBoxToRoomMigratorTest {
     } catch (_: Exception) {
     }
     // Ensure Room database remains empty or unaffected by the invalid data
-    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertTrue(actualData.isEmpty())
 
     // Test large data migration for recent searches
@@ -269,7 +270,7 @@ class ObjectBoxToRoomMigratorTest {
     val endTime = System.currentTimeMillis()
     val migrationTime = endTime - startTime
     // Check if data successfully migrated to Room
-    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertEquals(numEntities, actualData.size)
     // Assert that the migration completes within a reasonable time frame
     assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
@@ -298,7 +299,7 @@ class ObjectBoxToRoomMigratorTest {
     // migrate data into room database
     objectBoxToRoomMigrator.migrateNotes(box)
     // check if data successfully migrated to room
-    var notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    var notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     with(notesList.first()) {
       assertThat(zimId, equalTo(noteItem.zimId))
       assertThat(zimUrl, equalTo(noteItem.zimUrl))
@@ -313,7 +314,7 @@ class ObjectBoxToRoomMigratorTest {
 
     // Migrate data from empty ObjectBox database
     objectBoxToRoomMigrator.migrateNotes(box)
-    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertTrue(notesList.isEmpty())
 
     // Test if data successfully migrated to Room and existing data is preserved
@@ -321,7 +322,7 @@ class ObjectBoxToRoomMigratorTest {
     box.put(NotesEntity(noteItem))
     // Migrate data into Room database
     objectBoxToRoomMigrator.migrateNotes(box)
-    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertEquals(noteItem.title, notesList.first().title)
     assertEquals(2, notesList.size)
     val existingItem =
@@ -342,7 +343,7 @@ class ObjectBoxToRoomMigratorTest {
     box.put(NotesEntity(noteItem1))
     // Migrate data into Room database
     objectBoxToRoomMigrator.migrateNotes(box)
-    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertEquals(1, notesList.size)
 
     clearRoomAndBoxStoreDatabases(box)
@@ -356,7 +357,7 @@ class ObjectBoxToRoomMigratorTest {
     } catch (_: Exception) {
     }
     // Ensure Room database remains empty or unaffected by the invalid data
-    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertTrue(notesList.isEmpty())
 
     // Test large data migration for recent searches
@@ -378,7 +379,7 @@ class ObjectBoxToRoomMigratorTest {
     val endTime = System.currentTimeMillis()
     val migrationTime = endTime - startTime
     // Check if data successfully migrated to Room
-    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertEquals(numEntities, notesList.size)
     // Assert that the migration completes within a reasonable time frame
     assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -36,11 +36,14 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.KiwixRoomDatabaseTest.Companion.getHistoryItem
+import org.kiwix.kiwixmobile.KiwixRoomDatabaseTest.Companion.getNoteListItem
 import org.kiwix.kiwixmobile.core.dao.entities.HistoryEntity
+import org.kiwix.kiwixmobile.core.dao.entities.NotesEntity
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.modules.DatabaseModule
+import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
 @RunWith(AndroidJUnit4::class)
@@ -162,10 +165,11 @@ class ObjectBoxToRoomMigratorTest {
     assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
   }
 
-  private fun <T> clearRoomAndBoxStoreDatabases(box: Box<T>) {
+  private suspend fun <T> clearRoomAndBoxStoreDatabases(box: Box<T>) {
     // delete history for testing other edge cases
     kiwixRoomDatabase.recentSearchRoomDao().deleteSearchHistory()
     kiwixRoomDatabase.historyRoomDao().deleteAllHistory()
+    kiwixRoomDatabase.notesRoomDao().deletePages(kiwixRoomDatabase.notesRoomDao().notes().first())
     box.removeAll()
   }
 
@@ -267,6 +271,115 @@ class ObjectBoxToRoomMigratorTest {
     // Check if data successfully migrated to Room
     actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().first()
     assertEquals(numEntities, actualData.size)
+    // Assert that the migration completes within a reasonable time frame
+    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
+  }
+
+  @Test
+  fun migrateNotes_shouldInsertDataIntoRoomDatabase() = runBlocking {
+    val box = boxStore.boxFor(NotesEntity::class.java)
+    // clear both databases for history to test more edge cases
+    clearRoomAndBoxStoreDatabases(box)
+
+    val noteItem = getNoteListItem(
+      zimUrl = "http://kiwix.app/MainPage",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/MainPage.txt"
+    )
+
+    val noteItem1 = getNoteListItem(
+      databaseId = 1,
+      title = "Installing",
+      zimUrl = "http://kiwix.app/Installing",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
+    )
+
+    // insert into object box
+    box.put(NotesEntity(noteItem))
+    // migrate data into room database
+    objectBoxToRoomMigrator.migrateNotes(box)
+    // check if data successfully migrated to room
+    var notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    with(notesList.first()) {
+      assertThat(zimId, equalTo(noteItem.zimId))
+      assertThat(zimUrl, equalTo(noteItem.zimUrl))
+      assertThat(title, equalTo(noteItem.title))
+      assertThat(zimFilePath, equalTo(noteItem.zimFilePath))
+      assertThat(noteFilePath, equalTo(noteItem.noteFilePath))
+      assertThat(favicon, equalTo(noteItem.favicon))
+    }
+    assertEquals(notesList.size, 1)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Migrate data from empty ObjectBox database
+    objectBoxToRoomMigrator.migrateNotes(box)
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    assertTrue(notesList.isEmpty())
+
+    // Test if data successfully migrated to Room and existing data is preserved
+    kiwixRoomDatabase.notesRoomDao().saveNote(noteItem1)
+    box.put(NotesEntity(noteItem))
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateNotes(box)
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    assertEquals(noteItem.title, notesList.first().title)
+    assertEquals(2, notesList.size)
+    val existingItem =
+      notesList.find {
+        it.zimUrl == noteItem.zimUrl && it.title == noteItem.title
+      }
+    assertNotNull(existingItem)
+    val newItem =
+      notesList.find {
+        it.zimUrl == noteItem1.zimUrl && it.title == noteItem1.title
+      }
+    assertNotNull(newItem)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Test room will update the already exiting data in the database while migration.
+    kiwixRoomDatabase.notesRoomDao().saveNote(noteItem1)
+    box.put(NotesEntity(noteItem1))
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateNotes(box)
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    assertEquals(1, notesList.size)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Test migration if ObjectBox has null values
+    try {
+      lateinit var invalidNotesEntity: NotesEntity
+      box.put(invalidNotesEntity)
+      // Migrate data into Room database
+      objectBoxToRoomMigrator.migrateNotes(box)
+    } catch (_: Exception) {
+    }
+    // Ensure Room database remains empty or unaffected by the invalid data
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    assertTrue(notesList.isEmpty())
+
+    // Test large data migration for recent searches
+    val numEntities = 5000
+    // Insert a large number of recent search entities into ObjectBox
+    for (i in 1..numEntities) {
+      box.put(
+        NotesEntity(
+          getNoteListItem(
+            title = "Installation$i",
+            zimUrl = "https://kiwix.app/A/Installation$i"
+          )
+        )
+      )
+    }
+    val startTime = System.currentTimeMillis()
+    // Migrate data into Room database
+    objectBoxToRoomMigrator.migrateNotes(box)
+    val endTime = System.currentTimeMillis()
+    val migrationTime = endTime - startTime
+    // Check if data successfully migrated to Room
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().first() as List<NoteListItem>
+    assertEquals(numEntities, notesList.size)
     // Assert that the migration completes within a reasonable time frame
     assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
@@ -65,7 +64,7 @@ class HistoryRoomDaoTest {
 
     // Save and retrieve a history item
     historyRoomDao.saveHistory(historyItem)
-    var historyList = historyRoomDao.historyRoomEntity().first()
+    var historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     with(historyList.first()) {
       assertThat(historyTitle, equalTo(historyItem.title))
       assertThat(zimId, equalTo(historyItem.zimId))
@@ -79,26 +78,26 @@ class HistoryRoomDaoTest {
 
     // Test to update the same day history for url
     historyRoomDao.saveHistory(historyItem)
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertEquals(historyList.size, 1)
 
     // Delete the saved history item
     historyRoomDao.deleteHistory(listOf(historyItem))
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertEquals(historyList.size, 0)
 
     // Save and delete all history items
     historyRoomDao.saveHistory(historyItem)
     historyRoomDao.saveHistory(getHistoryItem(databaseId = 2, dateString = "31 May 2024"))
     historyRoomDao.deleteAllHistory()
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertThat(historyList.size, equalTo(0))
 
     // Save history item with empty fields
     val emptyHistoryUrl = ""
     val emptyTitle = ""
     historyRoomDao.saveHistory(getHistoryItem(emptyTitle, emptyHistoryUrl, databaseId = 1))
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertThat(historyList.size, equalTo(1))
     historyRoomDao.deleteAllHistory()
 
@@ -118,13 +117,13 @@ class HistoryRoomDaoTest {
     val unicodeTitle = "title \u03A3" // Unicode character for Greek capital letter Sigma
     val historyItem2 = getHistoryItem(title = unicodeTitle, databaseId = 2)
     historyRoomDao.saveHistory(historyItem2)
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertThat(historyList.first().historyTitle, equalTo("title Σ"))
 
     // Test deletePages function
     historyRoomDao.saveHistory(historyItem)
     historyRoomDao.deletePages(listOf(historyItem, historyItem2))
-    historyList = historyRoomDao.historyRoomEntity().first()
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
     assertThat(historyList.size, equalTo(0))
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
@@ -75,7 +75,7 @@ class NoteRoomDaoTest {
     }
     assertEquals(notesList.size, 1)
 
-    // Test duplicate note can not be saved
+    // Test update the existing note
     notesRoomDao.saveNote(noteItem)
     notesList = notesRoomDao.notes().first() as List<NoteListItem>
     assertEquals(notesList.size, 1)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.roomDao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.KiwixRoomDatabaseTest.Companion.getNoteListItem
+import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
+
+@RunWith(AndroidJUnit4::class)
+class NoteRoomDaoTest {
+  private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
+  private lateinit var notesRoomDao: NotesRoomDao
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    kiwixRoomDatabase = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java).build()
+    notesRoomDao = kiwixRoomDatabase.notesRoomDao()
+  }
+
+  @After
+  fun tearDown() {
+    kiwixRoomDatabase.close()
+  }
+
+  @Test
+  fun testNotesRoomDao() = runBlocking {
+    // delete all the notes from database to properly run the test cases.
+    clearNotes()
+    val noteItem = getNoteListItem(
+      zimUrl = "http://kiwix.app/MainPage",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/MainPage.txt"
+    )
+
+    // Save and retrieve a notes item
+    notesRoomDao.saveNote(noteItem)
+    var notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    with(notesList.first()) {
+      assertThat(zimId, equalTo(noteItem.zimId))
+      assertThat(zimUrl, equalTo(noteItem.zimUrl))
+      assertThat(title, equalTo(noteItem.title))
+      assertThat(zimFilePath, equalTo(noteItem.zimFilePath))
+      assertThat(noteFilePath, equalTo(noteItem.noteFilePath))
+      assertThat(favicon, equalTo(noteItem.favicon))
+    }
+    assertEquals(notesList.size, 1)
+
+    // Test duplicate note can not be saved
+    notesRoomDao.saveNote(noteItem)
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertEquals(notesList.size, 1)
+
+    // Delete the saved note item with all delete methods available in NoteRoomDao.
+    // delete via noteTitle
+    notesRoomDao.deleteNote(noteItem.title)
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertEquals(notesList.size, 0)
+
+    // delete with deletePages method
+    notesRoomDao.saveNote(noteItem)
+    notesRoomDao.deletePages(listOf(noteItem))
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertEquals(notesList.size, 0)
+
+    // delete with list of NoteListItem
+    notesRoomDao.saveNote(noteItem)
+    notesRoomDao.deleteNotes(listOf(noteItem))
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertEquals(notesList.size, 0)
+
+    // Save note with empty title
+    notesRoomDao.saveNote(
+      getNoteListItem(
+        title = "",
+        zimUrl = "http://kiwix.app/Installing",
+        noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
+      )
+    )
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertEquals(notesList.size, 1)
+    clearNotes()
+
+    // Attempt to save undefined history item
+    lateinit var undefinedNoteListItem: NoteListItem
+    try {
+      notesRoomDao.saveNote(undefinedNoteListItem)
+      assertThat(
+        "Undefined value was saved into database",
+        false
+      )
+    } catch (e: Exception) {
+      assertThat("Undefined value was not saved, as expected.", true)
+    }
+
+    // Save history item with Unicode values
+    val unicodeTitle = "title \u03A3" // Unicode character for Greek capital letter Sigma
+    val noteListItem2 =
+      getNoteListItem(title = unicodeTitle, zimUrl = "http://kiwix.app/Installing")
+    notesRoomDao.saveNote(noteListItem2)
+    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    assertThat(notesList.first().title, equalTo("title Σ"))
+  }
+
+  private suspend fun clearNotes() {
+    notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
@@ -64,7 +64,7 @@ class NoteRoomDaoTest {
 
     // Save and retrieve a notes item
     notesRoomDao.saveNote(noteItem)
-    var notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    var notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     with(notesList.first()) {
       assertThat(zimId, equalTo(noteItem.zimId))
       assertThat(zimUrl, equalTo(noteItem.zimUrl))
@@ -77,25 +77,25 @@ class NoteRoomDaoTest {
 
     // Test update the existing note
     notesRoomDao.saveNote(noteItem)
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 1)
 
     // Delete the saved note item with all delete methods available in NoteRoomDao.
     // delete via noteTitle
     notesRoomDao.deleteNote(noteItem.title)
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 0)
 
     // delete with deletePages method
     notesRoomDao.saveNote(noteItem)
     notesRoomDao.deletePages(listOf(noteItem))
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 0)
 
     // delete with list of NoteListItem
     notesRoomDao.saveNote(noteItem)
     notesRoomDao.deleteNotes(listOf(noteItem))
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 0)
 
     // Save note with empty title
@@ -106,7 +106,7 @@ class NoteRoomDaoTest {
         noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
       )
     )
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 1)
     clearNotes()
 
@@ -127,11 +127,11 @@ class NoteRoomDaoTest {
     val noteListItem2 =
       getNoteListItem(title = unicodeTitle, zimUrl = "http://kiwix.app/Installing")
     notesRoomDao.saveNote(noteListItem2)
-    notesList = notesRoomDao.notes().first() as List<NoteListItem>
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertThat(notesList.first().title, equalTo("title Σ"))
   }
 
   private suspend fun clearNotes() {
-    notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
+    notesRoomDao.deleteNotes(notesRoomDao.notes().blockingFirst() as List<NoteListItem>)
   }
 }

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -27,12 +27,6 @@ object Libs {
     Versions.org_jetbrains_kotlinx_kotlinx_coroutines
 
   /**
-   * https://github.com/Kotlin/kotlinx.coroutines
-   */
-  const val kotlinx_coroutines_rx2: String = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:" +
-    Versions.org_jetbrains_kotlinx_kotlinx_coroutines
-
-  /**
    * https://developer.android.com/testing
    */
   const val espresso_contrib: String = "androidx.test.espresso:espresso-contrib:" +
@@ -363,4 +357,6 @@ object Libs {
   const val roomCompiler = "androidx.room:room-compiler:" + Versions.roomVersion
 
   const val roomRuntime = "androidx.room:room-runtime:" + Versions.roomVersion
+
+  const val roomRxjava2 = "androidx.room:room-rxjava2:" + Versions.roomVersion
 }

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -204,12 +204,12 @@ class AllProjectConfigurer {
       implementation(Libs.fetch)
       implementation(Libs.rxandroid)
       implementation(Libs.rxjava)
-      implementation(Libs.kotlinx_coroutines_rx2)
       implementation(Libs.preference_ktx)
       implementation(Libs.material_show_case_view)
       implementation(Libs.roomKtx)
       annotationProcessor(Libs.roomCompiler)
       implementation(Libs.roomRuntime)
+      implementation(Libs.roomRxjava2)
       kapt(Libs.roomCompiler)
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
@@ -24,18 +24,17 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.TypeConverter
 import androidx.room.Update
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import io.reactivex.Flowable
 import org.kiwix.kiwixmobile.core.dao.entities.HistoryRoomEntity
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
 
 @Dao
-abstract class HistoryRoomDao : PageRoomDao {
+abstract class HistoryRoomDao : PageDao {
   @Query("SELECT * FROM HistoryRoomEntity ORDER BY HistoryRoomEntity.timeStamp DESC")
-  abstract fun historyRoomEntity(): Flow<List<HistoryRoomEntity>>
+  abstract fun historyRoomEntity(): Flowable<List<HistoryRoomEntity>>
 
-  fun history(): Flow<List<Page>> = historyRoomEntity().map {
+  fun history(): Flowable<List<Page>> = historyRoomEntity().map {
     it.map(HistoryListItem::HistoryItem)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -45,13 +45,13 @@ abstract class NotesRoomDao : PageRoomDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   abstract fun saveNote(notesRoomEntity: NotesRoomEntity)
 
-  @Query("DELETE FROM NotesRoomEntity WHERE noteTitle=:noteUniqueKey")
-  abstract fun deleteNote(noteUniqueKey: String)
+  @Query("DELETE FROM NotesRoomEntity WHERE noteTitle=:noteTitle")
+  abstract fun deleteNote(noteTitle: String)
 
   fun deleteNotes(notesList: List<NoteListItem>) {
     notesList.forEachIndexed { _, note ->
       val notesRoomEntity = NotesRoomEntity(note)
-      deleteNote(noteUniqueKey = notesRoomEntity.noteTitle)
+      deleteNote(noteTitle = notesRoomEntity.noteTitle)
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -22,19 +22,18 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import io.reactivex.Flowable
 import org.kiwix.kiwixmobile.core.dao.entities.NotesRoomEntity
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 
 @Dao
-abstract class NotesRoomDao : PageRoomDao {
+abstract class NotesRoomDao : PageDao {
   @Query("SELECT * FROM NotesRoomEntity ORDER BY NotesRoomEntity.noteTitle")
-  abstract fun notesAsEntity(): Flow<List<NotesRoomEntity>>
+  abstract fun notesAsEntity(): Flowable<List<NotesRoomEntity>>
 
-  fun notes(): Flow<List<Page>> = notesAsEntity().map { it.map(::NoteListItem) }
-  override fun pages(): Flow<List<Page>> = notes()
+  fun notes(): Flowable<List<Page>> = notesAsEntity().map { it.map(::NoteListItem) }
+  override fun pages(): Flowable<List<Page>> = notes()
   override fun deletePages(pagesToDelete: List<Page>) =
     deleteNotes(pagesToDelete as List<NoteListItem>)
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -1,0 +1,57 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.kiwix.kiwixmobile.core.dao.entities.NotesRoomEntity
+import org.kiwix.kiwixmobile.core.page.adapter.Page
+import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
+
+@Dao
+abstract class NotesRoomDao : PageRoomDao {
+  @Query("SELECT * FROM NotesRoomEntity ORDER BY NotesRoomEntity.noteTitle")
+  abstract fun notesAsEntity(): Flow<List<NotesRoomEntity>>
+
+  fun notes(): Flow<List<Page>> = notesAsEntity().map { it.map(::NoteListItem) }
+  override fun pages(): Flow<List<Page>> = notes()
+  override fun deletePages(pagesToDelete: List<Page>) =
+    deleteNotes(pagesToDelete as List<NoteListItem>)
+
+  fun saveNote(noteItem: NoteListItem) {
+    saveNote(NotesRoomEntity(noteItem))
+  }
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  abstract fun saveNote(notesRoomEntity: NotesRoomEntity)
+
+  @Query("DELETE FROM NotesRoomEntity WHERE noteTitle=:noteUniqueKey")
+  abstract fun deleteNote(noteUniqueKey: String)
+
+  fun deleteNotes(notesList: List<NoteListItem>) {
+    notesList.forEachIndexed { _, note ->
+      val notesRoomEntity = NotesRoomEntity(note)
+      deleteNote(noteUniqueKey = notesRoomEntity.noteTitle)
+    }
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
@@ -19,18 +19,9 @@
 package org.kiwix.kiwixmobile.core.dao
 
 import io.reactivex.Flowable
-import kotlinx.coroutines.flow.Flow
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 
-interface PageDao : BasePageDao {
-  override fun pages(): Flowable<List<Page>>
-}
-
-interface PageRoomDao : BasePageDao {
-  override fun pages(): Flow<List<Page>>
-}
-
-interface BasePageDao {
-  fun pages(): Any
+interface PageDao {
+  fun pages(): Flowable<List<Page>>
   fun deletePages(pagesToDelete: List<Page>)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/NotesRoomEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/NotesRoomEntity.kt
@@ -1,0 +1,46 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.dao.entities
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
+
+@Entity(indices = [Index(value = ["noteTitle"], unique = true)])
+data class NotesRoomEntity(
+  @PrimaryKey(autoGenerate = true)
+  var id: Long = 0L,
+  val zimId: String,
+  var zimFilePath: String?,
+  val zimUrl: String,
+  var noteTitle: String,
+  var noteFilePath: String,
+  var favicon: String?
+) {
+  constructor(item: NoteListItem) : this(
+    id = item.databaseId,
+    zimId = item.zimId,
+    zimFilePath = item.zimFilePath,
+    zimUrl = item.zimUrl,
+    noteTitle = item.title,
+    noteFilePath = item.noteFilePath,
+    favicon = item.favicon
+  )
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/DataSource.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/DataSource.kt
@@ -49,6 +49,6 @@ interface DataSource {
   fun booksOnDiskAsListItems(): Flowable<List<BooksOnDiskListItem>>
 
   fun saveNote(noteListItem: NoteListItem): Completable
-  fun deleteNote(noteUniqueKey: String): Completable
+  fun deleteNote(noteTitle: String): Completable
   fun deleteNotes(noteList: List<NoteListItem>): Completable
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -47,7 +47,7 @@ import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 abstract class KiwixRoomDatabase : RoomDatabase() {
   abstract fun recentSearchRoomDao(): RecentSearchRoomDao
   abstract fun historyRoomDao(): HistoryRoomDao
-  abstract fun noteRoomDao(): NotesRoomDao
+  abstract fun notesRoomDao(): NotesRoomDao
 
   companion object {
     private var db: KiwixRoomDatabase? = null

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -132,7 +132,7 @@ class Repository @Inject internal constructor(
     Completable.fromAction { notesRoomDao.deleteNotes(noteList) }
       .subscribeOn(io)
 
-  override fun deleteNote(noteUniqueKey: String): Completable =
-    Completable.fromAction { notesRoomDao.deleteNote(noteUniqueKey) }
+  override fun deleteNote(noteTitle: String): Completable =
+    Completable.fromAction { notesRoomDao.deleteNote(noteTitle) }
       .subscribeOn(io)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -26,7 +26,7 @@ import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
-import org.kiwix.kiwixmobile.core.dao.NewNoteDao
+import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.di.qualifiers.IO
 import org.kiwix.kiwixmobile.core.di.qualifiers.MainThread
@@ -55,7 +55,7 @@ class Repository @Inject internal constructor(
   private val bookDao: NewBookDao,
   private val libkiwixBookmarks: LibkiwixBookmarks,
   private val historyRoomDao: HistoryRoomDao,
-  private val notesDao: NewNoteDao,
+  private val notesRoomDao: NotesRoomDao,
   private val languageDao: NewLanguagesDao,
   private val recentSearchRoomDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer
@@ -125,14 +125,14 @@ class Repository @Inject internal constructor(
       .subscribeOn(io)
 
   override fun saveNote(noteListItem: NoteListItem): Completable =
-    Completable.fromAction { notesDao.saveNote(noteListItem) }
+    Completable.fromAction { notesRoomDao.saveNote(noteListItem) }
       .subscribeOn(io)
 
   override fun deleteNotes(noteList: List<NoteListItem>) =
-    Completable.fromAction { notesDao.deleteNotes(noteList) }
+    Completable.fromAction { notesRoomDao.deleteNotes(noteList) }
       .subscribeOn(io)
 
   override fun deleteNote(noteUniqueKey: String): Completable =
-    Completable.fromAction { notesDao.deleteNote(noteUniqueKey) }
+    Completable.fromAction { notesRoomDao.deleteNote(noteUniqueKey) }
       .subscribeOn(io)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.core.dao.NewBookmarksDao
 import org.kiwix.kiwixmobile.core.dao.NewLanguagesDao
 import org.kiwix.kiwixmobile.core.dao.NewNoteDao
 import org.kiwix.kiwixmobile.core.dao.NewRecentSearchDao
+import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.data.DataModule
 import org.kiwix.kiwixmobile.core.data.DataSource
@@ -102,6 +103,7 @@ interface CoreComponent {
   fun libkiwixBookmarks(): LibkiwixBookmarks
   fun recentSearchRoomDao(): RecentSearchRoomDao
   fun historyRoomDao(): HistoryRoomDao
+  fun noteRoomDao(): NotesRoomDao
   fun objectBoxToRoomMigrator(): ObjectBoxToRoomMigrator
   fun context(): Context
   fun downloader(): Downloader

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -92,4 +92,8 @@ open class DatabaseModule {
   @Provides
   @Singleton
   fun provideHistoryDao(db: KiwixRoomDatabase) = db.historyRoomDao()
+
+  @Singleton
+  @Provides
+  fun provideNoteRoomDao(db: KiwixRoomDatabase) = db.noteRoomDao()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -95,5 +95,5 @@ open class DatabaseModule {
 
   @Singleton
   @Provides
-  fun provideNoteRoomDao(db: KiwixRoomDatabase) = db.noteRoomDao()
+  fun provideNoteRoomDao(db: KiwixRoomDatabase) = db.notesRoomDao()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/MainRepositoryActions.kt
@@ -58,8 +58,8 @@ class MainRepositoryActions @Inject constructor(private val dataSource: DataSour
       .subscribe({}, { e -> Log.e(TAG, "Unable to save note", e) })
   }
 
-  fun deleteNote(noteUniqueKey: String) {
-    deleteNoteDisposable = dataSource.deleteNote(noteUniqueKey)
+  fun deleteNote(noteTitle: String) {
+    deleteNoteDisposable = dataSource.deleteNote(noteTitle)
       .subscribe({}, { e -> Log.e(TAG, "Unable to delete note", e) })
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -66,7 +66,7 @@ class BookmarkViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: BookmarkState, viewModelScope: CoroutineScope) =
-    ShowDeleteBookmarksDialog(effects, state, basePageDao, viewModelScope)
+    ShowDeleteBookmarksDialog(effects, state, pageDao, viewModelScope)
 
   override fun copyWithNewItems(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.BasePageDao
+import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
@@ -35,7 +35,7 @@ import javax.inject.Inject
 data class ShowDeleteBookmarksDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: PageState<LibkiwixBookmarkItem>,
-  private val basePageDao: BasePageDao,
+  private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
@@ -43,7 +43,7 @@ data class ShowDeleteBookmarksDialog(
     activity.cachedComponent.inject(this)
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedBookmarks else DeleteAllBookmarks,
-      { effects.offer(DeletePageItems(state, basePageDao, viewModelScope)) }
+      { effects.offer(DeletePageItems(state, pageDao, viewModelScope)) }
     )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -62,7 +62,7 @@ class HistoryViewModel @Inject constructor(
     state: HistoryState,
     viewModelScope: CoroutineScope
   ) =
-    ShowDeleteHistoryDialog(effects, state, basePageDao, viewModelScope)
+    ShowDeleteHistoryDialog(effects, state, pageDao, viewModelScope)
 
   override fun deselectAllPages(state: HistoryState): HistoryState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.BasePageDao
+import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.HistoryState
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems
@@ -34,14 +34,14 @@ import javax.inject.Inject
 data class ShowDeleteHistoryDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: HistoryState,
-  private val basePageDao: BasePageDao,
+  private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
   override fun invokeWith(activity: AppCompatActivity) {
     activity.cachedComponent.inject(this)
     dialogShower.show(if (state.isInSelectionState) DeleteSelectedHistory else DeleteAllHistory, {
-      effects.offer(DeletePageItems(state, basePageDao, viewModelScope))
+      effects.offer(DeletePageItems(state, pageDao, viewModelScope))
     })
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/adapter/NoteListItem.kt
@@ -1,6 +1,7 @@
 package org.kiwix.kiwixmobile.core.page.notes.adapter
 
 import org.kiwix.kiwixmobile.core.dao.entities.NotesEntity
+import org.kiwix.kiwixmobile.core.dao.entities.NotesRoomEntity
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 
@@ -39,5 +40,15 @@ data class NoteListItem(
     zimUrl = url,
     favicon = zimFileReader.favicon,
     noteFilePath = noteFilePath
+  )
+
+  constructor(notesRoomEntity: NotesRoomEntity) : this(
+    notesRoomEntity.id,
+    notesRoomEntity.zimId,
+    notesRoomEntity.noteTitle,
+    notesRoomEntity.zimFilePath,
+    notesRoomEntity.zimUrl,
+    notesRoomEntity.noteFilePath,
+    notesRoomEntity.favicon
   )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -19,7 +19,7 @@
 package org.kiwix.kiwixmobile.core.page.notes.viewmodel
 
 import kotlinx.coroutines.CoroutineScope
-import org.kiwix.kiwixmobile.core.dao.NewNoteDao
+import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 import org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects.ShowDeleteNotesDialog
@@ -33,10 +33,10 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
 
 class NotesViewModel @Inject constructor(
-  notesDao: NewNoteDao,
+  notesRoomDao: NotesRoomDao,
   zimReaderContainer: ZimReaderContainer,
   sharedPrefs: SharedPreferenceUtil
-) : PageViewModel<NoteListItem, NotesState>(notesDao, sharedPrefs, zimReaderContainer),
+) : PageViewModel<NoteListItem, NotesState>(notesRoomDao, sharedPrefs, zimReaderContainer),
   PageViewModelClickListener {
 
   init {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -67,7 +67,7 @@ class NotesViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: NotesState, viewModelScope: CoroutineScope) =
-    ShowDeleteNotesDialog(effects, state, basePageDao, viewModelScope)
+    ShowDeleteNotesDialog(effects, state, pageDao, viewModelScope)
 
   override fun onItemClick(page: Page) =
     ShowOpenNoteDialog(effects, page, zimReaderContainer)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.processors.PublishProcessor
 import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.BasePageDao
+import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.page.notes.viewmodel.NotesState
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems
@@ -35,7 +35,7 @@ import javax.inject.Inject
 data class ShowDeleteNotesDialog(
   private val effects: PublishProcessor<SideEffect<*>>,
   private val state: NotesState,
-  private val basePageDao: BasePageDao,
+  private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   @Inject lateinit var dialogShower: DialogShower
@@ -45,7 +45,7 @@ data class ShowDeleteNotesDialog(
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedNotes else DeleteAllNotes,
       {
-        effects.offer(DeletePageItems(state, basePageDao, viewModelScope))
+        effects.offer(DeletePageItems(state, pageDao, viewModelScope))
       }
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -23,21 +23,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.dao.BasePageDao
+import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
 
 data class DeletePageItems(
   private val state: PageState<*>,
-  private val basePageDao: BasePageDao,
+  private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     viewModelScope.launch(Dispatchers.IO) {
       if (state.isInSelectionState) {
-        basePageDao.deletePages(state.pageItems.filter(Page::isSelected))
+        pageDao.deletePages(state.pageItems.filter(Page::isSelected))
       } else {
-        basePageDao.deletePages(state.pageItems)
+        pageDao.deletePages(state.pageItems)
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -96,6 +96,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsRecentSearchMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_RECENT_SEARCH_MIGRATED, false)
 
+  val prefIsNotesMigrated: Boolean
+    get() = sharedPreferences.getBoolean(PREF_NOTES_MIGRATED, false)
+
   val prefIsHistoryMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_HISTORY_MIGRATED, false)
 
@@ -134,6 +137,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun putPrefHistoryMigrated(isMigrated: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_HISTORY_MIGRATED, isMigrated) }
+
+  fun putPrefNotesMigrated(isMigrated: Boolean) =
+    sharedPreferences.edit { putBoolean(PREF_NOTES_MIGRATED, isMigrated) }
 
   fun putPrefLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_LANG, language) }
@@ -296,5 +302,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_BOOKMARKS_MIGRATED = "pref_bookmarks_migrated"
     const val PREF_RECENT_SEARCH_MIGRATED = "pref_recent_search_migrated"
     const val PREF_HISTORY_MIGRATED = "pref_history_migrated"
+    const val PREF_NOTES_MIGRATED = "pref_notes_migrated"
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
@@ -4,12 +4,11 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.processors.PublishProcessor
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.schedulers.TestScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -44,8 +43,8 @@ internal class HistoryViewModelTest {
     RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
   }
 
-  private val itemsFromDb: Flow<List<Page>> =
-    flow { }
+  private val itemsFromDb: PublishProcessor<List<Page>> =
+    PublishProcessor.create()
 
   @BeforeEach
   fun init() {


### PR DESCRIPTION
Fixes #3113 

* Now all the new notes will be saved in the room database instead of `objectbox`.
* We have added the migration code for previously saved notes from `objectbox` to `room`. This will ensure that the previously saved notes will be shown to the user.
* Added the test cases for testing the migration with different scenarios, and with large data sets. Also, added the test cases for `NoteRoomDaoTest`, and `KiwixRoomDatabaseTest` to test that it can save the different types of data.
* We have refactored our code to use PageDao for managing data related to Bookmarks, Notes, and History. With the ability to return Flowable from the Room database, the BasePageDao interface has become unnecessary. Consequently, we have removed BasePageDao and streamlined our code to use PageDao, providing a unified approach for these functionalities. This change reduces code complexity and enhances readability, making the codebase easier to understand and maintain.
