### PR TITLE
Added a donation popup to our application.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -66,6 +66,7 @@ class DeepLinksTest : BaseActivityTest() {
         prefIsTest = true
         playStoreRestrictionPermissionDialog = false
         putPrefLanguage("en")
+        lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -94,6 +94,10 @@ class DownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -57,7 +57,9 @@ class HelpFragmentTest : BaseActivityTest() {
         handleLocaleChange(
           it,
           "en",
-          SharedPreferenceUtil(context)
+          SharedPreferenceUtil(context).apply {
+            lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
+          }
         )
       }
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -85,6 +85,10 @@ class InitialDownloadTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -67,6 +67,10 @@ class IntroFragmentTest : BaseActivityTest() {
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -82,6 +82,10 @@ class LanguageFragmentTest {
         putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
         putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
         putString(SharedPreferenceUtil.PREF_LANG, "en")
+        putLong(
+          SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+          System.currentTimeMillis()
+        )
       }
     ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -77,6 +77,10 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -64,6 +64,10 @@ class TopLevelDestinationTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -56,6 +56,10 @@ class MimeTypeTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -90,6 +90,10 @@ class LocalLibraryTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -74,6 +74,10 @@ class NoteFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -113,6 +113,10 @@ class ImportBookmarkTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -70,6 +70,10 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -68,6 +68,10 @@ class NavigationHistoryTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -56,6 +56,10 @@ class EncodedUrlTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -87,6 +87,10 @@ class SearchFragmentTest : BaseActivityTest() {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -82,6 +82,7 @@ class KiwixSettingsFragmentTest {
           SharedPreferenceUtil(it).apply {
             setIsPlayStoreBuildType(true)
             playStoreRestrictionPermissionDialog = false
+            lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
           }
         )
         it.navigate(R.id.introFragment)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -108,6 +108,7 @@ class ZimHostFragmentTest {
         prefIsTest = true
         playStoreRestrictionPermissionDialog = false
         putPrefLanguage("en")
+        lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
       }
     }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -287,7 +287,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     drawerContainerLayout.closeDrawer(drawerNavView)
   }
 
-  private fun openSupportKiwixExternalLink() {
+  fun openSupportKiwixExternalLink() {
     externalLinkOpener.openExternalUrl(KIWIX_SUPPORT_URL.toUri().browserIntent())
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -398,7 +398,7 @@ abstract class CoreReaderFragment :
   ) {
     super.onViewCreated(view, savedInstanceState)
     setupMenu()
-    donationDialogHandler?.showDonationDialogCallBack(this)
+    donationDialogHandler?.setDonationDialogCallBack(this)
     val activity = requireActivity() as AppCompatActivity?
     activity?.let {
       WebView(it).destroy() // Workaround for buggy webViews see #710
@@ -1224,7 +1224,7 @@ abstract class CoreReaderFragment :
     unRegisterReadAloudService()
     storagePermissionForNotesLauncher?.unregister()
     storagePermissionForNotesLauncher = null
-    donationDialogHandler?.showDonationDialogCallBack(null)
+    donationDialogHandler?.setDonationDialogCallBack(null)
     donationDialogHandler = null
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -46,6 +46,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
+import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
@@ -133,6 +134,8 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchItemToOpen
 import org.kiwix.kiwixmobile.core.utils.AnimationUtils.rotate
 import org.kiwix.kiwixmobile.core.utils.DimenUtils.getToolbarHeight
+import org.kiwix.kiwixmobile.core.utils.DonationDialogHandler
+import org.kiwix.kiwixmobile.core.utils.DonationDialogHandler.ShowDonationDialogCallback
 import org.kiwix.kiwixmobile.core.utils.ExternalLinkOpener
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
@@ -173,7 +176,8 @@ abstract class CoreReaderFragment :
   FragmentActivityExtensions,
   WebViewProvider,
   ReadAloudCallbacks,
-  NavigationHistoryClickListener {
+  NavigationHistoryClickListener,
+  ShowDonationDialogCallback {
   protected val webViewList: MutableList<KiwixWebView> = ArrayList()
   private val webUrlsProcessor = BehaviorProcessor.create<String>()
   private var fragmentReaderBinding: FragmentReaderBinding? = null
@@ -226,6 +230,10 @@ abstract class CoreReaderFragment :
   @JvmField
   @Inject
   var alertDialogShower: DialogShower? = null
+
+  @JvmField
+  @Inject
+  var donationDialogHandler: DonationDialogHandler? = null
 
   @JvmField
   @Inject
@@ -297,6 +305,7 @@ abstract class CoreReaderFragment :
   private var tableDrawerAdapter: TableDrawerAdapter? = null
   private var tableDrawerRight: RecyclerView? = null
   private var tabCallback: ItemTouchHelper.Callback? = null
+  private var donationLayout: FrameLayout? = null
   private var bookmarkingDisposable: Disposable? = null
   private var isBookmarked = false
   private lateinit var serviceConnection: ServiceConnection
@@ -389,6 +398,7 @@ abstract class CoreReaderFragment :
   ) {
     super.onViewCreated(view, savedInstanceState)
     setupMenu()
+    donationDialogHandler?.showDonationDialogCallBack(this)
     val activity = requireActivity() as AppCompatActivity?
     activity?.let {
       WebView(it).destroy() // Workaround for buggy webViews see #710
@@ -511,6 +521,7 @@ abstract class CoreReaderFragment :
         tabRecyclerView = findViewById(R.id.tab_switcher_recycler_view)
         snackBarRoot = findViewById(R.id.snackbar_root)
         bottomToolbarToc = findViewById(R.id.bottom_toolbar_toc)
+        donationLayout = findViewById(R.id.donation_layout)
       }
     }
   }
@@ -1213,6 +1224,8 @@ abstract class CoreReaderFragment :
     unRegisterReadAloudService()
     storagePermissionForNotesLauncher?.unregister()
     storagePermissionForNotesLauncher = null
+    donationDialogHandler?.showDonationDialogCallBack(null)
+    donationDialogHandler = null
   }
 
   private fun unBindViewsAndBinding() {
@@ -1243,6 +1256,8 @@ abstract class CoreReaderFragment :
     closeAllTabsButton = null
     tableDrawerRightContainer = null
     fragmentReaderBinding = null
+    donationLayout?.removeAllViews()
+    donationLayout = null
   }
 
   private fun updateTableOfContents() {
@@ -1846,6 +1861,53 @@ abstract class CoreReaderFragment :
     if (tts == null) {
       setUpTTS()
     }
+    donationDialogHandler?.attemptToShowDonationPopup()
+  }
+
+  @Suppress("InflateParams", "MagicNumber")
+  protected open fun showDonationLayout() {
+    val donationCardView = layoutInflater.inflate(R.layout.layout_donation_bottom_sheet, null)
+    val layoutParams = FrameLayout.LayoutParams(
+      FrameLayout.LayoutParams.MATCH_PARENT,
+      FrameLayout.LayoutParams.WRAP_CONTENT
+    )
+    val bottomToolBarHeight =
+      requireActivity()
+        .findViewById<BottomAppBar>(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar).measuredHeight
+    layoutParams.setMargins(16, 0, 16, bottomToolBarHeight + 10)
+
+    donationCardView.layoutParams = layoutParams
+    donationLayout?.apply {
+      removeAllViews()
+      addView(donationCardView)
+      setDonationLayoutVisibility(VISIBLE)
+    }
+    donationCardView.findViewById<TextView>(R.id.descriptionText).apply {
+      text = getString(
+        R.string.donation_dialog_description,
+        (requireActivity() as CoreMainActivity).appName
+      )
+    }
+    val donateButton: TextView = donationCardView.findViewById(R.id.donateButton)
+    donateButton.setOnClickListener {
+      donationDialogHandler?.updateLastDonationPopupShownTime()
+      setDonationLayoutVisibility(GONE)
+      openKiwixSupportUrl()
+    }
+
+    val laterButton: TextView = donationCardView.findViewById(R.id.laterButton)
+    laterButton.setOnClickListener {
+      donationDialogHandler?.donateLater()
+      setDonationLayoutVisibility(GONE)
+    }
+  }
+
+  protected open fun openKiwixSupportUrl() {
+    (requireActivity() as CoreMainActivity).openSupportKiwixExternalLink()
+  }
+
+  private fun setDonationLayoutVisibility(visibility: Int) {
+    donationLayout?.visibility = visibility
   }
 
   private fun openFullScreenIfEnabled() {
@@ -2386,6 +2448,10 @@ abstract class CoreReaderFragment :
   override fun onStop() {
     super.onStop()
     unbindService()
+  }
+
+  override fun showDonationDialog() {
+    showDonationLayout()
   }
 
   private fun bindService() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1870,11 +1870,17 @@ abstract class CoreReaderFragment :
     val layoutParams = FrameLayout.LayoutParams(
       FrameLayout.LayoutParams.MATCH_PARENT,
       FrameLayout.LayoutParams.WRAP_CONTENT
-    )
-    val bottomToolBarHeight =
-      requireActivity()
-        .findViewById<BottomAppBar>(org.kiwix.kiwixmobile.core.R.id.bottom_toolbar).measuredHeight
-    layoutParams.setMargins(16, 0, 16, bottomToolBarHeight + 10)
+    ).apply {
+      val rightAndLeftMargin = requireActivity().resources.getDimensionPixelSize(
+        org.kiwix.kiwixmobile.core.R.dimen.activity_horizontal_margin
+      )
+      setMargins(
+        rightAndLeftMargin,
+        0,
+        rightAndLeftMargin,
+        getBottomMarginForDonationPopup()
+      )
+    }
 
     donationCardView.layoutParams = layoutParams
     donationLayout?.apply {
@@ -1900,6 +1906,23 @@ abstract class CoreReaderFragment :
       donationDialogHandler?.donateLater()
       setDonationLayoutVisibility(GONE)
     }
+  }
+
+  private fun getBottomMarginForDonationPopup(): Int {
+    var bottomMargin = requireActivity().resources.getDimensionPixelSize(
+      R.dimen.donation_popup_bottom_margin
+    )
+    val bottomAppBar = requireActivity()
+      .findViewById<BottomAppBar>(R.id.bottom_toolbar)
+    if (bottomAppBar.visibility == VISIBLE) {
+      // if bottomAppBar is visible then add the height of the bottomAppBar.
+      bottomMargin += requireActivity().resources.getDimensionPixelSize(
+        R.dimen.material_minimum_height_and_width
+      )
+      bottomMargin += requireActivity().resources.getDimensionPixelSize(R.dimen.card_margin)
+    }
+
+    return bottomMargin
   }
 
   protected open fun openKiwixSupportUrl() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
@@ -34,7 +34,7 @@ class DonationDialogHandler @Inject constructor(
 
   private var showDonationDialogCallback: ShowDonationDialogCallback? = null
 
-  fun showDonationDialogCallBack(showDonationDialogCallback: ShowDonationDialogCallback?) {
+  fun setDonationDialogCallBack(showDonationDialogCallback: ShowDonationDialogCallback?) {
     this.showDonationDialogCallback = showDonationDialogCallback
   }
 
@@ -61,18 +61,18 @@ class DonationDialogHandler @Inject constructor(
     return timeDifference >= THREE_DAYS_IN_MILLISECONDS
   }
 
-  private fun isZimFilesAvailableInLibrary(): Boolean =
+  fun isZimFilesAvailableInLibrary(): Boolean =
     if (activity.isCustomApp()) true else newBookDao.getBooks().isNotEmpty()
 
   fun updateLastDonationPopupShownTime() {
     sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
   }
 
-  fun donateLater() {
-    sharedPreferenceUtil.laterClickedMilliSeconds = System.currentTimeMillis()
+  fun donateLater(currentMillis: Long = System.currentTimeMillis()) {
+    sharedPreferenceUtil.laterClickedMilliSeconds = currentMillis
   }
 
-  private fun resetDonateLater() {
+  fun resetDonateLater() {
     sharedPreferenceUtil.laterClickedMilliSeconds = 0L
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
@@ -1,0 +1,82 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils
+
+import android.app.Activity
+import org.kiwix.kiwixmobile.core.dao.NewBookDao
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isCustomApp
+import javax.inject.Inject
+
+const val THREE_DAYS_IN_MILLISECONDS = 3 * 24 * 60 * 60 * 1000L
+const val THREE_MONTHS_IN_MILLISECONDS = 90 * 24 * 60 * 60 * 1000L
+
+class DonationDialogHandler @Inject constructor(
+  private val activity: Activity,
+  private val sharedPreferenceUtil: SharedPreferenceUtil,
+  private val newBookDao: NewBookDao
+) {
+
+  private var showDonationDialogCallback: ShowDonationDialogCallback? = null
+
+  fun showDonationDialogCallBack(showDonationDialogCallback: ShowDonationDialogCallback?) {
+    this.showDonationDialogCallback = showDonationDialogCallback
+  }
+
+  fun attemptToShowDonationPopup() {
+    val currentMilliSeconds = System.currentTimeMillis()
+    val lastPopupMillis = sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds
+    val timeDifference = currentMilliSeconds - lastPopupMillis
+    if (shouldShowInitialPopup(lastPopupMillis) || timeDifference >= THREE_MONTHS_IN_MILLISECONDS) {
+      if (isZimFilesAvailableInLibrary() && isTimeToShowDonation(currentMilliSeconds)) {
+        showDonationDialogCallback?.showDonationDialog()
+        resetDonateLater()
+      }
+    }
+  }
+
+  private fun shouldShowInitialPopup(lastPopupMillis: Long): Boolean = lastPopupMillis == 0L
+  private fun isTimeToShowDonation(currentMillis: Long): Boolean =
+    isLaterNotClicked() || isLaterPeriodOver(currentMillis)
+
+  private fun isLaterNotClicked(): Boolean = sharedPreferenceUtil.laterClickedMilliSeconds == 0L
+
+  private fun isLaterPeriodOver(currentMillis: Long): Boolean {
+    val timeDifference = currentMillis - sharedPreferenceUtil.laterClickedMilliSeconds
+    return timeDifference >= THREE_DAYS_IN_MILLISECONDS
+  }
+
+  private fun isZimFilesAvailableInLibrary(): Boolean =
+    if (activity.isCustomApp()) true else newBookDao.getBooks().isNotEmpty()
+
+  fun updateLastDonationPopupShownTime() {
+    sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
+  }
+
+  fun donateLater() {
+    sharedPreferenceUtil.laterClickedMilliSeconds = System.currentTimeMillis()
+  }
+
+  private fun resetDonateLater() {
+    sharedPreferenceUtil.laterClickedMilliSeconds = 0L
+  }
+
+  interface ShowDonationDialogCallback {
+    fun showDonationDialog()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -271,6 +271,22 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
       }
     }
 
+  var lastDonationPopupShownInMilliSeconds: Long
+    get() = sharedPreferences.getLong(PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS, 0L)
+    set(value) {
+      sharedPreferences.edit {
+        putLong(PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS, value)
+      }
+    }
+
+  var laterClickedMilliSeconds: Long
+    get() = sharedPreferences.getLong(PREF_LATER_CLICKED_MILLIS, 0L)
+    set(value) {
+      sharedPreferences.edit {
+        putLong(PREF_LATER_CLICKED_MILLIS, value)
+      }
+    }
+
   fun getPublicDirectoryPath(path: String): String =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       path
@@ -321,5 +337,8 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_NOTES_MIGRATED = "pref_notes_migrated"
     const val PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED = "pref_app_directory_to_public_migrated"
     const val PREF_COPY_MOVE_PERMISSION = "pref_copy_move_permission"
+    private const val PREF_LATER_CLICKED_MILLIS = "pref_later_clicked_millis"
+    private const val PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS =
+      "pref_last_donation_shown_in_milliseconds"
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -338,7 +338,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED = "pref_app_directory_to_public_migrated"
     const val PREF_COPY_MOVE_PERMISSION = "pref_copy_move_permission"
     private const val PREF_LATER_CLICKED_MILLIS = "pref_later_clicked_millis"
-    private const val PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS =
+    const val PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS =
       "pref_last_donation_shown_in_milliseconds"
   }
 }

--- a/core/src/main/res/drawable/ic_donation_icon.xml
+++ b/core/src/main/res/drawable/ic_donation_icon.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2024 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="512"
+  android:viewportHeight="512">
+
+  <path
+    android:fillColor="@color/denim_blue200"
+    android:pathData="M256 8c136.8 0 248 111.2 248 248s-111.2 248-248 248S8 392.8 8 256 119.2 8 256 8z" />
+
+  <group
+    android:scaleX="0.5"
+    android:scaleY="0.5"
+    android:translateX="127"
+    android:translateY="135">
+    <path
+      android:fillColor="@color/stopServerRed"
+      android:pathData="M225.8 468.2l-2.5-2.3L48.1 303.2C17.4 274.7 0 234.7 0 192.8v-3.3c0-70.4 50-130.8 119.2-144C158.6 37.9 198.9 47 231 69.6c9 6.4 17.4 13.8 25 22.3c4.2-4.8 8.7-9.2 13.5-13.3c3.7-3.2 7.5-6.2 11.5-9c0 0 0 0 0 0C313.1 47 353.4 37.9 392.8 45.4C462 58.6 512 119.1 512 189.5v3.3c0 41.9-17.4 81.9-48.1 110.4L288.7 465.9l-2.5 2.3c-8.2 7.6-19 11.9-30.2 11.9s-22-4.2-30.2-11.9z" />
+  </group>
+</vector>
+
+

--- a/core/src/main/res/layout/fragment_reader.xml
+++ b/core/src/main/res/layout/fragment_reader.xml
@@ -57,6 +57,14 @@
       android:layout_height="match_parent"
       android:background="@android:color/black"
       android:visibility="invisible" />
+
+    <FrameLayout
+      android:id="@+id/donation_layout"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:visibility="visible"
+      app:layout_constraintBottom_toBottomOf="parent"
+      android:layout_margin="@dimen/activity_horizontal_margin" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/core/src/main/res/layout/fragment_reader.xml
+++ b/core/src/main/res/layout/fragment_reader.xml
@@ -63,8 +63,9 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:visibility="visible"
-      app:layout_constraintBottom_toBottomOf="parent"
-      android:layout_margin="@dimen/activity_horizontal_margin" />
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent" />
   </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/core/src/main/res/layout/layout_donation_bottom_sheet.xml
+++ b/core/src/main/res/layout/layout_donation_bottom_sheet.xml
@@ -31,13 +31,13 @@
 
     <ImageView
       android:id="@+id/heart_icon"
-      android:layout_width="40dp"
-      android:layout_height="40dp"
+      android:layout_width="50dp"
+      android:layout_height="50dp"
       android:layout_alignParentStart="true"
       android:layout_margin="@dimen/activity_horizontal_margin"
       android:layout_marginEnd="12dp"
       android:contentDescription="@string/donation_dialog_title"
-      android:src="@drawable/ic_support_24px"
+      android:src="@drawable/ic_donation_icon"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 

--- a/core/src/main/res/layout/layout_donation_bottom_sheet.xml
+++ b/core/src/main/res/layout/layout_donation_bottom_sheet.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2024 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  android:layout_margin="16dp"
+  android:padding="16dp"
+  app:cardCornerRadius="12dp"
+  app:cardElevation="6dp">
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+      android:id="@+id/heart_icon"
+      android:layout_width="40dp"
+      android:layout_height="40dp"
+      android:layout_alignParentStart="true"
+      android:layout_margin="@dimen/activity_horizontal_margin"
+      android:layout_marginEnd="12dp"
+      android:contentDescription="@string/donation_dialog_title"
+      android:src="@drawable/ic_support_24px"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+      android:id="@+id/titleText"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/fullscreen_control_button_margin"
+      android:text="@string/donation_dialog_title"
+      android:textSize="16sp"
+      android:textAppearance="@style/TextAppearance.M3.Sys.Typescale.TitleMedium"
+      android:textColor="@color/mine_shaft_gray900"
+      app:layout_constraintStart_toEndOf="@id/heart_icon"
+      app:layout_constraintTop_toTopOf="@+id/heart_icon" />
+
+    <TextView
+      android:id="@+id/descriptionText"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="4dp"
+      android:text="@string/donation_dialog_description"
+      android:textSize="14sp"
+      app:layout_constraintStart_toStartOf="@id/titleText"
+      app:layout_constraintTop_toBottomOf="@+id/titleText" />
+
+    <TextView
+      android:id="@+id/laterButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="@dimen/activity_horizontal_margin"
+      android:text="@string/rate_dialog_neutral"
+      android:textColor="@color/denim_blue800"
+      app:layout_constraintEnd_toStartOf="@+id/donateButton"
+      app:layout_constraintTop_toBottomOf="@id/descriptionText" />
+
+    <TextView
+      android:id="@+id/donateButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="@dimen/activity_horizontal_margin"
+      android:text="@string/make_donation"
+      android:textColor="@color/denim_blue800"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/descriptionText" />
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>
+

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -24,4 +24,5 @@
   <dimen name="material_minimum_height_and_width">48dp</dimen>
   <dimen name="close_tab_button_size">24dp</dimen>
   <dimen name="find_in_page_button_padding">13dp</dimen>
+  <dimen name="donation_popup_bottom_margin">20dp</dimen>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -389,4 +389,7 @@
   <string name="toolbar_back_button_content_description">Go to previous screen</string>
   <string name="save_or_open_unsupported_files_dialog_title">Save or Open this file?</string>
   <string name="save_or_open_unsupported_files_dialog_message">Choosing Open will open this file in external reader application.</string>
+  <string name="donation_dialog_title">Donate Today</string>
+  <string name="donation_dialog_description">%s needs your help.</string>
+  <string name="make_donation">Make a donation</string>
 </resources>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandlerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandlerTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils
+
+import android.app.Activity
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.dao.NewBookDao
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions
+
+class DonationDialogHandlerTest {
+  private lateinit var activity: Activity
+  private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  private lateinit var newBookDao: NewBookDao
+  private lateinit var donationDialogHandler: DonationDialogHandler
+  private lateinit var showDonationDialogCallback: DonationDialogHandler.ShowDonationDialogCallback
+
+  @BeforeEach
+  fun setup() {
+    activity = mockk(relaxed = true)
+    sharedPreferenceUtil = mockk(relaxed = true)
+    newBookDao = mockk(relaxed = true)
+    showDonationDialogCallback = mockk(relaxed = true)
+    donationDialogHandler = DonationDialogHandler(activity, sharedPreferenceUtil, newBookDao)
+    donationDialogHandler.setDonationDialogCallBack(showDonationDialogCallback)
+  }
+
+  @Test
+  fun `test should show initial popup`() {
+    every { sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds } returns 0L
+    every { newBookDao.getBooks() } returns listOf(mockk())
+    donationDialogHandler.attemptToShowDonationPopup()
+    verify { showDonationDialogCallback.showDonationDialog() }
+  }
+
+  @Test
+  fun `test should not show popup when time difference is less than 3 months`() {
+    val currentMilliSeconds = System.currentTimeMillis()
+    every {
+      sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds
+    } returns currentMilliSeconds - (THREE_MONTHS_IN_MILLISECONDS / 2)
+    every { newBookDao.getBooks() } returns listOf(mockk())
+    donationDialogHandler.attemptToShowDonationPopup()
+    verify(exactly = 0) { showDonationDialogCallback.showDonationDialog() }
+  }
+
+  @Test
+  fun `test should show popup when time difference is more than 3 months`() {
+    val currentMilliSeconds = System.currentTimeMillis()
+    every {
+      sharedPreferenceUtil.lastDonationPopupShownInMilliSeconds
+    } returns currentMilliSeconds - (THREE_MONTHS_IN_MILLISECONDS + 1000)
+    every { newBookDao.getBooks() } returns listOf(mockk())
+    donationDialogHandler.attemptToShowDonationPopup()
+    verify { showDonationDialogCallback.showDonationDialog() }
+  }
+
+  @Test
+  fun `test donate later saves the correct time`() {
+    val currentMilliSeconds = System.currentTimeMillis()
+    every { sharedPreferenceUtil.laterClickedMilliSeconds = any() } just Runs
+    donationDialogHandler.donateLater(currentMilliSeconds)
+    verify { sharedPreferenceUtil.laterClickedMilliSeconds = currentMilliSeconds }
+  }
+
+  @Test
+  fun `test reset donate later sets value to zero`() {
+    every { sharedPreferenceUtil.laterClickedMilliSeconds = 0L } just Runs
+    donationDialogHandler.resetDonateLater()
+    verify { sharedPreferenceUtil.laterClickedMilliSeconds = 0L }
+  }
+
+  @Test
+  fun `test isZimFilesAvailableInLibrary returns true when isCustomApp is true`() {
+    with(mockk<ActivityExtensions>()) {
+      every { activity.packageName } returns "org.kiwix.kiwixcustom"
+      every { activity.isCustomApp() } returns true
+      val result = donationDialogHandler.isZimFilesAvailableInLibrary()
+      assertTrue(result)
+    }
+  }
+
+  @Test
+  fun `test isZimFilesAvailableInLibrary returns false when no books and isCustomApp is false`() {
+    with(mockk<ActivityExtensions>()) {
+      every { activity.packageName } returns "org.kiwix.kiwixmobile"
+      every { activity.isCustomApp() } returns false
+      every { newBookDao.getBooks() } returns emptyList()
+      val result = donationDialogHandler.isZimFilesAvailableInLibrary()
+      assertFalse(result)
+    }
+  }
+
+  @Test
+  fun `isZimFilesAvailableInLibrary returns true when books available and isCustomApp is false`() {
+    with(mockk<ActivityExtensions>()) {
+      every { activity.packageName } returns "org.kiwix.kiwixmobile"
+      every { activity.isCustomApp() } returns false
+      every { newBookDao.getBooks() } returns listOf(mockk())
+      val result = donationDialogHandler.isZimFilesAvailableInLibrary()
+      assertTrue(result)
+    }
+  }
+}

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
@@ -98,6 +98,10 @@ class SearchFragmentTestForCustomApp {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
     }
     activityScenario = ActivityScenario.launch(CustomMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -28,10 +28,12 @@ import android.view.View.VISIBLE
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.net.toUri
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.fragment.findNavController
 import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.core.base.BaseActivity
+import org.kiwix.kiwixmobile.core.extensions.browserIntent
 import org.kiwix.kiwixmobile.core.extensions.getResizedDrawable
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.main.CoreReaderFragment
@@ -326,6 +328,22 @@ class CustomReaderFragment : CoreReaderFragment() {
 
   override fun createNewTab() {
     newMainPageTab()
+  }
+
+  /**
+   * Overrides the method to show the donation popup. When the "Support url" is disabled
+   * in a custom app, this function stop to show the donationPopup.
+   */
+  override fun showDonationLayout() {
+    if (BuildConfig.SUPPORT_URL.isNotEmpty()) {
+      super.showDonationLayout()
+    }
+  }
+
+  override fun openKiwixSupportUrl() {
+    if (BuildConfig.SUPPORT_URL.isNotEmpty()) {
+      openExternalUrl(BuildConfig.SUPPORT_URL.toUri().browserIntent())
+    }
   }
 
   override fun onDestroyView() {


### PR DESCRIPTION
Fixes #3736 

* The donation popup will be shown to the user every three months.
* If the user clicks the "Later" button, the popup will appear again after 3 days.
* The donation popup will only be shown when there is at least one book available in the library. If no ZIM file is present, it’s not ideal to ask for a donation, as the user has not yet used the application.
* The donation popup will only be shown for custom apps when the support_url is configured. If the support menu item is hidden in the sidebar (a feature we offer), the donation popup will not be displayed, as there is no support_url available for that custom app.

| Kiwix App(When no bottomAppBar)  | Kiwix App(When bottomAppBar showing) | Custom Apps |
| ------------- | ------------- | ------------- |
| ![Screenshot from 2024-09-06 12-21-39](https://github.com/user-attachments/assets/d4740c28-270e-40c9-b3cf-236f0fa8d110)  | ![Screenshot from 2024-09-06 12-24-26](https://github.com/user-attachments/assets/ebcda4ab-9712-41f3-b944-3a42b833d8f3) | ![Screenshot from 2024-09-06 12-20-00](https://github.com/user-attachments/assets/be65ad39-8ccc-447f-88ce-1f0db0fb2c04) |