### PR TITLE
Fixed ServiceWorker Initialization Issue

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/CoreApp.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/CoreApp.kt
@@ -83,6 +83,7 @@ abstract class CoreApp : Application() {
       .build()
     AndroidThreeTen.init(this)
     coreComponent.inject(this)
+    serviceWorkerInitialiser.init(this)
     downloadMonitor.init()
     nightModeConfig.init()
     fileLogger.writeLogFile(this)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
@@ -29,11 +29,8 @@ import androidx.webkit.WebViewFeature
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import javax.inject.Inject
 
-class ServiceWorkerInitialiser @Inject constructor(
-  context: Context,
-  zimReaderContainer: ZimReaderContainer
-) {
-  init {
+class ServiceWorkerInitialiser @Inject constructor(val zimReaderContainer: ZimReaderContainer) {
+  fun init(context: Context) {
     if (isMainProcess(context) &&
       WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)
     ) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ServiceWorkerInitialiser.kt
@@ -18,6 +18,9 @@
 
 package org.kiwix.kiwixmobile.core
 
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Process
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import androidx.webkit.ServiceWorkerClientCompat
@@ -26,14 +29,26 @@ import androidx.webkit.WebViewFeature
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import javax.inject.Inject
 
-class ServiceWorkerInitialiser @Inject constructor(zimReaderContainer: ZimReaderContainer) {
+class ServiceWorkerInitialiser @Inject constructor(
+  context: Context,
+  zimReaderContainer: ZimReaderContainer
+) {
   init {
-    if (WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)) {
+    if (isMainProcess(context) &&
+      WebViewFeature.isFeatureSupported(WebViewFeature.SERVICE_WORKER_BASIC_USAGE)
+    ) {
       ServiceWorkerControllerCompat.getInstance()
         .setServiceWorkerClient(object : ServiceWorkerClientCompat() {
           override fun shouldInterceptRequest(request: WebResourceRequest): WebResourceResponse? =
             zimReaderContainer.load(request.url.toString(), request.requestHeaders)
         })
     }
+  }
+
+  private fun isMainProcess(context: Context): Boolean {
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    return activityManager.runningAppProcesses.find {
+      it.pid == Process.myPid()
+    }?.processName == context.packageName
   }
 }


### PR DESCRIPTION
Fixes #3878 

Thanks to @Popolechien for sharing this crash report in https://github.com/kiwix/kiwix-android/issues/3600#issuecomment-2164966644

* ServiceWorker was being initialized every time the `CoreApp` instance was created. When the application crashed, `ErrorActivity` was invoked to send a crash report, running in a separate process. In this new process, the ServiceWorker was also being initialized.
* Upon user interaction (e.g., clicking "No Thanks" to relaunch the app), the application returned to the main process, leading to a second initialization of the ServiceWorker with the same data directory, causing a crash.
* Since `ErrorActivity` does not require any WebView-related functionality, it is unnecessary to initialize the ServiceWorker in this process.
* The fix involves modifying the initialization code to ensure the ServiceWorker is only initialized in the main process of the application.


* In this crash report see the lock owner is `error_activity`, and the current process is `org.kiwix.kiwixmobile`.
    ```kotlin
       Caused by: java.lang.RuntimeException: Using WebView from more than one process at once with the same data 
       directory is not supported. https://crbug.com/558377 : Current process org.kiwix.kiwixmobile (pid 22073), lock owner 
       org.kiwix.kiwixmobile:error_activity (pid 21360)
   ```
**Full logs:**
```kotlin
06-12 22:49:30.853 22073 22073 E AndroidRuntime: Process: org.kiwix.kiwixmobile, PID: 22073
06-12 22:49:30.853 22073 22073 E AndroidRuntime: java.lang.ExceptionInInitializerError
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at org.kiwix.kiwixmobile.core.di.components.DaggerCoreComponent$CoreComponentImpl.inject(DaggerCoreComponent.java:23)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at org.kiwix.kiwixmobile.core.CoreApp.onCreate(CoreApp.kt:104)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1266)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7619)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.app.ActivityThread.-$$Nest$mhandleBindApplication(Unknown Source:0)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2400)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:226)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:313)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8762)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: Caused by: java.lang.RuntimeException: Using WebView from more than one process at once with the same data directory is not supported. https://crbug.com/558377 : Current process org.kiwix.kiwixmobile (pid 22073), lock owner org.kiwix.kiwixmobile:error_activity (pid 21360)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at org.chromium.android_webview.AwDataDirLock.b(chromium-TrichromeWebViewGoogle6432.aab-stable-642216533:201)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at org.chromium.android_webview.AwBrowserProcess.j(chromium-TrichromeWebViewGoogle6432.aab-stable-642216533:16)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at com.android.webview.chromium.L.d(chromium-TrichromeWebViewGoogle6432.aab-stable-642216533:203)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at com.android.webview.chromium.L.b(chromium-TrichromeWebViewGoogle6432.aab-stable-642216533:42)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at com.android.webview.chromium.WebViewChromiumFactoryProvider.getServiceWorkerController(chromium-TrichromeWebViewGoogle6432.aab-stable-642216533:22)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at android.webkit.ServiceWorkerController.getInstance(ServiceWorkerController.java:57)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at androidx.webkit.internal.ApiHelperForN.getServiceWorkerControllerInstance(ApiHelperForN.java:1)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at androidx.webkit.internal.ServiceWorkerControllerImpl.<init>(ServiceWorkerControllerImpl.java:9)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	at androidx.webkit.ServiceWorkerControllerCompat$LAZY_HOLDER.<clinit>(ServiceWorkerControllerCompat.java:3)
06-12 22:49:30.853 22073 22073 E AndroidRuntime: 	... 13 more
```

* Initializing the `ServiceWorker` in the `onCreate` method of the `CoreApp` class so that all necessary application setup is complete before the service worker is initialized and provides better control over the initialization sequence.