### PR TITLE
Added the `foregroundServiceType` in manifest for `ReadAloudService`, and `HotspotService`.

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
   <uses-permission
     android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
   <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <queries>
     <intent>
       <action android:name="android.intent.action.TTS_SERVICE" />
@@ -97,7 +99,11 @@
     <activity
       android:name=".error.DiagnosticReportActivity"
       android:exported="false" />
-    <service android:name=".read_aloud.ReadAloudService" />
-    <service android:name=".webserver.wifi_hotspot.HotspotService" />
+    <service
+      android:name=".read_aloud.ReadAloudService"
+      android:foregroundServiceType="mediaPlayback" />
+    <service
+      android:name=".webserver.wifi_hotspot.HotspotService"
+      android:foregroundServiceType="specialUse" />
   </application>
 </manifest>


### PR DESCRIPTION
Fixes #4016 

Added the `foregroundServiceType` in the manifest for `ReadAloudService`, and `HotspotService` to properly work with android 14.
