### PR TITLE
Fixed: CI sometimes stuck on instrumentation test cases.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -37,7 +37,6 @@ import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
-import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
@@ -193,15 +192,6 @@ class DownloadRobot : BaseRobot() {
         "DOWNLOAD_TEST",
         "Failed to stop downloading. Probably because it is not downloading the zim file"
       )
-    }
-  }
-
-  fun refreshLocalLibraryData() {
-    try {
-      refresh(R.id.zim_swiperefresh)
-      pauseForBetterTestPerformance()
-    } catch (e: RuntimeException) {
-      Log.w(KIWIX_DOWNLOAD_TEST, "Failed to refresh ZIM list: " + e.localizedMessage)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -140,7 +140,8 @@ class DownloadRobot : BaseRobot() {
     onView(withText(org.kiwix.kiwixmobile.core.R.string.paused_state)).check(doesNotExist())
   }
 
-  fun waitUntilDownloadComplete(retryCountForDownloadingZimFile: Int = 25) {
+  // wait for 5 minutes for downloading the ZIM file
+  fun waitUntilDownloadComplete(retryCountForDownloadingZimFile: Int = 30) {
     try {
       onView(withId(R.id.stop)).check(doesNotExist())
       Log.i("kiwixDownloadTest", "Download complete")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -18,7 +18,11 @@
 
 package org.kiwix.kiwixmobile.download
 
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -30,6 +34,7 @@ import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
+import org.hamcrest.Matcher
 import org.junit.Assert
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
@@ -40,6 +45,7 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
+import org.kiwix.kiwixmobile.zimManager.libraryView.adapter.LibraryListItem
 
 fun downloadRobot(func: DownloadRobot.() -> Unit) =
   DownloadRobot().applyWithViewHierarchyPrinting(func)
@@ -102,12 +108,12 @@ class DownloadRobot : BaseRobot() {
     refresh(R.id.librarySwipeRefresh)
   }
 
-  fun downloadZimFile() {
+  fun downloadZimFile(position: Int = 1) {
     pauseForBetterTestPerformance()
     testFlakyView({
       onView(
         RecyclerViewMatcher(R.id.libraryList).atPosition(
-          1
+          position
         )
       ).perform(click())
     })
@@ -188,6 +194,54 @@ class DownloadRobot : BaseRobot() {
         "DOWNLOAD_TEST",
         "Failed to stop downloading. Probably because it is not downloading the zim file"
       )
+    }
+  }
+
+  fun getSmallestZimFileIndex(it: List<LibraryListItem>?): Int {
+    var zimFileSizeWithIndex: Pair<Int, Long> = 0 to Long.MAX_VALUE
+    it?.forEachIndexed { index, libraryItem ->
+      if (libraryItem is LibraryListItem.BookItem) {
+        val bookSize = libraryItem.book.size.toLong()
+        if (bookSize < 20000L) {
+          return@getSmallestZimFileIndex index
+        } else if (bookSize < zimFileSizeWithIndex.second) {
+          zimFileSizeWithIndex = index to bookSize
+        }
+      }
+    }
+    return zimFileSizeWithIndex.first
+  }
+
+  fun scrollToZimFileIndex(index: Int) {
+    testFlakyView({
+      onView(withId(R.id.libraryList))
+        .perform(scrollToTop(index))
+    })
+  }
+
+  private fun scrollToTop(position: Int): ViewAction {
+    return object : ViewAction {
+      override fun getDescription(): String =
+        "scroll RecyclerView item at position $position to the top"
+
+      override fun getConstraints(): Matcher<View> =
+        androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom(RecyclerView::class.java)
+
+      override fun perform(uiController: UiController, view: View) {
+        val recyclerView = view as RecyclerView
+        val viewHolder = recyclerView.findViewHolderForAdapterPosition(position)
+
+        if (viewHolder?.itemView == null) {
+          recyclerView.scrollToPosition(position)
+          uiController.loopMainThreadUntilIdle()
+        }
+
+        val newViewHolder = recyclerView.findViewHolderForAdapterPosition(position)
+        newViewHolder?.let {
+          val top = newViewHolder.itemView.top
+          recyclerView.scrollBy(0, top)
+        }
+      }
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -153,6 +153,7 @@ class DownloadRobot : BaseRobot() {
       Log.i("kiwixDownloadTest", "Download complete")
     } catch (e: AssertionFailedError) {
       if (retryCountForDownloadingZimFile > 0) {
+        resumeDownloadIfPaused()
         BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
         Log.i("kiwixDownloadTest", "Downloading in progress")
         waitUntilDownloadComplete(retryCountForDownloadingZimFile - 1)
@@ -160,6 +161,15 @@ class DownloadRobot : BaseRobot() {
       }
       // throw the exception when there is no more retry left.
       throw RuntimeException("Couldn't download the ZIM file.\n Original exception = $e")
+    }
+  }
+
+  private fun resumeDownloadIfPaused() {
+    try {
+      onView(withSubstring(context.getString(string.paused_state))).check(matches(isDisplayed()))
+      resumeDownload()
+    } catch (e: RuntimeException) {
+      // do nothing since downloading is In Progress.
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -150,14 +150,14 @@ class DownloadRobot : BaseRobot() {
     onView(withText(org.kiwix.kiwixmobile.core.R.string.paused_state)).check(doesNotExist())
   }
 
-  fun waitUntilDownloadComplete() {
+  fun waitUntilDownloadComplete(retryCountForDownloadingZimFile: Int = 20) {
     try {
       onView(withId(R.id.stop)).check(doesNotExist())
       Log.i("kiwixDownloadTest", "Download complete")
     } catch (e: AssertionFailedError) {
       BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
       Log.i("kiwixDownloadTest", "Downloading in progress")
-      waitUntilDownloadComplete()
+      waitUntilDownloadComplete(retryCountForDownloadingZimFile - 1)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -139,6 +139,10 @@ class DownloadTest : BaseActivityTest() {
         stopDownloadIfAlreadyStarted()
         downloadZimFile(smallestZimFileIndex)
         assertDownloadStart()
+        pauseDownload()
+        assertDownloadPaused()
+        resumeDownload()
+        assertDownloadResumed()
         waitUntilDownloadComplete()
         clickLibraryOnBottomNav()
         // refresh the local library list to show the downloaded zim file

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -48,6 +48,7 @@ import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChan
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
+import org.kiwix.kiwixmobile.nav.destination.library.LibraryRobot
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
@@ -117,10 +118,10 @@ class DownloadTest : BaseActivityTest() {
       it.navigate(R.id.libraryFragment)
     }
     try {
-      downloadRobot(DownloadRobot::refreshLocalLibraryData)
       // delete all the ZIM files showing in the LocalLibrary
       // screen to properly test the scenario.
       library {
+        refreshList()
         waitUntilZimFilesRefreshing()
         deleteZimIfExists()
       }
@@ -138,7 +139,7 @@ class DownloadTest : BaseActivityTest() {
         waitUntilDownloadComplete()
         clickLibraryOnBottomNav()
         // refresh the local library list to show the downloaded zim file
-        refreshLocalLibraryData()
+        library(LibraryRobot::refreshList)
         checkIfZimFileDownloaded()
       }
     } catch (e: Exception) {
@@ -156,10 +157,10 @@ class DownloadTest : BaseActivityTest() {
       it.navigate(R.id.libraryFragment)
     }
     try {
-      downloadRobot(DownloadRobot::refreshLocalLibraryData)
       // delete all the ZIM files showing in the LocalLibrary
       // screen to properly test the scenario.
       library {
+        refreshList()
         waitUntilZimFilesRefreshing()
         deleteZimIfExists()
       }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -40,6 +40,7 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.BaseActivityTest
@@ -51,6 +52,7 @@ import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.nav.destination.library.LibraryRobot
 import org.kiwix.kiwixmobile.nav.destination.library.OnlineLibraryFragment
 import org.kiwix.kiwixmobile.nav.destination.library.library
+import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
@@ -62,9 +64,9 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class DownloadTest : BaseActivityTest() {
 
-  // @Rule
-  // @JvmField
-  // var retryRule = RetryRule()
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
 
@@ -137,10 +139,6 @@ class DownloadTest : BaseActivityTest() {
         stopDownloadIfAlreadyStarted()
         downloadZimFile(smallestZimFileIndex)
         assertDownloadStart()
-        pauseDownload()
-        assertDownloadPaused()
-        resumeDownload()
-        assertDownloadResumed()
         waitUntilDownloadComplete()
         clickLibraryOnBottomNav()
         // refresh the local library list to show the downloaded zim file

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -118,16 +118,8 @@ class DownloadTest : BaseActivityTest() {
       it.navigate(R.id.libraryFragment)
     }
     try {
-      // delete all the ZIM files showing in the LocalLibrary
-      // screen to properly test the scenario.
-      library {
-        refreshList()
-        waitUntilZimFilesRefreshing()
-        deleteZimIfExists()
-      }
       downloadRobot {
         clickDownloadOnBottomNav()
-        refreshOnlineList()
         waitForDataToLoad()
         stopDownloadIfAlreadyStarted()
         downloadZimFile()
@@ -157,13 +149,6 @@ class DownloadTest : BaseActivityTest() {
       it.navigate(R.id.libraryFragment)
     }
     try {
-      // delete all the ZIM files showing in the LocalLibrary
-      // screen to properly test the scenario.
-      library {
-        refreshList()
-        waitUntilZimFilesRefreshing()
-        deleteZimIfExists()
-      }
       downloadRobot {
         // change the application language
         topLevel {
@@ -177,7 +162,6 @@ class DownloadTest : BaseActivityTest() {
           }
         }
         clickDownloadOnBottomNav()
-        refreshOnlineList()
         waitForDataToLoad()
         stopDownloadIfAlreadyStarted()
         downloadZimFile()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -28,7 +28,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
-import junit.framework.AssertionFailedError
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
@@ -53,7 +52,7 @@ class InitialDownloadRobot : BaseRobot() {
     isVisible(ViewId(R.id.libraryList))
   }
 
-  fun refreshOnlineList() {
+  private fun refreshOnlineList() {
     refresh(R.id.librarySwipeRefresh)
   }
 
@@ -119,12 +118,7 @@ class InitialDownloadRobot : BaseRobot() {
   }
 
   fun assertDownloadStop() {
-    try {
-      onView(withId(R.id.stop)).check(doesNotExist())
-    } catch (e: AssertionFailedError) {
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
-      assertDownloadStop()
-    }
+    testFlakyView({ onView(withId(R.id.stop)).check(doesNotExist()) }, 10)
   }
 
   private fun pauseForBetterTestPerformance() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -57,15 +57,6 @@ class InitialDownloadRobot : BaseRobot() {
     refresh(R.id.librarySwipeRefresh)
   }
 
-  fun refreshLocalLibraryData() {
-    try {
-      refresh(R.id.zim_swiperefresh)
-      pauseForBetterTestPerformance()
-    } catch (e: RuntimeException) {
-      Log.w("InitialDownloadTest", "Failed to refresh ZIM list: " + e.localizedMessage)
-    }
-  }
-
   fun waitForDataToLoad(retryCountForDataToLoad: Int = 10) {
     try {
       isVisible(TextId(string.your_languages))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -118,7 +118,6 @@ class InitialDownloadTest : BaseActivityTest() {
     initialDownload {
       clickDownloadOnBottomNav()
       assertLibraryListDisplayed()
-      refreshOnlineList()
       waitForDataToLoad()
       stopDownloadIfAlreadyStarted()
       downloadZimFile()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -108,10 +108,10 @@ class InitialDownloadTest : BaseActivityTest() {
     activityScenario.onActivity {
       it.navigate(R.id.libraryFragment)
     }
-    initialDownload(InitialDownloadRobot::refreshLocalLibraryData)
     // delete all the ZIM files showing in the LocalLibrary
     // screen to properly test the scenario.
     library {
+      refreshList()
       waitUntilZimFilesRefreshing()
       deleteZimIfExists()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -35,6 +35,7 @@ import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import uk.co.deanwild.materialshowcaseview.R.id
 
 /**
  * Authored by Ayush Shrivastava on 29/10/20
@@ -84,20 +85,24 @@ class LocalFileTransferRobot : BaseRobot() {
   fun assertClickNearbyDeviceMessageVisible() {
     pauseForBetterTestPerformance()
     testFlakyView({
-      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+      onView(withId(id.tv_content))
         .check(matches(withText(string.click_nearby_devices_message)))
     })
   }
 
   fun clickOnGotItButton() {
     pauseForBetterTestPerformance()
-    testFlakyView({ onView(withText(string.got_it)).perform(click()) })
+    testFlakyView({
+      onView(withId(id.tv_dismiss))
+        .check(matches(isDisplayed()))
+        .perform(click())
+    })
   }
 
   fun assertDeviceNameMessageVisible() {
     pauseForBetterTestPerformance()
     testFlakyView({
-      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+      onView(withId(id.tv_content))
         .check(matches(withText(string.your_device_name_message)))
     })
   }
@@ -105,7 +110,7 @@ class LocalFileTransferRobot : BaseRobot() {
   fun assertNearbyDeviceListMessageVisible() {
     pauseForBetterTestPerformance()
     testFlakyView({
-      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+      onView(withId(id.tv_content))
         .check(matches(withText(string.nearby_devices_list_message)))
     })
   }
@@ -113,7 +118,7 @@ class LocalFileTransferRobot : BaseRobot() {
   fun assertTransferZimFilesListMessageVisible() {
     pauseForBetterTestPerformance()
     testFlakyView({
-      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+      onView(withId(id.tv_content))
         .check(matches(withText(string.transfer_zim_files_list_message)))
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -94,7 +94,7 @@ class LocalFileTransferRobot : BaseRobot() {
     pauseForBetterTestPerformance()
     testFlakyView({
       onView(withId(id.tv_dismiss))
-        .check(matches(isDisplayed()))
+        .check(matches(withText(string.got_it)))
         .perform(click())
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -94,7 +94,6 @@ class LocalFileTransferRobot : BaseRobot() {
     pauseForBetterTestPerformance()
     testFlakyView({
       onView(withId(id.tv_dismiss))
-        .check(matches(withText(string.got_it)))
         .perform(click())
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
@@ -82,7 +83,10 @@ class LocalFileTransferRobot : BaseRobot() {
 
   fun assertClickNearbyDeviceMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(string.click_nearby_devices_message))
+    testFlakyView({
+      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+        .check(matches(withText(string.click_nearby_devices_message)))
+    })
   }
 
   fun clickOnGotItButton() {
@@ -92,17 +96,26 @@ class LocalFileTransferRobot : BaseRobot() {
 
   fun assertDeviceNameMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(string.your_device_name_message))
+    testFlakyView({
+      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+        .check(matches(withText(string.your_device_name_message)))
+    })
   }
 
   fun assertNearbyDeviceListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(string.nearby_devices_list_message))
+    testFlakyView({
+      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+        .check(matches(withText(string.nearby_devices_list_message)))
+    })
   }
 
   fun assertTransferZimFilesListMessageVisible() {
     pauseForBetterTestPerformance()
-    isVisible(TextId(string.transfer_zim_files_list_message))
+    testFlakyView({
+      onView(withId(uk.co.deanwild.materialshowcaseview.R.id.tv_content))
+        .check(matches(withText(string.transfer_zim_files_list_message)))
+    })
   }
 
   fun assertClickNearbyDeviceMessageNotVisible() {
@@ -111,6 +124,6 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_LOCAL_LIBRARY_TEST.toLong())
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRobot.kt
@@ -111,6 +111,6 @@ class LocalFileTransferRobot : BaseRobot() {
   }
 
   private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_LOCAL_LIBRARY_TEST.toLong())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -147,35 +147,37 @@ class LocalFileTransferTest {
 
   @Test
   fun showCaseFeature() {
-    shouldShowShowCaseFeatureToUser(true, isResetShowCaseId = true)
-    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        handleLocaleChange(
-          it,
-          "en",
-          SharedPreferenceUtil(context)
-        )
-        it.navigate(R.id.libraryFragment)
+    if (Build.VERSION.SDK_INT != Build.VERSION_CODES.TIRAMISU) {
+      shouldShowShowCaseFeatureToUser(true, isResetShowCaseId = true)
+      activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+        moveToState(Lifecycle.State.RESUMED)
+        onActivity {
+          handleLocaleChange(
+            it,
+            "en",
+            SharedPreferenceUtil(context)
+          )
+          it.navigate(R.id.libraryFragment)
+        }
       }
-    }
-    StandardActions.closeDrawer()
-    library {
-      assertGetZimNearbyDeviceDisplayed()
-      clickFileTransferIcon {
-        assertClickNearbyDeviceMessageVisible()
-        clickOnGotItButton()
-        assertDeviceNameMessageVisible()
-        clickOnGotItButton()
-        assertNearbyDeviceListMessageVisible()
-        clickOnGotItButton()
-        assertTransferZimFilesListMessageVisible()
-        clickOnGotItButton()
-        pressBack()
+      StandardActions.closeDrawer()
+      library {
         assertGetZimNearbyDeviceDisplayed()
+        clickFileTransferIcon {
+          assertClickNearbyDeviceMessageVisible()
+          clickOnGotItButton()
+          assertDeviceNameMessageVisible()
+          clickOnGotItButton()
+          assertNearbyDeviceListMessageVisible()
+          clickOnGotItButton()
+          assertTransferZimFilesListMessageVisible()
+          clickOnGotItButton()
+          pressBack()
+          assertGetZimNearbyDeviceDisplayed()
+        }
       }
+      LeakAssertions.assertNoLeaks()
     }
-    LeakAssertions.assertNoLeaks()
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -49,7 +49,6 @@ fun library(func: LibraryRobot.() -> Unit) = LibraryRobot().applyWithViewHierarc
 class LibraryRobot : BaseRobot() {
 
   private val zimFileTitle = "Test_Zim"
-  private var retryCountForRefreshingZimFiles = 5
 
   fun assertGetZimNearbyDeviceDisplayed() {
     isVisible(ViewId(R.id.get_zim_nearby_device))
@@ -70,18 +69,29 @@ class LibraryRobot : BaseRobot() {
   }
 
   fun refreshList() {
-    refresh(R.id.zim_swiperefresh)
+    pauseForBetterTestPerformance()
+    try {
+      onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))
+      refresh(R.id.zim_swiperefresh)
+      return
+    } catch (ignore: Exception) {
+      try {
+        onView(withId(R.id.zimfilelist)).check(matches(isDisplayed()))
+        refresh(R.id.zim_swiperefresh)
+      } catch (e: AssertionFailedError) {
+        // do nothing
+      }
+    }
   }
 
-  fun waitUntilZimFilesRefreshing() {
+  fun waitUntilZimFilesRefreshing(retryCountForRefreshingZimFiles: Int = 5) {
     try {
       onView(withId(R.id.scanning_progress_view)).check(matches(not(isDisplayed())))
     } catch (ignore: AssertionFailedError) {
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
       Log.i("LOCAL_LIBRARY", "Scanning of storage to find ZIM files in progress")
       if (retryCountForRefreshingZimFiles > 0) {
-        retryCountForRefreshingZimFiles--
-        waitUntilZimFilesRefreshing()
+        waitUntilZimFilesRefreshing(retryCountForRefreshingZimFiles - 1)
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -74,7 +74,7 @@ class LibraryRobot : BaseRobot() {
       onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))
       refresh(R.id.zim_swiperefresh)
       return
-    } catch (ignore: Exception) {
+    } catch (ignore: AssertionFailedError) {
       try {
         onView(withId(R.id.zimfilelist)).check(matches(isDisplayed()))
         refresh(R.id.zim_swiperefresh)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -73,13 +73,15 @@ class LibraryRobot : BaseRobot() {
     try {
       onView(withId(R.id.file_management_no_files)).check(matches(isDisplayed()))
       refresh(R.id.zim_swiperefresh)
-      return
     } catch (ignore: AssertionFailedError) {
       try {
         onView(withId(R.id.zimfilelist)).check(matches(isDisplayed()))
         refresh(R.id.zim_swiperefresh)
       } catch (e: AssertionFailedError) {
-        // do nothing
+        Log.i(
+          "LOCAL_LIBRARY",
+          "No need to refresh the data, since there is no files found"
+        )
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -86,16 +86,10 @@ class LibraryRobot : BaseRobot() {
     }
   }
 
-  fun waitUntilZimFilesRefreshing(retryCountForRefreshingZimFiles: Int = 5) {
-    try {
+  fun waitUntilZimFilesRefreshing() {
+    testFlakyView({
       onView(withId(R.id.scanning_progress_view)).check(matches(not(isDisplayed())))
-    } catch (ignore: AssertionFailedError) {
-      BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
-      Log.i("LOCAL_LIBRARY", "Scanning of storage to find ZIM files in progress")
-      if (retryCountForRefreshingZimFiles > 0) {
-        waitUntilZimFilesRefreshing(retryCountForRefreshingZimFiles - 1)
-      }
-    }
+    })
   }
 
   fun deleteZimIfExists() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -27,7 +27,6 @@ import androidx.test.espresso.accessibility.AccessibilityChecks
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
@@ -138,8 +137,10 @@ class LocalLibraryTest : BaseActivityTest() {
         }
       }
     }
-    refresh(R.id.zim_swiperefresh)
-    library(LibraryRobot::assertLibraryListDisplayed)
+    library {
+      refreshList()
+      assertLibraryListDisplayed()
+    }
     LeakAssertions.assertNoLeaks()
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -164,9 +164,8 @@ class NoteFragmentTest : BaseActivityTest() {
       kiwixMainActivity.navigate(R.id.libraryFragment)
     }
 
-    note(NoteRobot::refreshList)
-
     library {
+      refreshList()
       waitUntilZimFilesRefreshing()
       deleteZimIfExists()
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -35,7 +35,6 @@ import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.Locator
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
@@ -110,10 +109,6 @@ class NoteRobot : BaseRobot() {
     // This is flaky since it is shown in a dialog and sometimes
     // UIDevice does not found the view immediately due to rendering process.
     testFlakyView({ isVisible(Text(noteText)) })
-  }
-
-  fun refreshList() {
-    refresh(org.kiwix.kiwixmobile.R.id.zim_swiperefresh)
   }
 
   fun clickOnTrashIcon() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -54,7 +54,6 @@ import java.util.Date
 object TestUtils {
   private const val TAG = "TESTUTILS"
   @JvmField var TEST_PAUSE_MS = 3000
-  const val TEST_PAUSE_MS_FOR_LOCAL_LIBRARY_TEST = 6000
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
   const val RETRY_COUNT_FOR_FLAKY_TEST = 3

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -54,6 +54,7 @@ import java.util.Date
 object TestUtils {
   private const val TAG = "TESTUTILS"
   @JvmField var TEST_PAUSE_MS = 3000
+  const val TEST_PAUSE_MS_FOR_LOCAL_LIBRARY_TEST = 6000
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
   var TEST_PAUSE_MS_FOR_DOWNLOAD_TEST = 10000
   const val RETRY_COUNT_FOR_FLAKY_TEST = 3

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -132,10 +132,10 @@ class ZimHostFragmentTest {
         it.navigate(R.id.libraryFragment)
       }
       StandardActions.closeDrawer() // close the drawer if open before running the test cases.
-      zimHost(ZimHostRobot::refreshLibraryList)
       // delete all the ZIM files showing in the LocalLibrary
       // screen to properly test the scenario.
       library {
+        refreshList()
         waitUntilZimFilesRefreshing()
         deleteZimIfExists()
       }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -34,6 +34,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -110,6 +111,9 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private val zimManageViewModel by lazy {
     requireActivity().viewModel<ZimManageViewModel>(viewModelFactory)
   }
+
+  @VisibleForTesting
+  fun getOnlineLibraryList() = libraryAdapter.items
 
   private val libraryAdapter: LibraryAdapter by lazy {
     LibraryAdapter(


### PR DESCRIPTION
Fixes #4001 

* Fixed the `LocalFileTransferTest`, which was failing on API level 33 in the CI.
* Fixed: CI was sometimes stuck on the `DownloadTest`.
* Improved the `DownloadTest` to download the smallest ZIM file, as it was previously downloading a 156MB file, which took too much time.