### PR TITLE
Use `Android/media/org.kiwix/kiwixmobile/` public app folder instead of private app folder (to download ZIM files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ to 13](https://github.com/kiwix/kiwix-android/blob/main/buildSrc/src/main/kotlin
 **Important Note**: Starting from Android 11, the ZIM file picker
 feature has been restricted in the [Play Store
 variant](https://play.google.com/store/apps/details?id=org.kiwix.kiwixmobile)
-due to Play Store policies.  This means that users running Android 11
+due to Play Store policies. This means that users running Android 11
 and above will not be able to load ZIM files from internal/external
 storage directly within the app if they have downloaded Kiwix from the
-Google Play Store.  This restriction is in place to comply with the
-Play Store policies.  The Play Store variant of Kiwix does not require
+Google Play Store. This restriction is in place to comply with the
+Play Store policies. The Play Store variant of Kiwix does not require
 the `MANAGE_EXTERNAL_STORAGE` permission anymore, which is necessary
 to scan storage and access ZIM files at arbitrary locations.
 Therefore, the storage scanning & file picking functionalities are not
@@ -41,6 +41,15 @@ restriction may cause inconvenience, but it is necessary to comply
 with the Play Store policies and ensure a smooth user experience.  We
 recommend using the official version of the app available on our
 website to access the complete set of features.
+
+Possible paths for play store version which supports for the scanning/reading zim files.
+
+| Storage path                                            | Viewable outside kiwix(in File manager) | Could be scanned by Kiwix |
+|---------------------------------------------------------|-----------------------------------------|---------------------------|
+| storge/0/Android/media/org.kiwix.kiwixmobile/           | Yes                                     | Yes                       |
+| storge/0/Android/data/org.kiwix.kiwixmobile/            | No                                      | Yes                       |
+| storge/sdcard-name/Android/media/org.kiwix.kiwixmobile/ | Yes                                     | Yes                       |
+| storge/sdcard-name/Android/data/org.kiwix.kiwixmobile/  | No                                      | Yes                       |
 
 Kiwix Android is written in [Kotlin](https://kotlinlang.org/)
 
@@ -65,24 +74,30 @@ root directory of the project. The project requires `Java 11` to run,
 Therefore set the `Gradle JDK` to `Java 11`.
 
 Kiwix Android is a multi-module project, in 99% of scenarios you will
-want to build the `app` module in the `debug` configuration.  If you
+want to build the `app` module in the `debug` configuration. If you
 are interested in our custom apps, they have their own repo
 [kiwix-android-custom](https://github.com/kiwix/kiwix-android-custom).
 
 ## Libraries Used
 
-- [Libkiwix](https://github.com/kiwix/java-libkiwix) - Kotlin/Java binding for the core Kiwix library
+- [Libkiwix](https://github.com/kiwix/java-libkiwix) - Kotlin/Java binding for the core Kiwix
+  library
 - [Dagger 2](https://github.com/google/dagger) - A fast dependency injector for Android and Java
-- [Retrofit](https://square.github.io/retrofit/) - Retrofit turns your REST API into a Java interface
+- [Retrofit](https://square.github.io/retrofit/) - Retrofit turns your REST API into a Java
+  interface
 - [OkHttp](https://github.com/square/okhttp) - An HTTP+SPDY client for Android and Java applications
 - [Butterknife](https://jakewharton.github.io/butterknife/) - View "injection" library for Android
-- [Mockito](https://github.com/mockito/mockito) - Most popular Mocking framework for unit tests written in Java
-- [RxJava](https://github.com/ReactiveX/RxJava) - Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM.
+- [Mockito](https://github.com/mockito/mockito) - Most popular Mocking framework for unit tests
+  written in Java
+- [RxJava](https://github.com/ReactiveX/RxJava) - Reactive Extensions for the JVM – a library for
+  composing asynchronous and event-based programs using observable sequences for the Java VM.
 - [ObjectBox](https://github.com/objectbox/objectbox-java) - Reactive NoSQL Database
-- [MockK](https://github.com/mockk/mockk) - Kotlin mocking library that allows mocking of final classes by default.
+- [MockK](https://github.com/mockk/mockk) - Kotlin mocking library that allows mocking of final
+  classes by default.
 - [JUnit5](https://github.com/junit-team/junit5/) - The next generation of JUnit
 - [AssertJ](https://github.com/joel-costigliola/assertj-core) - Fluent assertions for test code
-- [Fetch](https://github.com/tonyofrancis/Fetch) - A customizable file download manager library for Android
+- [Fetch](https://github.com/tonyofrancis/Fetch) - A customizable file download manager library for
+  Android
 - [ZXing](https://github.com/zxing/zxing) - Barcode scanning library for Java, Android
 
 ## Contributing
@@ -98,8 +113,10 @@ pull request.
 ## Communication
 
 Available communication channels:
+
 * [Email](mailto:contact+android@kiwix.org)
-* [Slack](https://kiwixoffline.slack.com): #android channel [Get an invite](https://join.slack.com/t/kiwixoffline/shared_invite/zt-19s7tsi68-xlgHdmDr5c6MJ7uFmJuBkg)
+* [Slack](https://kiwixoffline.slack.com): #android
+  channel [Get an invite](https://join.slack.com/t/kiwixoffline/shared_invite/zt-19s7tsi68-xlgHdmDr5c6MJ7uFmJuBkg)
 
 For more information, please refer to
 [https://wiki.kiwix.org/wiki/Communication](https://wiki.kiwix.org/wiki/Communication).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Play Store policies.  The Play Store variant of Kiwix does not require
 the `MANAGE_EXTERNAL_STORAGE` permission anymore, which is necessary
 to scan storage and access ZIM files at arbitrary locations.
 Therefore, the storage scanning & file picking functionalities are not
-available in this variant anymore.  To use the full version of Kiwix
+available in this variant anymore. For already downloaded ZIM files, You can copy
+them to the `Android/media/org.kiwix.kiwixmobile/` folder, and the application will read them.
+Before uninstalling the application, please ensure that you move all your ZIM files
+from this folder, as they will be automatically deleted when the application is uninstalled
+or if the application data is cleared.  To use the full version of Kiwix
 and benefit of the ZIM file picker feature, you can download it
 directly from the [official
 repository](https://download.kiwix.org/release/kiwix-android/) or use

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -19,6 +19,7 @@
 package eu.mhutti1.utils.storage
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Environment
 import androidx.core.content.ContextCompat
 import java.io.File
@@ -28,7 +29,8 @@ import java.util.ArrayList
 
 object StorageDeviceUtils {
   @JvmStatic
-  fun getWritableStorage(context: Context) = validate(externalFilesDirsDevices(context, true), true)
+  fun getWritableStorage(context: Context) =
+    validate(externalMediaFilesDirsDevices(context), true)
 
   @JvmStatic
   fun getReadableStorage(context: Context): List<StorageDevice> {
@@ -36,6 +38,7 @@ object StorageDeviceUtils {
       add(environmentDevices(context))
       addAll(externalMountPointDevices())
       addAll(externalFilesDirsDevices(context, false))
+      addAll(externalMediaFilesDirsDevices(context))
       // Scan the app-specific directory as well because we have limitations in scanning
       // all directories on Android 11 and above in the Play Store variant.
       // If a user copies the ZIM file to the app-specific directory on the SD card,
@@ -54,6 +57,12 @@ object StorageDeviceUtils {
   ) = ContextCompat.getExternalFilesDirs(context, "")
     .filterNotNull()
     .mapIndexed { index, dir -> StorageDevice(generalisePath(dir.path, writable), index == 0) }
+
+  private fun externalMediaFilesDirsDevices(
+    context: Context
+  ) = ContextWrapper(context).externalMediaDirs
+    .filterNotNull()
+    .mapIndexed { index, dir -> StorageDevice(generalisePath(dir.path, true), index == 0) }
 
   private fun externalMountPointDevices(): Collection<StorageDevice> =
     ExternalPaths.possiblePaths.fold(mutableListOf(), { acc, path ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -114,12 +114,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       }
     }
 
-    setMainActivityToCoreApp().also {
-      // Creates the public app-specific directory for existing users who have not
-      // configured storage, allowing them to copy their ZIM files into this
-      // public directory. This directory is created only once.
-      sharedPreferenceUtil.defaultPublicStorage()
-    }
+    setMainActivityToCoreApp()
     if (!sharedPreferenceUtil.prefIsBookmarksMigrated) {
       // run the migration on background thread to avoid any UI related issues.
       CoroutineScope(Dispatchers.IO).launch {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -114,7 +114,12 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       }
     }
 
-    setMainActivityToCoreApp()
+    setMainActivityToCoreApp().also {
+      // Creates the public app-specific directory for existing users who have not
+      // configured storage, allowing them to copy their ZIM files into this
+      // public directory. This directory is created only once.
+      sharedPreferenceUtil.defaultPublicStorage()
+    }
     if (!sharedPreferenceUtil.prefIsBookmarksMigrated) {
       // run the migration on background thread to avoid any UI related issues.
       CoroutineScope(Dispatchers.IO).launch {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -103,6 +103,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsHistoryMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_HISTORY_MIGRATED, false)
 
+  val prefIsAppDirectoryMigrated: Boolean
+    get() = sharedPreferences.getBoolean(PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, false)
+
   val prefStorage: String
     get() {
       val storage = sharedPreferences.getString(PREF_STORAGE, null)
@@ -145,6 +148,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun putPrefNotesMigrated(isMigrated: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_NOTES_MIGRATED, isMigrated) }
+
+  fun putPrefAppDirectoryMigrated(isMigrated: Boolean) =
+    sharedPreferences.edit { putBoolean(PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, isMigrated) }
 
   fun putPrefLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_LANG, language) }
@@ -310,5 +316,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_RECENT_SEARCH_MIGRATED = "pref_recent_search_migrated"
     const val PREF_HISTORY_MIGRATED = "pref_history_migrated"
     const val PREF_NOTES_MIGRATED = "pref_notes_migrated"
+    const val PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED = "pref_app_directory_to_public_migrated"
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.utils
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
@@ -106,12 +107,12 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     get() {
       val storage = sharedPreferences.getString(PREF_STORAGE, null)
       return when {
-        storage == null -> getPublicDirectoryPath(defaultStorage()).also {
+        storage == null -> getPublicDirectoryPath(defaultPublicStorage()).also {
           putPrefStorage(it)
           putStoragePosition(0)
         }
 
-        !File(storage).isFileExist() -> getPublicDirectoryPath(defaultStorage()).also {
+        !File(storage).isFileExist() -> getPublicDirectoryPath(defaultPublicStorage()).also {
           putStoragePosition(0)
         }
 
@@ -124,6 +125,10 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun defaultStorage(): String =
     getExternalFilesDirs(context, null)[0]?.path
+      ?: context.filesDir.path // a workaround for emulators
+
+  fun defaultPublicStorage(): String =
+    ContextWrapper(context).externalMediaDirs[0]?.path
       ?: context.filesDir.path // a workaround for emulators
 
   fun getPrefStorageTitle(defaultTitle: String): String =

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/effects/SetPreferredStorageWithMostSpace.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/effects/SetPreferredStorageWithMostSpace.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.custom.download.effects
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -30,7 +29,7 @@ class SetPreferredStorageWithMostSpace @Inject constructor(
   private val sharedPreferenceUtil: SharedPreferenceUtil
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    ContextCompat.getExternalFilesDirs(activity, null)
+    activity.externalMediaDirs
       .filterNotNull()
       .maxBy(storageCalculator::availableBytes)
       ?.let { sharedPreferenceUtil.putPrefStorage(it.path) }

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/effects/SetPreferredStorageWithMostSpaceTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/effects/SetPreferredStorageWithMostSpaceTest.kt
@@ -19,10 +19,8 @@
 package org.kiwix.kiwixmobile.custom.download.effects
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
@@ -36,10 +34,9 @@ internal class SetPreferredStorageWithMostSpaceTest {
     val storageCalculator = mockk<StorageCalculator>()
     val sharedPreferenceUtil = mockk<SharedPreferenceUtil>()
     val activity = mockk<AppCompatActivity>()
-    mockkStatic(ContextCompat::class)
     val directoryWithMoreStorage = mockk<File>()
     val directoryWithLessStorage = mockk<File>()
-    every { ContextCompat.getExternalFilesDirs(activity, null) } returns arrayOf(
+    every { activity.externalMediaDirs } returns arrayOf(
       directoryWithMoreStorage, null, directoryWithLessStorage
     )
     every { storageCalculator.availableBytes(directoryWithMoreStorage) } returns 1


### PR DESCRIPTION
Fixes #3939 

* Now all the downloading files will be stored in this public app-specific directory.
* Refactored the code to show this new location in settings for both internal and external storage. For existing users, the previously selected location will be replaced by the new public directory like https://github.com/kiwix/kiwix-android/issues/3940#issuecomment-2282722108.
* Updated the `README.md` file to educate users on how they can read already downloaded zim files in the PS version.
* Refactored the test cases according to this change.


https://github.com/user-attachments/assets/4453b456-7f86-4999-b5bf-23e83ac3c898

