### PR TITLE
Fixed: `getDirectAccessInformation()` method throw the `InvocationTargetException` and crash the application.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -49,7 +49,6 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
-import java.lang.reflect.InvocationTargetException
 import java.net.URLDecoder
 import javax.inject.Inject
 
@@ -278,7 +277,7 @@ class ZimFileReader constructor(
     }
     val infoPair = try {
       article?.directAccessInformation
-    } catch (ignore: InvocationTargetException) {
+    } catch (ignore: Exception) {
       Log.e(
         TAG,
         "Could not get directAccessInformation for uri = $uri \n" +


### PR DESCRIPTION
Fixes #3897 

Handling the exception thrown by the `getDirectAccessInformation()`. [InvocationTargetException](https://developer.android.com/reference/kotlin/java/lang/reflect/InvocationTargetException) is a checked exception that wraps an exception thrown by an invoked method or constructor, and here it was thrown when constructing the `DirectAccessInformation` constructor. This method is used for loading media files e.g. photos, videos, etc. The reproducible steps are unknown, and there has been only 1 error in the last 60 days so it hardly occurs or occurs when an `Item` fails to provide the `directAccessInformation`. Now, we are catching that exception if thrown by this method so that it will not crash the application, and handle the loading of that media file on the Android side as shown in the below code.

```kotlin
 private fun loadAsset(uri: String): InputStream? {
    val article = try {
      jniKiwixReader.getEntryByPath(uri.filePath).getItem(true)
    } catch (exception: Exception) {
      Log.e(TAG, "Could not get Item for uri = $uri \n original exception = $exception")
      null
    }
    val infoPair = try {
      article?.directAccessInformation
    } catch (ignore: InvocationTargetException) {
      Log.e(
        TAG,
        "Could not get directAccessInformation for uri = $uri \n" +
          "original exception = $ignore"
      )
      null
    }
    if (infoPair == null || !File(infoPair.filename).exists()) {
      return loadAssetFromCache(uri)
    }
    return article?.size?.let {
      AssetFileDescriptor(
        infoPair.parcelFileDescriptor,
        infoPair.offset,
        it
      ).createInputStream()
    }
  }

  @Throws(IOException::class)
  private fun loadAssetFromCache(uri: String): FileInputStream {
    return File(
      FileUtils.getFileCacheDir(CoreApp.instance),
      uri.substringAfterLast("/")
    ).apply { getContent(uri)?.let(::writeBytes) }
      .inputStream()
  }
```