### PR TITLE
Fixed: Duplicate bookmarks showing on the bookmark screen, and bookmark.xml showing to bookmarks connected to each other.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -56,7 +56,7 @@ class ImportBookmarkTest : BaseActivityTest() {
   private val library = Library()
   private val manager = Manager(library)
   private val newBookDao = NewBookDao(boxStore!!.boxFor(BookOnDiskEntity::class.java))
-  lateinit var libkiwixBookmarks: LibkiwixBookmarks
+  private lateinit var libkiwixBookmarks: LibkiwixBookmarks
 
   private val bookmarkXmlData = """
         <bookmarks>
@@ -125,7 +125,13 @@ class ImportBookmarkTest : BaseActivityTest() {
       }
     }
     libkiwixBookmarks =
-      LibkiwixBookmarks(library, manager, SharedPreferenceUtil(context), newBookDao)
+      LibkiwixBookmarks(
+        library,
+        manager,
+        SharedPreferenceUtil(context),
+        newBookDao,
+        null
+      )
   }
 
   init {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -237,7 +237,7 @@ class LibkiwixBookmarks @Inject constructor(
   private fun getBookmarksList(): List<LibkiwixBookmarkItem> {
     if (!bookmarksChanged && bookmarkList.isNotEmpty()) {
       // No changes, return the cached data
-      return bookmarkList
+      return bookmarkList.distinctBy(LibkiwixBookmarkItem::bookmarkUrl)
     }
     // Retrieve the list of bookmarks from the library, or return an empty list if it's null.
     val bookmarkArray =
@@ -283,6 +283,14 @@ class LibkiwixBookmarks @Inject constructor(
 
   private fun deleteDuplicateBookmarks() {
     bookmarkList.groupBy { it.bookmarkUrl to it.zimFilePath }
+      .filter { it.value.size > 1 }
+      .forEach { (_, value) ->
+        value.drop(1).forEach { bookmarkItem ->
+          deleteBookmark(bookmarkItem.zimId, bookmarkItem.bookmarkUrl)
+        }
+      }
+    // Fixes #3890
+    bookmarkList.groupBy { it.title to it.zimFilePath }
       .filter { it.value.size > 1 }
       .forEach { (_, value) ->
         value.drop(1).forEach { bookmarkItem ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -56,7 +56,7 @@ class LibkiwixBookmarks @Inject constructor(
   manager: Manager,
   val sharedPreferenceUtil: SharedPreferenceUtil,
   private val bookDao: NewBookDao,
-  private val zimReaderContainer: ZimReaderContainer
+  private val zimReaderContainer: ZimReaderContainer?
 ) : PageDao {
 
   /**
@@ -307,7 +307,7 @@ class LibkiwixBookmarks @Inject constructor(
             // in custom apps we are using the assetFileDescriptor so we do not have the filePath
             // and in custom apps there is only a single zim file so we are directly
             // getting the zimFileReader object.
-            zimReaderContainer.zimFileReader
+            zimReaderContainer?.zimFileReader
           } else {
             bookmarkItem.zimFilePath?.let {
               val archive = Archive(it)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -29,13 +29,17 @@ import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.CoreApp
+import org.kiwix.kiwixmobile.core.NightModeConfig
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.reader.ILLUSTRATION_SIZE
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.libkiwix.Book
@@ -43,6 +47,7 @@ import org.kiwix.libkiwix.Bookmark
 import org.kiwix.libkiwix.Library
 import org.kiwix.libkiwix.Manager
 import org.kiwix.libzim.Archive
+import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
 import javax.inject.Inject
 
@@ -50,7 +55,8 @@ class LibkiwixBookmarks @Inject constructor(
   val library: Library,
   manager: Manager,
   val sharedPreferenceUtil: SharedPreferenceUtil,
-  private val bookDao: NewBookDao
+  private val bookDao: NewBookDao,
+  private val zimReaderContainer: ZimReaderContainer
 ) : PageDao {
 
   /**
@@ -281,6 +287,7 @@ class LibkiwixBookmarks @Inject constructor(
     return bookmarkList.distinctBy(LibkiwixBookmarkItem::bookmarkUrl)
   }
 
+  @Suppress("NestedBlockDepth")
   private fun deleteDuplicateBookmarks() {
     bookmarkList.groupBy { it.bookmarkUrl to it.zimFilePath }
       .filter { it.value.size > 1 }
@@ -293,8 +300,36 @@ class LibkiwixBookmarks @Inject constructor(
     bookmarkList.groupBy { it.title to it.zimFilePath }
       .filter { it.value.size > 1 }
       .forEach { (_, value) ->
-        value.drop(1).forEach { bookmarkItem ->
-          deleteBookmark(bookmarkItem.zimId, bookmarkItem.bookmarkUrl)
+        value.forEach { bookmarkItem ->
+          // This is a special case where two urls have the same title in a zim file.
+          val coreApp = sharedPreferenceUtil.context as CoreApp
+          val zimFileReader = if (coreApp.getMainActivity().isCustomApp()) {
+            // in custom apps we are using the assetFileDescriptor so we do not have the filePath
+            // and in custom apps there is only a single zim file so we are directly
+            // getting the zimFileReader object.
+            zimReaderContainer.zimFileReader
+          } else {
+            bookmarkItem.zimFilePath?.let {
+              val archive = Archive(it)
+              ZimFileReader(
+                File(it),
+                emptyList(),
+                null,
+                archive,
+                NightModeConfig(sharedPreferenceUtil, sharedPreferenceUtil.context),
+                SuggestionSearcher(archive)
+              )
+            }
+          }
+          // get the redirect entry so that we can delete the other bookmark.
+          zimFileReader?.getPageUrlFrom(bookmarkItem.title)?.let {
+            // check if the bookmark url is not equals to redirect entry,
+            // then delete the duplicate bookmark. It will keep the original bookmark.
+            if (it != bookmarkItem.bookmarkUrl) {
+              deleteBookmark(bookmarkItem.zimId, bookmarkItem.bookmarkUrl)
+            }
+          }
+          if (!coreApp.getMainActivity().isCustomApp()) zimFileReader?.dispose()
         }
       }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/JNIModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/JNIModule.kt
@@ -22,6 +22,7 @@ import dagger.Module
 import dagger.Provides
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.libkiwix.JNIKiwix
 import org.kiwix.libkiwix.Library
@@ -47,6 +48,8 @@ class JNIModule {
     library: Library,
     manager: Manager,
     sharedPreferenceUtil: SharedPreferenceUtil,
-    bookDao: NewBookDao
-  ): LibkiwixBookmarks = LibkiwixBookmarks(library, manager, sharedPreferenceUtil, bookDao)
+    bookDao: NewBookDao,
+    zimReaderContainer: ZimReaderContainer
+  ): LibkiwixBookmarks =
+    LibkiwixBookmarks(library, manager, sharedPreferenceUtil, bookDao, zimReaderContainer)
 }


### PR DESCRIPTION
Fixes #3890 

* [wikipedia_zh_top_maxi_2024-06.zim](https://download.kiwix.org/zim/wikipedia/wikipedia_zh_top_maxi_2024-06.zim) have the same redirected entry(`英伟达`) for searched terms(輝達, 英偉達, Nvidia, Nvidia, NVIDIA) but these search terms have the same content as on `英伟达` probably that's why all these URLs have the same redirect entry like shown below.

```
1) Title = 輝達
Url = https://kiwix.app/A/%E8%BC%9D%E9%81%94
Redirect entry = https://kiwix.app/A/英伟达

2) Title = 英偉達
Url = https://w/kiwix.app/A/%E8%8B%B1%E5%81%89%E9%81%94
Redirect entry = https://kiwix.app/A/英伟达
```

* The user was facing this issue on his device where he saved the bookmark for different URLs due to we had a latency issue #3912 in showing the bookmark toggle, The user saved two bookmarks with different URLs but the title is the same for both URLs(Since both urls have the same content). That's why it was showing two same bookmarks on the bookmarks screen. The latency issue was already fixed, and for showing multiple bookmarks we have refactored our code so that multiple bookmarks not show on bookmark screen as well as not saved in the bookmark.xml.