### PR TITLE
Fixed: Not able to open a ZIM file from Samsung's file explorer.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,18 @@
 
       </intent-filter>
       <intent-filter>
+        <!-- Intent filter for Samsung's "My Files" file manager.
+         This is necessary because it returns an empty mimeType for ZIM files,
+         preventing our application from appearing in the suggestion list. -->
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <!-- This will match any URI that starts with "content://0@media/external/file/" -->
+        <data android:scheme="content" />
+        <data android:host="media" />
+        <data android:pathPrefix="/external/file/" />
+        <data android:mimeType="*/*" />
+      </intent-filter>
+      <intent-filter>
         <action android:name="android.intent.action.VIEW" />
 
         <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Fixes #4002 

* Created a custom intent filter for Samsung's "My Files" app to handle all MIME types, allowing ZIM files to be opened directly from this file manager.