### PR TITLE
Fixed: Medical wikimedia (mini) keeps crashing.

### DIFF
--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -58,7 +58,7 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
   }
 
   @Suppress("MagicNumber")
-  private fun getAssetFileDescriptorListFromPlayAssetDelivery(): List<AssetFileDescriptor> {
+  fun getAssetFileDescriptorListFromPlayAssetDelivery(): List<AssetFileDescriptor> {
     try {
       val assetManager = context.createPackageContext(context.packageName, 0).assets
       val assetFileDescriptorList: ArrayList<AssetFileDescriptor> = arrayListOf()

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.content.res.AssetManager
 import androidx.core.content.ContextCompat
+import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasBothFiles
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasFile
@@ -94,28 +95,34 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
     return chunkFiles
   }
 
-  private fun obbFiles() = scanDirs(ContextCompat.getObbDirs(context), "obb")
+  private fun obbFiles() =
+    scanDirs(
+      ContextCompat.getObbDirs(context).filterNotNull().filter(File::isFileExist).toTypedArray(),
+      "obb"
+    )
 
   private fun zimFiles(): List<File> {
     // Create a list to store the parent directories
     val directoryList = mutableListOf<File>()
 
     // Get the external files directories for the app
-    ContextCompat.getExternalFilesDirs(context, null).forEach { dir ->
-      // Check if the directory's parent is not null
-      dir?.parent?.let { parentPath ->
-        // Add the parent directory to the list, so we can scan all the files contained in the folder.
-        // We are doing this because ContextCompat.getExternalFilesDirs(context, null) method returns the path to the
-        // "files" folder, which is specific to the app's package name, both for internal and SD card storage.
-        // By obtaining the parent directory, we can scan files from the app-specific directory itself.
-        directoryList.add(File(parentPath))
-      } ?: kotlin.run {
-        // If the parent directory is null, it means the current directory is the target folder itself.
-        // Add the current directory to the list, as it represents the app-specific directory for both internal
-        // and SD card storage. This allows us to scan files directly from this directory.
-        directoryList.add(dir)
+    ContextCompat.getExternalFilesDirs(context, null).filterNotNull()
+      .filter(File::isFileExist)
+      .forEach { dir ->
+        // Check if the directory's parent is not null
+        dir.parent?.let { parentPath ->
+          // Add the parent directory to the list, so we can scan all the files contained in the folder.
+          // We are doing this because ContextCompat.getExternalFilesDirs(context, null) method returns the path to the
+          // "files" folder, which is specific to the app's package name, both for internal and SD card storage.
+          // By obtaining the parent directory, we can scan files from the app-specific directory itself.
+          directoryList.add(File(parentPath))
+        } ?: kotlin.run {
+          // If the parent directory is null, it means the current directory is the target folder itself.
+          // Add the current directory to the list, as it represents the app-specific directory for both internal
+          // and SD card storage. This allows us to scan files directly from this directory.
+          directoryList.add(dir)
+        }
       }
-    }
     return scanDirs(directoryList.toTypedArray(), "zim")
   }
 

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.custom.download.main
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.AssetFileDescriptor
+import android.content.res.AssetManager
+import androidx.core.content.ContextCompat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.custom.main.CustomFileValidator
+import org.kiwix.kiwixmobile.custom.main.ValidationState
+import java.io.File
+
+class CustomFileValidatorTest {
+
+  private lateinit var context: Context
+  private lateinit var customFileValidator: CustomFileValidator
+  private lateinit var assetManager: AssetManager
+
+  @BeforeEach
+  fun setUp() {
+    context = mockk(relaxed = true)
+    assetManager = mockk(relaxed = true)
+    customFileValidator = CustomFileValidator(context)
+  }
+
+  @Test
+  fun `validate should call onFilesFound when both OBB and ZIM files are found`() {
+    val obbFile = mockk<File>()
+    val zimFile = mockk<File>()
+    mockZimFiles(arrayOf(obbFile), obbFile, "obb")
+    mockZimFiles(arrayOf(zimFile), zimFile, "zim")
+
+    customFileValidator.validate(
+      onFilesFound = {
+        assertTrue(it is ValidationState.HasBothFiles)
+        assertEquals(obbFile, (it as ValidationState.HasBothFiles).obbFile)
+        assertEquals(zimFile, it.zimFile)
+      },
+      onNoFilesFound = { fail("Should not call onNoFilesFound") }
+    )
+  }
+
+  @Test
+  fun `validate should call onFilesFound when only OBB file is found`() {
+    val obbFile = mockk<File>()
+    mockZimFiles(arrayOf(obbFile), obbFile, "obb")
+    mockZimFiles(emptyArray(), obbFile, "zim")
+
+    customFileValidator.validate(
+      onFilesFound = {
+        assertTrue(it is ValidationState.HasFile)
+        assertEquals(obbFile, (it as ValidationState.HasFile).file)
+      },
+      onNoFilesFound = { fail("Should not call onNoFilesFound") }
+    )
+  }
+
+  @Test
+  fun `validate should call onFilesFound when only ZIM file is found`() {
+    val zimFile = mockk<File>()
+    mockZimFiles(emptyArray(), zimFile, "obb")
+    mockZimFiles(arrayOf(zimFile), zimFile, "zim")
+
+    customFileValidator.validate(
+      onFilesFound = {
+        assertTrue(it is ValidationState.HasFile)
+        assertEquals(zimFile, (it as ValidationState.HasFile).file)
+      },
+      onNoFilesFound = { fail("Should not call onNoFilesFound") }
+    )
+  }
+
+  @Test
+  fun `validate should call onNoFilesFound when no OBB or ZIM files are found`() {
+    mockZimFiles(emptyArray(), mockk(), extension = "zim")
+    mockZimFiles(emptyArray(), mockk(), extension = "obb")
+
+    customFileValidator.validate(
+      onFilesFound = { fail("Should not call onFilesFound") },
+      onNoFilesFound = { /* Success */ }
+    )
+  }
+
+  @Test
+  fun `getAssetFileDescriptorListFromPlayAssetDelivery returns empty list when exception occurs`() {
+    every {
+      context.createPackageContext(
+        any(),
+        any()
+      ).assets
+    } throws PackageManager.NameNotFoundException()
+
+    val assetList = customFileValidator.getAssetFileDescriptorListFromPlayAssetDelivery()
+
+    assertTrue(assetList.isEmpty())
+  }
+
+  @Test
+  fun `getAssetFileDescriptorListFromPlayAssetDelivery returns list of asset descriptors`() {
+    val descriptor = mockk<AssetFileDescriptor>()
+    every { context.createPackageContext(any(), any()).assets } returns assetManager
+    every { assetManager.openFd(any()) } returns descriptor
+    every { assetManager.list("") } returns arrayOf("chunk1.zim", "chunk2.zim")
+
+    val assetList = customFileValidator.getAssetFileDescriptorListFromPlayAssetDelivery()
+
+    assertEquals(2, assetList.size)
+    assertEquals(descriptor, assetList[0])
+  }
+
+  private fun mockZimFiles(
+    storageDirectory: Array<File?>,
+    zimFile: File,
+    extension: String
+  ) {
+    every { zimFile.exists() } returns true
+    every { zimFile.isFile } returns true
+    every { zimFile.extension } returns extension
+    mockkStatic(File::walk)
+    storageDirectory.forEach { dir ->
+      dir?.let {
+        every { dir.exists() } returns true
+        every { dir.isDirectory } returns true
+        every { dir.extension } returns ""
+        every { dir.parent } returns null
+        every { dir.listFiles() } returns arrayOf(zimFile)
+        every { dir.walk() } answers { mockFileWalk(listOf(zimFile)) }
+      }
+    }
+
+    if (extension == "zim") {
+      every { ContextCompat.getExternalFilesDirs(context, null) } returns storageDirectory
+    } else {
+      every { ContextCompat.getObbDirs(context) } returns storageDirectory
+    }
+  }
+
+  private fun mockFileWalk(files: List<File>): FileTreeWalk {
+    val fileTreeWalk = mockk<FileTreeWalk>()
+    every { fileTreeWalk.iterator() } returns files.iterator()
+    return fileTreeWalk
+  }
+}


### PR DESCRIPTION
Fixes #4000

* This issue occurred when we tried to access ZIM files from the application’s folder in the `zimFiles()` method. In this method, we add directories to a non-null list of files. However, when attempting to retrieve the list of files from the application directory, the SD card path was null due to the SD card being unmounted, which caused the application to crash.
* To fix this, we have improved our `zimFiles()` and `obbFiles()` methods to return only existing, non-null directories. This ensures proper handling of file system detection, so if a directory is unavailable or returns null, these methods handle it appropriately.

