### PR TITLE
Fixed: Zimit2 Youtube video still doesn't play on Android reader.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -308,7 +308,7 @@ class ZimFileReader constructor(
       .subscribe({ }, Throwable::printStackTrace)
   }
 
-  private fun getItem(url: String): Item? =
+  fun getItem(url: String): Item? =
     try {
       val actualPath = url.toUri().filePath.decodeUrl
       jniKiwixReader.getEntryByPath(actualPath)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -72,7 +72,7 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
         val headers = mutableMapOf("Accept-Ranges" to "bytes")
         if ("Range" in requestHeaders.keys) {
           setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = data?.available()?.toLong() ?: 0L
+          val fullSize = zimFileReader?.getItem(url)?.size ?: 0L
           val lastByte = fullSize - 1
           val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
           headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"


### PR DESCRIPTION
Fixes #3860 

* YouTube videos were not playing in the Android reader because the response code for the video URL was 206 (Partial Content). The `Content-Range` header of the incoming data was being set incorrectly. This happened because the `data` had a size of 0, as the content was being written on the IO thread (to avoid blocking the UI thread) when loading in the WebView. Due to this, the `Content-Range` was set incorrectly, preventing the YouTube video from playing.

![Screenshot from 2024-06-12 17-30-05](https://github.com/kiwix/kiwix-android/assets/34593983/80cee29d-b809-4479-9fb1-63d2c8f08bcc)


* To fix this, the correct content length is now passed to the `Content-Range` header, ensuring that the video plays correctly.


https://github.com/kiwix/kiwix-android/assets/34593983/6f1e2911-38a6-423f-ae4d-e7386d46e21e

