### PR TITLE
Re-enabled the emulator caching in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,33 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: default
+          arch: x86_64
+          profile: pixel_2
+          ram-size: 4096M
+          force-avd-creation: false
+          sdcard-path-or-size: 2048M
+          cores: 4
+          disable-animations: false
+          heap-size: 512M
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          channel: canary
+          script: echo "Generated AVD snapshot for caching."
+
       - name: create instrumentation coverage
         uses: reactivecircus/android-emulator-runner@v2
         env:
@@ -54,8 +81,10 @@ jobs:
           profile: pixel_2
           ram-size: 4096M
           cores: 4
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           sdcard-path-or-size: 2048M
           disable-animations: true
+          force-avd-creation: false
           heap-size: 512M
           emulator-boot-timeout: 1200
           script: bash contrib/instrumentation.sh
@@ -71,8 +100,10 @@ jobs:
           profile: pixel_2
           ram-size: 3072M
           cores: 4
-          sdcard-path-or-size: 1024M
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          force-avd-creation: false
+          sdcard-path-or-size: 1024M
           emulator-boot-timeout: 1200
           heap-size: 512M
           script: bash contrib/instrumentation-customapps.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,18 +117,18 @@ jobs:
           path: screencap.png
 
       - name: create unit coverage
-        if: ${{ matrix.api-level==25 }}
+        if: ${{ matrix.api-level==30 }}
         run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.api-level==25 }}
+        if: ${{ matrix.api-level==30 }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Coverage to GH-Actions
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.api-level==25 }}
+        if: ${{ matrix.api-level==30 }}
         with:
           name: Tests Coverage Report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,9 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          ram-size: 4096M
+          ram-size: 3072M
           force-avd-creation: false
-          sdcard-path-or-size: 2048M
+          sdcard-path-or-size: 1024M
           cores: 4
           disable-animations: false
           heap-size: 512M
@@ -79,10 +79,10 @@ jobs:
           target: default
           arch: x86_64
           profile: pixel_2
-          ram-size: 4096M
+          ram-size: 3072M
           cores: 4
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          sdcard-path-or-size: 2048M
+          sdcard-path-or-size: 1024M
           disable-animations: true
           force-avd-creation: false
           heap-size: 512M


### PR DESCRIPTION
Fixes #3978 

* Stabilized the emulator caching; CI is now running without errors related to caching.
* Configured the emulator to use 3GB of RAM and a 1024MB SD card instead of 4GB of RAM and a 2048MB SD card to reduce resource usage on CI. Since the emulator works well with 3GB of RAM and a 1024MB SD card on CI for running test cases for custom apps, it is better to use this configuration for the app's test cases as well.
* Now we are generating the `codecov` report on API level 30 instead of API level 25, since some instrumentation test cases, we are running on API level 30 and above, like testing the WifiHotspot, ShowingPlayStoreRestriction in HelpFragment, etc. This change increased the code coverage by 2.75%.

![Screenshot from 2024-09-04 17-29-50](https://github.com/user-attachments/assets/2d660178-beea-46bf-8a19-6ffd245ec55d)
