### PR TITLE
Added (unit test/UI test) cases for the `DarkModeViewPainter`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -46,7 +46,6 @@ fun downloadRobot(func: DownloadRobot.() -> Unit) =
 
 class DownloadRobot : BaseRobot() {
 
-  private var retryCountForDataToLoad = 10
   private var retryCountForCheckDownloadStart = 10
 
   fun clickLibraryOnBottomNav() {
@@ -57,17 +56,27 @@ class DownloadRobot : BaseRobot() {
     clickOn(ViewId(R.id.downloadsFragment))
   }
 
-  fun waitForDataToLoad() {
+  fun waitForDataToLoad(retryCountForDataToLoad: Int = 10) {
     try {
       isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
-        retryCountForDataToLoad--
-        waitForDataToLoad()
+        // refresh the data if there is "Swipe Down for Library" visible on the screen.
+        refreshOnlineListIfSwipeDownForLibraryTextVisible()
+        waitForDataToLoad(retryCountForDataToLoad - 1)
         return
       }
       // throw the exception when there is no more retry left.
       throw RuntimeException("Couldn't load the online library list.\n Original exception = $e")
+    }
+  }
+
+  private fun refreshOnlineListIfSwipeDownForLibraryTextVisible() {
+    try {
+      onView(withText(string.swipe_down_for_library)).check(matches(isDisplayed()))
+      refreshOnlineList()
+    } catch (e: RuntimeException) {
+      // do nothing as the view is not visible
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -71,11 +71,22 @@ class InitialDownloadRobot : BaseRobot() {
       isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
+        // refresh the data if there is "Swipe Down for Library" visible on the screen.
+        refreshOnlineListIfSwipeDownForLibraryTextVisible()
         waitForDataToLoad(retryCountForDataToLoad - 1)
         return
       }
       // throw the exception when there is no more retry left.
       throw RuntimeException("Couldn't load the online library list.\n Original exception = $e")
+    }
+  }
+
+  private fun refreshOnlineListIfSwipeDownForLibraryTextVisible() {
+    try {
+      onView(withText(string.swipe_down_for_library)).check(matches(isDisplayed()))
+      refreshOnlineList()
+    } catch (e: RuntimeException) {
+      // do nothing as the view is not visible
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageRobot.kt
@@ -21,16 +21,19 @@ package org.kiwix.kiwixmobile.language
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
-import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -50,12 +53,27 @@ class LanguageRobot : BaseRobot() {
       isVisible(TextId(string.your_languages))
     } catch (e: RuntimeException) {
       if (retryCountForDataToLoad > 0) {
+        // refresh the data if there is "Swipe Down for Library" visible on the screen.
+        refreshOnlineListIfSwipeDownForLibraryTextVisible()
         waitForDataToLoad(retryCountForDataToLoad - 1)
         return
       }
       // throw the exception when there is no more retry left.
       throw RuntimeException("Couldn't load the online library list.\n Original exception = $e")
     }
+  }
+
+  private fun refreshOnlineListIfSwipeDownForLibraryTextVisible() {
+    try {
+      onView(ViewMatchers.withText(string.swipe_down_for_library)).check(matches(isDisplayed()))
+      refreshOnlineList()
+    } catch (e: RuntimeException) {
+      // do nothing as the view is not visible
+    }
+  }
+
+  private fun refreshOnlineList() {
+    refresh(R.id.librarySwipeRefresh)
   }
 
   fun clickOnLanguageIcon() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterRobot.kt
@@ -1,0 +1,63 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.main
+
+import android.view.View
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import applyWithViewHierarchyPrinting
+import org.junit.Assert.assertEquals
+import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.main.KiwixWebView
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.utils.StandardActions.enterSettings
+import org.kiwix.kiwixmobile.utils.StandardActions.openDrawer
+
+fun darkModeViewPainter(func: DarkModeViewPainterRobot.() -> Unit) =
+  DarkModeViewPainterRobot().applyWithViewHierarchyPrinting(func)
+
+class DarkModeViewPainterRobot : BaseRobot() {
+
+  fun openSettings() {
+    openDrawer()
+    enterSettings()
+  }
+
+  fun enableTheDarkMode() {
+    testFlakyView({
+      onView(withText(R.string.on)).perform(ViewActions.click())
+    })
+  }
+
+  fun enableTheLightMode() {
+    testFlakyView({
+      onView(withText(R.string.off)).perform(ViewActions.click())
+    })
+  }
+
+  fun assertNightModeEnabled(kiwixWebView: KiwixWebView) {
+    assertEquals(kiwixWebView.layerType, View.LAYER_TYPE_HARDWARE)
+  }
+
+  fun assertLightModeEnabled(kiwixWebView: KiwixWebView) {
+    assertEquals(kiwixWebView.layerType, View.LAYER_TYPE_NONE)
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.main
+
+import androidx.core.content.ContextCompat
+import androidx.core.content.edit
+import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.fragment.NavHostFragment
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.internal.runner.junit4.statement.UiThreadStatement
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import leakcanary.LeakAssertions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.nav.destination.library.LocalLibraryFragmentDirections
+import org.kiwix.kiwixmobile.nav.destination.reader.KiwixReaderFragment
+import org.kiwix.kiwixmobile.settings.SettingsRobot
+import org.kiwix.kiwixmobile.settings.settingsRobo
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+
+class DarkModeViewPainterTest : BaseActivityTest() {
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+  private lateinit var kiwixMainActivity: KiwixMainActivity
+
+  @Before
+  override fun waitForIdle() {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
+        TestUtils.closeSystemDialogs(context, this)
+      }
+      waitForIdle()
+    }
+    PreferenceManager.getDefaultSharedPreferences(
+      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    ).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
+      putBoolean(SharedPreferenceUtil.PREF_PLAY_STORE_RESTRICTION, false)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
+    }
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        LanguageUtils.handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
+    }
+  }
+
+  init {
+    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+  }
+
+  @Test
+  fun testDarkMode() {
+    toggleDarkMode(true)
+    openZimFileInReader()
+    verifyDarkMode(true)
+    toggleDarkMode(false)
+    openZimFileInReader()
+    verifyDarkMode(false)
+    LeakAssertions.assertNoLeaks()
+  }
+
+  private fun openZimFileInReader() {
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(R.id.libraryFragment)
+    }
+    loadZimFileInReader()
+  }
+
+  private fun toggleDarkMode(enable: Boolean) {
+    darkModeViewPainter(DarkModeViewPainterRobot::openSettings)
+    settingsRobo(SettingsRobot::clickNightModePreference)
+    darkModeViewPainter {
+      if (enable) {
+        enableTheDarkMode()
+      } else {
+        enableTheLightMode()
+      }
+      pressBack()
+    }
+  }
+
+  private fun verifyDarkMode(isEnabled: Boolean) {
+    UiThreadStatement.runOnUiThread {
+      val navHostFragment: NavHostFragment =
+        kiwixMainActivity.supportFragmentManager
+          .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+      val kiwixReaderFragment =
+        navHostFragment.childFragmentManager.fragments[0] as KiwixReaderFragment
+      val currentWebView = kiwixReaderFragment.getCurrentWebView()
+      currentWebView?.let {
+        darkModeViewPainter {
+          if (isEnabled) {
+            assertNightModeEnabled(it)
+          } else {
+            assertLightModeEnabled(it)
+          }
+        }
+      } ?: run {
+        throw RuntimeException(
+          "Could not check the dark mode enable or not because zim file is not loaded in the reader"
+        )
+      }
+    }
+  }
+
+  private fun loadZimFileInReader() {
+    val loadFileStream =
+      DarkModeViewPainterTest::class.java.classLoader.getResourceAsStream("testzim.zim")
+    val zimFile = File(
+      ContextCompat.getExternalFilesDirs(context, null)[0],
+      "testzim.zim"
+    )
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      val outputStream: OutputStream = FileOutputStream(zimFile)
+      outputStream.use { it ->
+        val buffer = ByteArray(inputStream.available())
+        var length: Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+          it.write(buffer, 0, length)
+        }
+      }
+    }
+    UiThreadStatement.runOnUiThread {
+      kiwixMainActivity.navigate(
+        LocalLibraryFragmentDirections.actionNavigationLibraryToNavigationReader()
+          .apply { zimFileUri = zimFile.toUri().toString() }
+      )
+    }
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
@@ -29,7 +29,6 @@ import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import leakcanary.LeakAssertions
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,7 +95,6 @@ class DarkModeViewPainterTest : BaseActivityTest() {
     toggleDarkMode(false)
     openZimFileInReader()
     verifyDarkMode(false)
-    LeakAssertions.assertNoLeaks()
   }
 
   private fun openZimFileInReader() {

--- a/core/src/main/res/xml/preferences.xml
+++ b/core/src/main/res/xml/preferences.xml
@@ -103,7 +103,7 @@
   </PreferenceCategory>
 
   <PreferenceCategory
-    android:key="pref_notes"
+    android:key="pref_bookmark"
     android:title="@string/bookmarks"
     app:iconSpaceReserved="false">
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/DarkModeConfigTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/DarkModeConfigTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core
+
+import android.content.Context
+import android.content.res.Configuration
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+
+class DarkModeConfigTest {
+  private lateinit var darkModeConfig: DarkModeConfig
+  private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  private lateinit var context: Context
+
+  @BeforeEach
+  fun setUp() {
+    sharedPreferenceUtil = mockk()
+    context = mockk()
+    darkModeConfig = DarkModeConfig(sharedPreferenceUtil, context)
+  }
+
+  @Test
+  fun `should return true when dark mode is ON`() {
+    every { sharedPreferenceUtil.darkMode } returns DarkModeConfig.Mode.ON
+    val result = darkModeConfig.isDarkModeActive()
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should return false when dark mode is OFF`() {
+    every { sharedPreferenceUtil.darkMode } returns DarkModeConfig.Mode.OFF
+    val result = darkModeConfig.isDarkModeActive()
+    assertFalse(result)
+  }
+
+  @Test
+  fun `should return true when dark mode is SYSTEM and uiMode is ON`() {
+    val configuration = Configuration().apply {
+      uiMode = Configuration.UI_MODE_NIGHT_YES
+    }
+    every { context.resources } returns mockk(relaxed = true)
+    every { context.resources.configuration } returns configuration
+    every { sharedPreferenceUtil.darkMode } returns DarkModeConfig.Mode.SYSTEM
+    val result = darkModeConfig.isDarkModeActive()
+    assertTrue(result)
+  }
+
+  @Test
+  fun `should return false when dark mode is SYSTEM and uiMode is OFF`() {
+    val configuration = Configuration().apply {
+      uiMode = Configuration.UI_MODE_NIGHT_NO
+    }
+    every { context.resources } returns mockk(relaxed = true)
+    every { context.resources.configuration } returns configuration
+    every { sharedPreferenceUtil.darkMode } returns DarkModeConfig.Mode.SYSTEM
+    val result = darkModeConfig.isDarkModeActive()
+    assertFalse(result)
+  }
+
+  @Test
+  fun `should return false when dark mode is SYSTEM and uiMode is NOT_SET`() {
+    val configuration = Configuration().apply {
+      uiMode = Configuration.UI_MODE_NIGHT_UNDEFINED
+    }
+    every { context.resources } returns mockk(relaxed = true)
+    every { context.resources.configuration } returns configuration
+    every { sharedPreferenceUtil.darkMode } returns DarkModeConfig.Mode.SYSTEM
+    val result = darkModeConfig.isDarkModeActive()
+    assertFalse(result)
+  }
+
+  @Test
+  fun `should call setMode during init`() {
+    every { sharedPreferenceUtil.darkModes() } returns mockk(relaxed = true)
+    darkModeConfig.init()
+    verify { sharedPreferenceUtil.darkModes() }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/DarkModeViewPainterTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/DarkModeViewPainterTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.main
+
+import android.view.View
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.DarkModeConfig
+
+class DarkModeViewPainterTest {
+  private lateinit var darkModeConfig: DarkModeConfig
+  private lateinit var darkModeViewPainter: DarkModeViewPainter
+  private lateinit var view: View
+
+  @BeforeEach
+  fun setUp() {
+    darkModeConfig = mockk()
+    view = mockk(relaxed = true)
+    darkModeViewPainter = DarkModeViewPainter(darkModeConfig)
+  }
+
+  @Test
+  fun `should activate dark mode when dark mode is active and criteria is true`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    val shouldActivateCriteria: (View) -> Boolean = { true }
+    darkModeViewPainter.update(view, shouldActivateCriteria)
+    verify { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+
+  @Test
+  fun `should not activate dark mode when dark mode is active but criteria is false`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    val shouldActivateCriteria: (View) -> Boolean = { false }
+    darkModeViewPainter.update(view, shouldActivateCriteria)
+    verify(exactly = 0) { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+
+  @Test
+  fun `should deactivate dark mode when dark mode is inactive`() {
+    every { darkModeConfig.isDarkModeActive() } returns false
+    darkModeViewPainter.update(view)
+    verify { view.setLayerType(View.LAYER_TYPE_NONE, null) }
+  }
+
+  @Test
+  fun `should handle null views without crashing`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    darkModeViewPainter.update(null)
+    assertTrue(true)
+  }
+
+  @Test
+  fun `should activate dark mode for multiple additional views when dark mode is active`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    val additionalView1 = mockk<View>(relaxed = true)
+    val additionalView2 = mockk<View>(relaxed = true)
+    darkModeViewPainter.update(view, { true }, additionalView1, additionalView2)
+    verify { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+    verify { additionalView1.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+    verify { additionalView2.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+
+  @Test
+  fun `should deactivate dark mode for multiple additional views when dark mode is inactive`() {
+    every { darkModeConfig.isDarkModeActive() } returns false
+    val additionalView1 = mockk<View>(relaxed = true)
+    val additionalView2 = mockk<View>(relaxed = true)
+    darkModeViewPainter.update(view, { true }, additionalView1, additionalView2)
+    verify { view.setLayerType(View.LAYER_TYPE_NONE, null) }
+    verify { additionalView1.setLayerType(View.LAYER_TYPE_NONE, null) }
+    verify { additionalView2.setLayerType(View.LAYER_TYPE_NONE, null) }
+  }
+
+  @Test
+  fun `should handle null additional views without crashing when dark mode is active`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    darkModeViewPainter.update(view, { true }, null, null)
+    verify { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+
+  @Test
+  fun `should handle null additional views without crashing when dark mode is inactive`() {
+    every { darkModeConfig.isDarkModeActive() } returns false
+    darkModeViewPainter.update(view, { true }, null, null)
+    verify { view.setLayerType(View.LAYER_TYPE_NONE, null) }
+  }
+
+  @Test
+  fun `should only update main view when no additional views are passed and dark mode is active`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    darkModeViewPainter.update(view)
+    verify { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+
+  @Test
+  fun shouldOnlyUpdateMainViewWhenNoAdditionalViewsArePassedAndDarkModeIsInactive() {
+    every { darkModeConfig.isDarkModeActive() } returns false
+    darkModeViewPainter.update(view)
+    verify { view.setLayerType(View.LAYER_TYPE_NONE, null) }
+  }
+
+  @Test
+  fun `should handle empty additional views array without crashing`() {
+    every { darkModeConfig.isDarkModeActive() } returns true
+    darkModeViewPainter.update(view, { true }, *arrayOf())
+    verify { view.setLayerType(View.LAYER_TYPE_HARDWARE, any()) }
+  }
+}


### PR DESCRIPTION
Fixes #1999 

* Added unit test cases for the `DarkModeViewPainter` class with all the edge cases.
* Added unit test cases for the `DarkModeConfig` class as this class is used in the `DarkModeViewPainter`.
* Added UI test cases to test whether the `DarkModeViewPainter` works correctly or not.
* Sometimes CI stuck on DownloadTest when the test case waits for data to load, but the "Swipe Down for Library" error text shows on the screen because of that CI takes a long time to fail, so to improve this scenario we have refactored our test case if this text is shown on the screen then it tries to refresh the online content and test case will pass. See:
            * https://github.com/kiwix/kiwix-android/actions/runs/10770667301/job/29864502974
            * https://github.com/kiwix/kiwix-android/actions/runs/10770667301/job/29864503741