### PR TITLE
Fixed: Kiwix opens in the Samsung file navigator.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
       android:configChanges="orientation|keyboardHidden|screenSize"
       android:exported="true"
       android:label="@string/app_name"
-      android:launchMode="singleTop"
+      android:launchMode="singleInstance"
       android:theme="@style/KiwixTheme.Launcher"
       android:windowSoftInputMode="adjustPan">
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -117,9 +117,6 @@ class KiwixMainActivity : CoreMainActivity() {
     super.onCreate(savedInstanceState)
     activityKiwixMainBinding = ActivityKiwixMainBinding.inflate(layoutInflater)
     setContentView(activityKiwixMainBinding.root)
-    if (intent.action == "GET_CONTENT") {
-      navigate(R.id.downloadsFragment)
-    }
 
     navController.addOnDestinationChangedListener(finishActionModeOnDestinationChange)
     activityKiwixMainBinding.drawerNavView.setupWithNavController(navController)
@@ -130,6 +127,7 @@ class KiwixMainActivity : CoreMainActivity() {
     activityKiwixMainBinding.bottomNavView.setupWithNavController(navController)
     migrateInternalToPublicAppDirectory()
     handleZimFileIntent(intent)
+    handleGetContentIntent(intent)
   }
 
   private fun migrateInternalToPublicAppDirectory() {
@@ -220,8 +218,15 @@ class KiwixMainActivity : CoreMainActivity() {
     super.onNewIntent(intent)
     handleNotificationIntent(intent)
     handleZimFileIntent(intent)
+    handleGetContentIntent(intent)
     supportFragmentManager.fragments.filterIsInstance<FragmentActivityExtensions>().forEach {
       it.onNewIntent(intent, this)
+    }
+  }
+
+  private fun handleGetContentIntent(intent: Intent?) {
+    if (intent?.action == ACTION_GET_CONTENT) {
+      navigate(R.id.downloadsFragment)
     }
   }
 


### PR DESCRIPTION
Fixes #4048

* We are now using the `singleInstance` launch mode instead of `singleTop` to prevent Kiwix from opening within the file manager.
* Improved the handling of the `GET_CONTENT` shortcut(it was not properly working if the application was in the background).


https://github.com/user-attachments/assets/3a0fce5f-7299-4fd7-b5fc-98f33678a0f0


