### PR TITLE
Fixed: latency in showing whether a bookmark is added in the toggle button.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -2116,7 +2116,6 @@ abstract class CoreReaderFragment :
       }
       updateTableOfContents()
       tabsAdapter?.notifyDataSetChanged()
-      updateUrlProcessor()
       updateBottomToolbarArrowsAlpha()
       val zimFileReader = zimReaderContainer?.zimFileReader
       if (hasValidFileAndUrl(getCurrentWebView()?.url, zimFileReader)) {
@@ -2150,6 +2149,10 @@ abstract class CoreReaderFragment :
 
   override fun webViewFailedLoading(url: String) {
     if (isAdded) {
+      // If a URL fails to load, update the bookmark toggle.
+      // This fixes the scenario where the previous page is bookmarked and the next
+      // page fails to load, ensuring the bookmark toggle is unset correctly.
+      updateUrlProcessor()
       Log.d(TAG_KIWIX, String.format(getString(R.string.error_article_url_not_found), url))
     }
   }
@@ -2157,6 +2160,7 @@ abstract class CoreReaderFragment :
   @Suppress("MagicNumber")
   override fun webViewProgressChanged(progress: Int, webView: WebView) {
     if (isAdded) {
+      updateUrlProcessor()
       progressBar?.apply {
         visibility = View.VISIBLE
         show()


### PR DESCRIPTION
Fixes #3912 

* Reproduced on a low-end device that is very slow.
* Previously, we are checking the bookmark is added or not when a page is fully loaded in the webView. In the meantime previously set bookmark toggle is showing e.g. if the previous page is added as a bookmark then until the page is fully loaded the toggle is showing that the current is added as a bookmark. However, this new page is not added as a bookmark.
* To fix this latency, we moved our `updateUrlProcessor()` method to the `webViewProgressChanged` method to update the bookmark toggle when a page starts loading in the webView. This fixes the latency in updating the bookmark toggle.

| Before fix  | After fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/e7209bc0-54ff-4bfd-b223-249cf12588f2"/>  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/bbe1ecc1-a817-4668-a81a-1c104aca780b"/>  |