### PR TITLE
Upgraded the `java-libkiwix` to `2.2.3` to start using the `libkiwix14`.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -86,7 +86,7 @@ object Versions {
 
   const val core_ktx: String = "1.9.0"
 
-  const val libkiwix: String = "2.2.2"
+  const val libkiwix: String = "2.2.3"
 
   const val material: String = "1.8.0"
 


### PR DESCRIPTION
Fixes #4032 