### PR TITLE
Fixed: Dark mode failing on "Astrolabe" homepage.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -442,11 +442,7 @@ class ZimFileReader constructor(
            -webkit-filter: invert(1); 
            filter: invert(1); 
         }
-        img#header-profile{
-          -webkit-filter: invert(0); 
-          filter: invert(0); 
-        }
-        div[poster] > video {
+        div[poster] img, div[poster] video {
           -webkit-filter: invert(0); 
           filter: invert(0); 
         }


### PR DESCRIPTION
Fixes #3965 

* Removed the unnecessary rule that was inverting the header image. Since the image was already inverted, there is no need to apply the filter again.
* The poster image was being inverted due to the first rule being applied to the poster element, which caused the image and video inside the poster to be inverted. To correct this, a CSS rule is added to prevent the inversion of the poster's image and video.


https://github.com/user-attachments/assets/23be058d-f6d0-472d-874b-540d7ac277af

