### PR TITLE
Displaying the ZIM title in the notification instead of the file name.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/FetchDownloadDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/FetchDownloadDao.kt
@@ -71,6 +71,14 @@ class FetchDownloadDao @Inject constructor(
       equal(FetchDownloadEntity_.downloadId, download.id)
     }.find().getOrNull(0)
 
+  fun getEntityForFileName(fileName: String) =
+    box.query {
+      endsWith(
+        FetchDownloadEntity_.file, fileName,
+        QueryBuilder.StringOrder.CASE_INSENSITIVE
+      )
+    }.findFirst()
+
   fun insert(downloadId: Long, book: Book) {
     box.put(FetchDownloadEntity(downloadId, book))
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
@@ -91,6 +91,6 @@ object DownloaderModule {
 
   @Provides
   @Singleton
-  fun provideFetchDownloadNotificationManager(context: Context):
-    FetchNotificationManager = FetchDownloadNotificationManager(context)
+  fun provideFetchDownloadNotificationManager(context: Context, fetchDownloadDao: FetchDownloadDao):
+    FetchNotificationManager = FetchDownloadNotificationManager(context, fetchDownloadDao)
 }


### PR DESCRIPTION
Fixes #3908 

In the notification, the information coming from `fetch` does not include the ZIM title (only the file name is currently shown in the notification). However, we have the `FetchDownloadDao` where we save all the details related to downloads. We have created a method in `FetchDownloadDao` that retrieves the `downloadEntity` from the file name, which includes the ZIM title, and we are now displaying that title in the notification.


https://github.com/kiwix/kiwix-android/assets/34593983/39875853-a0be-45c7-8a8a-3af4aa1137ce

