### PR TITLE
feat: handle `android.intent.action.WEB_SEARCH`  and open wikipedia links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,10 +125,6 @@
           android:host="search"
           android:scheme="kiwix" />
       </intent-filter>
-      <intent-filter>
-        <action android:name="android.intent.action.WEB_SEARCH" />
-        <category android:name="android.intent.category.DEFAULT" />
-      </intent-filter>
       <intent-filter android:label="@string/app_search_string">
         <action android:name="android.intent.action.PROCESS_TEXT" />
 
@@ -141,6 +137,16 @@
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
     </activity>
+    <activity-alias
+      android:name=".main.KiwixMainActivityWebSearch"
+      android:exported="true"
+      android:enabled="false"
+      android:targetActivity=".main.KiwixMainActivity" >
+      <intent-filter android:enabled="true">
+        <action android:name="android.intent.action.WEB_SEARCH" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity-alias>
 
     <receiver
       android:name=".main.KiwixSearchWidget"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,6 @@
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
-
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
@@ -58,7 +57,21 @@
         <data android:pathPattern="/.*\\..*\\.zim" />
         <data android:pathPattern="/.*\\..*\\..*\\.zim" />
         <data android:pathPattern="/.*\\..*\\..*\\..*\\.zim" />
-        <data android:host="*" />
+        <data android:host="*"/>
+      </intent-filter>
+
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="https"/>
+        <data android:scheme="http"/>
+        <data android:host="*.wikipedia.fr"/>
+        <data android:host="*.wikipedia.org"/>
+        <data android:host="*.wikipedia.com"/>
+        <data android:host="*.wikipedia.de"/>
+        <data android:pathPattern=".*"/>
       </intent-filter>
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
@@ -111,6 +124,10 @@
         <data
           android:host="search"
           android:scheme="kiwix" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.WEB_SEARCH" />
+        <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter android:label="@string/app_search_string">
         <action android:name="android.intent.action.PROCESS_TEXT" />

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -184,9 +184,6 @@ class KiwixMainActivity : CoreMainActivity() {
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     handleNotificationIntent(intent)
-    // supportFragmentManager.fragments.filterIsInstance<FragmentActivityExtensions>().forEach {
-    //   it.onNewIntent(intent, this)
-    // }
   }
 
   @Suppress("MagicNumber")

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -184,6 +184,9 @@ class KiwixMainActivity : CoreMainActivity() {
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     handleNotificationIntent(intent)
+    supportFragmentManager.fragments.filterIsInstance<FragmentActivityExtensions>().forEach {
+      it.onNewIntent(intent, this)
+    }
   }
 
   @Suppress("MagicNumber")

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -184,9 +184,9 @@ class KiwixMainActivity : CoreMainActivity() {
   override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     handleNotificationIntent(intent)
-    supportFragmentManager.fragments.filterIsInstance<FragmentActivityExtensions>().forEach {
-      it.onNewIntent(intent, this)
-    }
+    // supportFragmentManager.fragments.filterIsInstance<FragmentActivityExtensions>().forEach {
+    //   it.onNewIntent(intent, this)
+    // }
   }
 
   @Suppress("MagicNumber")

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -314,7 +314,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
           }, 300)
         }
 
-        else -> activity.toast(R.string.cannot_open_file)
+        else -> {}
       }
     }
     return ShouldCall

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewBookDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewBookDao.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.core.dao
 
+import android.net.Uri
 import io.objectbox.Box
 import io.objectbox.kotlin.inValues
 import io.objectbox.kotlin.query
@@ -94,4 +95,23 @@ class NewBookDao @Inject constructor(private val box: Box<BookOnDiskEntity>) {
       QueryBuilder.StringOrder.CASE_INSENSITIVE
     )
   }.findFirst()
+
+  fun bookMatchingUrl(url: Uri): BookOnDiskEntity? {
+    url.host?.let {
+      it.split(".").let { splittedHost ->
+        val list = box.query {
+          contains(
+            BookOnDiskEntity_.name, if (splittedHost.size > 2) splittedHost[1] else splittedHost[0],
+            QueryBuilder.StringOrder.CASE_INSENSITIVE
+          )
+        }.find()
+        list.sortWith(Comparator { book1: BookOnDiskEntity, book2: BookOnDiskEntity ->
+          if (book1.language == splittedHost[0] || book1.language == splittedHost[splittedHost.size - 1]
+          ) 1 else 0
+        })
+        return@bookMatchingUrl list.first()
+      }
+    }
+    return null
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -112,6 +112,8 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigatio
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ViewGroupExtensions.findFirstTextView
 import org.kiwix.kiwixmobile.core.extensions.closeFullScreenMode
+import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
+import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
 import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
@@ -1888,6 +1890,8 @@ abstract class CoreReaderFragment :
           isOpenedFromTabView = false,
           isVoice = false
         )
+        intent.action = null
+        requireActivity().intent.action = null
       }
 
       Intent.ACTION_VIEW -> if (
@@ -1897,8 +1901,18 @@ abstract class CoreReaderFragment :
         // prevents such occurrences.
         intent.scheme !in listOf("file", "content")
       ) {
+        intent.action = null
+        requireActivity().intent.action = null
         var searchString: String? = null
         if (intent.data != null) {
+          val book = coreComponent.newBookDao().bookMatchingUrl(intent.data!!)
+          if (book != null) {
+            (requireActivity() as CoreMainActivity).openPage(
+              pageUrl = "https://kiwix.app/A/" + intent.data!!.lastPathSegment,
+              zimFilePath = book.file.path
+            )
+            return
+          }
           val params = intent.data!!.queryParameterNames
           searchString = if (params.contains("search")) {
             intent.data!!.getQueryParameter("search")
@@ -1913,8 +1927,6 @@ abstract class CoreReaderFragment :
           isOpenedFromTabView = false,
           isVoice = false
         )
-        intent.action = null
-        requireActivity().intent.action = null
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.settings
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
+import android.content.ComponentName
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
@@ -93,12 +94,28 @@ abstract class CorePrefsFragment :
     setStorage()
     setUpSettings()
     setupZoom()
+    setupWebSearchIntent()
     sharedPreferenceUtil?.let {
       LanguageUtils(requireActivity()).changeFont(
         requireActivity(),
         it
       )
     }
+  }
+
+  private fun setupWebSearchIntent() {
+    val pref = findPreference<Preference>(SharedPreferenceUtil.PREF_ENABLE_WEB_SEARCH_INTENT)
+    pref?.onPreferenceChangeListener =
+      Preference.OnPreferenceChangeListener { _, newValue ->
+        val boolValue = newValue as Boolean
+        val pm: PackageManager = requireActivity().packageManager
+        pm.setComponentEnabledSetting(
+          ComponentName(requireActivity(), "org.kiwix.kiwixmobile.main.KiwixMainActivityWebSearch"),
+          if (boolValue) PackageManager.COMPONENT_ENABLED_STATE_ENABLED else PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+          PackageManager.DONT_KILL_APP
+        )
+        true
+      }
   }
 
   private fun setupZoom() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -285,6 +285,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_EXTERNAL_LINK_POPUP = "pref_external_link_popup"
     const val PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP =
       "pref_supported_external_links_open_in_app"
+    const val PREF_ENABLE_WEB_SEARCH_INTENT = "pref_enable_web_search_intent"
     const val PREF_SHOW_STORAGE_OPTION = "show_storgae_option"
     private const val PREF_IS_FIRST_RUN = "isFirstRun"
     private const val PREF_SHOW_BOOKMARKS_ALL_BOOKS = "show_bookmarks_current_book"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -81,6 +81,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefExternalLinkPopup: Boolean
     get() = sharedPreferences.getBoolean(PREF_EXTERNAL_LINK_POPUP, true)
 
+  val prefSupportedExternalLinksOpenInApp: Boolean
+    get() = sharedPreferences.getBoolean(PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP, false)
+
   val isPlayStoreBuild: Boolean
     get() = sharedPreferences.getBoolean(IS_PLAY_STORE_BUILD, false)
 
@@ -280,6 +283,8 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     private const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"
     private const val PREF_STORAGE_TITLE = "pref_selected_title"
     const val PREF_EXTERNAL_LINK_POPUP = "pref_external_link_popup"
+    const val PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP =
+      "pref_supported_external_links_open_in_app"
     const val PREF_SHOW_STORAGE_OPTION = "show_storgae_option"
     private const val PREF_IS_FIRST_RUN = "isFirstRun"
     private const val PREF_SHOW_BOOKMARKS_ALL_BOOKS = "show_bookmarks_current_book"

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
   <string name="time_yesterday">Yesterday</string>
   <string name="pref_external_link_popup_title">Warn when entering external links</string>
   <string name="pref_external_link_popup_summary">Display popup to warn about additional costs or not working in offline links.</string>
+  <string name="pref_supported_external_links_open_in_app_title">Open supported links in app</string>
+  <string name="pref_supported_external_links_open_in_app_summary">Automatically open supported external links within the app</string>
   <string name="external_link_popup_dialog_title">Entering External Link!</string>
   <string name="external_link_popup_dialog_message">You are entering an external link. This could lead to additional costs for data transfer or will just not work when you are offline. Do you want to continue?</string>
   <string name="do_not_ask_anymore">Do not ask anymore</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -164,6 +164,8 @@
   <string name="pref_external_link_popup_summary">Display popup to warn about additional costs or not working in offline links.</string>
   <string name="pref_supported_external_links_open_in_app_title">Open supported links in app</string>
   <string name="pref_supported_external_links_open_in_app_summary">Automatically open supported external links within the app</string>
+  <string name="pref_enable_web_search_intent_title">Use as a web search application</string>
+  <string name="pref_enable_web_search_intent_summary">When enabled Kiwix can be used when other applications request a web search</string>
   <string name="external_link_popup_dialog_title">Entering External Link!</string>
   <string name="external_link_popup_dialog_message">You are entering an external link. This could lead to additional costs for data transfer or will just not work when you are offline. Do you want to continue?</string>
   <string name="do_not_ask_anymore">Do not ask anymore</string>

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -53,6 +53,13 @@
       app:iconSpaceReserved="false" />
 
     <SwitchPreferenceCompat
+      android:defaultValue="false"
+      android:key="pref_supported_external_links_open_in_app"
+      android:summary="@string/pref_supported_external_links_open_in_app_summary"
+      android:title="@string/pref_supported_external_links_open_in_app_title"
+      app:iconSpaceReserved="false" />
+
+    <SwitchPreferenceCompat
       android:defaultValue="true"
       android:key="pref_wifi_only"
       android:summary="@string/pref_wifi_only"

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -65,6 +65,14 @@
       android:summary="@string/pref_wifi_only"
       android:title="@string/pref_wifi_only"
       app:iconSpaceReserved="false" />
+
+
+    <SwitchPreferenceCompat
+      android:defaultValue="false"
+      android:key="pref_enable_web_search_intent"
+      android:summary="@string/pref_enable_web_search_intent_summary"
+      android:title="@string/pref_enable_web_search_intent_title"
+      app:iconSpaceReserved="false" />
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #731

<!-- Add here what changes were made in this issue and if possible provide links. -->
This PR adds 2 things:
* supports for wikipedia search links to be opened. Different links are supported:
   - search links `https://en.wikipedia.org/wiki/Special:Search?search=query`
   - i added support for the common `q` query parameter and the wikipedia `search` query parameter
   - for now i only added links for wikipedia.com/.org/.fr/.de
* support for `android.intent.action.WEB_SEARCH` which is the default web search intent. If an app triggers a web search then Kiwix can be used to handle the search. It is disabled by default and can be enabled in the settings

I also added a setting to automatically open supported external links within the app.
How does the project handles localization? i only added english localization.

When you make  a search with openSearch, is it searched in all books? 

I have a remaining question. If i have an url pointing to an existing page within a book like `https://fr.wikipedia.org/wiki/Gi%C3%A8res` is it possible to open it directly within a book? Right now it is always seen as a search so i kind of end up in a endless search loop

EDIT: i found a "basic" way of finding the correct book/zim for an url (`https://fr.wikipedia.org/wiki/Gi%C3%A8res`) but when i try to open that page within that book i get an webview error `the page cannot be loaded`. Are the URLs transformed in the zim? @kelson42  maybe you know?


**Screenshots** 
