### PR TITLE
Fixed: "Send diagnostic report" function should open the user's email client.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -25,7 +25,6 @@ import android.os.Bundle
 import android.os.Process
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
@@ -102,12 +101,7 @@ open class ErrorActivity : BaseActivity() {
         if (activities.isNotEmpty()) {
           sendEmailLauncher.launch(Intent.createChooser(emailIntent, "Send email..."))
         } else {
-          toast(
-            getString(
-              R.string.no_email_application_installed,
-              CRASH_AND_FEEDBACK_EMAIL_ADDRESS
-            )
-          )
+          toast(getString(R.string.no_email_application_installed))
         }
       }
     }
@@ -124,20 +118,11 @@ open class ErrorActivity : BaseActivity() {
       data = Uri.parse("mailto:")
       putExtra(Intent.EXTRA_EMAIL, arrayOf(CRASH_AND_FEEDBACK_EMAIL_ADDRESS))
       putExtra(Intent.EXTRA_SUBJECT, subject)
-      putExtra(Intent.EXTRA_TEXT, emailBody)
       val file = fileLogger.writeLogFile(
         this@ErrorActivity,
         activityKiwixErrorBinding?.allowLogs?.isChecked == true
       )
-      file.appendText(emailBody)
-      val path =
-        FileProvider.getUriForFile(
-          this@ErrorActivity,
-          applicationContext.packageName + ".fileprovider",
-          file
-        )
-      addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
-      putExtra(android.content.Intent.EXTRA_STREAM, path)
+      putExtra(Intent.EXTRA_TEXT, "$emailBody\n\nDevice Logs:\n$${file.readText()}")
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.core.error
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Process
@@ -28,12 +29,17 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInformation
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.queryIntentActivitiesCompat
+import org.kiwix.kiwixmobile.core.compat.ResolveInfoFlagsCompat
 import org.kiwix.kiwixmobile.core.dao.NewBookDao
 import org.kiwix.kiwixmobile.core.databinding.ActivityKiwixErrorBinding
+import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+import org.kiwix.kiwixmobile.core.utils.CRASH_AND_FEEDBACK_EMAIL_ADDRESS
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
 import org.kiwix.kiwixmobile.core.utils.files.FileLogger
 import org.kiwix.kiwixmobile.core.zim_manager.MountPointProducer
@@ -90,7 +96,19 @@ open class ErrorActivity : BaseActivity() {
   private fun setupReportButton() {
     activityKiwixErrorBinding?.reportButton?.setOnClickListener {
       lifecycleScope.launch {
-        sendEmailLauncher.launch(Intent.createChooser(emailIntent(), "Send email..."))
+        val emailIntent = emailIntent()
+        val activities =
+          packageManager.queryIntentActivitiesCompat(emailIntent, ResolveInfoFlagsCompat.EMPTY)
+        if (activities.isNotEmpty()) {
+          sendEmailLauncher.launch(Intent.createChooser(emailIntent, "Send email..."))
+        } else {
+          toast(
+            getString(
+              R.string.no_email_application_installed,
+              CRASH_AND_FEEDBACK_EMAIL_ADDRESS
+            )
+          )
+        }
       }
     }
   }
@@ -102,12 +120,9 @@ open class ErrorActivity : BaseActivity() {
 
   private suspend fun emailIntent(): Intent {
     val emailBody = buildBody()
-    return Intent(Intent.ACTION_SEND).apply {
-      type = "text/plain"
-      putExtra(
-        Intent.EXTRA_EMAIL,
-        arrayOf("android-crash-feedback@kiwix.org")
-      )
+    return Intent(Intent.ACTION_SENDTO).apply {
+      data = Uri.parse("mailto:")
+      putExtra(Intent.EXTRA_EMAIL, arrayOf(CRASH_AND_FEEDBACK_EMAIL_ADDRESS))
       putExtra(Intent.EXTRA_SUBJECT, subject)
       putExtra(Intent.EXTRA_TEXT, emailBody)
       val file = fileLogger.writeLogFile(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
@@ -18,6 +18,7 @@
 package org.kiwix.kiwixmobile.core.utils
 
 const val TAG_KIWIX = "kiwix"
+const val CRASH_AND_FEEDBACK_EMAIL_ADDRESS = "android-crash-feedback@kiwix.org"
 
 // Request stuff
 const val REQUEST_STORAGE_PERMISSION = 1

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
   <string name="pref_credits_title">Credits</string>
   <string name="tts_lang_not_supported">The language of this page is not supported. The article may not be properly read.</string>
   <string name="no_reader_application_installed">Could not find an installed application for this type of file</string>
+  <string name="no_email_application_installed">Please install an email client</string>
   <string name="no_app_found_to_select_bookmark_file">No app found to select a bookmark file</string>
   <string name="no_section_info">No Content Headers Found</string>
   <string name="request_storage">To access offline content we need access to your storage</string>


### PR DESCRIPTION
Fixes #4005 

* Previously, other apps were appearing in the suggestions when sending the diagnostic report. We have improved our intent so that it now directly opens the user's email client to send the diagnostic report to us.
* We cannot attach a file to the email when using the `ACTION_SENDTO` action in the intent. So we have removed the file from the email and attached the device logs in emailBody.

https://github.com/user-attachments/assets/f1918473-5b55-4fa2-ac78-6a6c6d658175