### PR TITLE
Fixed: Playing video is too slow to start.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -74,7 +74,19 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
         val headers = mutableMapOf("Accept-Ranges" to "bytes")
         if ("Range" in requestHeaders.keys) {
           setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = zimFileReader?.getItem(url)?.size ?: 0L
+          val fullSize = when {
+            // check if the previously loaded data has the size then return it.
+            // It will prevent the again data loading for those videos that are already loaded.
+            // See #3909
+            data?.available() != null && data.available().toLong() != 0L ->
+              data.available().toLong()
+
+            else -> {
+              // if the loaded data does not have the size, especially for YT videos.
+              // Then get the content size from libzim and set it to the headers.
+              zimFileReader?.getItem(url)?.size ?: 0L
+            }
+          }
           val lastByte = fullSize - 1
           val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
           headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"


### PR DESCRIPTION
Fixes #3909 

* Previously the `data` has been read for the video within the application for setting the content range, which slowdowns the process of video loading so we have refactored our code to not use that, and should directly pass the stream for video to webView so that webView handled the stream itself.
* Rendering the HTML data, and video data on the IO thread.
* Now we are passing the stream if any uncompressed item over 1MB comes to render, and loading the data via libkiwix for the rest.