### PR TITLE
Fix bottom page content being cut

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/helper/ScrollingViewWithBottomNavigationBehavior.kt
@@ -38,7 +38,7 @@ class ScrollingViewWithBottomNavigationBehavior(context: Context, attrs: Attribu
   private var bottomMargin = 0
 
   companion object {
-    const val DEFAULT_BOTTOM_NAVIGATION_MARGIN_ON_HIDDEN = -2
+    const val DEFAULT_BOTTOM_NAVIGATION_MARGIN_ON_HIDDEN = 2
     const val EXTRA_MARGIN_FOR_BOTTOM_BAR = 30
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1335,6 +1335,12 @@ abstract class CoreReaderFragment :
   private fun safelyAddWebView(webView: KiwixWebView) {
     webView.parent?.let { (it as ViewGroup).removeView(webView) }
     contentFrame?.addView(webView)
+    contentFrame?.setPadding(
+      contentFrame?.paddingLeft ?: 0,
+      contentFrame?.paddingTop ?: 0,
+      contentFrame?.paddingRight ?: 0,
+      CONTENT_FRAME_BOTTOM_PADDING
+    )
   }
 
   protected fun selectTab(position: Int) {
@@ -2417,3 +2423,5 @@ abstract class CoreReaderFragment :
    */
   abstract fun restoreViewStateOnInvalidJSON()
 }
+
+private const val CONTENT_FRAME_BOTTOM_PADDING = 32

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -2424,4 +2424,4 @@ abstract class CoreReaderFragment :
   abstract fun restoreViewStateOnInvalidJSON()
 }
 
-private const val CONTENT_FRAME_BOTTOM_PADDING = 32
+private const val CONTENT_FRAME_BOTTOM_PADDING = 40

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1335,12 +1335,6 @@ abstract class CoreReaderFragment :
   private fun safelyAddWebView(webView: KiwixWebView) {
     webView.parent?.let { (it as ViewGroup).removeView(webView) }
     contentFrame?.addView(webView)
-    contentFrame?.setPadding(
-      contentFrame?.paddingLeft ?: 0,
-      contentFrame?.paddingTop ?: 0,
-      contentFrame?.paddingRight ?: 0,
-      CONTENT_FRAME_BOTTOM_PADDING
-    )
   }
 
   protected fun selectTab(position: Int) {
@@ -2423,5 +2417,3 @@ abstract class CoreReaderFragment :
    */
   abstract fun restoreViewStateOnInvalidJSON()
 }
-
-private const val CONTENT_FRAME_BOTTOM_PADDING = 40


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #3964

<!-- Add here what changes were made in this issue and if possible provide links. -->
This PR fixes the bottom page being cut when scrolling up and down. Since the zimfile content being fetched is already wrapped with a specific color, adding a big padding will make the color scheme inconsistent. I have tested with 40dp and it seems to work well from my device and emulator. 
<!-- If possible, please add relevant screenshots / GIFs -->