### PR TITLE
Fixed: Opening with Kiwix a ZIM file (just after download) from Firefox fails.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -20,9 +20,13 @@ package org.kiwix.kiwixmobile.deeplinks
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.core.content.FileProvider
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.junit.Before
@@ -31,11 +35,13 @@ import org.junit.Test
 import org.junit.jupiter.api.fail
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.page.history.navigationHistory
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -76,6 +82,7 @@ class DeepLinksTest : BaseActivityTest() {
     loadZimFileInApplicationAndReturnSchemeTypeUri("file")?.let {
       // Launch the activity to test the deep link
       ActivityScenario.launch<KiwixMainActivity>(createDeepLinkIntent(it)).onActivity {}
+      clickOnCopy()
       navigationHistory {
         checkZimFileLoadedSuccessful(R.id.readerFragment)
         assertZimFileLoaded() // check if the zim file successfully loaded
@@ -87,11 +94,20 @@ class DeepLinksTest : BaseActivityTest() {
     }
   }
 
+  private fun clickOnCopy() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      testFlakyView({
+        onView(withText(string.action_copy)).perform(click())
+      })
+    }
+  }
+
   @Test
   fun contentTypeDeepLinkTest() {
     loadZimFileInApplicationAndReturnSchemeTypeUri("content")?.let {
       // Launch the activity to test the deep link
       ActivityScenario.launch<KiwixMainActivity>(createDeepLinkIntent(it)).onActivity {}
+      clickOnCopy()
       navigationHistory {
         checkZimFileLoadedSuccessful(R.id.readerFragment)
         assertZimFileLoaded() // check if the zim file successfully loaded

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -302,6 +302,15 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
         }
       }
     )
+    showCopyMoveDialogForOpenedZimFileFromStorage()
+  }
+
+  private fun showCopyMoveDialogForOpenedZimFileFromStorage() {
+    val args = LocalLibraryFragmentArgs.fromBundle(requireArguments())
+    if (args.zimFileUri.isNotEmpty()) {
+      handleSelectedFileUri(args.zimFileUri.toUri())
+    }
+    requireArguments().clear()
   }
 
   private fun setUpSwipeRefreshLayout() {

--- a/app/src/main/res/navigation/kiwix_nav_graph.xml
+++ b/app/src/main/res/navigation/kiwix_nav_graph.xml
@@ -81,6 +81,10 @@
     <action
       android:id="@+id/action_libraryFragment_to_localFileTransferFragment"
       app:destination="@id/localFileTransferFragment" />
+    <argument
+      android:name="zimFileUri"
+      android:defaultValue=""
+      app:argType="string" />
   </fragment>
 
   <fragment


### PR DESCRIPTION
Fixes #3997 
Fixes #3941 

* Fixed an issue where the ZIM file would not load when opened directly from the file manager.
* Fixed the issue with opening a ZIM file from the browser's download screen.
* We improved the DeppLinksTest to test this functionality, so that we can avoid this type of error in the future.

| Before Fix  | After Fix | After Fix | 
| ------------- | ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/5c23e442-050e-4e64-b2a1-fc9ed12c839d"/>  | <video src="https://github.com/user-attachments/assets/4a7cbdff-f854-41c7-a012-edc0078a64d1"/>  | <video src="https://github.com/user-attachments/assets/6f6b8707-64f7-4e2e-a7b0-d9eb76702d83"/> | 










