### PR TITLE
Fixed: Xapian crash scenarios.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/core/di/components/TestComponent.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/core/di/components/TestComponent.kt
@@ -26,6 +26,7 @@ import org.kiwix.kiwixmobile.core.data.DataModule
 import org.kiwix.kiwixmobile.core.di.modules.ApplicationModule
 import org.kiwix.kiwixmobile.core.di.modules.CoreViewModelModule
 import org.kiwix.kiwixmobile.core.di.modules.JNIModule
+import org.kiwix.kiwixmobile.core.di.modules.MutexModule
 import org.kiwix.kiwixmobile.core.di.modules.SearchModule
 import org.kiwix.kiwixmobile.core.di.modules.TestNetworkModule
 import javax.inject.Singleton
@@ -42,7 +43,8 @@ import javax.inject.Singleton
     JNIModule::class,
     DataModule::class,
     CoreViewModelModule::class,
-    SearchModule::class
+    SearchModule::class,
+    MutexModule::class
   ]
 )
 interface TestComponent : CoreComponent {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -40,6 +40,7 @@ import okhttp3.Request
 import okhttp3.ResponseBody
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
@@ -49,6 +50,7 @@ import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChan
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
@@ -61,9 +63,9 @@ class SearchFragmentTest : BaseActivityTest() {
   private val rayCharlesZimFileUrl =
     "https://dev.kiwix.org/kiwix-android/test/wikipedia_en_ray_charles_maxi_2023-12.zim"
 
-  // @Rule
-  // @JvmField
-  // var retryRule = RetryRule()
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var uiDevice: UiDevice

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -21,6 +21,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
+import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
@@ -31,21 +32,23 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
 import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import org.hamcrest.Matchers.allOf
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.search.SearchFragment
+import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader
-import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import java.io.File
@@ -58,9 +61,9 @@ class SearchFragmentTest : BaseActivityTest() {
   private val rayCharlesZimFileUrl =
     "https://dev.kiwix.org/kiwix-android/test/wikipedia_en_ray_charles_maxi_2023-12.zim"
 
-  @Rule
-  @JvmField
-  var retryRule = RetryRule()
+  // @Rule
+  // @JvmField
+  // var retryRule = RetryRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var uiDevice: UiDevice
@@ -205,9 +208,60 @@ class SearchFragmentTest : BaseActivityTest() {
     LeakAssertions.assertNoLeaks()
   }
 
+  @Test
+  fun testConcurrencyOfSearch() = runBlocking {
+    val searchTerms = listOf(
+      "A Song",
+      "The Ra",
+      "The Ge",
+      "Wish",
+      "WIFI",
+      "Woman",
+      "Big Ba",
+      "My Wor",
+      "100"
+    )
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(R.id.libraryFragment)
+    }
+    downloadingZimFile = getDownloadingZimFile(false)
+    openKiwixReaderFragmentWithFile(downloadingZimFile)
+    search { checkZimFileSearchSuccessful(R.id.readerFragment) }
+    openSearchWithQuery(searchTerms[0], downloadingZimFile)
+    // wait for searchFragment become visible on screen.
+    delay(2000)
+    val navHostFragment: NavHostFragment =
+      kiwixMainActivity.supportFragmentManager
+        .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+    val searchFragment = navHostFragment.childFragmentManager.fragments[0] as SearchFragment
+    for (i in 1..100) {
+      // This will execute the render method 100 times frequently.
+      val searchTerm = searchTerms[i % searchTerms.size]
+      searchFragment.searchViewModel.actions.trySend(Action.Filter(searchTerm)).isSuccess
+    }
+    for (i in 1..100) {
+      // this will execute the render method 100 times with 100MS delay.
+      delay(100)
+      val searchTerm = searchTerms[i % searchTerms.size]
+      searchFragment.searchViewModel.actions.trySend(Action.Filter(searchTerm)).isSuccess
+    }
+    for (i in 1..100) {
+      // this will execute the render method 100 times with 200MS delay.
+      delay(200)
+      val searchTerm = searchTerms[i % searchTerms.size]
+      searchFragment.searchViewModel.actions.trySend(Action.Filter(searchTerm)).isSuccess
+    }
+    for (i in 1..100) {
+      // this will execute the render method 100 times with 200MS delay.
+      delay(300)
+      val searchTerm = searchTerms[i % searchTerms.size]
+      searchFragment.searchViewModel.actions.trySend(Action.Filter(searchTerm)).isSuccess
+    }
+  }
+
   private fun removeTemporaryZimFilesToFreeUpDeviceStorage() {
     testZimFile.delete()
-    downloadingZimFile.delete()
   }
 
   private fun openKiwixReaderFragmentWithFile(zimFile: File) {
@@ -273,10 +327,12 @@ class SearchFragmentTest : BaseActivityTest() {
     return zimFile
   }
 
-  private fun getDownloadingZimFile(): File {
+  private fun getDownloadingZimFile(isDeletePreviousZimFile: Boolean = true): File {
     val zimFile = File(context.cacheDir, "ray_charles.zim")
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
+    if (isDeletePreviousZimFile) {
+      if (zimFile.exists()) zimFile.delete()
+      zimFile.createNewFile()
+    }
     return zimFile
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -25,6 +25,7 @@ import android.net.wifi.WifiManager
 import dagger.BindsInstance
 import dagger.Component
 import eu.mhutti1.utils.storage.StorageSelectDialog
+import kotlinx.coroutines.sync.Mutex
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.dao.FetchDownloadDao
@@ -46,6 +47,7 @@ import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.modules.ApplicationModule
 import org.kiwix.kiwixmobile.core.di.modules.CoreViewModelModule
 import org.kiwix.kiwixmobile.core.di.modules.JNIModule
+import org.kiwix.kiwixmobile.core.di.modules.MutexModule
 import org.kiwix.kiwixmobile.core.di.modules.NetworkModule
 import org.kiwix.kiwixmobile.core.di.modules.SearchModule
 import org.kiwix.kiwixmobile.core.downloader.Downloader
@@ -68,7 +70,8 @@ import javax.inject.Singleton
     JNIModule::class,
     DataModule::class,
     CoreViewModelModule::class,
-    SearchModule::class
+    SearchModule::class,
+    MutexModule::class
   ]
 )
 interface CoreComponent {
@@ -109,6 +112,7 @@ interface CoreComponent {
   fun downloader(): Downloader
   fun notificationManager(): NotificationManager
   fun searchResultGenerator(): SearchResultGenerator
+  fun mutex(): Mutex
 
   fun inject(application: CoreApp)
   fun inject(kiwixWebView: KiwixWebView)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/MutexModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/MutexModule.kt
@@ -1,0 +1,32 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.di.modules
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.sync.Mutex
+import javax.inject.Singleton
+
+@Module
+class MutexModule {
+
+  @Provides
+  @Singleton
+  fun provideMutex(): Mutex = Mutex()
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -90,7 +90,7 @@ class SearchFragment : BaseFragment() {
   private var findInPageTextView: TextView? = null
   private var fragmentSearchBinding: FragmentSearchBinding? = null
 
-  private val searchViewModel by lazy { viewModel<SearchViewModel>(viewModelFactory) }
+  val searchViewModel by lazy { viewModel<SearchViewModel>(viewModelFactory) }
   private var searchAdapter: SearchAdapter? = null
   private var isDataLoading = false
   private var renderingJob: Job? = null
@@ -284,7 +284,7 @@ class SearchFragment : BaseFragment() {
       it.value.equals(query, ignoreCase = true)
     }
 
-  private suspend fun render(state: SearchState) {
+  suspend fun render(state: SearchState) {
     renderingJob?.apply {
       // cancel the children job. Since we are getting the result on IO thread
       // with `withContext` that is child for this job

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchState.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchState.kt
@@ -19,7 +19,9 @@
 package org.kiwix.kiwixmobile.core.search.viewmodel
 
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
+import kotlin.coroutines.resume
 
 data class SearchState(
   val searchTerm: String,
@@ -28,39 +30,41 @@ data class SearchState(
   val searchOrigin: SearchOrigin
 ) {
   @Suppress("NestedBlockDepth")
-  fun getVisibleResults(
+  suspend fun getVisibleResults(
     startIndex: Int,
     job: Job? = null
   ): List<SearchListItem.RecentSearchListItem>? =
-    if (searchTerm.isEmpty()) {
-      recentResults
-    } else {
-      searchResultsWithTerm.suggestionSearch?.let {
-        val searchResults = mutableListOf<SearchListItem.RecentSearchListItem>()
-        if (job?.isActive == false) {
-          // if the previous job is cancel then do not execute the code
-          return@getVisibleResults searchResults
-        }
-        val safeEndIndex = startIndex + 100
-        val searchIterator =
-          it.getResults(startIndex, safeEndIndex)
-        while (searchIterator.hasNext()) {
+    suspendCancellableCoroutine { cancellableCoroutine ->
+      if (searchTerm.isEmpty()) {
+        cancellableCoroutine.resume(recentResults)
+      } else {
+        searchResultsWithTerm.suggestionSearch?.let {
+          val searchResults = mutableListOf<SearchListItem.RecentSearchListItem>()
           if (job?.isActive == false) {
-            // check if the previous job is cancel while retrieving the data for previous searched item
-            // then break the execution of code.
-            break
+            // if the previous job is cancel then do not execute the code
+            cancellableCoroutine.resume(searchResults)
           }
-          val entry = searchIterator.next()
-          searchResults.add(SearchListItem.RecentSearchListItem(entry.title, entry.path))
+          val safeEndIndex = startIndex + 100
+          val searchIterator =
+            it.getResults(startIndex, safeEndIndex)
+          while (searchIterator.hasNext()) {
+            if (job?.isActive == false) {
+              // check if the previous job is cancel while retrieving the data for previous
+              // searched item then break the execution of code.
+              break
+            }
+            val entry = searchIterator.next()
+            searchResults.add(SearchListItem.RecentSearchListItem(entry.title, entry.path))
+          }
+          /**
+           * Returns null if there are no suggestions left in the iterator.
+           * We check this in SearchFragment to avoid unnecessary data loading
+           * while scrolling to the end of the list when there are no items available.
+           */
+          cancellableCoroutine.resume(searchResults.ifEmpty { null })
+        } ?: kotlin.run {
+          cancellableCoroutine.resume(recentResults)
         }
-        /**
-         * Returns null if there are no suggestions left in the iterator.
-         * We check this in SearchFragment to avoid unnecessary data loading
-         * while scrolling to the end of the list when there are no items available.
-         */
-        searchResults.ifEmpty { null }
-      } ?: kotlin.run {
-        recentResults
       }
     }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -67,10 +67,10 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
   private val recentSearchRoomDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer,
-  private val searchResultGenerator: SearchResultGenerator
+  private val searchResultGenerator: SearchResultGenerator,
+  private val searchMutex: Mutex = Mutex()
 ) : ViewModel() {
 
-  private val searchMutex = Mutex()
   private val initialState: SearchState =
     SearchState(
       "",

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -20,21 +20,17 @@ package org.kiwix.kiwixmobile.core.search.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.trySendBlocking
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
@@ -188,21 +184,17 @@ class SearchViewModel @Inject constructor(
    * @param startIndex The index from which to start loading more results.
    * @param existingSearchList The existing list of search results, if any, to check for duplicates.
    *
-   * @return A Flowable emitting a list of non-duplicate search results or null if there are no more results.
+   * @return List of non-duplicate search results or null if there are no more results.
    */
-  fun loadMoreSearchResults(
+  suspend fun loadMoreSearchResults(
     startIndex: Int,
     existingSearchList: List<SearchListItem>?
-  ): Flow<List<SearchListItem.RecentSearchListItem>?> = flow {
-    val searchResults = withContext(Dispatchers.IO) {
-      state.value.getVisibleResults(startIndex)
-    }
+  ): List<SearchListItem.RecentSearchListItem>? {
+    val searchResults = state.value.getVisibleResults(startIndex)
 
-    val nonDuplicateResults = searchResults?.filter { newItem ->
+    return searchResults?.filter { newItem ->
       existingSearchList?.none { it == newItem } ?: true
     }
-    // Emit the non-duplicate data to the Flow's subscribers
-    emit(nonDuplicateResults)
   }
 }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
@@ -69,12 +70,14 @@ class SearchViewModel @Inject constructor(
   private val searchResultGenerator: SearchResultGenerator
 ) : ViewModel() {
 
+  private val searchMutex = Mutex()
   private val initialState: SearchState =
     SearchState(
       "",
       SearchResultsWithTerm(
         "",
-        null
+        null,
+        searchMutex
       ),
       emptyList(),
       FromWebView
@@ -112,7 +115,8 @@ class SearchViewModel @Inject constructor(
     .mapLatest {
       SearchResultsWithTerm(
         it,
-        searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader)
+        searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader),
+        searchMutex
       )
     }
 
@@ -198,4 +202,8 @@ class SearchViewModel @Inject constructor(
   }
 }
 
-data class SearchResultsWithTerm(val searchTerm: String, val suggestionSearch: SuggestionSearch?)
+data class SearchResultsWithTerm(
+  val searchTerm: String,
+  val suggestionSearch: SuggestionSearch?,
+  val searchMutex: Mutex
+)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -20,9 +20,13 @@ package org.kiwix.kiwixmobile.core.search.viewmodel
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem
 import org.kiwix.kiwixmobile.core.search.adapter.SearchListItem.RecentSearchListItem
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchOrigin.FromWebView
 
@@ -96,5 +100,43 @@ internal class SearchStateTest {
         FromWebView
       ).isLoading
     ).isFalse
+  }
+
+  @Test
+  fun `test search cancellation`() = runTest {
+    val searchTerm = "cancelTest"
+    val suggestionSearchWrapper: SuggestionSearchWrapper = mockk()
+    val searchIteratorWrapper: SuggestionIteratorWrapper = mockk()
+    val entryWrapper: SuggestionItemWrapper = mockk()
+
+    every { suggestionSearchWrapper.estimatedMatches } returns 100
+    every { searchIteratorWrapper.hasNext() } returnsMany listOf(true, false)
+    every { searchIteratorWrapper.next() } returns entryWrapper
+    every { entryWrapper.title } returns "Result"
+    every { entryWrapper.path } returns "path"
+    every { suggestionSearchWrapper.getResults(any(), any()) } returns searchIteratorWrapper
+
+    val searchResultsWithTerm = SearchResultsWithTerm(searchTerm, suggestionSearchWrapper, mockk())
+    val searchState = SearchState(searchTerm, searchResultsWithTerm, emptyList(), FromWebView)
+    var list: List<SearchListItem.RecentSearchListItem>? = emptyList()
+    var list1: List<SearchListItem.RecentSearchListItem>? = emptyList()
+    val job = launch(Dispatchers.IO) {
+      list = searchState.getVisibleResults(0)
+    }
+
+    val job1 = launch(Dispatchers.IO) {
+      list1 = searchState.getVisibleResults(0)
+    }
+    job.cancelAndJoin()
+
+    // test the coroutine job is cancelled properly
+    assertThat(job.isCancelled).isTrue
+    assertThat(list?.size).isEqualTo(0)
+
+    // test the second job is successfully return the data
+    assertThat(job1.isCompleted).isTrue
+    assertThat(list1?.size).isEqualTo(1)
+    assertThat(list1?.get(0)?.url).isEqualTo("path")
+    assertThat(list1?.get(0)?.value).isEqualTo("Result")
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -53,7 +53,7 @@ internal class SearchStateTest {
     assertThat(
       SearchState(
         searchTerm,
-        SearchResultsWithTerm("", suggestionSearchWrapper),
+        SearchResultsWithTerm("", suggestionSearchWrapper, mockk()),
         emptyList(),
         FromWebView
       ).getVisibleResults(0)
@@ -66,7 +66,7 @@ internal class SearchStateTest {
     assertThat(
       SearchState(
         "",
-        SearchResultsWithTerm("", null),
+        SearchResultsWithTerm("", null, mockk()),
         results,
         FromWebView
       ).getVisibleResults(0)
@@ -78,7 +78,7 @@ internal class SearchStateTest {
     assertThat(
       SearchState(
         "",
-        SearchResultsWithTerm("notEqual", null),
+        SearchResultsWithTerm("notEqual", null, mockk()),
         emptyList(),
         FromWebView
       ).isLoading
@@ -91,7 +91,7 @@ internal class SearchStateTest {
     assertThat(
       SearchState(
         searchTerm,
-        SearchResultsWithTerm(searchTerm, null),
+        SearchResultsWithTerm(searchTerm, null, mockk()),
         emptyList(),
         FromWebView
       ).isLoading


### PR DESCRIPTION
Fixes #3877 

* There was a concurrency issue in the search functionality in a very specific condition, causing data corruption and race conditions when users searched for different terms simultaneously.
* Introduced a global Mutex in the SearchResultsWithTerm class to control access to search results.
* Applied the Mutex in the SearchState class to lock execution and ensure that only one coroutine can process search results at a time. Since here we are getting the data from libzim this global mutex will prevent getting data via multiple coroutines.
* Enhanced retrieval of suggestion lists from libzim.
* Implemented task cancellation if the fragment is not visible.
* Refactored `getVisibleResults` into a suspend method to ensure efficient job cancellation.
* Handled exceptions thrown by coroutines.
* Employed lifecycleScope for coroutine launch to prevent unnecessary calls when the fragment is hidden.
* Added unit test cases for testing the previous job is canceled properly.
* Testing the render method with different scenarios to ensure that libzim does not crash due to a broken call stack.
