### PR TITLE
Fixed: `SQLiteConstraintException` when inserting the same id item of hisotry/notes in room database.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -239,6 +239,20 @@ class ObjectBoxToRoomMigratorTest {
 
     clearRoomAndBoxStoreDatabases(box)
 
+    // Test to insert the items with same id.
+    val historyItem4 = getHistoryItem(
+      databaseId = 2,
+      title = "Main Page",
+      historyUrl = "https://kiwix.app/A/MainPage"
+    )
+    kiwixRoomDatabase.historyRoomDao().saveHistory(historyItem4)
+    box.put(HistoryEntity(historyItem))
+    objectBoxToRoomMigrator.migrateHistory(box)
+    actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
+    assertEquals(2, actualData.size)
+
+    clearRoomAndBoxStoreDatabases(box)
+
     // Test migration if ObjectBox has null values
     try {
       lateinit var invalidHistoryEntity: HistoryEntity
@@ -345,6 +359,20 @@ class ObjectBoxToRoomMigratorTest {
     objectBoxToRoomMigrator.migrateNotes(box)
     notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertEquals(1, notesList.size)
+
+    clearRoomAndBoxStoreDatabases(box)
+
+    // Test to insert the items with same id.
+    val noteItem2 = getNoteListItem(
+      databaseId = 1,
+      zimUrl = "http://kiwix.app/Installing",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
+    )
+    kiwixRoomDatabase.notesRoomDao().saveNote(noteItem1)
+    box.put(NotesEntity(noteItem2))
+    objectBoxToRoomMigrator.migrateNotes(box)
+    notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
+    assertEquals(2, notesList.size)
 
     clearRoomAndBoxStoreDatabases(box)
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/HistoryRoomDaoTest.kt
@@ -101,6 +101,26 @@ class HistoryRoomDaoTest {
     assertThat(historyList.size, equalTo(1))
     historyRoomDao.deleteAllHistory()
 
+    // Save two entity same data and database id but with different date
+    historyRoomDao.saveHistory(historyItem)
+    val historyItem1 = getHistoryItem(
+      title = "Main Page",
+      historyUrl = "https://kiwix.app/A/MainPage",
+      databaseId = 1,
+      dateString = "31 May 2024"
+    )
+    historyRoomDao.saveHistory(historyItem1)
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
+    assertThat(historyList.size, equalTo(2))
+    historyRoomDao.deleteAllHistory()
+
+    // Save two entity with same and database id with same date to see if it's updated or not.
+    historyRoomDao.saveHistory(historyItem)
+    historyRoomDao.saveHistory(historyItem)
+    historyList = historyRoomDao.historyRoomEntity().blockingFirst()
+    assertThat(historyList.size, equalTo(1))
+    historyRoomDao.deleteAllHistory()
+
     // Attempt to save undefined history item
     lateinit var undefinedHistoryItem: HistoryListItem.HistoryItem
     try {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/roomDao/NoteRoomDaoTest.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
@@ -108,6 +107,24 @@ class NoteRoomDaoTest {
     )
     notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
     assertEquals(notesList.size, 1)
+    clearNotes()
+
+    // Test to insert the items with same id.
+    val noteItem2 = getNoteListItem(
+      databaseId = 1,
+      zimUrl = "http://kiwix.app/Installing",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
+    )
+    val noteItem3 = getNoteListItem(
+      databaseId = 1,
+      title = "Installing",
+      zimUrl = "http://kiwix.app/Installing",
+      noteFilePath = "/storage/emulated/0/Download/Notes/Alpine linux/Installing.txt"
+    )
+    kiwixRoomDatabase.notesRoomDao().saveNote(noteItem2)
+    kiwixRoomDatabase.notesRoomDao().saveNote(noteItem3)
+    notesList = notesRoomDao.notes().blockingFirst() as List<NoteListItem>
+    assertEquals(2, notesList.size)
     clearNotes()
 
     // Attempt to save undefined history item

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
@@ -51,6 +51,9 @@ abstract class HistoryRoomDao : PageDao {
   @Insert
   abstract fun insertHistoryItem(historyRoomEntity: HistoryRoomEntity)
 
+  @Query("SELECT COUNT() FROM HistoryRoomEntity WHERE id = :id")
+  abstract fun count(id: Int): Int
+
   fun saveHistory(historyItem: HistoryListItem.HistoryItem) {
     getHistoryRoomEntity(
       historyItem.historyUrl,
@@ -65,7 +68,12 @@ abstract class HistoryRoomDao : PageDao {
       }
       updateHistoryItem(it)
     } ?: run {
-      insertHistoryItem(HistoryRoomEntity(historyItem))
+      val historyEntity = HistoryRoomEntity(historyItem)
+      if (count(historyEntity.id.toInt()) > 0) {
+        // set the default id so that room will automatically generates the database id.
+        historyEntity.id = 0
+      }
+      insertHistoryItem(historyEntity)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -38,8 +38,16 @@ abstract class NotesRoomDao : PageDao {
     deleteNotes(pagesToDelete as List<NoteListItem>)
 
   fun saveNote(noteItem: NoteListItem) {
-    saveNote(NotesRoomEntity(noteItem))
+    val notesEntity = NotesRoomEntity(noteItem)
+    if (count(notesEntity.id.toInt()) > 0) {
+      // set the default id so that room will automatically generates the database id.
+      notesEntity.id = 0
+    }
+    saveNote(notesEntity)
   }
+
+  @Query("SELECT COUNT() FROM NotesRoomEntity WHERE id = :id")
+  abstract fun count(id: Int): Int
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   abstract fun saveNote(notesRoomEntity: NotesRoomEntity)


### PR DESCRIPTION
Fixes #3899

* ID is the primary key for notes/history and when there is an already id available in the room database, and if there is the same id present in the objectbox database and we try to put that entity in the room it gives the SQLiteConstraintException. To fix this we have modified our saving functions of history and notes. If there is already an ID that exists in the room database that we are trying to put in the database it will set the ID to 0 so that the room will automatically assign the ID to that entity and our history/notes will prevent it from being lost.
* Added the test cases to properly test these scenarios.