### PR TITLE
Fixed: Application crashing due to `Input dispatching timed out` when deleting the ZIM files.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -31,7 +31,9 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -253,24 +255,26 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       destinationFile.name,
       "testCopyMove_1.zim"
     )
-    deleteBothPreviousFiles()
+    kiwixMainActivity.lifecycleScope.launch {
+      withContext(Dispatchers.IO) {
+        deleteBothPreviousFiles()
+      }
 
-    // test when there is no zim file available in the storage it should return the same fileName
-    selectedFile = File(parentFile, selectedFileName)
-    copyMoveFileHandler.setSelectedFileAndUri(null, DocumentFile.fromFile(selectedFile))
-    destinationFile = copyMoveFileHandler.getDestinationFile()
-    Assert.assertEquals(
-      destinationFile.name,
-      selectedFile.name
-    )
-    deleteBothPreviousFiles()
+      // test when there is no zim file available in the storage it should return the same fileName
+      selectedFile = File(parentFile, selectedFileName)
+      copyMoveFileHandler.setSelectedFileAndUri(null, DocumentFile.fromFile(selectedFile))
+      destinationFile = copyMoveFileHandler.getDestinationFile()
+      Assert.assertEquals(
+        destinationFile.name,
+        selectedFile.name
+      )
+      deleteBothPreviousFiles()
+    }
   }
 
-  private fun deleteBothPreviousFiles() {
-    kiwixMainActivity.lifecycleScope.launch {
-      selectedFile.deleteFile()
-      destinationFile.deleteFile()
-    }
+  private suspend fun deleteBothPreviousFiles() {
+    selectedFile.deleteFile()
+    destinationFile.deleteFile()
   }
 
   private fun deleteAllFilesInDirectory(directory: File) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -24,12 +24,14 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import kotlinx.coroutines.launch
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -265,8 +267,10 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
   }
 
   private fun deleteBothPreviousFiles() {
-    selectedFile.deleteFile()
-    destinationFile.deleteFile()
+    kiwixMainActivity.lifecycleScope.launch {
+      selectedFile.deleteFile()
+      destinationFile.deleteFile()
+    }
   }
 
   private fun deleteAllFilesInDirectory(directory: File) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -301,7 +301,9 @@ class CopyMoveFileHandler @Inject constructor(
     }
     fileCopyMoveCallback?.onError(userFriendlyMessage).also {
       // Clean up the destination file if an error occurs
-      destinationFile.deleteFile()
+      CoroutineScope(Dispatchers.IO).launch {
+        destinationFile.deleteFile()
+      }
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -301,7 +301,7 @@ class CopyMoveFileHandler @Inject constructor(
     }
     fileCopyMoveCallback?.onError(userFriendlyMessage).also {
       // Clean up the destination file if an error occurs
-      CoroutineScope(Dispatchers.IO).launch {
+      lifecycleScope?.launch {
         destinationFile.deleteFile()
       }
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/AppProgressListenerProvider.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/AppProgressListenerProvider.kt
@@ -33,12 +33,12 @@ class AppProgressListenerProvider(
       if (contentLength == DEFAULT_INT_VALUE.toLong()) {
         ZERO
       } else {
-        (bytesRead * HUNDERED / contentLength).toInt() * 3
+        (bytesRead * 3 * HUNDERED / contentLength).coerceAtMost(HUNDERED.toLong())
       }
     zimManageViewModel.downloadProgress.postValue(
       zimManageViewModel.context.getString(
         R.string.downloading_library,
-        zimManageViewModel.context.getString(R.string.percentage, progress)
+        zimManageViewModel.context.getString(R.string.percentage, progress.toInt())
       )
     )
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -34,7 +34,6 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteZims
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
 import javax.inject.Inject
 
@@ -69,7 +68,6 @@ data class DeleteFiles(private val booksOnDiskListItems: List<BookOnDisk>) :
   private suspend fun List<BookOnDisk>.deleteAll(): Boolean {
     return fold(true) { acc, book ->
       acc && deleteSpecificZimFile(book).also {
-        Log.i("kiwix", "Deleting file: ${book.zimReaderSource.file?.path}, success: $it")
         if (it && book.zimReaderSource == zimReaderContainer.zimReaderSource) {
           zimReaderContainer.setZimReaderSource(null)
         }
@@ -80,16 +78,13 @@ data class DeleteFiles(private val booksOnDiskListItems: List<BookOnDisk>) :
   private suspend fun deleteSpecificZimFile(book: BookOnDisk): Boolean {
     val file = book.zimReaderSource.file
     file?.let {
-      Log.i("kiwix", "Attempting to delete file: ${it.path}")
       @Suppress("UnreachableCode")
       FileUtils.deleteZimFile(it.path)
     }
     if (file?.isFileExist() == true) {
-      Log.e("kiwix", "File deletion failed: ${file.path}")
       return false
     }
     newBookDao.delete(book.databaseId)
-    Log.i("kiwix", "Book entry deleted: ${book.databaseId}")
     return true
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -19,8 +19,12 @@
 package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
-import org.kiwix.kiwixmobile.core.R
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.cachedComponent
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
@@ -30,6 +34,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteZims
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
 import javax.inject.Inject
 
@@ -46,19 +51,25 @@ data class DeleteFiles(private val booksOnDiskListItems: List<BookOnDisk>) :
     val name = booksOnDiskListItems.joinToString(separator = "\n") { it.book.title }
 
     dialogShower.show(DeleteZims(name), {
-      activity.toast(
-        if (booksOnDiskListItems.deleteAll()) {
-          R.string.delete_zims_toast
-        } else {
-          R.string.delete_zim_failed
+      activity.lifecycleScope.launch {
+        val deleteResult = withContext(Dispatchers.IO) {
+          booksOnDiskListItems.deleteAll()
         }
-      )
+        activity.toast(
+          if (deleteResult) {
+            R.string.delete_zims_toast
+          } else {
+            R.string.delete_zim_failed
+          }
+        )
+      }
     })
   }
 
-  private fun List<BookOnDisk>.deleteAll(): Boolean {
+  private suspend fun List<BookOnDisk>.deleteAll(): Boolean {
     return fold(true) { acc, book ->
       acc && deleteSpecificZimFile(book).also {
+        Log.i("kiwix", "Deleting file: ${book.zimReaderSource.file?.path}, success: $it")
         if (it && book.zimReaderSource == zimReaderContainer.zimReaderSource) {
           zimReaderContainer.setZimReaderSource(null)
         }
@@ -66,16 +77,19 @@ data class DeleteFiles(private val booksOnDiskListItems: List<BookOnDisk>) :
     }
   }
 
-  private fun deleteSpecificZimFile(book: BookOnDisk): Boolean {
+  private suspend fun deleteSpecificZimFile(book: BookOnDisk): Boolean {
     val file = book.zimReaderSource.file
     file?.let {
+      Log.i("kiwix", "Attempting to delete file: ${it.path}")
       @Suppress("UnreachableCode")
       FileUtils.deleteZimFile(it.path)
     }
     if (file?.isFileExist() == true) {
+      Log.e("kiwix", "File deletion failed: ${file.path}")
       return false
     }
     newBookDao.delete(book.databaseId)
+    Log.i("kiwix", "Book entry deleted: ${book.databaseId}")
     return true
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
@@ -25,6 +25,9 @@ import androidx.room.Query
 import androidx.room.Update
 import io.reactivex.Flowable
 import io.reactivex.Single
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.entities.DownloadRoomEntity
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.Status
@@ -95,7 +98,9 @@ abstract class DownloadRoomDao {
   fun delete(downloadId: Long) {
     // remove the previous file from storage since we have cancelled the download.
     getEntityForDownloadId(downloadId)?.file?.let {
-      File(it).deleteFile()
+      CoroutineScope(Dispatchers.IO).launch {
+        File(it).deleteFile()
+      }
     }
     deleteDownloadByDownloadId(downloadId)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -47,8 +47,4 @@ fun File.canReadFile(): Boolean = runBlocking {
   }
 }
 
-fun File.deleteFile(): Boolean = runBlocking {
-  withContext(Dispatchers.IO) {
-    delete()
-  }
-}
+suspend fun File.deleteFile(): Boolean = withContext(Dispatchers.IO) { delete() }


### PR DESCRIPTION
Fixes #4031 

* Moved the file-deleting logic on the IO thread, and refactored our code according to this change.
* Removed the unused code from the `FileUtils` class.