### PR TITLE
Fixed: A `NotSerializableException` was attached to the crash logs instead of the actual crash logs when there was an error in the coroutine.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -14,7 +14,7 @@ object Versions {
 
   const val document_file_version: String = "1.0.1"
 
-  const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.4.1"
+  const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.7.3"
 
   const val androidx_test_espresso: String = "3.5.1"
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -212,6 +212,7 @@ class ZimFileReader constructor(
 
   fun getRandomArticleUrl(): String? = jniKiwixReader.randomEntry.path
 
+  @Suppress("UnreachableCode")
   fun load(uri: String): InputStream? {
     val extension = uri.substringAfterLast(".")
     if (assetExtensions.any { it == extension }) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ServerUtils.kt
@@ -58,8 +58,7 @@ object ServerUtils {
     val ipRegex =
       "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
         .toRegex()
-    val ipMatch = ipRegex.find(ip, 0) ?: throw IllegalArgumentException()
-    return ipMatch.value
+    return ipRegex.find(ip, 0)?.value ?: throw IllegalArgumentException()
   }
 
   @JvmStatic fun getSocketAddress(): String =


### PR DESCRIPTION
Fixes #3901
Fixes #3902 

 
* The serialization issue was fixed in coroutine version `1.7.0`, so we have upgraded the coroutine dependency to `1.7.3` to address this issue.
* In the new version of coroutines, `ConflatedBroadcastChannel` is replaced with `StateFlow`, so we have refactored our code to use `StateFlow`.
* Fixed some detekt issues which occur after upgrading this dependency.