### PR TITLE
Fixed: Application crashes when loading the asset(videos) from cache.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -347,7 +347,12 @@ class ZimFileReader constructor(
       .inputStream()
   }
 
-  private fun getContent(url: String) = getItem(url)?.data?.data
+  private fun getContent(url: String) = try {
+    getItem(url)?.data?.data
+  } catch (ignore: Exception) {
+    Log.e(TAG, "Could not get content for url = $url original exception = $ignore")
+    null
+  }
 
   @SuppressLint("CheckResult")
   private fun streamZimContentToPipe(item: Item?, uri: String, outputStream: OutputStream) {
@@ -365,8 +370,8 @@ class ZimFileReader constructor(
             }
           }
         }
-      } catch (ioException: IOException) {
-        Log.e(TAG, "error writing pipe for $uri", ioException)
+      } catch (ignore: Exception) {
+        Log.e(TAG, "error writing pipe for $uri", ignore)
       }
     }
   }


### PR DESCRIPTION
Fixes #3945 

The getData method of the Item class was throwing an error due to any condition, the reason is unknown(maybe the data is corrupted or anything) since there are only very less occurrences but it was crashing the application so we are catching the exception if thrown by the `getData()` method so that our application will not crash.