### PR TITLE
Fixed: Sometimes migration test took longer in migration in lower device(e.g. API level 25) and fails the test case.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -52,6 +52,7 @@ class ObjectBoxToRoomMigratorTest {
   private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
   private lateinit var boxStore: BoxStore
   private lateinit var objectBoxToRoomMigrator: ObjectBoxToRoomMigrator
+  private val migrationMaxTime = 25000
 
   @Before
   fun setup() {
@@ -162,7 +163,10 @@ class ObjectBoxToRoomMigratorTest {
       kiwixRoomDatabase.recentSearchRoomDao().fullSearch().first()
     assertEquals(numEntities, actualDataAfterLargeMigration.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
+    assertTrue(
+      "Migration took too long: $migrationTime ms",
+      migrationTime < migrationMaxTime
+    )
   }
 
   private suspend fun <T> clearRoomAndBoxStoreDatabases(box: Box<T>) {
@@ -287,7 +291,10 @@ class ObjectBoxToRoomMigratorTest {
     actualData = kiwixRoomDatabase.historyRoomDao().historyRoomEntity().blockingFirst()
     assertEquals(numEntities, actualData.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
+    assertTrue(
+      "Migration took too long: $migrationTime ms",
+      migrationTime < migrationMaxTime
+    )
   }
 
   @Test
@@ -410,6 +417,9 @@ class ObjectBoxToRoomMigratorTest {
     notesList = kiwixRoomDatabase.notesRoomDao().notes().blockingFirst() as List<NoteListItem>
     assertEquals(numEntities, notesList.size)
     // Assert that the migration completes within a reasonable time frame
-    assertTrue("Migration took too long: $migrationTime ms", migrationTime < 20000)
+    assertTrue(
+      "Migration took too long: $migrationTime ms",
+      migrationTime < migrationMaxTime
+    )
   }
 }


### PR DESCRIPTION
Fixes #3907 

Increased the migration timing a little bit as migration sometimes takes a few milliseconds more on CI(e.g. 100MS, and sometimes 50MS). On the real devices, it takes a few seconds to migrate 5000 history so the issue is only on the CI emulator.