### PR TITLE
Fixed outdated text showing when a zim file could not open.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 <resources>
   <string name="file_system_does_not_support_4gb">Your file system doesn’t support files over 4GB</string>
   <string name="detecting_file_system">Detecting if file system can create 4GB files</string>
-  <string name="cannot_open_file">Failed to open file\nPlease try looking for this file in the Device Tab of your Library</string>
+  <string name="cannot_open_file">Failed to open file\nPlease try looking for this file in your Library</string>
   <string name="send_files_title">Send Files</string>
   <string name="receive_files_title">Receive Files</string>
   <string name="no_app_found_to_open">No app found to select zim file!</string>


### PR DESCRIPTION
Fixes #3884 

Outdated text was showing when a zim file could not open in the Kiwix, this text was for the older UI, and now we have removed the "Device Tab" from the "Library" screen so this text is outdated and misleading the users. so we have changed this text according to the new UI.