### PR TITLE
Fixed: The application crashes when opening a random article.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1950,6 +1950,13 @@ abstract class CoreReaderFragment :
 
   private fun openRandomArticle() {
     val articleUrl = zimReaderContainer?.getRandomArticleUrl()
+    if (articleUrl == null) {
+      // Check if the random url is null due to some internal error in libzim(See #3926)
+      // then again try to get the random article. So that the user can see the random article
+      // instead of a (blank/same page) currently loaded in the webView.
+      openRandomArticle()
+      return
+    }
     Log.d(TAG_KIWIX, "openRandomArticle: $articleUrl")
     openArticle(articleUrl)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -210,7 +210,13 @@ class ZimFileReader constructor(
       null
     }
 
-  fun getRandomArticleUrl(): String? = jniKiwixReader.randomEntry.path
+  fun getRandomArticleUrl(): String? =
+    try {
+      jniKiwixReader.randomEntry.path
+    } catch (exception: Exception) {
+      Log.e(TAG, "Could not get random entry \n original exception = $exception")
+      null
+    }
 
   @Suppress("UnreachableCode")
   fun load(uri: String): InputStream? {


### PR DESCRIPTION
Fixes #3926 

* Caught the exception if any thrown by the libzim when getting the random entry so that it will not crash the application.
* When this type of error occurs then we have refactored our code to show the random article instead of a (blank/ same page) currently loaded in the webView.