### PR TITLE
Use java-libkiwix `2.2.0`

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -86,7 +86,7 @@ object Versions {
 
   const val core_ktx: String = "1.9.0"
 
-  const val libkiwix: String = "2.1.1"
+  const val libkiwix: String = "2.2.0"
 
   const val material: String = "1.8.0"
 


### PR DESCRIPTION
We have the new version available for `java-libkiwix` that fixes the crash scenarios on `arm` architecture.

1. https://github.com/kiwix/kiwix-android/issues/3661
2. https://github.com/kiwix/kiwix-android/issues/3692

and many more crashes reported by the playStore.