### PR TITLE
Fixed: The donation popup does not look well in tablet.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
@@ -185,4 +186,7 @@ object ActivityExtensions {
     } else {
       true
     }
+
+  fun Activity.isLandScapeMode(): Boolean =
+    resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/DonationDialogHandler.kt
@@ -50,7 +50,9 @@ class DonationDialogHandler @Inject constructor(
     }
   }
 
-  private fun shouldShowInitialPopup(lastPopupMillis: Long): Boolean = lastPopupMillis == 0L
+  private fun shouldShowInitialPopup(lastPopupMillis: Long): Boolean =
+    lastPopupMillis == 0L && isZimFilesAvailableInLibrary()
+
   private fun isTimeToShowDonation(currentMillis: Long): Boolean =
     isLaterNotClicked() || isLaterPeriodOver(currentMillis)
 

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -25,4 +25,5 @@
   <dimen name="close_tab_button_size">24dp</dimen>
   <dimen name="find_in_page_button_padding">13dp</dimen>
   <dimen name="donation_popup_bottom_margin">20dp</dimen>
+  <dimen name="maximum_donation_popup_width">400dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #3736

The donation popup was not looking good on tablets, so we have improved the design of the donation popup for tablets.

| Tablet landscape  | Tablet portrait |
| ------------- | ------------- |
| ![TabletDayModeLandscape](https://github.com/user-attachments/assets/e69ef986-b318-46a6-8699-b517bce38897) | ![TabletDayModePotrait](https://github.com/user-attachments/assets/e1e881fd-a21b-4c65-9c62-90647d58c01c) | 


| Tablet landscape in Dark mode | Tablet portrait in Dark mode |
| ------------- | ------------- |
| ![TabletDarkModeLandscape](https://github.com/user-attachments/assets/e768cf1d-c5ed-4318-b8eb-31e4c07e86ab) | ![TabletDarkMode](https://github.com/user-attachments/assets/eb928545-63ac-4385-a884-fdbbb5751a0f) |


In normal devices
![Screenshot from 2024-10-07 14-25-36](https://github.com/user-attachments/assets/d5f8b053-289c-44fa-9d9a-9c0cd927d7d6)


