### PR TITLE
Fixed: Sometimes not all Bookmarks are showing.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -29,9 +29,9 @@ import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
+import org.junit.Assert
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
-import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.utils.files.Log
@@ -47,7 +47,6 @@ class DownloadRobot : BaseRobot() {
 
   private var retryCountForDataToLoad = 10
   private var retryCountForCheckDownloadStart = 10
-  private val zimFileTitle = "Off the Grid"
 
   fun clickLibraryOnBottomNav() {
     clickOn(ViewId(R.id.libraryFragment))
@@ -72,7 +71,17 @@ class DownloadRobot : BaseRobot() {
   }
 
   fun checkIfZimFileDownloaded() {
-    isVisible(Text(zimFileTitle))
+    pauseForBetterTestPerformance()
+    try {
+      testFlakyView({
+        onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))
+      })
+      // if the "No files here" text found that means it failed to download the ZIM file.
+      Assert.fail("Couldn't download the zim file. The [No files here] text is visible on screen")
+    } catch (e: AssertionFailedError) {
+      // check if "No files here" text is not visible on
+      // screen that means zim file is downloaded successfully.
+    }
   }
 
   fun refreshOnlineList() {
@@ -163,8 +172,7 @@ class DownloadRobot : BaseRobot() {
     } catch (e: Exception) {
       Log.i(
         "DOWNLOAD_TEST",
-        "Failed to stop download with title [" + zimFileTitle + "]... " +
-          "Probably because it doesn't download the zim file"
+        "Failed to stop downloading. Probably because it is not downloading the zim file"
       )
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -140,7 +140,7 @@ class DownloadTest : BaseActivityTest() {
       }
     } catch (e: Exception) {
       Assert.fail(
-        "Couldn't find downloaded file ' Off the Grid ' Original Exception: ${e.message}"
+        "Couldn't find downloaded file\n Original Exception: ${e.message}"
       )
     }
     LeakAssertions.assertNoLeaks()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -18,10 +18,14 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
@@ -33,8 +37,10 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.utils.StandardActions.openDrawer
 import java.util.concurrent.TimeUnit
 
 fun bookmarks(func: BookmarksRobot.() -> Unit) =
@@ -104,5 +110,22 @@ class BookmarksRobot : BaseRobot() {
 
   private fun pauseForBetterTestPerformance() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
+  }
+
+  fun openBookmarkScreen() {
+    testFlakyView({
+      openDrawer()
+      onView(withText(R.string.bookmarks)).perform(click())
+    })
+  }
+
+  fun testAllBookmarkShowing(bookmarkList: ArrayList<LibkiwixBookmarkItem>) {
+    bookmarkList.forEachIndexed { index, libkiwixBookmarkItem ->
+      testFlakyView({
+        onView(withId(R.id.recycler_view))
+          .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(index))
+          .check(matches(hasDescendant(withText(libkiwixBookmarkItem.title))))
+      })
+    }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/LibkiwixBookmarkItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/adapter/LibkiwixBookmarkItem.kt
@@ -23,9 +23,10 @@ import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.Bookmark
+import java.util.UUID
 
 data class LibkiwixBookmarkItem(
-  val databaseId: Long = 0L,
+  val databaseId: Long = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE,
   override val zimId: String,
   val zimName: String,
   override val zimFilePath: String?,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/PageTestHelpers.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/PageTestHelpers.kt
@@ -71,6 +71,7 @@ fun historyState(
   )
 
 fun bookmark(
+  databaseId: Long,
   bookmarkTitle: String = "bookmarkTitle",
   isSelected: Boolean = false,
   id: Long = 2,
@@ -81,6 +82,7 @@ fun bookmark(
   favicon: String = "favicon"
 ): LibkiwixBookmarkItem {
   return LibkiwixBookmarkItem(
+    databaseId = databaseId,
     id = id,
     zimId = zimId,
     zimName = zimName,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkStateTest.kt
@@ -22,12 +22,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.page.bookmark
 import org.kiwix.kiwixmobile.core.page.bookmarkState
+import java.util.UUID
 
 internal class BookmarkStateTest {
   @Test
   internal fun `copyNewItems should set new items to pageItems`() {
-    assertThat(bookmarkState(emptyList()).copy(listOf(bookmark())).pageItems).isEqualTo(
-      listOf(bookmark())
+    val databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
+    assertThat(bookmarkState(emptyList()).copy(listOf(bookmark(databaseId))).pageItems).isEqualTo(
+      listOf(bookmark(databaseId))
     )
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -44,6 +44,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.sharedFunctions.InstantExecutorExtension
 import org.kiwix.sharedFunctions.setScheduler
+import java.util.UUID
 
 @ExtendWith(InstantExecutorExtension::class)
 internal class BookmarkViewModelTest {
@@ -89,8 +90,14 @@ internal class BookmarkViewModelTest {
 
   @Test
   fun `updatePages return state with bookmark items`() {
-    assertThat(viewModel.updatePages(bookmarkState(), UpdatePages(listOf(bookmark())))).isEqualTo(
-      bookmarkState(listOf(bookmark()))
+    val databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
+    assertThat(
+      viewModel.updatePages(
+        bookmarkState(),
+        UpdatePages(listOf(bookmark(databaseId)))
+      )
+    ).isEqualTo(
+      bookmarkState(listOf(bookmark(databaseId)))
     )
   }
 
@@ -115,19 +122,30 @@ internal class BookmarkViewModelTest {
 
   @Test
   internal fun `updatePages returns state with updated items`() {
+    val databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
     assertThat(
-      viewModel.updatePages(bookmarkState(), UpdatePages(listOf(bookmark())))
+      viewModel.updatePages(bookmarkState(), UpdatePages(listOf(bookmark(databaseId))))
     ).isEqualTo(
-      bookmarkState(listOf(bookmark()))
+      bookmarkState(listOf(bookmark(databaseId)))
     )
   }
 
   @Test
   internal fun `deselectAllPages deselects bookmarks items`() {
+    val databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
     assertThat(
-      viewModel.deselectAllPages(bookmarkState(bookmarks = listOf(bookmark(isSelected = true))))
+      viewModel.deselectAllPages(
+        bookmarkState(
+          bookmarks = listOf(
+            bookmark(
+              isSelected = true,
+              databaseId = databaseId
+            )
+          )
+        )
+      )
     ).isEqualTo(
-      bookmarkState(bookmarks = listOf(bookmark(isSelected = false)))
+      bookmarkState(bookmarks = listOf(bookmark(isSelected = false, databaseId = databaseId)))
     )
   }
 
@@ -147,10 +165,11 @@ internal class BookmarkViewModelTest {
 
   @Test
   internal fun `copyWithNewItems returns state with copied items`() {
+    val databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
     assertThat(
-      viewModel.copyWithNewItems(bookmarkState(), listOf(bookmark()))
+      viewModel.copyWithNewItems(bookmarkState(), listOf(bookmark(databaseId)))
     ).isEqualTo(
-      bookmarkState(listOf(bookmark()))
+      bookmarkState(listOf(bookmark(databaseId)))
     )
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialogTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialogTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteAllBookmarks
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteSelectedBookmarks
+import java.util.UUID
 
 internal class ShowDeleteBookmarksDialogTest {
   val effects = mockk<PublishProcessor<SideEffect<*>>>(relaxed = true)
@@ -68,7 +69,14 @@ internal class ShowDeleteBookmarksDialogTest {
     val showDeleteBookmarksDialog =
       ShowDeleteBookmarksDialog(
         effects,
-        bookmarkState(listOf(bookmark(isSelected = true))),
+        bookmarkState(
+          listOf(
+            bookmark(
+              isSelected = true,
+              databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
+            )
+          )
+        ),
         newBookmarksDao,
         viewModelScope
       )
@@ -82,7 +90,13 @@ internal class ShowDeleteBookmarksDialogTest {
     val showDeleteBookmarksDialog =
       ShowDeleteBookmarksDialog(
         effects,
-        bookmarkState(listOf(bookmark())),
+        bookmarkState(
+          listOf(
+            bookmark(
+              databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE
+            )
+          )
+        ),
         newBookmarksDao,
         viewModelScope
       )


### PR DESCRIPTION
Fixes #3889 

* We have implemented `setHasStableIds(true)` in our RecyclerView, which handles data updates efficiently and enhances view recycling. It also provides smooth animations when data is refreshed. However, it requires unique IDs to perform these operations effectively. Since our bookmarks are stored in libkiwix and do not have unique IDs (database IDs), this sometimes results in duplicate data being displayed in the list instead of the actual data, as the lack of unique IDs causes the same data to be repeated when recycling non-visible items.
* To fix this, we have explicitly provided unique IDs by combining a UUID with the maximum value of a long. This ensures that RecyclerView can efficiently handle large data sets.
* Added instrumentation test case to avoid this type of error in the future.
* Fixed DownloadTest, initialDownload. The Library order and zim file name is changed so these test cases are failing so we have implemented a generic approach to not dependent on zim file name.