### PR TITLE
Fixed: In Samsung tablet of Android 14, downloaded files can not be opened via file picker or deep linking in non-PS variant.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
@@ -406,6 +406,15 @@ class FileUtilsInstrumentationTest {
         Uri.parse(
           "${downloadUriPrefix}0"
         )
+      ),
+      DummyUrlData(
+        null,
+        null,
+        null,
+        null,
+        Uri.parse(
+          "${downloadDocumentUriPrefix}msf%3A1000000057"
+        )
       )
     )
     context?.let { context ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -186,7 +186,9 @@ object FileUtils {
     var actualFilePath: String? = null
     if (filePath?.isNotEmpty() == true) {
       getStorageVolumesList(context).forEach { volume ->
-        val file = File("$volume/$filePath")
+        // Check if the volume is part of the file path and remove it
+        val trimmedFilePath = filePath.removePrefix(volume)
+        val file = File("$volume/$trimmedFilePath")
         if (file.isFileExist()) {
           actualFilePath = file.path
         }
@@ -283,7 +285,9 @@ object FileUtils {
     if (pathSegments.isNotEmpty()) {
       // Returns the path of the folder containing the file with the specified fileName,
       // from which the user selects the file.
-      return pathSegments.drop(1).joinToString(separator = "/")
+      return pathSegments.drop(1)
+        .filterNot { it.startsWith("0") } // remove the prefix of primary storage device
+        .joinToString(separator = "/")
     }
     return null
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -184,10 +184,12 @@ object FileUtils {
     filePath: String?
   ): String? {
     var actualFilePath: String? = null
-    getStorageVolumesList(context).forEach { volume ->
-      val file = File("$volume/$filePath")
-      if (file.isFileExist()) {
-        actualFilePath = file.path
+    if (filePath?.isNotEmpty() == true) {
+      getStorageVolumesList(context).forEach { volume ->
+        val file = File("$volume/$filePath")
+        if (file.isFileExist()) {
+          actualFilePath = file.path
+        }
       }
     }
     return actualFilePath


### PR DESCRIPTION
Fixes #4008

* When we open a file from different browsers, they provide a URI through their own file provider, and the content resolver cannot retrieve the file path for these types of URIs. To fix this issue, we have introduced a fallback method that returns the exact path of the file located in the Downloads folder.
* Another issue we encountered on tablets is that the URIs are different from those on regular mobile devices, and our `documentProviderContentQuery` method could not return the path for these types of URIs from the Downloads folder. To fix this issue, we used our fallback method to retrieve the file path for these URIs.


**Before Fix **

https://github.com/user-attachments/assets/7bf5b236-dfe0-47bb-a6bc-1fde772a4bd7

**After Fix**

https://github.com/user-attachments/assets/8cf41ad0-f1c0-48d2-8266-c0451afb0580


File opening issue from the file manager in Huawei phones:

Before fix:


https://github.com/user-attachments/assets/3caf4083-a799-4d7c-9dce-26d06ae55c44


After Fix:


https://github.com/user-attachments/assets/5b4793e9-5a3e-408e-9159-042d687a34a0

* Added the proper comments on methods for dev's reference, why we are using those methods.
