### PR TITLE
Added support for Android 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34 ]
-        system-image:
-          - { api: 34, image: "default" }
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
@@ -59,7 +57,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: ${{ matrix.api-level == 33 || matrix.api-level == 34 && 'aosp_atd' || 'default' }}
           arch: x86_64
           profile: pixel_2
           ram-size: 4096M
@@ -78,7 +76,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: ${{ matrix.api-level == 33 || matrix.api-level == 34 && 'aosp_atd' || 'default' }}
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level == 33 || matrix.api-level == 34 && 'aosp_atd' || 'default' }}
+          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
           arch: x86_64
           profile: pixel_2
           ram-size: 4096M
@@ -76,7 +76,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level == 33 || matrix.api-level == 34 && 'aosp_atd' || 'default' }}
+          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -95,7 +95,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
           force-avd-creation: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34 ]
+        system-image:
+          - { api: 34, image: "default" }
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: default
           arch: x86_64
           profile: pixel_2
           ram-size: 4096M
@@ -76,7 +76,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: default
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -95,7 +95,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
+          target: default
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Automated tests
     strategy:
       matrix:
-        api-level: [ 25, 30, 33 ]
+        api-level: [ 25, 30, 33, 34 ]
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
-          force-avd-creation: true
+          force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: 512M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: create instrumentation coverage
         uses: reactivecircus/android-emulator-runner@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
           force-avd-creation: false
@@ -101,7 +101,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
-          force-avd-creation: false
+          force-avd-creation: true
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: 512M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Restore Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
+          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
           arch: x86_64
           profile: pixel_2
           ram-size: 4096M
@@ -76,7 +76,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
+          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -95,7 +95,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ (matrix.api-level == 33 || matrix.api-level == 34) && 'aosp_atd' || 'default' }}
+          target: ${{ matrix.api-level != 33 && 'default' || 'aosp_atd' }}
           arch: x86_64
           profile: pixel_2
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           disable-animations: false
           heap-size: 512M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          channel: canary
+          emulator-boot-timeout: 1200
           script: echo "Generated AVD snapshot for caching."
 
       - name: create instrumentation coverage
@@ -86,7 +86,7 @@ jobs:
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: 512M
-          channel: canary
+          emulator-boot-timeout: 1200
           script: bash contrib/instrumentation.sh
 
       - name: Test custom app
@@ -103,6 +103,7 @@ jobs:
           force-avd-creation: true
           sdcard-path-or-size: 2048M
           disable-animations: true
+          emulator-boot-timeout: 1200
           heap-size: 512M
           script: bash contrib/instrumentation-customapps.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          ram-size: 4096M
+          ram-size: 3072M
           cores: 4
-          sdcard-path-or-size: 2048M
+          sdcard-path-or-size: 1024M
           disable-animations: true
           emulator-boot-timeout: 1200
           heap-size: 512M

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
           force-avd-creation: false
@@ -98,9 +98,10 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
-          force-avd-creation: true
+          force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
           emulator-boot-timeout: 1200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,39 +37,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: default
-          arch: x86_64
-          profile: pixel_2
-          ram-size: 4096M
-          force-avd-creation: false
-          sdcard-path-or-size: 2048M
-          cores: 4
-          disable-animations: false
-          heap-size: 512M
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          emulator-boot-timeout: 1200
-          script: echo "Generated AVD snapshot for caching."
-
       - name: create instrumentation coverage
         uses: reactivecircus/android-emulator-runner@v2
         env:
@@ -79,10 +46,8 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
-          force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: 512M
@@ -98,10 +63,8 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
-          force-avd-creation: false
           sdcard-path-or-size: 2048M
           disable-animations: true
           emulator-boot-timeout: 1200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,14 +98,12 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           ram-size: 4096M
           cores: 4
           force-avd-creation: true
           sdcard-path-or-size: 2048M
           disable-animations: true
           heap-size: 512M
-          channel: canary
           script: bash contrib/instrumentation-customapps.sh
 
 

--- a/.github/workflows/fdroid_nightly.yml
+++ b/.github/workflows/fdroid_nightly.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Decrypt files

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache
@@ -55,10 +55,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache
@@ -93,10 +93,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Restore Cache
@@ -131,10 +131,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build all configurations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Retrieve secrets to files

--- a/.github/workflows/testing_release.yml
+++ b/.github/workflows/testing_release.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Retrieve secrets to files

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Studio](https://developer.android.com/studio).
 
 If you prefer to build without Android Studio you must first set up
 the Android SDK and then run the command: `./gradlew build ` from the
-root directory of the project. The project requires `Java 11` to run,
-Therefore set the `Gradle JDK` to `Java 11`.
+root directory of the project. The project requires `Java 17` to run,
+Therefore set the `Gradle JDK` to `Java 17`.
 
 Kiwix Android is a multi-module project, in 99% of scenarios you will
 want to build the `app` module in the `debug` configuration. If you

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ fun generateVersionName() = "${Config.versionMajor}.${Config.versionMinor}.${Con
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
 
 android {
-
+  namespace = "org.kiwix.kiwixmobile"
   defaultConfig {
     base.archivesName.set(apkPrefix)
     resValue("string", "app_name", "Kiwix")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,9 @@ fun generateVersionName() = "${Config.versionMajor}.${Config.versionMinor}.${Con
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
 
 android {
+  // Added namespace in response to Gradle 8.0 and above.
+  // This is now specified in the Gradle configuration instead of declaring
+  // it directly in the AndroidManifest file.
   namespace = "org.kiwix.kiwixmobile"
   defaultConfig {
     base.archivesName.set(apkPrefix)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -52,3 +52,33 @@
 -keepclassmembers class org.kiwix.kiwixmobile.core.entity.MetaLinkNetworkEntity$* {
     <init>(...);
 }
+
+-keep class javax.xml.stream.** { *; }
+-dontwarn javax.xml.stream.Location
+-dontwarn javax.xml.stream.XMLEventReader
+-dontwarn javax.xml.stream.XMLInputFactory
+-dontwarn javax.xml.stream.events.Attribute
+-dontwarn javax.xml.stream.events.Characters
+-dontwarn javax.xml.stream.events.StartElement
+-dontwarn javax.xml.stream.events.XMLEvent
+
+-keep class okhttp3.internal.** { *; }
+-dontwarn okhttp3.internal.Version
+-dontwarn okhttp3.internal.annotations.EverythingIsNonNull
+-dontwarn okhttp3.internal.http.HttpDate
+-dontwarn okhttp3.internal.http.UnrepeatableRequestBody
+
+-keep class org.bouncycastle.jsse.** { *; }
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+
+-keep class org.conscrypt.** { *; }
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+
+-keep class org.openjsse.javax.net.ssl.** { *; }
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.kiwix.kiwixmobile">
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
   <!-- support for androidx.test.orchestrator clearPackageData for android 33
        see more information here https://github.com/kiwix/kiwix-android/issues/3172

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/NetworkTest.kt
@@ -47,6 +47,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
 import java.util.concurrent.TimeUnit
+import org.kiwix.kiwixmobile.core.R.string
 
 /**
  * Created by mhutti1 on 14/04/17.
@@ -95,7 +96,7 @@ class NetworkTest {
   fun networkTest() {
     ActivityScenario.launch(KiwixMainActivity::class.java)
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    clickMenu(TestUtils.getResourceString(R.string.library))
+    clickMenu(TestUtils.getResourceString(string.library))
     TestUtils.allowStoragePermissionsIfNeeded()
     Espresso.onData(TestUtils.withContent("wikipedia_ab_all_2017-03"))
       .inAdapterView(ViewMatchers.withId(R.id.libraryList))
@@ -105,7 +106,7 @@ class NetworkTest {
     } catch (e: RuntimeException) {
       Log.w(NETWORK_TEST_TAG, "failed to perform click action on the view : ${e.localizedMessage} ")
     }
-    clickOn(R.string.local_zims)
+    clickOn(string.local_zims)
     try {
       Espresso.onData(CoreMatchers.allOf(ViewMatchers.withId(R.id.zim_swiperefresh)))
       refresh(R.id.zim_swiperefresh)
@@ -124,7 +125,7 @@ class NetworkTest {
         .inAdapterView(ViewMatchers.withId(R.id.zimfilelist))
       // TODO how can we get a count of the items matching the dataInteraction?
       dataInteraction.atPosition(0).perform(ViewActions.click())
-      clickMenu(R.string.library)
+      clickMenu(string.library)
       val dataInteraction1 = Espresso.onData(TestUtils.withContent("wikipedia_ab_all_2017-03"))
         .inAdapterView(ViewMatchers.withId(R.id.zimfilelist))
       dataInteraction1.atPosition(0).perform(ViewActions.longClick()) // to delete the zim file

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -34,6 +34,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -58,7 +59,7 @@ class DownloadRobot : BaseRobot() {
 
   fun waitForDataToLoad() {
     try {
-      isVisible(TextId(R.string.your_languages))
+      isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
         retryCountForDataToLoad--
@@ -155,7 +156,7 @@ class DownloadRobot : BaseRobot() {
 
   private fun assertStopDownloadDialogDisplayed() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.confirm_stop_download_title))
+    isVisible(TextId(string.confirm_stop_download_title))
   }
 
   private fun clickOnYesButton() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -34,6 +34,7 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
@@ -67,7 +68,7 @@ class InitialDownloadRobot : BaseRobot() {
 
   fun waitForDataToLoad(retryCountForDataToLoad: Int = 10) {
     try {
-      isVisible(TextId(R.string.your_languages))
+      isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
         waitForDataToLoad(retryCountForDataToLoad - 1)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroRobot.kt
@@ -27,6 +27,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.main.TopLevelDestinationRobot
 import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
@@ -37,11 +38,11 @@ class IntroRobot : BaseRobot() {
 
   fun swipeLeft() {
     isVisible(ViewId(R.id.get_started))
-    isVisible(TextId(R.string.welcome_to_the_family))
-    isVisible(TextId(R.string.humankind_knowledge))
+    isVisible(TextId(string.welcome_to_the_family))
+    isVisible(TextId(string.humankind_knowledge))
     attempt(10) {
-      isVisible(TextId(R.string.save_books_offline))
-      isVisible(TextId(R.string.download_books_message))
+      isVisible(TextId(string.save_books_offline))
+      isVisible(TextId(string.download_books_message))
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -28,10 +28,11 @@ import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
-import org.kiwix.kiwixmobile.Findable
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
+import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
@@ -40,20 +41,20 @@ fun language(func: LanguageRobot.() -> Unit) = LanguageRobot().applyWithViewHier
 
 class LanguageRobot : BaseRobot() {
 
-  private var retryCountForDataToLoad = 10
-
   fun clickDownloadOnBottomNav() {
     clickOn(ViewId(R.id.downloadsFragment))
   }
 
-  fun waitForDataToLoad() {
+  fun waitForDataToLoad(retryCountForDataToLoad: Int = 10) {
     try {
-      isVisible(Findable.Text("Off the Grid"))
+      isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
-        retryCountForDataToLoad--
-        waitForDataToLoad()
+        waitForDataToLoad(retryCountForDataToLoad - 1)
+        return
       }
+      // throw the exception when there is no more retry left.
+      throw RuntimeException("Couldn't load the online library list.\n Original exception = $e")
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -31,6 +31,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
@@ -76,37 +77,37 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   fun assertLocalLibraryVisible() {
-    isVisible(TextId(R.string.library))
+    isVisible(TextId(string.library))
   }
 
   fun assertClickNearbyDeviceMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.click_nearby_devices_message))
+    isVisible(TextId(string.click_nearby_devices_message))
   }
 
   fun clickOnGotItButton() {
     pauseForBetterTestPerformance()
-    testFlakyView({ onView(withText(R.string.got_it)).perform(click()) })
+    testFlakyView({ onView(withText(string.got_it)).perform(click()) })
   }
 
   fun assertDeviceNameMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.your_device_name_message))
+    isVisible(TextId(string.your_device_name_message))
   }
 
   fun assertNearbyDeviceListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.nearby_devices_list_message))
+    isVisible(TextId(string.nearby_devices_list_message))
   }
 
   fun assertTransferZimFilesListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(R.string.transfer_zim_files_list_message))
+    isVisible(TextId(string.transfer_zim_files_list_message))
   }
 
   fun assertClickNearbyDeviceMessageNotVisible() {
     pauseForBetterTestPerformance()
-    onView(withText(R.string.click_nearby_devices_message)).check(doesNotExist())
+    onView(withText(string.click_nearby_devices_message)).check(doesNotExist())
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -65,7 +65,7 @@ class LocalFileTransferRobot : BaseRobot() {
   private fun closeEnableWifiP2PDialogIfVisible() {
     try {
       testFlakyView({
-        onView(withText(R.string.request_enable_wifi)).check(matches(isDisplayed()))
+        onView(withText(string.request_enable_wifi)).check(matches(isDisplayed()))
         pressBack()
       })
     } catch (ignore: Throwable) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -86,11 +86,11 @@ class LocalFileTransferTest {
         anyOf(
           allOf(
             matchesCheck(SpeakableTextPresentCheck::class.java),
-            matchesViews(withId(R.id.tv_skip))
+            matchesViews(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_skip))
           ),
           allOf(
             matchesCheck(TouchTargetSizeCheck::class.java),
-            matchesViews(withId(R.id.tv_skip))
+            matchesViews(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_skip))
           ),
           allOf(
             matchesCheck(TouchTargetSizeCheck::class.java),

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationRobot.kt
@@ -27,6 +27,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.help.help
 import org.kiwix.kiwixmobile.nav.destination.library.LibraryRobot
@@ -78,7 +79,7 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickBookmarksOnNavDrawer(func: BookmarksRobot.() -> Unit) {
     inNavDrawer {
-      testFlakyView({ onView(withText(R.string.bookmarks)).perform(click()) })
+      testFlakyView({ onView(withText(string.bookmarks)).perform(click()) })
       bookmarks(func)
       pressBack()
     }
@@ -86,7 +87,7 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickHistoryOnSideNav(func: HistoryRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.history))
+      clickOn(TextId(string.history))
       history(func)
       pressBack()
     }
@@ -94,32 +95,32 @@ class TopLevelDestinationRobot : BaseRobot() {
 
   fun clickHostBooksOnSideNav(func: ZimHostRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_wifi_hotspot))
+      clickOn(TextId(string.menu_wifi_hotspot))
       zimHost(func)
     }
   }
 
   fun clickSettingsOnSideNav(func: SettingsRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_settings))
+      clickOn(TextId(string.menu_settings))
       settingsRobo(func)
     }
   }
 
   fun clickHelpOnSideNav(func: HelpRobot.() -> Unit) {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_help))
+      clickOn(TextId(string.menu_help))
       help(func)
     }
   }
 
   fun clickSupportKiwixOnSideNav() {
     inNavDrawer {
-      clickOn(TextId(R.string.menu_support_kiwix))
+      clickOn(TextId(string.menu_support_kiwix))
     }
   }
 
   fun assertExternalLinkDialogDisplayed() {
-    testFlakyView({ isVisible(TextId(R.string.external_link_popup_dialog_title)) })
+    testFlakyView({ isVisible(TextId(string.external_link_popup_dialog_title)) })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
@@ -21,7 +21,7 @@ package org.kiwix.kiwixmobile.nav.destination.reader
 import applyWithViewHierarchyPrinting
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 
 fun reader(func: ReaderRobot.() -> Unit) = ReaderRobot().applyWithViewHierarchyPrinting(func)
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -36,7 +36,7 @@ import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/HistoryRobot.kt
@@ -23,7 +23,7 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.ContentDesc
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 fun history(func: HistoryRobot.() -> Unit) = HistoryRobot().applyWithViewHierarchyPrinting(func)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -32,7 +32,7 @@ import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -147,6 +147,6 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun clickOnReaderFragment() {
-    testFlakyView({ onView(withId(R.id.readerFragment)).perform(click()) })
+    testFlakyView({ onView(withId(org.kiwix.kiwixmobile.R.id.readerFragment)).perform(click()) })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -44,6 +44,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.id
 import org.kiwix.kiwixmobile.core.search.SearchFragment
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
@@ -105,7 +106,7 @@ class SearchFragmentTest : BaseActivityTest() {
       setSuppressingResultMatcher(
         allOf(
           matchesCheck(TouchTargetSizeCheck::class.java),
-          matchesViews(ViewMatchers.withId(R.id.menu_searchintext))
+          matchesViews(ViewMatchers.withId(id.menu_searchintext))
         )
       )
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -226,7 +226,19 @@ class SearchFragmentTest : BaseActivityTest() {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(R.id.libraryFragment)
     }
-    downloadingZimFile = getDownloadingZimFile(false)
+    downloadingZimFile = getDownloadingZimFile()
+    OkHttpClient().newCall(downloadRequest()).execute().use { response ->
+      if (response.isSuccessful) {
+        response.body?.let { responseBody ->
+          writeZimFileData(responseBody, downloadingZimFile)
+        }
+      } else {
+        throw RuntimeException(
+          "Download Failed. Error: ${response.message}\n" +
+            " Status Code: ${response.code}"
+        )
+      }
+    }
     openKiwixReaderFragmentWithFile(downloadingZimFile)
     search { checkZimFileSearchSuccessful(R.id.readerFragment) }
     openSearchWithQuery(searchTerms[0], downloadingZimFile)
@@ -328,12 +340,10 @@ class SearchFragmentTest : BaseActivityTest() {
     return zimFile
   }
 
-  private fun getDownloadingZimFile(isDeletePreviousZimFile: Boolean = true): File {
+  private fun getDownloadingZimFile(): File {
     val zimFile = File(context.cacheDir, "ray_charles.zim")
-    if (isDeletePreviousZimFile) {
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-    }
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
     return zimFile
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -185,10 +185,8 @@ class SearchFragmentTest : BaseActivityTest() {
       searchWithFrequentlyTypedWords(searchQueryForDownloadedZimFile, 300)
       assertSearchSuccessful(searchResultForDownloadedZimFile)
       deleteSearchedQueryFrequently(searchQueryForDownloadedZimFile, uiDevice, 300)
-      // to close the keyboard
-      pressBack()
-      // go to reader screen
-      pressBack()
+      // open the reader fragment for next text case.
+      openKiwixReaderFragmentWithFile(downloadingZimFile)
     }
 
     // Added test for checking the crash scenario where the application was crashing when we

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -69,7 +69,7 @@ class SearchRobot : BaseRobot() {
 
   fun searchWithFrequentlyTypedWords(query: String, wait: Long = 0L) {
     testFlakyView({
-      val searchView = onView(withId(R.id.search_src_text))
+      val searchView = onView(withId(androidx.appcompat.R.id.search_src_text))
       for (char in query) {
         searchView.perform(typeText(char.toString()))
         if (wait != 0L) {
@@ -99,7 +99,7 @@ class SearchRobot : BaseRobot() {
     }
 
     // clear search query if any remains due to any condition not to affect any other test scenario
-    val searchView = onView(withId(R.id.search_src_text))
+    val searchView = onView(withId(androidx.appcompat.R.id.search_src_text))
     searchView.perform(clearText())
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -173,14 +173,16 @@ class SettingsRobot : BaseRobot() {
 
   fun selectAlbanianLanguage() {
     testFlakyView({
-      onData(anything()).inAdapterView(withId(R.id.select_dialog_listview)).atPosition(2)
+      onData(anything()).inAdapterView(withId(androidx.appcompat.R.id.select_dialog_listview))
+        .atPosition(2)
         .perform(click())
     })
   }
 
   fun selectDeviceDefaultLanguage() {
     testFlakyView({
-      onData(anything()).inAdapterView(withId(R.id.select_dialog_listview)).atPosition(0)
+      onData(anything()).inAdapterView(withId(androidx.appcompat.R.id.select_dialog_listview))
+        .atPosition(0)
         .perform(click())
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
@@ -28,6 +28,7 @@ import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.closeD
 import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawerWithGravity
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 
 /**
@@ -36,7 +37,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 object StandardActions {
   fun enterSettings() {
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-    clickOn(TestUtils.getResourceString(R.string.menu_settings))
+    clickOn(TestUtils.getResourceString(string.menu_settings))
   }
 
   fun openDrawer() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostRobot.kt
@@ -34,7 +34,7 @@ import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
@@ -53,7 +53,7 @@ class ZimHostRobot : BaseRobot() {
 
   fun refreshLibraryList() {
     pauseForBetterTestPerformance()
-    refresh(R.id.zim_swiperefresh)
+    refresh(org.kiwix.kiwixmobile.R.id.zim_swiperefresh)
   }
 
   fun assertZimFilesLoaded() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission
     android:name="android.permission.ACCESS_FINE_LOCATION"

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/CustomPageIndicator.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/CustomPageIndicator.kt
@@ -32,7 +32,6 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.View
 import android.view.animation.Interpolator
-import androidx.core.view.ViewCompat
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.viewpager.widget.ViewPager
 import androidx.viewpager.widget.ViewPager.OnPageChangeListener
@@ -510,7 +509,7 @@ class CustomPageIndicator @JvmOverloads constructor(
     moveSelected.addUpdateListener { valueAnimator -> // todo avoid autoboxing
       selectedDotX = valueAnimator.animatedValue as Float
       retreatAnimation!!.startIfNecessary(selectedDotX)
-      ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+      this@CustomPageIndicator.postInvalidateOnAnimation()
     }
     moveSelected.addListener(object : AnimatorListenerAdapter() {
       override fun onAnimationStart(animation: Animator) {
@@ -536,20 +535,20 @@ class CustomPageIndicator @JvmOverloads constructor(
   private fun setJoiningFraction(leftDot: Int, fraction: Float) {
     if (leftDot < joiningFractions.size) {
       joiningFractions[leftDot] = fraction
-      ViewCompat.postInvalidateOnAnimation(this)
+      this.postInvalidateOnAnimation()
     }
   }
 
   private fun clearJoiningFractions() {
     Arrays.fill(joiningFractions, 0f)
-    ViewCompat.postInvalidateOnAnimation(this)
+    this.postInvalidateOnAnimation()
   }
 
   private fun setDotRevealFraction(dot: Int, fraction: Float) {
     if (dot < dotRevealFractions.size) {
       dotRevealFractions[dot] = fraction
     }
-    ViewCompat.postInvalidateOnAnimation(this)
+    this.postInvalidateOnAnimation()
   }
 
   private fun cancelJoiningAnimations() {
@@ -608,7 +607,7 @@ class CustomPageIndicator @JvmOverloads constructor(
         }
         addUpdateListener { valueAnimator -> // todo avoid autoboxing
           retreatingJoinX1 = valueAnimator.animatedValue as Float
-          ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+          this@CustomPageIndicator.postInvalidateOnAnimation()
           // start any reveal animations if we've passed them
           for (pendingReveal in revealAnimations) {
             pendingReveal!!.startIfNecessary(retreatingJoinX1)
@@ -626,7 +625,7 @@ class CustomPageIndicator @JvmOverloads constructor(
         }
         addUpdateListener { valueAnimator -> // todo avoid autoboxing
           retreatingJoinX2 = valueAnimator.animatedValue as Float
-          ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+          this@CustomPageIndicator.postInvalidateOnAnimation()
           // start any reveal animations if we've passed them
           for (pendingReveal in revealAnimations) {
             pendingReveal!!.startIfNecessary(retreatingJoinX2)
@@ -643,13 +642,13 @@ class CustomPageIndicator @JvmOverloads constructor(
           }
           retreatingJoinX1 = initialX1
           retreatingJoinX2 = initialX2
-          ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+          this@CustomPageIndicator.postInvalidateOnAnimation()
         }
 
         override fun onAnimationEnd(animation: Animator) {
           retreatingJoinX1 = INVALID_FRACTION
           retreatingJoinX2 = INVALID_FRACTION
-          ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+          this@CustomPageIndicator.postInvalidateOnAnimation()
         }
       })
     }
@@ -676,7 +675,7 @@ class CustomPageIndicator @JvmOverloads constructor(
       addListener(object : AnimatorListenerAdapter() {
         override fun onAnimationEnd(animation: Animator) {
           setDotRevealFraction(this@PendingRevealAnimator.dot, 0f)
-          ViewCompat.postInvalidateOnAnimation(this@CustomPageIndicator)
+          this@CustomPageIndicator.postInvalidateOnAnimation()
         }
       })
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -36,6 +36,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.disposables.CompositeDisposable
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -88,8 +89,8 @@ class LanguageFragment : BaseFragment() {
 
     activity.supportActionBar?.let {
       it.setDisplayHomeAsUpEnabled(true)
-      it.setHomeAsUpIndicator(R.drawable.ic_clear_white_24dp)
-      it.setTitle(R.string.select_languages)
+      it.setHomeAsUpIndicator(drawable.ic_clear_white_24dp)
+      it.setTitle(string.select_languages)
     }
     // set the contentDescription to navigation back button
     toolbar.getToolbarNavigationIcon()?.setToolTipWithContentDescription(

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -55,8 +55,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.R.drawable
+import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
@@ -183,23 +184,23 @@ class LocalFileTransferFragment :
         setConfig(config)
         addSequenceItem(
           it,
-          getString(R.string.click_nearby_devices_message),
-          getString(R.string.got_it)
+          getString(string.click_nearby_devices_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.textViewDeviceName,
-          getString(R.string.your_device_name_message),
-          getString(R.string.got_it)
+          getString(string.your_device_name_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.listPeerDevices,
-          getString(R.string.nearby_devices_list_message),
-          getString(R.string.got_it)
+          getString(string.nearby_devices_list_message),
+          getString(string.got_it)
         )
         addSequenceItem(
           fragmentLocalFileTransferBinding?.recyclerViewTransferFiles,
-          getString(R.string.transfer_zim_files_list_message),
-          getString(R.string.got_it)
+          getString(string.transfer_zim_files_list_message),
+          getString(string.got_it)
         )
         setOnItemDismissedListener { showcaseView, _ ->
           // To fix the memory leak by setting setTarget to null
@@ -255,7 +256,7 @@ class LocalFileTransferFragment :
       title =
         if (isReceiver) getString(R.string.receive_files_title)
         else getString(R.string.send_files_title)
-      setNavigationIcon(R.drawable.ic_close_white_24dp)
+      setNavigationIcon(drawable.ic_close_white_24dp)
       // set the contentDescription to navigation back button
       getToolbarNavigationIcon()?.setToolTipWithContentDescription(
         getString(string.toolbar_back_button_content_description)
@@ -406,13 +407,13 @@ class LocalFileTransferFragment :
         PERMISSION_REQUEST_FINE_LOCATION,
         PERMISSION_REQUEST_CODE_NEARBY_WIFI_DEVICES -> {
           Log.e(TAG, "Location permission not granted")
-          toast(R.string.permission_refused_location, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_location, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
 
         PERMISSION_REQUEST_CODE_STORAGE_WRITE_ACCESS -> {
           Log.e(TAG, "Storage write permission not granted")
-          toast(R.string.permission_refused_storage, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_storage, Toast.LENGTH_SHORT)
           requireActivity().popNavigationBackstack()
         }
 
@@ -457,7 +458,7 @@ class LocalFileTransferFragment :
       KiwixDialog.EnableLocationServices, {
         enableLocationServicesLauncher.launch(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
       },
-      { toast(R.string.discovery_needs_location, Toast.LENGTH_SHORT) }
+      { toast(string.discovery_needs_location, Toast.LENGTH_SHORT) }
     )
   }
 
@@ -466,7 +467,7 @@ class LocalFileTransferFragment :
       KiwixDialog.EnableWifiP2pServices, {
         startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
       },
-      { toast(R.string.discovery_needs_wifi, Toast.LENGTH_SHORT) }
+      { toast(string.discovery_needs_wifi, Toast.LENGTH_SHORT) }
     )
   }
 
@@ -478,7 +479,7 @@ class LocalFileTransferFragment :
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
       if (result.resultCode != Activity.RESULT_OK) {
         if (!isLocationServiceEnabled) {
-          toast(R.string.permission_refused_location, Toast.LENGTH_SHORT)
+          toast(string.permission_refused_location, Toast.LENGTH_SHORT)
         }
       }
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -145,7 +145,7 @@ class LocalFileTransferFragment :
     wifiDirectManager.startWifiDirectManager(filesForTransfer)
     fragmentLocalFileTransferBinding
       ?.textViewDeviceName
-      ?.setToolTipWithContentDescription(getString(R.string.your_device))
+      ?.setToolTipWithContentDescription(getString(string.your_device))
   }
 
   private fun setupMenu() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -41,7 +41,6 @@ import android.widget.Toast
 import androidx.lifecycle.LifecycleCoroutineScope
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -40,7 +40,8 @@ import android.os.Looper.getMainLooper
 import android.widget.Toast
 import androidx.lifecycle.LifecycleCoroutineScope
 import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -80,6 +80,7 @@ class KiwixMainActivity : CoreMainActivity() {
   @Inject lateinit var newBookDao: NewBookDao
 
   override val mainActivity: AppCompatActivity by lazy { this }
+  override val appName: String by lazy { getString(R.string.app_name) }
 
   override val bookmarksFragmentResId: Int = R.id.bookmarksFragment
   override val settingsFragmentResId: Int = R.id.kiwixSettingsFragment

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -36,6 +36,8 @@ import com.google.android.material.navigation.NavigationView
 import eu.mhutti1.utils.storage.StorageDeviceUtils
 import org.kiwix.kiwixmobile.BuildConfig
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.mipmap
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_NOTIFICATION_TITLE
@@ -134,18 +136,25 @@ class KiwixMainActivity : CoreMainActivity() {
     super.onConfigurationChanged(newConfig)
     if (::activityKiwixMainBinding.isInitialized) {
       activityKiwixMainBinding.bottomNavView.menu.apply {
-        findItem(R.id.readerFragment)?.title = resources.getString(R.string.reader)
-        findItem(R.id.libraryFragment)?.title = resources.getString(R.string.library)
-        findItem(R.id.downloadsFragment)?.title = resources.getString(R.string.download)
+        findItem(R.id.readerFragment)?.title = resources.getString(string.reader)
+        findItem(R.id.libraryFragment)?.title = resources.getString(string.library)
+        findItem(R.id.downloadsFragment)?.title = resources.getString(string.download)
       }
       activityKiwixMainBinding.drawerNavView.menu.apply {
-        findItem(R.id.menu_bookmarks_list)?.title = resources.getString(R.string.bookmarks)
-        findItem(R.id.menu_history)?.title = resources.getString(R.string.history)
-        findItem(R.id.menu_notes)?.title = resources.getString(R.string.pref_notes)
-        findItem(R.id.menu_host_books)?.title = resources.getString(R.string.menu_wifi_hotspot)
-        findItem(R.id.menu_settings)?.title = resources.getString(R.string.menu_settings)
-        findItem(R.id.menu_help)?.title = resources.getString(R.string.menu_help)
-        findItem(R.id.menu_support_kiwix)?.title = resources.getString(R.string.menu_support_kiwix)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_bookmarks_list)?.title =
+          resources.getString(string.bookmarks)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_history)?.title =
+          resources.getString(string.history)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_notes)?.title =
+          resources.getString(string.pref_notes)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.title =
+          resources.getString(string.menu_wifi_hotspot)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_settings)?.title =
+          resources.getString(string.menu_settings)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_help)?.title =
+          resources.getString(string.menu_help)
+        findItem(org.kiwix.kiwixmobile.core.R.id.menu_support_kiwix)?.title =
+          resources.getString(string.menu_support_kiwix)
       }
     }
   }
@@ -219,5 +228,5 @@ class KiwixMainActivity : CoreMainActivity() {
     }
   }
 
-  override fun getIconResId() = R.mipmap.ic_launcher
+  override fun getIconResId() = mipmap.ic_launcher
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -58,6 +58,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -133,9 +134,9 @@ class LocalLibraryFragment : BaseFragment() {
           fileManagementNoFiles.visibility = VISIBLE
           goToDownloadsButtonNoFiles.visibility = VISIBLE
           fileManagementNoFiles.text =
-            requireActivity().resources.getString(R.string.grant_read_storage_permission)
+            requireActivity().resources.getString(string.grant_read_storage_permission)
           goToDownloadsButtonNoFiles.text =
-            requireActivity().resources.getString(R.string.go_to_settings_label)
+            requireActivity().resources.getString(string.go_to_settings_label)
           zimfilelist.visibility = GONE
         }
       } else if (isGranted) {
@@ -188,7 +189,7 @@ class LocalLibraryFragment : BaseFragment() {
     activity.setSupportActionBar(toolbar)
     activity.supportActionBar?.apply {
       setDisplayHomeAsUpEnabled(true)
-      setTitle(R.string.library)
+      setTitle(string.library)
     }
     if (toolbar != null) {
       activity.setupDrawerToggle(toolbar)
@@ -381,12 +382,12 @@ class LocalLibraryFragment : BaseFragment() {
       requireActivity().applicationContext, uri
     )
     if (filePath == null || !File(filePath).exists()) {
-      activity.toast(R.string.error_file_not_found)
+      activity.toast(string.error_file_not_found)
       return null
     }
     val file = File(filePath)
     return if (!FileUtils.isValidZimFile(file.path)) {
-      activity.toast(R.string.error_file_invalid)
+      activity.toast(string.error_file_invalid)
       null
     } else {
       file
@@ -395,7 +396,7 @@ class LocalLibraryFragment : BaseFragment() {
 
   private fun navigateToReaderFragment(file: File) {
     if (!file.canRead()) {
-      activity.toast(R.string.unable_to_read_zim_file)
+      activity.toast(string.unable_to_read_zim_file)
     } else {
       // Save the ZIM file to the database to display it on the local library screen.
       // This is particularly useful when storage is slow or contains a large number of files.
@@ -501,9 +502,9 @@ class LocalLibraryFragment : BaseFragment() {
     setActionModeTitle(state.selectedBooks.size)
     fragmentDestinationLibraryBinding?.apply {
       if (items.isEmpty()) {
-        fileManagementNoFiles.text = requireActivity().resources.getString(R.string.no_files_here)
+        fileManagementNoFiles.text = requireActivity().resources.getString(string.no_files_here)
         goToDownloadsButtonNoFiles.text =
-          requireActivity().resources.getString(R.string.download_books)
+          requireActivity().resources.getString(string.download_books)
 
         fileManagementNoFiles.visibility = View.VISIBLE
         goToDownloadsButtonNoFiles.visibility = View.VISIBLE
@@ -532,7 +533,7 @@ class LocalLibraryFragment : BaseFragment() {
       ) != PackageManager.PERMISSION_GRANTED
     ) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-        context.toast(R.string.request_storage)
+        context.toast(string.request_storage)
         storagePermissionLauncher?.launch(
           arrayOf(
             Manifest.permission.READ_EXTERNAL_STORAGE,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -52,6 +52,7 @@ import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageSelectDialog
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.cachedComponent
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
@@ -163,7 +164,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     activity.setSupportActionBar(toolbar)
     activity.supportActionBar?.apply {
       setDisplayHomeAsUpEnabled(true)
-      setTitle(R.string.download)
+      setTitle(string.download)
     }
     if (toolbar != null) {
       activity.setupDrawerToggle(toolbar)
@@ -255,7 +256,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       {
         onRefreshStateChange(false)
         context.toast(
-          resources.getString(R.string.denied_internet_permission_message),
+          resources.getString(string.denied_internet_permission_message),
           Toast.LENGTH_SHORT
         )
         hideRecyclerviewAndShowSwipeDownForLibraryErrorText()
@@ -273,7 +274,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private fun hideRecyclerviewAndShowSwipeDownForLibraryErrorText() {
     fragmentDestinationDownloadBinding?.apply {
       libraryErrorText.setText(
-        R.string.swipe_down_for_library
+        string.swipe_down_for_library
       )
       libraryErrorText.visibility = View.VISIBLE
       libraryList.visibility = View.GONE
@@ -321,7 +322,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       noInternetSnackbar()
     } else {
       fragmentDestinationDownloadBinding?.libraryErrorText?.setText(
-        R.string.no_network_connection
+        string.no_network_connection
       )
       fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
     }
@@ -330,9 +331,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
 
   private fun noInternetSnackbar() {
     fragmentDestinationDownloadBinding?.libraryList?.snack(
-      R.string.no_network_connection,
+      string.no_network_connection,
       requireActivity().findViewById(R.id.bottom_nav_view),
-      R.string.menu_settings,
+      string.menu_settings,
       ::openNetworkSettings
     )
   }
@@ -347,8 +348,8 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     }
     if (it?.isEmpty() == true) {
       fragmentDestinationDownloadBinding?.libraryErrorText?.setText(
-        if (isNotConnected) R.string.no_network_connection
-        else R.string.no_items_msg
+        if (isNotConnected) string.no_network_connection
+        else string.no_items_msg
       )
       fragmentDestinationDownloadBinding?.libraryErrorText?.visibility = View.VISIBLE
     } else {
@@ -498,11 +499,11 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
               {
                 fragmentDestinationDownloadBinding?.libraryList?.snack(
                   """ 
-                ${getString(R.string.download_no_space)}
-                ${getString(R.string.space_available)} $it
+                ${getString(string.download_no_space)}
+                ${getString(string.space_available)} $it
                   """.trimIndent(),
                   requireActivity().findViewById(R.id.bottom_nav_view),
-                  R.string.download_change_storage,
+                  string.download_change_storage,
                   ::showStorageSelectDialog
                 )
               }
@@ -519,7 +520,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     .apply {
       onSelectAction = ::storeDeviceInPreferences
     }
-    .show(parentFragmentManager, getString(R.string.pref_storage))
+    .show(parentFragmentManager, getString(string.pref_storage))
 
   private fun showStorageConfigureDialog() {
     alertDialogShower.show(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -133,7 +133,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
           context?.let { context ->
             downloader.pauseResumeDownload(
               it.downloadId,
-              it.downloadState.toReadableState(context).contains(getString(R.string.paused_state))
+              it.downloadState.toReadableState(context).contains(getString(string.paused_state))
             )
           }
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -336,12 +336,12 @@ class KiwixReaderFragment : CoreReaderFragment() {
       requireActivity().applicationContext, uri
     )
     if (filePath == null || !File(filePath).isFileExist()) {
-      activity.toast(R.string.error_file_not_found)
+      activity.toast(string.error_file_not_found)
       return null
     }
     val file = File(filePath)
     return if (!FileUtils.isValidZimFile(file.path)) {
-      activity.toast(R.string.error_file_invalid)
+      activity.toast(string.error_file_invalid)
       null
     } else if (!file.canReadFile()) {
       activity.toast(R.string.cannot_open_file)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -37,6 +37,8 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R.anim
+import org.kiwix.kiwixmobile.core.R.drawable
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions.Super
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions.Super.ShouldCall
@@ -58,7 +60,6 @@ import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.File
-import kotlin.Throws
 
 private const val HIDE_TAB_SWITCHER_DELAY: Long = 300
 
@@ -120,7 +121,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
       // it will attempt to open the last opened ZIM file with the last loaded URL,
       // which is inside the non-existing ZIM file. This leads to unexpected behavior.
       exitBook()
-      activity.toast(R.string.error_file_not_found)
+      activity.toast(string.error_file_not_found)
       return
     }
     openZimFile(File(filePath))
@@ -146,7 +147,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
 
       setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
 
-      closeAllTabsButton?.setImageDrawableCompat(R.drawable.ic_close_black_24dp)
+      closeAllTabsButton?.setImageDrawableCompat(drawable.ic_close_black_24dp)
       if (tabSwitcherRoot?.visibility == View.VISIBLE) {
         tabSwitcherRoot?.visibility = GONE
         startAnimation(tabSwitcherRoot, anim.slide_up)
@@ -233,7 +234,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
         zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
       }
     } else {
-      getCurrentWebView()?.snack(R.string.zim_not_opened)
+      getCurrentWebView()?.snack(string.zim_not_opened)
       exitBook() // hide the options for zim file to avoid unexpected UI behavior
       return // book not found so don't need to restore the tabs for this file
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
@@ -62,7 +62,8 @@ class ScrollingViewWithBottomNavigationBehavior(context: Context, attrs: Attribu
     navigationBar: BottomNavigationView,
     coordinatorLayout: CoordinatorLayout
   ): Boolean {
-    val readerBottomAppBar: BottomAppBar? = fragmentContainer.findViewById(R.id.bottom_toolbar)
+    val readerBottomAppBar: BottomAppBar? =
+      fragmentContainer.findViewById(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar)
     if (readerBottomAppBar != null) {
       val newBottomMargin = calculateNewBottomMargin(navigationBar, coordinatorLayout)
       if (newBottomMargin != bottomMargin) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixPrefsFragment.kt
@@ -156,9 +156,9 @@ class KiwixPrefsFragment : CorePrefsFragment() {
       showPermissionPreference()
       val externalStorageManager = Environment.isExternalStorageManager()
       if (externalStorageManager) {
-        permissionPref?.setSummary(org.kiwix.kiwixmobile.core.R.string.allowed)
+        permissionPref?.setSummary(R.string.allowed)
       } else {
-        permissionPref?.setSummary(org.kiwix.kiwixmobile.core.R.string.not_allowed)
+        permissionPref?.setSummary(R.string.not_allowed)
       }
       permissionPref?.onPreferenceClickListener =
         Preference.OnPreferenceClickListener {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -19,7 +19,7 @@
 package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
@@ -20,7 +20,7 @@ package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
-import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.navigate
 import org.kiwix.kiwixmobile.core.extensions.canReadFile

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.zimManager.libraryView.adapter
 
 import android.view.View
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.Error
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.Status
@@ -106,13 +107,13 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       itemDownloadBinding.libraryDownloadDescription.text = item.description
       itemDownloadBinding.downloadProgress.progress = item.progress
       itemDownloadBinding.stop.apply {
-        setToolTipWithContentDescription(itemDownloadBinding.root.context.getString(R.string.stop))
+        setToolTipWithContentDescription(itemDownloadBinding.root.context.getString(string.stop))
         setOnClickListener { clickAction.invoke(item) }
       }
       itemDownloadBinding.pauseResume.apply {
         val context = itemDownloadBinding.root.context
         val description =
-          "${context.getString(R.string.tts_pause)}/${context.getString(R.string.tts_resume)}"
+          "${context.getString(string.tts_pause)}/${context.getString(string.tts_resume)}"
         setToolTipWithContentDescription(description)
         setOnClickListener {
           pauseResumeClickAction.invoke(item)
@@ -121,7 +122,7 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
       itemDownloadBinding.downloadState.text =
         item.downloadState.toReadableState(containerView.context).also {
           val pauseResumeIconId =
-            if (it.contains(itemDownloadBinding.root.context.getString(R.string.paused_state))) {
+            if (it.contains(itemDownloadBinding.root.context.getString(string.paused_state))) {
               R.drawable.ic_play_24dp
             } else {
               R.drawable.ic_pause_24dp

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:7.4.2")
+  implementation("com.android.tools.build:gradle:8.1.3")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
   implementation("org.jacoco:org.jacoco.core:0.8.8")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   implementation("com.android.tools.build:gradle:8.1.3")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
   implementation("org.jacoco:org.jacoco.core:0.8.8")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20230406-2.0.0") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 dependencies {
   implementation("com.android.tools.build:gradle:8.1.3")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
-  implementation("org.jacoco:org.jacoco.core:0.8.8")
+  implementation("org.jacoco:org.jacoco.core:0.8.12")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20230406-2.0.0") {
     exclude(group = "com.google.guava", module = "guava")

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -22,9 +22,9 @@ object Config {
 
   // Here is a list of all Android versions with their corresponding API
   // levels: https://apilevels.com/
-  const val compileSdk = 33 // SDK version used by Gradle to compile our app.
+  const val compileSdk = 34 // SDK version used by Gradle to compile our app.
   const val minSdk = 25 // Minimum SDK (Minimum Support Device) is 25 (Android 7.1 Nougat).
-  const val targetSdk = 33 // Target SDK (Maximum Support Device) is 33 (Android 13).
+  const val targetSdk = 34 // Target SDK (Maximum Support Device) is 34 (Android 14).
 
   val javaVersion = JavaVersion.VERSION_1_8
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -145,23 +145,6 @@ object Libs {
     Versions.com_google_dagger
 
   /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife: String = "com.jakewharton:butterknife:" + Versions.com_jakewharton
-
-  /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife_compiler: String = "com.jakewharton:butterknife-compiler:" +
-    Versions.com_jakewharton
-
-  /**
-   * https://github.com/JakeWharton/butterknife/
-   */
-  const val butterknife_gradle_plugin: String = "com.jakewharton:butterknife-gradle-plugin:" +
-    Versions.com_jakewharton
-
-  /**
    * https://developer.android.com/testing
    */
   const val androidx_test_core: String = "androidx.test:core:" + Versions.androidx_test_core

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -44,7 +44,7 @@ object Versions {
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
-  const val com_android_tools_build_gradle: String = "7.4.2"
+  const val com_android_tools_build_gradle: String = "8.1.3"
 
   const val de_fayard_buildsrcversions_gradle_plugin: String = "0.7.0"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -38,7 +38,7 @@ object Versions {
 
   const val io_objectbox: String = "3.5.0"
 
-  const val io_mockk: String = "1.13.12"
+  const val io_mockk: String = "1.13.7"
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -96,7 +96,7 @@ object Versions {
 
   const val rxjava: String = "2.2.21"
 
-  const val webkit: String = "1.7.0"
+  const val webkit: String = "1.11.0"
 
   const val junit: String = "1.1.5"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,13 +22,13 @@ object Versions {
 
   const val com_squareup_okhttp3: String = "4.10.0"
 
-  const val org_jetbrains_kotlin: String = "1.7.0"
+  const val org_jetbrains_kotlin: String = "1.9.20"
 
   const val androidx_navigation: String = "2.5.3"
 
   const val navigation_ui_ktx: String = "2.4.1"
 
-  const val com_google_dagger: String = "2.42"
+  const val com_google_dagger: String = "2.48.1"
 
   const val com_jakewharton: String = "10.2.3"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -14,7 +14,7 @@ object Versions {
 
   const val document_file_version: String = "1.0.1"
 
-  const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.7.3"
+  const val org_jetbrains_kotlinx_kotlinx_coroutines: String = "1.8.1"
 
   const val androidx_test_espresso: String = "3.5.1"
 
@@ -30,17 +30,15 @@ object Versions {
 
   const val com_google_dagger: String = "2.48.1"
 
-  const val com_jakewharton: String = "10.2.3"
+  const val androidx_test: String = "1.6.1"
 
-  const val androidx_test: String = "1.5.2"
+  const val androidx_test_core: String = "1.6.1"
 
-  const val androidx_test_core: String = "1.5.0"
-
-  const val androidx_test_orchestrator: String = "1.4.1"
+  const val androidx_test_orchestrator: String = "1.5.0"
 
   const val io_objectbox: String = "3.5.0"
 
-  const val io_mockk: String = "1.13.7"
+  const val io_mockk: String = "1.13.12"
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
@@ -62,9 +60,9 @@ object Versions {
 
   const val preference_ktx: String = "1.2.0"
 
-  const val junit_jupiter: String = "5.10.2"
+  const val junit_jupiter: String = "5.11.0"
 
-  const val assertj_core: String = "3.25.3"
+  const val assertj_core: String = "3.26.3"
 
   const val core_testing: String = "2.2.0"
 
@@ -74,13 +72,13 @@ object Versions {
 
   const val threetenabp: String = "1.3.0"
 
-  const val uiautomator: String = "2.3.0-alpha03"
+  const val uiautomator: String = "2.3.0"
 
-  const val annotation: String = "1.2.0"
+  const val annotation: String = "1.6.0"
 
   const val simple_xml: String = "2.7.1"
 
-  const val appcompat: String = "1.6.1"
+  const val appcompat: String = "1.7.0"
 
   const val rxandroid: String = "2.1.1"
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -45,6 +45,7 @@ class AllProjectConfigurer {
 
   fun configureBaseExtension(target: Project) {
     target.configureExtension<BaseExtension> {
+      namespace = ""
       setCompileSdkVersion(Config.compileSdk)
       defaultConfig {
         minSdk = Config.minSdk
@@ -115,7 +116,7 @@ class AllProjectConfigurer {
   }
 
   fun configureCommonExtension(target: Project) {
-    target.configureExtension<CommonExtension<*, *, *, *>> {
+    target.configureExtension<CommonExtension<*, *, *, *, *>> {
       lint {
         abortOnError = true
         checkAllWarnings = true

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -68,7 +68,15 @@ class AllProjectConfigurer {
       target.tasks.withType(KotlinCompile::class.java) {
         kotlinOptions.jvmTarget = "1.8"
       }
-      buildFeatures.viewBinding = true
+      buildFeatures.apply {
+        viewBinding = true
+        /*
+         * By default, the generation of the `BuildConfig` class is turned off in Gradle `8.1.3`.
+         * Since we are setting and using `buildConfig` properties in our project,
+         * enabling this attribute will generate the `BuildConfig` file.
+         */
+        buildConfig = true
+      }
 
       testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -43,9 +43,18 @@ class AllProjectConfigurer {
     target.plugins.apply("androidx.navigation.safeargs")
   }
 
-  fun configureBaseExtension(target: Project) {
+  fun configureBaseExtension(target: Project, isLibrary: Boolean) {
     target.configureExtension<BaseExtension> {
-      namespace = ""
+      // The namespace cannot be directly set in `LibraryExtension`.
+      // The core module is configured as a library for both Kiwix and custom apps.
+      // Therefore, we set the namespace in `BaseExtension` for the core module,
+      // based on the boolean value of `isLibrary`. This value is passed from the
+      // `KiwixConfigurationPlugin`. If the current plugin is `LibraryPlugin`,
+      // indicating it is the core module, then this value will be true,
+      // and we set the namespace accordingly.
+      if (isLibrary) {
+        namespace = "org.kiwix.kiwixmobile.core"
+      }
       setCompileSdkVersion(Config.compileSdk)
       defaultConfig {
         minSdk = Config.minSdk

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -217,8 +217,6 @@ class AllProjectConfigurer {
       implementation(Libs.core_ktx)
       implementation(Libs.fragment_ktx)
       implementation(Libs.collection_ktx)
-      implementation(Libs.butterknife)
-      kapt(Libs.butterknife_compiler)
       implementation(Libs.rxandroid)
       implementation(Libs.rxjava)
       implementation(Libs.preference_ktx)

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -64,7 +64,7 @@ class AllProjectConfigurer {
 
       buildTypes {
         getByName("debug") {
-          isTestCoverageEnabled = false
+          isTestCoverageEnabled = true
           multiDexEnabled = true
         }
       }

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -64,7 +64,7 @@ class AllProjectConfigurer {
 
       buildTypes {
         getByName("debug") {
-          isTestCoverageEnabled = true
+          isTestCoverageEnabled = false
           multiDexEnabled = true
         }
       }
@@ -165,7 +165,7 @@ class AllProjectConfigurer {
       resolutionStrategy {
         eachDependency {
           if ("org.jacoco" == this.requested.group) {
-            useVersion("0.8.8")
+            useVersion("0.8.12")
           }
         }
       }

--- a/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/KiwixConfigurationPlugin.kt
@@ -33,10 +33,10 @@ class KiwixConfigurationPlugin : Plugin<Project> {
     target.plugins.all {
       when (this) {
         is LibraryPlugin -> {
-          doDefaultConfiguration(target)
+          doDefaultConfiguration(target, true)
         }
         is AppPlugin -> {
-          doDefaultConfiguration(target)
+          doDefaultConfiguration(target, false)
           appConfigurer.configure(target)
         }
       }
@@ -47,8 +47,8 @@ class KiwixConfigurationPlugin : Plugin<Project> {
     allProjectConfigurer.configureJacoco(target)
   }
 
-  private fun doDefaultConfiguration(target: Project) {
-    allProjectConfigurer.configureBaseExtension(target)
+  private fun doDefaultConfiguration(target: Project, isLibrary: Boolean) {
+    allProjectConfigurer.configureBaseExtension(target, isLibrary)
     allProjectConfigurer.configureCommonExtension(target)
   }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,7 +9,6 @@ buildscript {
 
   dependencies {
     classpath(Libs.objectbox_gradle_plugin)
-    classpath(Libs.butterknife_gradle_plugin)
   }
 }
 plugins {
@@ -17,7 +16,6 @@ plugins {
 }
 plugins.apply(KiwixConfigurationPlugin::class)
 apply(plugin = "io.objectbox")
-apply(plugin = "com.jakewharton.butterknife")
 
 android {
   defaultConfig {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -36,10 +36,7 @@ dependencies {
 
   // Get kiwixlib online if it is not populated locally
   if (!shouldUseLocalVersion()) {
-    api(Libs.libkiwix) {
-      // TODO Should be removed after we upgrade to the SDK 34
-      exclude("org.jetbrains.kotlin", "kotlin-stdlib")
-    }
+    api(Libs.libkiwix)
   } else {
     implementation("com.getkeepsafe.relinker:relinker:1.4.5")
     api(fileTree(mapOf("include" to "*.aar", "dir" to "libs")))

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile.core"
   android:installLocation="auto">
 
   <uses-permission

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
@@ -18,10 +18,7 @@
 package org.kiwix.kiwixmobile.core.base
 
 import android.os.Bundle
-import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
-import butterknife.ButterKnife
-import butterknife.Unbinder
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import javax.inject.Inject
@@ -31,20 +28,8 @@ open class BaseActivity : AppCompatActivity() {
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
-  private var unbinder: Unbinder? = null
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     LanguageUtils.handleLocaleChange(this, sharedPreferenceUtil)
-  }
-
-  override fun setContentView(@LayoutRes layoutResID: Int) {
-    super.setContentView(layoutResID)
-    unbinder = ButterKnife.bind(this)
-  }
-
-  override fun onDestroy() {
-    super.onDestroy()
-    unbinder?.unbind()
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.downloader
 
 import android.annotation.SuppressLint
 import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
 import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity
@@ -38,6 +39,7 @@ class DownloaderImpl @Inject constructor(
   override fun download(book: LibraryNetworkEntity.Book) {
     urlProvider(book)
       .take(1)
+      .subscribeOn(Schedulers.io())
       .subscribe(
         {
           downloadRoomDao.addIfDoesNotExist(it, book, downloadRequester, sharedPreferenceUtil)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/SearchViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/SearchViewExtensions.kt
@@ -34,12 +34,12 @@ fun SearchView.setUpSearchView(context: Context) {
     R.dimen.material_minimum_height_and_width
   )
   val searchViewEditText =
-    findViewById<SearchView.SearchAutoComplete>(R.id.search_src_text) as EditText
-  val closeImageButton = findViewById<ImageView>(R.id.search_close_btn)
+    findViewById<SearchView.SearchAutoComplete>(androidx.appcompat.R.id.search_src_text) as EditText
+  val closeImageButton = findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
   // set the tooltip on close button to show the description if user long clicks on it.
   TooltipCompat.setTooltipText(
     closeImageButton,
-    context.getString(R.string.abc_searchview_description_clear)
+    context.getString(androidx.appcompat.R.string.abc_searchview_description_clear)
   )
   // override the default width of close image button.
   // by default it is 40dp, and the default accessibility width is 48dp

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -95,6 +95,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   abstract val topLevelDestinations: Set<Int>
   abstract val navHostContainer: FragmentContainerView
   abstract val mainActivity: AppCompatActivity
+  abstract val appName: String
   @Inject lateinit var objectBoxToLibkiwixMigrator: ObjectBoxToLibkiwixMigrator
   @Inject lateinit var objectBoxToRoomMigrator: ObjectBoxToRoomMigrator
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -291,7 +291,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
       return
     }
     if (activeFragments().filterIsInstance<FragmentActivityExtensions>().isEmpty()) {
-      return super.getOnBackPressedDispatcher().onBackPressed()
+      return super.onBackPressedDispatcher.onBackPressed()
     }
     activeFragments().filterIsInstance<FragmentActivityExtensions>().forEach {
       if (it.onBackPressed(this) == FragmentActivityExtensions.Super.ShouldCall) {
@@ -302,7 +302,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
           drawerToggle = null
           finish()
         } else {
-          super.getOnBackPressedDispatcher().onBackPressed()
+          super.onBackPressedDispatcher.onBackPressed()
         }
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -180,46 +180,26 @@ abstract class CoreReaderFragment :
   private val webUrlsProcessor = BehaviorProcessor.create<String>()
   private var fragmentReaderBinding: FragmentReaderBinding? = null
 
-  val toolbar: Toolbar? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.toolbar)
-  }
-  val toolbarContainer: AppBarLayout? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.fragment_main_app_bar)
-  }
-  val progressBar: ContentLoadingProgressBar? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.main_fragment_progress_view)
-  }
+  var toolbar: Toolbar? = null
+  var toolbarContainer: AppBarLayout? = null
+  var progressBar: ContentLoadingProgressBar? = null
 
   var drawerLayout: DrawerLayout? = null
   protected var tableDrawerRightContainer: NavigationView? = null
 
-  val contentFrame: FrameLayout? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_content_frame)
-  }
+  var contentFrame: FrameLayout? = null
 
-  val bottomToolbar: BottomAppBar? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar)
-  }
+  var bottomToolbar: BottomAppBar? = null
 
-  val tabSwitcherRoot: View? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tab_switcher)
-  }
+  var tabSwitcherRoot: View? = null
 
-  val closeAllTabsButton: FloatingActionButton? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_close_all_tabs)
-  }
+  var closeAllTabsButton: FloatingActionButton? = null
 
-  val videoView: ViewGroup? by lazy {
-    fragmentReaderBinding?.fullscreenVideoContainer
-  }
+  var videoView: ViewGroup? = null
 
-  val noOpenBookButton: Button? by lazy {
-    fragmentReaderBinding?.goToLibraryButtonNoOpenBook
-  }
+  var noOpenBookButton: Button? = null
 
-  val activityMainRoot: View? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_root)
-  }
+  var activityMainRoot: View? = null
 
   @JvmField
   @Inject
@@ -253,61 +233,32 @@ abstract class CoreReaderFragment :
   protected var actionBar: ActionBar? = null
   protected var mainMenu: MainMenu? = null
 
-  val toolbarWithSearchPlaceholder: ConstraintLayout? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.toolbarWithSearchPlaceholder)
-  }
+  var toolbarWithSearchPlaceholder: ConstraintLayout? = null
 
-  val backToTopButton: FloatingActionButton? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_back_to_top_fab)
-  }
+  var backToTopButton: FloatingActionButton? = null
 
-  private val stopTTSButton: Button? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_stop_tts)
-  }
+  private var stopTTSButton: Button? = null
 
-  val pauseTTSButton: Button? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_pause_tts)
-  }
+  var pauseTTSButton: Button? = null
 
-  val ttsControls: Group? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tts_controls)
-  }
+  var ttsControls: Group? = null
 
-  private val exitFullscreenButton: ImageButton? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_fullscreen_button)
-  }
+  private var exitFullscreenButton: ImageButton? = null
 
-  private val bottomToolbarBookmark: ImageView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_bookmark)
-  }
+  private var bottomToolbarBookmark: ImageView? = null
 
-  private val bottomToolbarArrowBack: ImageView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_back)
-  }
+  private var bottomToolbarArrowBack: ImageView? = null
 
-  private val bottomToolbarArrowForward: ImageView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_forward)
-  }
+  private var bottomToolbarArrowForward: ImageView? = null
 
-  private val bottomToolbarHome: ImageView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_home)
-  }
+  private var bottomToolbarHome: ImageView? = null
 
-  private val tabRecyclerView: RecyclerView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_recycler_view)
-  }
+  private var tabRecyclerView: RecyclerView? = null
 
-  private val snackBarRoot: CoordinatorLayout? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.snackbar_root)
-  }
+  private var snackBarRoot: CoordinatorLayout? = null
 
-  private val noOpenBookText: TextView? by lazy {
-    fragmentReaderBinding?.noOpenBookText
-  }
-
-  private val bottomToolbarToc: ImageView? by lazy {
-    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_toc)
-  }
+  private var noOpenBookText: TextView? = null
+  private var bottomToolbarToc: ImageView? = null
 
   private var isFirstTimeMainPageLoaded = true
 
@@ -440,6 +391,7 @@ abstract class CoreReaderFragment :
     activity?.let {
       WebView(it).destroy() // Workaround for buggy webViews see #710
     }
+    prepareViews()
     handleLocaleCheck()
     activity?.setSupportActionBar(toolbar)
     actionBar = activity?.supportActionBar
@@ -528,6 +480,37 @@ abstract class CoreReaderFragment :
       Observer(::openSearchItem)
     )
     handleClicks()
+  }
+
+  private fun prepareViews() {
+    fragmentReaderBinding?.let { readerBinding ->
+      videoView = readerBinding.fullscreenVideoContainer
+      noOpenBookButton = readerBinding.goToLibraryButtonNoOpenBook
+      noOpenBookText = readerBinding.noOpenBookText
+      with(readerBinding.root) {
+        activityMainRoot = findViewById(R.id.activity_main_root)
+        contentFrame = findViewById(R.id.activity_main_content_frame)
+        toolbar = findViewById(R.id.toolbar)
+        toolbarContainer = findViewById(R.id.fragment_main_app_bar)
+        progressBar = findViewById(R.id.main_fragment_progress_view)
+        bottomToolbar = findViewById(R.id.bottom_toolbar)
+        tabSwitcherRoot = findViewById(R.id.activity_main_tab_switcher)
+        closeAllTabsButton = findViewById(R.id.tab_switcher_close_all_tabs)
+        toolbarWithSearchPlaceholder = findViewById(R.id.toolbarWithSearchPlaceholder)
+        backToTopButton = findViewById(R.id.activity_main_back_to_top_fab)
+        stopTTSButton = findViewById(R.id.activity_main_button_stop_tts)
+        pauseTTSButton = findViewById(R.id.activity_main_button_pause_tts)
+        ttsControls = findViewById(R.id.activity_main_tts_controls)
+        exitFullscreenButton = findViewById(R.id.activity_main_fullscreen_button)
+        bottomToolbarBookmark = findViewById(R.id.bottom_toolbar_bookmark)
+        bottomToolbarArrowBack = findViewById(R.id.bottom_toolbar_arrow_back)
+        bottomToolbarArrowForward = findViewById(R.id.bottom_toolbar_arrow_forward)
+        bottomToolbarHome = findViewById(R.id.bottom_toolbar_home)
+        tabRecyclerView = findViewById(R.id.tab_switcher_recycler_view)
+        snackBarRoot = findViewById(R.id.snackbar_root)
+        bottomToolbarToc = findViewById(R.id.bottom_toolbar_toc)
+      }
+    }
   }
 
   private fun handleClicks() {
@@ -1198,6 +1181,7 @@ abstract class CoreReaderFragment :
     }
     repositoryActions?.dispose()
     safeDispose()
+    unBindViewsAndBinding()
     tabCallback = null
     hideBackToTopTimer?.cancel()
     hideBackToTopTimer = null
@@ -1207,6 +1191,7 @@ abstract class CoreReaderFragment :
     tabRecyclerView?.adapter = null
     tableDrawerRight?.adapter = null
     tableDrawerAdapter = null
+    tabsAdapter = null
     webViewList.clear()
     tempWebViewListForUndo.clear()
     // create a base Activity class that class this.
@@ -1226,6 +1211,35 @@ abstract class CoreReaderFragment :
     unRegisterReadAloudService()
     storagePermissionForNotesLauncher?.unregister()
     storagePermissionForNotesLauncher = null
+  }
+
+  private fun unBindViewsAndBinding() {
+    activityMainRoot = null
+    noOpenBookButton = null
+    toolbarWithSearchPlaceholder = null
+    backToTopButton = null
+    stopTTSButton = null
+    pauseTTSButton = null
+    ttsControls = null
+    exitFullscreenButton = null
+    bottomToolbarBookmark = null
+    bottomToolbarArrowBack = null
+    bottomToolbarArrowForward = null
+    bottomToolbarHome = null
+    tabRecyclerView = null
+    snackBarRoot = null
+    noOpenBookText = null
+    bottomToolbarToc = null
+    bottomToolbar = null
+    tabSwitcherRoot = null
+    videoView = null
+    contentFrame = null
+    toolbarContainer = null
+    toolbar = null
+    progressBar = null
+    drawerLayout = null
+    closeAllTabsButton = null
+    tableDrawerRightContainer = null
     fragmentReaderBinding = null
   }
 
@@ -1741,7 +1755,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun closeAllTabs() {
+  private fun closeAllTabs() {
     onReadAloudStop()
     closeAllTabsButton?.apply {
       rotate()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1080,7 +1080,7 @@ abstract class CoreReaderFragment :
   }
 
   private fun getValidTitle(zimFileTitle: String?): String =
-    if (isAdded && isInvalidTitle(zimFileTitle)) getString(R.string.app_name)
+    if (isAdded && isInvalidTitle(zimFileTitle)) (requireActivity() as CoreMainActivity).appName
     else zimFileTitle.toString()
 
   private fun isInvalidTitle(zimFileTitle: String?): Boolean =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -81,11 +81,6 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnClick
-import butterknife.OnLongClick
-import butterknife.Unbinder
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.bottomappbar.BottomAppBar
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -100,11 +95,11 @@ import org.json.JSONException
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.DarkModeConfig
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.R2
 import org.kiwix.kiwixmobile.core.StorageObserver
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
+import org.kiwix.kiwixmobile.core.databinding.FragmentReaderBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.consumeObservable
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
@@ -183,55 +178,50 @@ abstract class CoreReaderFragment :
   NavigationHistoryClickListener {
   protected val webViewList: MutableList<KiwixWebView> = ArrayList()
   private val webUrlsProcessor = BehaviorProcessor.create<String>()
+  private var fragmentReaderBinding: FragmentReaderBinding? = null
 
-  @JvmField
-  @BindView(R2.id.toolbar)
-  var toolbar: Toolbar? = null
+  val toolbar: Toolbar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.toolbar)
+  }
+  val toolbarContainer: AppBarLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.fragment_main_app_bar)
+  }
+  val progressBar: ContentLoadingProgressBar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.main_fragment_progress_view)
+  }
 
-  @JvmField
-  @BindView(R2.id.toolbarWithSearchPlaceholder)
-  var toolbarWithSearchPlaceholder: ConstraintLayout? = null
-
-  @JvmField
-  @BindView(R2.id.fragment_main_app_bar)
-  var toolbarContainer: AppBarLayout? = null
-
-  @JvmField
-  @BindView(R2.id.main_fragment_progress_view)
-  var progressBar: ContentLoadingProgressBar? = null
-
-  @JvmField
-  @BindView(R2.id.navigation_fragment_main_drawer_layout)
-  var drawerLayout: DrawerLayout? = null
+  val drawerLayout: DrawerLayout? by lazy {
+    fragmentReaderBinding?.navigationFragmentMainDrawerLayout
+  }
   protected var tableDrawerRightContainer: NavigationView? = null
 
-  @JvmField
-  @BindView(R2.id.activity_main_content_frame)
-  var contentFrame: FrameLayout? = null
+  val contentFrame: FrameLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_content_frame)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar)
-  var bottomToolbar: BottomAppBar? = null
+  val bottomToolbar: BottomAppBar? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_tab_switcher)
-  var tabSwitcherRoot: View? = null
+  val tabSwitcherRoot: View? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tab_switcher)
+  }
 
-  @JvmField
-  @BindView(R2.id.tab_switcher_close_all_tabs)
-  var closeAllTabsButton: FloatingActionButton? = null
+  val closeAllTabsButton: FloatingActionButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_close_all_tabs)
+  }
 
-  @JvmField
-  @BindView(R2.id.fullscreen_video_container)
-  var videoView: ViewGroup? = null
+  val videoView: ViewGroup? by lazy {
+    fragmentReaderBinding?.fullscreenVideoContainer
+  }
 
-  @JvmField
-  @BindView(R2.id.go_to_library_button_no_open_book)
-  var noOpenBookButton: Button? = null
+  val noOpenBookButton: Button? by lazy {
+    fragmentReaderBinding?.goToLibraryButtonNoOpenBook
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_root)
-  var activityMainRoot: View? = null
+  val activityMainRoot: View? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_root)
+  }
 
   @JvmField
   @Inject
@@ -265,49 +255,61 @@ abstract class CoreReaderFragment :
   protected var actionBar: ActionBar? = null
   protected var mainMenu: MainMenu? = null
 
-  @JvmField
-  @BindView(R2.id.activity_main_back_to_top_fab)
-  var backToTopButton: FloatingActionButton? = null
+  val toolbarWithSearchPlaceholder: ConstraintLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.toolbarWithSearchPlaceholder)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_button_stop_tts)
-  var stopTTSButton: Button? = null
+  val backToTopButton: FloatingActionButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_back_to_top_fab)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_button_pause_tts)
-  var pauseTTSButton: Button? = null
+  private val stopTTSButton: Button? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_stop_tts)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_tts_controls)
-  var ttsControls: Group? = null
+  val pauseTTSButton: Button? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_button_pause_tts)
+  }
 
-  @JvmField
-  @BindView(R2.id.activity_main_fullscreen_button)
-  var exitFullscreenButton: ImageButton? = null
+  val ttsControls: Group? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_tts_controls)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_bookmark)
-  var bottomToolbarBookmark: ImageView? = null
+  private val exitFullscreenButton: ImageButton? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.activity_main_fullscreen_button)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_arrow_back)
-  var bottomToolbarArrowBack: ImageView? = null
+  private val bottomToolbarBookmark: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_bookmark)
+  }
 
-  @JvmField
-  @BindView(R2.id.bottom_toolbar_arrow_forward)
-  var bottomToolbarArrowForward: ImageView? = null
+  private val bottomToolbarArrowBack: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_back)
+  }
 
-  @JvmField
-  @BindView(R2.id.tab_switcher_recycler_view)
-  var tabRecyclerView: RecyclerView? = null
+  private val bottomToolbarArrowForward: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_arrow_forward)
+  }
 
-  @JvmField
-  @BindView(R2.id.snackbar_root)
-  var snackBarRoot: CoordinatorLayout? = null
+  private val bottomToolbarHome: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_home)
+  }
 
-  @JvmField
-  @BindView(R2.id.no_open_book_text)
-  var noOpenBookText: TextView? = null
+  private val tabRecyclerView: RecyclerView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.tab_switcher_recycler_view)
+  }
+
+  private val snackBarRoot: CoordinatorLayout? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.snackbar_root)
+  }
+
+  private val noOpenBookText: TextView? by lazy {
+    fragmentReaderBinding?.noOpenBookText
+  }
+
+  private val bottomToolbarToc: ImageView? by lazy {
+    fragmentReaderBinding?.root?.findViewById(R.id.bottom_toolbar_toc)
+  }
 
   private var isFirstTimeMainPageLoaded = true
 
@@ -346,7 +348,6 @@ abstract class CoreReaderFragment :
   private var tabCallback: ItemTouchHelper.Callback? = null
   private var bookmarkingDisposable: Disposable? = null
   private var isBookmarked = false
-  private var unbinder: Unbinder? = null
   private lateinit var serviceConnection: ServiceConnection
   private var readAloudService: ReadAloudService? = null
   private var navigationHistoryList: MutableList<NavigationHistoryListItem> = ArrayList()
@@ -531,6 +532,53 @@ abstract class CoreReaderFragment :
     toolbarWithSearchPlaceholder?.setOnClickListener {
       openSearch(searchString = "", isOpenedFromTabView = false, false)
     }
+    backToTopButton?.setOnClickListener {
+      backToTop()
+    }
+    stopTTSButton?.setOnClickListener {
+      stopTts()
+    }
+    pauseTTSButton?.setOnClickListener {
+      pauseTts()
+    }
+    exitFullscreenButton?.setOnClickListener {
+      closeFullScreen()
+    }
+    bottomToolbarBookmark?.apply {
+      setOnClickListener {
+        toggleBookmark()
+      }
+      setOnLongClickListener {
+        goToBookmarks()
+      }
+    }
+    bottomToolbarArrowBack?.apply {
+      setOnClickListener {
+        goBack()
+      }
+      setOnLongClickListener {
+        showBackwardHistory()
+        true
+      }
+    }
+    bottomToolbarArrowForward?.apply {
+      setOnClickListener {
+        goForward()
+      }
+      setOnLongClickListener {
+        showForwardHistory()
+        true
+      }
+    }
+    bottomToolbarToc?.setOnClickListener {
+      openToc()
+    }
+    closeAllTabsButton?.setOnClickListener {
+      closeAllTabs()
+    }
+    bottomToolbarHome?.setOnClickListener {
+      openMainPage()
+    }
   }
 
   private fun initTabCallback() {
@@ -590,9 +638,8 @@ abstract class CoreReaderFragment :
     container: ViewGroup?,
     savedInstanceState: Bundle?
   ): View? {
-    val root = inflater.inflate(R.layout.fragment_reader, container, false)
-    unbinder = ButterKnife.bind(this, root)
-    return root
+    fragmentReaderBinding = FragmentReaderBinding.inflate(inflater, container, false)
+    return fragmentReaderBinding?.root
   }
 
   private fun handleIntentExtras(intent: Intent) {
@@ -840,19 +887,18 @@ abstract class CoreReaderFragment :
     drawerLayout?.setDrawerLockMode(lockMode)
   }
 
-  @OnClick(R2.id.bottom_toolbar_arrow_back) fun goBack() {
+  fun goBack() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.goBack()
     }
   }
 
-  @OnClick(R2.id.bottom_toolbar_arrow_forward) fun goForward() {
+  fun goForward() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.goForward()
     }
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_arrow_back)
   fun showBackwardHistory() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
@@ -868,7 +914,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_arrow_forward)
   fun showForwardHistory() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
@@ -945,7 +990,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.bottom_toolbar_toc)
   fun openToc() {
     drawerLayout?.openDrawer(GravityCompat.END)
   }
@@ -1112,7 +1156,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_button_pause_tts)
   fun pauseTts() {
     if (tts?.currentTTSTask == null) {
       tts?.stop()
@@ -1132,7 +1175,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_button_stop_tts)
   fun stopTts() {
     tts?.stop()
     setActionAndStartTTSService(ACTION_STOP_TTS)
@@ -1163,7 +1205,6 @@ abstract class CoreReaderFragment :
     tabRecyclerView?.adapter = null
     tableDrawerRight?.adapter = null
     tableDrawerAdapter = null
-    unbinder?.unbind()
     webViewList.clear()
     tempWebViewListForUndo.clear()
     // create a base Activity class that class this.
@@ -1514,7 +1555,6 @@ abstract class CoreReaderFragment :
     return isPermissionGranted
   }
 
-  @OnLongClick(R2.id.bottom_toolbar_bookmark)
   fun goToBookmarks(): Boolean {
     val parentActivity = requireActivity() as CoreMainActivity
     parentActivity.navigate(parentActivity.bookmarksFragmentResId)
@@ -1541,7 +1581,6 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("MagicNumber")
-  @OnClick(R2.id.activity_main_fullscreen_button)
   open fun closeFullScreen() {
     sharedPreferenceUtil?.putPrefFullScreen(false)
     toolbarContainer?.visibility = View.VISIBLE
@@ -1699,7 +1738,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.tab_switcher_close_all_tabs)
   fun closeAllTabs() {
     onReadAloudStop()
     closeAllTabsButton?.apply {
@@ -1769,7 +1807,6 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("NestedBlockDepth")
-  @OnClick(R2.id.bottom_toolbar_bookmark)
   fun toggleBookmark() {
     try {
       getCurrentWebView()?.url?.let { articleUrl ->
@@ -1971,7 +2008,6 @@ abstract class CoreReaderFragment :
     openArticle(articleUrl)
   }
 
-  @OnClick(R2.id.bottom_toolbar_home)
   fun openMainPage() {
     val articleUrl = zimReaderContainer?.mainPage
     openArticle(articleUrl)
@@ -1983,7 +2019,6 @@ abstract class CoreReaderFragment :
     }
   }
 
-  @OnClick(R2.id.activity_main_back_to_top_fab)
   fun backToTop() {
     getCurrentWebView()?.pageUp(true)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -889,19 +889,19 @@ abstract class CoreReaderFragment :
     drawerLayout?.setDrawerLockMode(lockMode)
   }
 
-  fun goBack() {
+  private fun goBack() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.goBack()
     }
   }
 
-  fun goForward() {
+  private fun goForward() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.goForward()
     }
   }
 
-  fun showBackwardHistory() {
+  private fun showBackwardHistory() {
     if (getCurrentWebView()?.canGoBack() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
         navigationHistoryList.clear()
@@ -916,7 +916,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun showForwardHistory() {
+  private fun showForwardHistory() {
     if (getCurrentWebView()?.canGoForward() == true) {
       getCurrentWebView()?.copyBackForwardList()?.let { historyList ->
         navigationHistoryList.clear()
@@ -992,7 +992,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun openToc() {
+  private fun openToc() {
     drawerLayout?.openDrawer(GravityCompat.END)
   }
 
@@ -1158,7 +1158,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun pauseTts() {
+  private fun pauseTts() {
     if (tts?.currentTTSTask == null) {
       tts?.stop()
       setActionAndStartTTSService(ACTION_STOP_TTS)
@@ -1177,7 +1177,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun stopTts() {
+  private fun stopTts() {
     tts?.stop()
     setActionAndStartTTSService(ACTION_STOP_TTS)
   }
@@ -1226,6 +1226,7 @@ abstract class CoreReaderFragment :
     unRegisterReadAloudService()
     storagePermissionForNotesLauncher?.unregister()
     storagePermissionForNotesLauncher = null
+    fragmentReaderBinding = null
   }
 
   private fun updateTableOfContents() {
@@ -1557,7 +1558,7 @@ abstract class CoreReaderFragment :
     return isPermissionGranted
   }
 
-  fun goToBookmarks(): Boolean {
+  private fun goToBookmarks(): Boolean {
     val parentActivity = requireActivity() as CoreMainActivity
     parentActivity.navigate(parentActivity.bookmarksFragmentResId)
     return true
@@ -1809,7 +1810,7 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("NestedBlockDepth")
-  fun toggleBookmark() {
+  private fun toggleBookmark() {
     try {
       getCurrentWebView()?.url?.let { articleUrl ->
         zimReaderContainer?.zimFileReader?.let { zimFileReader ->
@@ -2010,7 +2011,7 @@ abstract class CoreReaderFragment :
     openArticle(articleUrl)
   }
 
-  fun openMainPage() {
+  private fun openMainPage() {
     val articleUrl = zimReaderContainer?.mainPage
     openArticle(articleUrl)
   }
@@ -2021,7 +2022,7 @@ abstract class CoreReaderFragment :
     }
   }
 
-  fun backToTop() {
+  private fun backToTop() {
     getCurrentWebView()?.pageUp(true)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -529,6 +529,10 @@ abstract class CoreReaderFragment :
       viewLifecycleOwner,
       Observer(::openSearchItem)
     )
+    handleClicks()
+  }
+
+  private fun handleClicks() {
     toolbarWithSearchPlaceholder?.setOnClickListener {
       openSearch(searchString = "", isOpenedFromTabView = false, false)
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -190,9 +190,7 @@ abstract class CoreReaderFragment :
     fragmentReaderBinding?.root?.findViewById(R.id.main_fragment_progress_view)
   }
 
-  val drawerLayout: DrawerLayout? by lazy {
-    fragmentReaderBinding?.navigationFragmentMainDrawerLayout
-  }
+  var drawerLayout: DrawerLayout? = null
   protected var tableDrawerRightContainer: NavigationView? = null
 
   val contentFrame: FrameLayout? by lazy {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
@@ -35,7 +35,7 @@ abstract class CoreSearchWidget : AppWidgetProvider() {
     appWidgetManager: AppWidgetManager,
     appWidgetIds: IntArray
   ) {
-    val appName = context.getString(R.string.app_name)
+    val appName = (activityKClass as CoreMainActivity).appName
     appWidgetIds.forEach { appWidgetId ->
       val views = RemoteViews(context.packageName, R.layout.kiwix_search_widget)
       views.setTextViewText(R.id.search_widget_text, "Search $appName")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -52,7 +52,7 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
   context: Context,
   private val callback: WebViewCallback,
   attrs: AttributeSet,
-  nonVideoView: ViewGroup,
+  private var nonVideoView: ViewGroup?,
   videoView: ViewGroup,
   private val webViewClient: CoreWebViewClient,
   val sharedPreferenceUtil: SharedPreferenceUtil
@@ -146,6 +146,7 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    nonVideoView = null
     compositeDisposable.clear()
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
@@ -51,6 +51,9 @@ open class OnSwipeTouchListener constructor(context: Context) : OnTouchListener 
       return super.onSingleTapUp(event)
     }
 
+    // See:- https://stackoverflow.com/questions/73463685/gesturedetector-ongesturelistener-overridden-methods-are-not-working-in-android
+    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE")
+    @SuppressLint("NestedBlockDepth, ReturnCount")
     override fun onFling(
       e1: MotionEvent,
       e2: MotionEvent,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/OnSwipeTouchListener.kt
@@ -52,8 +52,7 @@ open class OnSwipeTouchListener constructor(context: Context) : OnTouchListener 
     }
 
     // See:- https://stackoverflow.com/questions/73463685/gesturedetector-ongesturelistener-overridden-methods-are-not-working-in-android
-    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE")
-    @SuppressLint("NestedBlockDepth, ReturnCount")
+    @Suppress("NOTHING_TO_OVERRIDE", "ACCIDENTAL_OVERRIDE", "NestedBlockDepth", "ReturnCount")
     override fun onFling(
       e1: MotionEvent,
       e2: MotionEvent,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/TabsAdapter.kt
@@ -36,6 +36,7 @@ import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
 import org.kiwix.kiwixmobile.core.R
+import com.google.android.material.R.attr
 import org.kiwix.kiwixmobile.core.extensions.getAttribute
 import org.kiwix.kiwixmobile.core.extensions.setImageDrawableCompat
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
@@ -73,7 +74,7 @@ class TabsAdapter internal constructor(
         val outValue = TypedValue()
         context.theme.resolveAttribute(android.R.attr.actionBarItemBackground, outValue, true)
         setBackgroundResource(outValue.resourceId)
-        tint(context.getAttribute(R.attr.colorOnSurface))
+        tint(context.getAttribute(attr.colorOnSurface))
       }
     val cardView = MaterialCardView(context)
       .apply {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -220,6 +220,7 @@ class ZimFileReader constructor(
       null
     }
 
+  @Suppress("UnreachableCode")
   suspend fun load(uri: String): InputStream? = withContext(Dispatchers.IO) {
     val extension = uri.substringAfterLast(".")
     if (assetExtensions.any { it == extension }) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInput.kt
@@ -25,6 +25,7 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.channels.Channel
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.StartSpeechInputFailed
 import java.util.Locale
@@ -41,7 +42,7 @@ data class StartSpeechInput(private val actions: Channel<Action>) : SideEffect<U
           putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
           putExtra(
             RecognizerIntent.EXTRA_PROMPT,
-            activity.getString(R.string.speech_prompt_text, activity.getString(R.string.app_name))
+            activity.getString(R.string.speech_prompt_text, (activity as CoreMainActivity).appName)
           )
         },
         REQ_CODE_SPEECH_INPUT

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -230,7 +230,7 @@ abstract class CorePrefsFragment :
       throw RuntimeException(e)
     }
 
-  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+  override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
     if (key == SharedPreferenceUtil.PREF_DARK_MODE) {
       sharedPreferenceUtil?.updateDarkMode()
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NestedCoordinatorLayout.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NestedCoordinatorLayout.kt
@@ -26,7 +26,7 @@ import androidx.annotation.AttrRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
-import org.kiwix.kiwixmobile.core.R
+import androidx.coordinatorlayout.R.attr
 
 /**
  * Taken from
@@ -39,7 +39,7 @@ class NestedCoordinatorLayout @JvmOverloads constructor(
   attrs: AttributeSet? = null,
   @AttrRes
   @SuppressLint("PrivateResource")
-  defStyleAttr: Int = R.attr.coordinatorLayoutStyle
+  defStyleAttr: Int = attr.coordinatorLayoutStyle
 ) : CoordinatorLayout(context, attrs, defStyleAttr), NestedScrollingChild3 {
 
   private val helper = NestedScrollingChildHelper(this)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -29,6 +29,7 @@ import android.view.ViewGroup.LayoutParams
 import android.widget.FrameLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.R.attr
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import org.kiwix.kiwixmobile.core.R
@@ -78,7 +79,7 @@ class AlertDialogShower @Inject constructor(private val activity: Activity) :
             layoutParams = getFrameLayoutParams()
             gravity = Gravity.CENTER
             minHeight = resources.getDimensionPixelSize(R.dimen.material_minimum_height_and_width)
-            setLinkTextColor(activity.getAttribute(R.attr.colorPrimary))
+            setLinkTextColor(activity.getAttribute(attr.colorPrimary))
             setOnLongClickListener {
               val clipboard =
                 ContextCompat.getSystemService(activity.baseContext, ClipboardManager::class.java)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.utils.dialog
 import android.app.Activity
 import android.view.View
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 
 @Suppress("LongParameterList")
 sealed class KiwixDialog(
@@ -199,7 +200,7 @@ sealed class KiwixDialog(
       listOf(
         String.format(
           activity.getString(R.string.rate_dialog_msg),
-          activity.getString(R.string.app_name)
+          (activity as CoreMainActivity).appName
         )
       ),
       icon

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -124,10 +124,10 @@ internal class SearchStateTest {
       list = searchState.getVisibleResults(0)
     }
 
+    job.cancelAndJoin()
     val job1 = launch(Dispatchers.IO) {
       list1 = searchState.getVisibleResults(0)
     }
-    job.cancelAndJoin()
 
     // test the coroutine job is cancelled properly
     assertThat(job.isCancelled).isTrue

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -109,7 +109,7 @@ internal class SearchStateTest {
     val searchIteratorWrapper: SuggestionIteratorWrapper = mockk()
     val entryWrapper: SuggestionItemWrapper = mockk()
 
-    every { suggestionSearchWrapper.estimatedMatches } returns 100
+    every { suggestionSearchWrapper.estimatedMatches } returns 500
     every { searchIteratorWrapper.hasNext() } returnsMany listOf(true, false)
     every { searchIteratorWrapper.next() } returns entryWrapper
     every { entryWrapper.title } returns "Result"

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInputTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/StartSpeechInputTest.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.speech.RecognizerIntent
-import androidx.appcompat.app.AppCompatActivity
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
@@ -29,6 +28,7 @@ import io.mockk.verify
 import kotlinx.coroutines.channels.Channel
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.StartSpeechInputFailed
 import java.util.Locale
@@ -40,7 +40,7 @@ internal class StartSpeechInputTest {
   @Suppress("DEPRECATION")
   @Test
   fun `when invoke with throws exception offer StartSpeechInputFailed action`() {
-    val activity = mockk<AppCompatActivity>(relaxed = true)
+    val activity = mockk<CoreMainActivity>(relaxed = true)
     every { activity.startActivityForResult(any(), any()) } throws ActivityNotFoundException()
     StartSpeechInput(actions).invokeWith(activity)
     verify { actions.trySend(StartSpeechInputFailed).isSuccess }
@@ -49,8 +49,8 @@ internal class StartSpeechInputTest {
   @Suppress("DEPRECATION")
   @Test
   fun `invoke with starts an activity for speech recognition`() {
-    val activity = mockk<AppCompatActivity>()
-    every { activity.getString(R.string.app_name) } returns "app"
+    val activity = mockk<CoreMainActivity>()
+    every { activity.appName } returns "app"
     every { activity.getString(R.string.speech_prompt_text, "app") } returns "the app"
     every { activity.startActivityForResult(any(), any()) } returns Unit
     mockkConstructor(Intent::class)

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -33,7 +33,7 @@ android {
       // Added namespace for every custom app to make it compatible with gradle 8.0 and above.
       // This is now specified in the Gradle configuration instead of declaring
       // it directly in the AndroidManifest file.
-      namespace = "org.kiwix.kiwixcustom$name"
+      namespace = "org.kiwix.kiwixmobile.custom"
       File("$projectDir/src", "$name/$name.zim").let {
         createDownloadTask(it)
         createPublishApkWithExpansionTask(it, applicationVariants)

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -30,6 +30,10 @@ android {
   productFlavors.apply {
     CustomApps.createDynamically(project.file("src"), this)
     all {
+      // Added namespace for every custom app to make it compatible with gradle 8.0 and above.
+      // This is now specified in the Gradle configuration instead of declaring
+      // it directly in the AndroidManifest file.
+      namespace = "org.kiwix.kiwixcustom$name"
       File("$projectDir/src", "$name/$name.zim").let {
         createDownloadTask(it)
         createPublishApkWithExpansionTask(it, applicationVariants)

--- a/custom/src/androidTest/AndroidManifest.xml
+++ b/custom/src/androidTest/AndroidManifest.xml
@@ -17,8 +17,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile.custom">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <!-- support for androidx.test.orchestrator clearPackageData for android 33
        see more information here https://github.com/kiwix/kiwix-android/issues/3172

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
@@ -40,7 +40,7 @@ fun search(searchRobot: SearchRobot.() -> Unit) = SearchRobot().searchRobot()
 class SearchRobot {
   fun searchWithFrequentlyTypedWords(query: String, wait: Long = 0L) {
     testFlakyView({
-      val searchView = Espresso.onView(ViewMatchers.withId(R.id.search_src_text))
+      val searchView = Espresso.onView(ViewMatchers.withId(androidx.appcompat.R.id.search_src_text))
       searchView.perform(ViewActions.clearText())
       for (char in query) {
         searchView.perform(ViewActions.typeText(char.toString()))
@@ -75,7 +75,7 @@ class SearchRobot {
       }
 
       // clear search query if any remains due to any condition not to affect any other test scenario
-      val searchView = Espresso.onView(ViewMatchers.withId(R.id.search_src_text))
+      val searchView = Espresso.onView(ViewMatchers.withId(androidx.appcompat.R.id.search_src_text))
       searchView.perform(ViewActions.clearText())
     })
   }

--- a/custom/src/main/AndroidManifest.xml
+++ b/custom/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="org.kiwix.kiwixmobile.custom">
+  xmlns:tools="http://schemas.android.com/tools">
 
 
   <application

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadFragment.kt
@@ -35,7 +35,7 @@ import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
 import org.kiwix.kiwixmobile.core.extensions.setDistinctDisplayedChild
 import org.kiwix.kiwixmobile.core.extensions.viewModel
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
-import org.kiwix.kiwixmobile.custom.R
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.FragmentCustomDownloadBinding
 import org.kiwix.kiwixmobile.custom.download.Action.ClickedDownload

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -104,7 +104,7 @@ class CustomMainActivity : CoreMainActivity() {
        * We will re-enable it for custom apps once the issue is resolved.
        * For more info see https://github.com/kiwix/kiwix-android/pull/3516
        */
-      menu.findItem(R.id.menu_host_books)?.isVisible = false
+      menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.isVisible = false
       /**
        * Hide the `HelpFragment` from custom apps.
        * We have not removed the relevant code for `HelpFragment` from custom apps.
@@ -112,15 +112,18 @@ class CustomMainActivity : CoreMainActivity() {
        * we can either remove the line below or configure it according to the requirements.
        * For more information, see https://github.com/kiwix/kiwix-android/issues/3584
        */
-      menu.findItem(R.id.menu_help)?.isVisible = false
+      menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_help)?.isVisible = false
 
       /**
        * If custom app is configured to show the "About app_name app" in navigation
        * then show it navigation. "app_name" will be replaced with custom app name.
        */
       if (BuildConfig.ABOUT_APP_URL.isNotEmpty()) {
-        menu.findItem(R.id.menu_about_app)?.apply {
-          title = getString(R.string.menu_about_app, getString(R.string.app_name))
+        menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_about_app)?.apply {
+          title = getString(
+            org.kiwix.kiwixmobile.core.R.string.menu_about_app,
+            getString(R.string.app_name)
+          )
           isVisible = true
         }
       }
@@ -130,9 +133,12 @@ class CustomMainActivity : CoreMainActivity() {
        * then show it navigation. "app_name" will be replaced with custom app name.
        */
       if (BuildConfig.SUPPORT_URL.isNotEmpty()) {
-        menu.findItem(R.id.menu_support_kiwix)?.apply {
+        menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_support_kiwix)?.apply {
           title =
-            getString(R.string.menu_support_kiwix_for_custom_apps, getString(R.string.app_name))
+            getString(
+              org.kiwix.kiwixmobile.core.R.string.menu_support_kiwix_for_custom_apps,
+              getString(R.string.app_name)
+            )
           isVisible = true
         }
       } else {
@@ -140,7 +146,7 @@ class CustomMainActivity : CoreMainActivity() {
          * If custom app is not configured to show the "Support app_name" in navigation
          * then hide it from navigation.
          */
-        menu.findItem(R.id.menu_support_kiwix)?.isVisible = false
+        menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_support_kiwix)?.isVisible = false
       }
       setNavigationItemSelectedListener { item ->
         closeNavigationDrawer()

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -57,6 +57,7 @@ class CustomMainActivity : CoreMainActivity() {
   }
 
   override val mainActivity: AppCompatActivity by lazy { this }
+  override val appName: String by lazy { getString(R.string.app_name) }
 
   override val searchFragmentResId: Int = R.id.searchFragment
   override val bookmarksFragmentResId: Int = R.id.bookmarksFragment
@@ -162,12 +163,12 @@ class CustomMainActivity : CoreMainActivity() {
    */
   override fun onNavigationItemSelected(item: MenuItem): Boolean {
     return when (item.itemId) {
-      R.id.menu_about_app -> {
+      org.kiwix.kiwixmobile.core.R.id.menu_about_app -> {
         openExternalUrl(BuildConfig.ABOUT_APP_URL)
         true
       }
 
-      R.id.menu_support_kiwix -> {
+      org.kiwix.kiwixmobile.core.R.id.menu_support_kiwix -> {
         openExternalUrl(BuildConfig.SUPPORT_URL)
         true
       }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -72,7 +72,8 @@ class CustomReaderFragment : CoreReaderFragment() {
     if (isAdded) {
       setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
       if (BuildConfig.DISABLE_SIDEBAR) {
-        val toolbarToc = activity?.findViewById<ImageView>(R.id.bottom_toolbar_toc)
+        val toolbarToc =
+          activity?.findViewById<ImageView>(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar_toc)
         toolbarToc?.isEnabled = false
       }
       with(activity as AppCompatActivity) {
@@ -221,8 +222,8 @@ class CustomReaderFragment : CoreReaderFragment() {
   @Suppress("DEPRECATION")
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     super.onCreateOptionsMenu(menu, inflater)
-    menu.findItem(R.id.menu_help)?.isVisible = false
-    menu.findItem(R.id.menu_host_books)?.isVisible = false
+    menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_help)?.isVisible = false
+    menu.findItem(org.kiwix.kiwixmobile.core.R.id.menu_host_books)?.isVisible = false
   }
 
   private fun enforcedLanguage(): Boolean {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 19 16:13:45 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -22,11 +22,12 @@ jacoco {
   toolVersion = "0.8.12"
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   jacoco.includeNoLocationClasses = true
 }
 
-task jacocoInstrumentationTestReport(type: JacocoReport, dependsOn: ['createDebugCoverageReport']) {
+tasks.register('jacocoInstrumentationTestReport', JacocoReport) {
+  dependsOn = ['createDebugCoverageReport']
   group "Reporting"
   description "Generate Jacoco coverage reports."
   reports {

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -19,7 +19,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-  toolVersion = "0.8.8"
+  toolVersion = "0.8.12"
 }
 
 tasks.withType(Test) {

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-  <issue id="TypographyQuotes">
+  <!-- TODO After upgrading to Android 14 this attribute will be removed and we will fix these errors on the upstream. -->
+  <issue id="TypographyQuotes" severity="warning">
     <ignore path="**-qq/**.xml" />
     <ignore path="**-iw/**.xml" />
   </issue>

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-  <!-- TODO After upgrading to Android 14 this attribute will be removed and we will fix these errors on the upstream. -->
-  <issue id="TypographyQuotes" severity="warning">
+  <issue id="TypographyQuotes">
     <ignore path="**-qq/**.xml" />
     <ignore path="**-iw/**.xml" />
   </issue>

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -35,7 +35,7 @@
   <issue id="InvalidPackage">
     <ignore path="**simple-xml-2.7.1.jar" />
     <ignore path="**javapoet-1.8.0.jar" />
-    <ignore path="**/org.jacoco.agent-0.8.10-runtime.jar" />
+    <ignore path="**/org.jacoco.agent-0.8.12-runtime.jar" />
     <ignore regexp="kotlinx.coroutines.debug.AgentPremain" />
   </issue>
   <issue id="IconLocation">

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -35,7 +35,7 @@
   <issue id="InvalidPackage">
     <ignore path="**simple-xml-2.7.1.jar" />
     <ignore path="**javapoet-1.8.0.jar" />
-    <ignore path="**/org.jacoco.agent-0.8.8-runtime.jar" />
+    <ignore path="**/org.jacoco.agent-0.8.10-runtime.jar" />
     <ignore regexp="kotlinx.coroutines.debug.AgentPremain" />
   </issue>
   <issue id="IconLocation">

--- a/team-props/git-hooks.gradle
+++ b/team-props/git-hooks.gradle
@@ -28,5 +28,7 @@ task installGitHooks(type: Exec) {
 }
 
 afterEvaluate {
-  tasks['preBuild'].dependsOn installGitHooks
+  tasks.named('preBuild').configure {
+    dependsOn installGitHooks
+  }
 }

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -14,8 +14,8 @@ else
     echo 1>&2 "Static analysis found violations and attempted to autofix, please commit these autoformat changes"
     echo "
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------
-    If the build failed with '.../.gradle/daemon/8.0/custom/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK11
-    Please make sure JAVA_HOME is set to JDK11
+    If the build failed with '.../.gradle/daemon/8.4/custom/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK17
+    Please make sure JAVA_HOME is set to JDK17
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------"
 
     exit 1


### PR DESCRIPTION
Fixes #3478 

* The `BuildConfig` file is by default off in the latest gradle version, so we have enabled this in our `AllProjectConfigure` class to allow this class for both modules.
```
A problem occurred configuring project ':app'.
> com.android.builder.errors.EvalIssueException: Build Type 'debug' contains custom BuildConfig fields, but the feature is disabled.
  To enable the feature, add the following to your module-level build.gradle:
  `android.buildFeatures.buildConfig true`
```

* Upgraded the `kotlin` version to `1.9.20`.
* Upgraded the `dagger` version to `2.48.1`.
* Upgraded the `gradle` version to `8.1.3`.
* Upgraded the `webkit` version to `1.11.0`.
* Upgraded the `jacoco` version to `0.8.12`.
* Upgraded the `uiautomator` version to `2.3.0`.
* Upgraded the `appcompat` version to `1.7.0`.
* Upgraded the coroutines version to `1.8.1`.
* Upgraded the `androidx.test:runner` version to `1.6.1`.
* Upgraded the `androidx.test:core` version to `1.6.1`.
* Upgraded the `androidx.test:orchestrator` version to `1.5.0`.
* Upgraded the `org.junit.jupiter:junit-jupiter` version to `5.11.0`.
* Upgraded the `org.assertj:assertj-core` version to `3.26.3`.
* Upgraded the `androidx.annotation:annotation` version to `1.6.0`.
* Improved the SearchStateTest.
* Fixed some deprecated code which is deprecated in new dependencies.
* Removed the `butterknife` dependency from the project since it is not compatible with the new gradle so we have used the binding for getting views instead of this deps.
* Refactored our code to support Android 14 properly.
* Added Android 14 emualtor in CI to run the test cases on Android 14.
* Fixed memory leaks in the application that come after upgrading the gradle. 
* Updated the `README` file to show that now our project requires the `JAVA 17` instead of `JAVA 11`.
* Updated the pre-commit failed message to show the error information properly