### PR TITLE
Implemented error handling for cases when the selected file is not a ZIM file.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.localLibrary
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.web.sugar.Web
@@ -48,6 +49,12 @@ class CopyMoveFileHandlerRobot : BaseRobot() {
 
   fun assertCopyMoveDialogDisplayed() {
     isVisible(TextId(R.string.copy_move_files_dialog_description))
+  }
+
+  fun assertCopyMoveDialogNotDisplayed() {
+    testFlakyView({
+      onView(withText(R.string.copy_move_files_dialog_description)).check(doesNotExist())
+    })
   }
 
   fun clickOnCopy() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -72,7 +72,7 @@ class CopyMoveFileHandler @Inject constructor(
   private var progressBar: ProgressBar? = null
   private var progressBarTextView: TextView? = null
   var isMoveOperation = false
-  private var shouldValidateZimFile: Boolean = false
+  var shouldValidateZimFile: Boolean = false
   private var fileSystemDisposable: Disposable? = null
 
   private val copyMoveTitle: String by lazy {
@@ -275,7 +275,6 @@ class CopyMoveFileHandler @Inject constructor(
     return try {
       val contentResolver = activity.contentResolver
       if (documentCanMove(selectedUri, contentResolver)) {
-
         DocumentsContract.moveDocument(
           contentResolver,
           selectedUri,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -415,9 +415,19 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
           DocumentFile.fromSingleUri(requireActivity(), uri)
         }
       }
+      // If the file is not valid, it shows an error message and stops further processing.
+      // If the file name is not found, then let them to copy the file
+      // and we will handle this later.
+      val fileName = documentFile?.name
+      if (fileName != null && !FileUtils.isValidZimFile(fileName)) {
+        activity.toast(string.error_file_invalid)
+        return
+      }
       copyMoveFileHandler?.showMoveFileToPublicDirectoryDialog(
         uri,
-        documentFile
+        documentFile,
+        // pass if fileName is null then we will validate it after copying/moving
+        fileName == null
       )
     } else {
       getZimFileFromUri(uri)?.let(::navigateToReaderFragment)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -407,7 +407,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       }
     }
 
-  private fun handleSelectedFileUri(uri: Uri) {
+  fun handleSelectedFileUri(uri: Uri) {
     if (sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove()) {
       val documentFile = when (uri.scheme) {
         "file" -> DocumentFile.fromFile(File("$uri"))


### PR DESCRIPTION
Parent Issue #4002

* We retrieve the file name from the incoming Uri using `DocumentFile` (the official way to handle Uris) and check if it contains `.zim` or `.zimma` before proceeding with the copy/move operation. If the file name is null, we copy/move the file first and then validate it as a ZIM file using `libkiwix`. If valid, the file opens in our reader; otherwise, we revert the copy/move operation.
* Added UI and unit test cases for this new functionality.


https://github.com/user-attachments/assets/52259656-f772-4855-af53-9faeac5f5871


