### PR TITLE
Removed the `usesCleartextTraffic` from our manifest

### DIFF
--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -6,7 +6,6 @@
        see more information here https://github.com/kiwix/kiwix-android/issues/3172
   -->
   <application
-    android:forceQueryable="true"
-    android:usesCleartextTraffic="true"/>
+    android:forceQueryable="true" />
   <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 </manifest>

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -58,7 +58,6 @@
     android:resizeableActivity="true"
     android:supportsRtl="true"
     android:theme="@style/KiwixTheme"
-    android:usesCleartextTraffic="true"
     tools:targetApi="tiramisu">
 
     <!-- Version < 3.0. DeX Mode and Screen Mirroring support -->

--- a/custom/src/androidTest/AndroidManifest.xml
+++ b/custom/src/androidTest/AndroidManifest.xml
@@ -23,7 +23,6 @@
        see more information here https://github.com/kiwix/kiwix-android/issues/3172
   -->
   <application
-    android:forceQueryable="true"
-    android:usesCleartextTraffic="true" />
+    android:forceQueryable="true" />
   <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 </manifest>


### PR DESCRIPTION
Fixes #4055 

* Removed the `usesCleartextTraffic` from our manifest, since this attribute is mainly used for allowing the http requests(Mainly used for network requests). The network requests are only used for downloading the ZIM files in our application, and now, no downloading URL is on HTTP, so now, we do not need to keep this attribute.
* Removed this attribute from our test cases manifest as well.
