### PR TITLE
Fixed: REGRESSION WikimedFR stuck on specifc article

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -345,8 +345,17 @@ class ZimFileReader constructor(
       jniKiwixReader.getEntryByPath(actualPath)
         .getItem(true)
     } catch (exception: Exception) {
-      Log.e(TAG, "Could not get Item for url = $url \n original exception = $exception")
-      null
+      try {
+        // check if we can get the article data when there are (#, ?, etc) any of these in the URL.
+        // See #3924 for more details.
+        jniKiwixReader.getEntryByPath(
+          url.toUri().toString().substringAfter(CONTENT_PREFIX).decodeUrl
+        )
+          .getItem(true)
+      } catch (exception: Exception) {
+        Log.e(TAG, "Could not get Item for url = $url \n original exception = $exception")
+        null
+      }
     }
 
   @Suppress("ExplicitThis") // this@ZimFileReader.name is required


### PR DESCRIPTION
Fixes #3924 

* Articles containing special characters like # in the URL were causing problems. We had previously implemented logic to retrieve data from libzim by trimming the URL before these characters to properly load videos, images, and other articles. However, this logic caused the URL to break under certain conditions.

```
Article = Trouble_du_déficit_de_l'attention 
Url = https://kiwix.app/A/Trouble_du_déficit_de_l'attention_avec_ou_sans_hyperactivité#Épidémiologie

Article = Trouble_du_déficit_de_l’attention_avec_ou_sans_hyperactivité 
Url = https://kiwix.app/A/Trouble_du_déficit_de_l'attention_avec_ou_sans_hyperactivité#Épidémiologie
```

* To address this, we implemented a fallback mechanism. If libzim does not return the expected data using our initial logic, we now attempt to retrieve the data using the full, unmodified URL. This change ensures that URLs with special characters (e.g., #, ?) will be processed correctly, preventing loading issues for such media and articles.

| Before Fix  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/kiwix/kiwix-android/assets/34593983/06d16c11-d1e3-4e22-b580-68029c5c6d34" />  | <video src="https://github.com/kiwix/kiwix-android/assets/34593983/9ec9268e-df08-418a-b600-97ce580e8d48" />  |



