### PR TITLE
Fixed: The UI showing incorrect colors in night mode.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -26,9 +26,14 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -54,7 +59,15 @@ class DeepLinksTest : BaseActivityTest() {
   private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(withContentDescription("More options"))
+        )
+      )
+    }
   }
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
@@ -26,9 +26,14 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -84,7 +89,17 @@ class DarkModeViewPainterTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -22,9 +22,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
 import leakcanary.LeakAssertions
+import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -81,7 +86,17 @@ class TopLevelDestinationTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -26,14 +26,17 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
 import leakcanary.LeakAssertions
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -96,9 +99,15 @@ class NoteFragmentTest : BaseActivityTest() {
     AccessibilityChecks.enable().apply {
       setRunChecksFromRootView(true)
       setSuppressingResultMatcher(
-        allOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesViews(ViewMatchers.withId(R.id.get_zim_nearby_device))
+        anyOf(
+          allOf(
+            matchesCheck(DuplicateClickableBoundsCheck::class.java),
+            matchesViews(ViewMatchers.withId(R.id.get_zim_nearby_device))
+          ),
+          allOf(
+            matchesCheck(TouchTargetSizeCheck::class.java),
+            matchesViews(withContentDescription("More options"))
+          )
         )
       )
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -26,8 +26,13 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -87,7 +92,17 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -25,10 +25,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
 import leakcanary.LeakAssertions
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -87,7 +92,17 @@ class NavigationHistoryTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -25,13 +25,18 @@ import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
 import leakcanary.LeakAssertions
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -85,7 +90,17 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -25,9 +25,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -86,7 +91,17 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
   }
 
   init {
-    AccessibilityChecks.enable().setRunChecksFromRootView(true)
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(
+            withContentDescription("More options")
+          )
+        )
+      )
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -26,6 +26,7 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -39,6 +40,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -109,9 +111,17 @@ class SearchFragmentTest : BaseActivityTest() {
     AccessibilityChecks.enable().apply {
       setRunChecksFromRootView(true)
       setSuppressingResultMatcher(
-        allOf(
-          matchesCheck(TouchTargetSizeCheck::class.java),
-          matchesViews(ViewMatchers.withId(id.menu_searchintext))
+        anyOf(
+          allOf(
+            matchesCheck(TouchTargetSizeCheck::class.java),
+            matchesViews(ViewMatchers.withId(id.menu_searchintext))
+          ),
+          allOf(
+            matchesCheck(TouchTargetSizeCheck::class.java),
+            matchesViews(
+              withContentDescription("More options")
+            )
+          )
         )
       )
     }

--- a/app/src/main/res/layout/fragment_destination_download.xml
+++ b/app/src/main/res/layout/fragment_destination_download.xml
@@ -68,10 +68,11 @@
 
   <androidx.cardview.widget.CardView
     android:id="@+id/onlineLibraryProgressLayout"
+    style="@style/ThemeOverlay.MaterialComponents.Dialog.Alert"
     android:layout_width="140dp"
     android:layout_height="100dp"
     android:layout_margin="16dp"
-    android:visibility="gone"
+    android:visibility="visible"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp"
     app:layout_constraintBottom_toBottomOf="parent"
@@ -99,7 +100,7 @@
         android:layout_marginTop="8dp"
         android:gravity="center"
         android:text="@string/reaching_remote_library"
-        android:textColor="@color/mine_shaft_gray900"
+        android:textAppearance="?textAppearanceSubtitle1"
         android:textSize="10sp"
         tools:ignore="SmallSp" />
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_destination_download.xml
+++ b/app/src/main/res/layout/fragment_destination_download.xml
@@ -72,7 +72,7 @@
     android:layout_width="140dp"
     android:layout_height="100dp"
     android:layout_margin="16dp"
-    android:visibility="visible"
+    android:visibility="gone"
     app:cardCornerRadius="8dp"
     app:cardElevation="4dp"
     app:layout_constraintBottom_toBottomOf="parent"

--- a/core/src/main/res/layout/layout_donation_bottom_sheet.xml
+++ b/core/src/main/res/layout/layout_donation_bottom_sheet.xml
@@ -18,6 +18,7 @@
 
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  style="@style/ThemeOverlay.MaterialComponents.Dialog.Alert"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:layout_margin="16dp"
@@ -43,13 +44,12 @@
 
     <TextView
       android:id="@+id/titleText"
+      style="@style/TextAppearance.M3.Sys.Typescale.TitleMedium"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginStart="@dimen/fullscreen_control_button_margin"
       android:text="@string/donation_dialog_title"
       android:textSize="16sp"
-      android:textAppearance="@style/TextAppearance.M3.Sys.Typescale.TitleMedium"
-      android:textColor="@color/mine_shaft_gray900"
       app:layout_constraintStart_toEndOf="@id/heart_icon"
       app:layout_constraintTop_toTopOf="@+id/heart_icon" />
 
@@ -69,7 +69,7 @@
       android:layout_height="wrap_content"
       android:padding="@dimen/activity_horizontal_margin"
       android:text="@string/rate_dialog_neutral"
-      android:textColor="@color/denim_blue800"
+      android:textColor="?attr/colorPrimary"
       app:layout_constraintEnd_toStartOf="@+id/donateButton"
       app:layout_constraintTop_toBottomOf="@id/descriptionText" />
 
@@ -79,7 +79,7 @@
       android:layout_height="wrap_content"
       android:padding="@dimen/activity_horizontal_margin"
       android:text="@string/make_donation"
-      android:textColor="@color/denim_blue800"
+      android:textColor="?attr/colorPrimary"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toBottomOf="@id/descriptionText" />
   </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #3991 

| Light Mode  | Night Mode |
| ------------- | ------------- |
|  ![1726828112615](https://github.com/user-attachments/assets/ac99eff8-3fb0-4089-b4a5-99bbcb92ef93)| ![1726828113126](https://github.com/user-attachments/assets/b0e3472e-077f-4225-8be8-6d2e3d509606)   |
| ![1726828112840](https://github.com/user-attachments/assets/4a909960-efbd-4a16-8325-c5d596d52715)  |  ![1726828113004](https://github.com/user-attachments/assets/e1963911-cbb9-4840-8cd5-7d5b4bbd6421) |


Apart from these, all other views use the Android standard colors in our project.


* Fixed an issue where the CI was sometimes failing due to an unknown reason related to the OverflowMenuButton (the three-dot default Android button) width. See this workflow https://github.com/kiwix/kiwix-android/actions/runs/11124822272/job/30911192279?pr=3998.
