### PR TITLE
Fixed: Long clicking on Download button in epub ZIM files shows the `Open in new tab` dialog which leads to a blank page.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -77,7 +77,7 @@ open class CoreWebViewClient(
   }
 
   @Suppress("NestedBlockDepth")
-  private fun handleUnsupportedFiles(url: String): Boolean {
+  fun handleUnsupportedFiles(url: String): Boolean {
     val extension = MimeTypeMap.getFileExtensionFromUrl(url)
     if (DOCUMENT_TYPES.containsKey(extension)) {
       callback.showSaveOrOpenUnsupportedFilesDialog(url, DOCUMENT_TYPES[extension])

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -54,7 +54,7 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
   attrs: AttributeSet,
   nonVideoView: ViewGroup,
   videoView: ViewGroup,
-  webViewClient: CoreWebViewClient,
+  private val webViewClient: CoreWebViewClient,
   val sharedPreferenceUtil: SharedPreferenceUtil
 ) : VideoEnabledWebView(context, attrs) {
 
@@ -108,7 +108,11 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
   override fun performLongClick(): Boolean {
     val result = hitTestResult
     if (result.type == HitTestResult.SRC_ANCHOR_TYPE) {
-      result.extra?.let(callback::webViewLongClick)
+      result.extra?.let {
+        if (!webViewClient.handleUnsupportedFiles(it)) {
+          callback.webViewLongClick(it)
+        }
+      }
       return true
     }
     return super.performLongClick()


### PR DESCRIPTION
Fixes #3869 

We didn't account for the scenario where a user long-clicks on an image that contains an anchor tag with a URL. For now, we only check when a link is loading(when the user simply clicks on the image button), and if the link is unsupported by Kiwix, we show the save/open dialog. Now, we are also checking for this scenario on long clicks. So now the "Open in new tab" does not show for these types of files.


https://github.com/kiwix/kiwix-android/assets/34593983/b0c17d70-30a7-480f-8a12-a2d0f0ba0c69

