### PR TITLE
Fixed: Application crashes when creating the webView.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -58,6 +58,7 @@ import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.File
+import kotlin.Throws
 
 private const val HIDE_TAB_SWITCHER_DELAY: Long = 300
 
@@ -239,12 +240,19 @@ class KiwixReaderFragment : CoreReaderFragment() {
     restoreTabs(zimArticles, zimPositions, currentTab)
   }
 
-  @Suppress("UnsafeCallOnNullableType")
-  override fun createWebView(attrs: AttributeSet?): ToolbarScrollingKiwixWebView {
+  @Throws(IllegalArgumentException::class)
+  override fun createWebView(attrs: AttributeSet?): ToolbarScrollingKiwixWebView? {
+    requireNotNull(activityMainRoot)
     return ToolbarScrollingKiwixWebView(
-      requireContext(), this, attrs!!, activityMainRoot as ViewGroup, videoView!!,
-      CoreWebViewClient(this, zimReaderContainer!!),
-      toolbarContainer!!, bottomToolbar!!, sharedPreferenceUtil = sharedPreferenceUtil!!,
+      requireContext(),
+      this,
+      attrs ?: throw IllegalArgumentException("AttributeSet must not be null"),
+      activityMainRoot as ViewGroup,
+      requireNotNull(videoView),
+      CoreWebViewClient(this, requireNotNull(zimReaderContainer)),
+      requireNotNull(toolbarContainer),
+      requireNotNull(bottomToolbar),
+      sharedPreferenceUtil = requireNotNull(sharedPreferenceUtil),
       parentNavigationBar = requireActivity().findViewById(R.id.bottom_nav_view)
     )
   }


### PR DESCRIPTION
Fixes #3944 

* The application was crashing while casting activityMainRoot to ViewGroup, which was null at that point (possibly because the user switched to another fragment). We were attempting to cast a null variable to a non-nullable type.
* The WebView can return null, and we handle that in our CoreReaderFragment when creating the WebView object.
* To fix this, we modified the `createWebView` method to avoid casting any null variables and to ensure that no null variables are passed when creating the `ToolbarScrollingKiwixWebView`. If a null variable is encountered, it will throw an `IllegalArgumentException`, which we handling during the creation of this object.