### PR TITLE
Fixed: SearchWidget is not properly working.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseRobot.kt
@@ -54,6 +54,10 @@ abstract class BaseRobot(
     uiDevice.pressBack()
   }
 
+  internal fun pressHome() {
+    uiDevice.pressHome()
+  }
+
   protected fun isVisible(findable: Findable, timeout: Long = VERY_LONG_WAIT) =
     waitFor(findable, timeout) ?: throw RuntimeException(findable.errorMessage(this))
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -42,6 +42,7 @@ import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
+import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
@@ -150,12 +151,12 @@ class DownloadRobot : BaseRobot() {
   fun waitUntilDownloadComplete(retryCountForDownloadingZimFile: Int = 30) {
     try {
       onView(withId(R.id.stop)).check(doesNotExist())
-      Log.i("kiwixDownloadTest", "Download complete")
+      Log.e(KIWIX_DOWNLOAD_TEST, "Download complete")
     } catch (e: AssertionFailedError) {
       if (retryCountForDownloadingZimFile > 0) {
         resumeDownloadIfPaused()
         BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
-        Log.i("kiwixDownloadTest", "Downloading in progress")
+        Log.e(KIWIX_DOWNLOAD_TEST, "Downloading in progress")
         waitUntilDownloadComplete(retryCountForDownloadingZimFile - 1)
         return
       }
@@ -203,7 +204,7 @@ class DownloadRobot : BaseRobot() {
       pauseForBetterTestPerformance()
     } catch (e: Exception) {
       Log.i(
-        "DOWNLOAD_TEST",
+        KIWIX_DOWNLOAD_TEST,
         "Failed to stop downloading. Probably because it is not downloading the zim file"
       )
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -203,7 +203,7 @@ class DownloadRobot : BaseRobot() {
       clickOnYesButton()
       pauseForBetterTestPerformance()
     } catch (e: Exception) {
-      Log.i(
+      Log.e(
         KIWIX_DOWNLOAD_TEST,
         "Failed to stop downloading. Probably because it is not downloading the zim file"
       )

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.download
 
+import android.util.Log
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.NavHostFragment
@@ -138,17 +139,21 @@ class DownloadTest : BaseActivityTest() {
         scrollToZimFileIndex(smallestZimFileIndex)
         stopDownloadIfAlreadyStarted()
         downloadZimFile(smallestZimFileIndex)
-        assertDownloadStart()
         try {
+          assertDownloadStart()
           pauseDownload()
           assertDownloadPaused()
           resumeDownload()
           assertDownloadResumed()
+          waitUntilDownloadComplete()
         } catch (ignore: Exception) {
           // do nothing as ZIM file already downloaded, since we are downloading the smallest file
           // so it can be downloaded immediately after starting.
+          Log.e(
+            KIWIX_DOWNLOAD_TEST,
+            "Could not pause download. Original exception = $ignore"
+          )
         }
-        waitUntilDownloadComplete()
         clickLibraryOnBottomNav()
         // refresh the local library list to show the downloaded zim file
         library(LibraryRobot::refreshList)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadRobot.kt
@@ -33,8 +33,8 @@ import org.kiwix.kiwixmobile.Findable.StringId.TextId
 import org.kiwix.kiwixmobile.Findable.Text
 import org.kiwix.kiwixmobile.Findable.ViewId
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.R.id
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
@@ -146,7 +146,7 @@ class InitialDownloadRobot : BaseRobot() {
       clickOnYesToConfirm()
       pauseForBetterTestPerformance()
     } catch (e: Exception) {
-      Log.i(
+      Log.e(
         "INITIAL_DOWNLOAD_TEST",
         "Failed to stop downloading. Probably because it is not downloading the zim file"
       )

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -21,12 +21,11 @@ package org.kiwix.kiwixmobile.mimetype
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -70,7 +69,7 @@ class MimeTypeTest : BaseActivityTest() {
   }
 
   @Test
-  fun testMimeType() {
+  fun testMimeType() = runBlocking {
     val loadFileStream = MimeTypeTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
       ContextCompat.getExternalFilesDirs(context, null)[0],
@@ -89,41 +88,37 @@ class MimeTypeTest : BaseActivityTest() {
       }
     }
     val zimSource = ZimReaderSource(zimFile)
-    activityScenario.onActivity {
-      it.lifecycleScope.launch {
-        val archive = zimSource.createArchive()
-        val zimFileReader = ZimFileReader(
-          zimSource,
-          archive!!,
-          DarkModeConfig(SharedPreferenceUtil(context), context),
-          SuggestionSearcher(archive)
+    val archive = zimSource.createArchive()
+    val zimFileReader = ZimFileReader(
+      zimSource,
+      archive!!,
+      DarkModeConfig(SharedPreferenceUtil(context), context),
+      SuggestionSearcher(archive)
+    )
+    zimFileReader.getRandomArticleUrl()?.let { randomArticle ->
+      val mimeType = zimFileReader.getMimeTypeFromUrl(randomArticle)
+      if (mimeType?.contains("^([^ ]+).*$") == true || mimeType?.contains(";") == true) {
+        Assert.fail(
+          "Unable to get mime type from zim file. File = " +
+            " $zimFile and url of article = $randomArticle"
         )
-        zimFileReader.getRandomArticleUrl()?.let { randomArticle ->
-          val mimeType = zimFileReader.getMimeTypeFromUrl(randomArticle)
-          if (mimeType?.contains("^([^ ]+).*$") == true || mimeType?.contains(";") == true) {
-            Assert.fail(
-              "Unable to get mime type from zim file. File = " +
-                " $zimFile and url of article = $randomArticle"
-            )
-          }
-        } ?: kotlin.run {
-          Assert.fail("Unable to get article from zim file $zimFile")
-        }
-        // test mimetypes for some actual url
-        Assert.assertEquals(
-          "text/html",
-          zimFileReader.getMimeTypeFromUrl("https://kiwix.app/A/index.html")
-        )
-        Assert.assertEquals(
-          "text/css",
-          zimFileReader.getMimeTypeFromUrl("https://kiwix.app/-/assets/style1.css")
-        )
-        // test mimetype for invalid url
-        Assert.assertEquals(null, zimFileReader.getMimeTypeFromUrl("https://kiwix.app/A/test.html"))
-        // dispose the ZimFileReader
-        zimFileReader.dispose()
       }
+    } ?: kotlin.run {
+      Assert.fail("Unable to get article from zim file $zimFile")
     }
+    // test mimetypes for some actual url
+    Assert.assertEquals(
+      "text/html",
+      zimFileReader.getMimeTypeFromUrl("https://kiwix.app/A/index.html")
+    )
+    Assert.assertEquals(
+      "text/css",
+      zimFileReader.getMimeTypeFromUrl("https://kiwix.app/-/assets/style1.css")
+    )
+    // test mimetype for invalid url
+    Assert.assertEquals(null, zimFileReader.getMimeTypeFromUrl("https://kiwix.app/A/test.html"))
+    // dispose the ZimFileReader
+    zimFileReader.dispose()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -21,12 +21,11 @@ package org.kiwix.kiwixmobile.reader
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -76,7 +75,7 @@ class EncodedUrlTest : BaseActivityTest() {
   }
 
   @Test
-  fun testEncodedUrls() {
+  fun testEncodedUrls() = runBlocking {
     val loadFileStream =
       EncodedUrlTest::class.java.classLoader.getResourceAsStream("characters_encoding.zim")
     val zimFile = File(
@@ -96,78 +95,74 @@ class EncodedUrlTest : BaseActivityTest() {
       }
     }
     val zimReaderSource = ZimReaderSource(zimFile)
-    activityScenario.onActivity {
-      it.lifecycleScope.launch {
-        val archive = zimReaderSource.createArchive()
-        val zimFileReader = ZimFileReader(
-          zimReaderSource,
-          archive!!,
-          DarkModeConfig(SharedPreferenceUtil(context), context),
-          SuggestionSearcher(archive)
-        )
-        val encodedUrls = arrayOf(
-          EncodedUrl(
-            "https://kiwix.app/foo/part%2520with%2520space/bar%253Fkey%253Dvalue",
-            "https://kiwix.app/foo/part%2520with%2520space/bar%253Fkey%253Dvalue"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part%20with%20space/bar%3Fkey%3Dvalue",
-            "https://kiwix.app/foo/part%20with%20space/bar%3Fkey%3Dvalue"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo%2Fpart%20with%20space%2Fbar%3Fkey%3Dvalue",
-            "https://kiwix.app/foo%2Fpart%20with%20space%2Fbar%3Fkey%3Dvalue"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part%20with%20space/bar?key=value",
-            "https://kiwix.app/foo/part%20with%20space/bar?key=value"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part/file%20with%20%3F%20and%20+?who=Chip%26Dale&quer=Is%20" +
-              "there%20any%20%2B%20here%3F",
-            "https://kiwix.app/foo/part/file%20with%20%3F%20and%20+?who=Chip%26Dale&quer" +
-              "=Is%20there%20any%20%2B%20here%3F"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part/file%20with%20%253F%20and%20%2B%3Fwho%3DChip%2526Dale%26" +
-              "quer%3DIs%2520there%2520any%2520%252B%2520here%253F",
-            "https://kiwix.app/foo/part/file%20with%20%253F%20and%20%2B%3Fwho%3DChip" +
-              "%2526Dale%26quer%3DIs%2520there%2520any%2520%252B%2520here%253F"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part/file%20with%20%3F%20and%20%2B%3Fwho%3DChip%26Dale%26" +
-              "question%3DIt%20there%20any%20%2B%20here%3F",
-            "https://kiwix.app/foo/part/file%20with%20%3F%20and%20%2B%3Fwho%3DChip%26" +
-              "Dale%26question%3DIt%20there%20any%20%2B%20here%3F"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2520there%2520any" +
-              "%2520%252B%2520here%253F",
-            "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2520there%2520" +
-              "any%2520%252B%2520here%253F"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2Bthere%2Bany%2B%252B%2Bhere%253F",
-            "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2Bthere%2Bany%2B%252B%2B" +
-              "here%253F"
-          ),
-          EncodedUrl(
-            "https://kiwix.app/%F0%9F%A5%B3%F0%9F%A5%B0%F0%9F%98%98%F0%9F%A4%A9%F0%9F%98%8D%F0%9F" +
-              "%A4%8D%F0%9F%8E%80%F0%9F%A7%B8%F0%9F%8C%B7%F0%9F%8D%AD",
-            "https://kiwix.app/%F0%9F%A5%B3%F0%9F%A5%B0%F0%9F%98%98%F0%9F%A4%A9%F0%9F%98%8D" +
-              "%F0%9F%A4%8D%F0%9F%8E%80%F0%9F%A7%B8%F0%9F%8C%B7%F0%9F%8D%AD"
-          )
-        )
-        encodedUrls.forEach { encodedUrl ->
-          Assert.assertEquals(
-            encodedUrl.expectedUrl,
-            zimFileReader.getRedirect(encodedUrl.url)
-          )
-        }
-        // dispose the ZimFileReader
-        zimFileReader.dispose()
-      }
+    val archive = zimReaderSource.createArchive()
+    val zimFileReader = ZimFileReader(
+      zimReaderSource,
+      archive!!,
+      DarkModeConfig(SharedPreferenceUtil(context), context),
+      SuggestionSearcher(archive)
+    )
+    val encodedUrls = arrayOf(
+      EncodedUrl(
+        "https://kiwix.app/foo/part%2520with%2520space/bar%253Fkey%253Dvalue",
+        "https://kiwix.app/foo/part%2520with%2520space/bar%253Fkey%253Dvalue"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part%20with%20space/bar%3Fkey%3Dvalue",
+        "https://kiwix.app/foo/part%20with%20space/bar%3Fkey%3Dvalue"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo%2Fpart%20with%20space%2Fbar%3Fkey%3Dvalue",
+        "https://kiwix.app/foo%2Fpart%20with%20space%2Fbar%3Fkey%3Dvalue"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part%20with%20space/bar?key=value",
+        "https://kiwix.app/foo/part%20with%20space/bar?key=value"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part/file%20with%20%3F%20and%20+?who=Chip%26Dale&quer=Is%20" +
+          "there%20any%20%2B%20here%3F",
+        "https://kiwix.app/foo/part/file%20with%20%3F%20and%20+?who=Chip%26Dale&quer" +
+          "=Is%20there%20any%20%2B%20here%3F"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part/file%20with%20%253F%20and%20%2B%3Fwho%3DChip%2526Dale%26" +
+          "quer%3DIs%2520there%2520any%2520%252B%2520here%253F",
+        "https://kiwix.app/foo/part/file%20with%20%253F%20and%20%2B%3Fwho%3DChip" +
+          "%2526Dale%26quer%3DIs%2520there%2520any%2520%252B%2520here%253F"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part/file%20with%20%3F%20and%20%2B%3Fwho%3DChip%26Dale%26" +
+          "question%3DIt%20there%20any%20%2B%20here%3F",
+        "https://kiwix.app/foo/part/file%20with%20%3F%20and%20%2B%3Fwho%3DChip%26" +
+          "Dale%26question%3DIt%20there%20any%20%2B%20here%3F"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2520there%2520any" +
+          "%2520%252B%2520here%253F",
+        "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2520there%2520" +
+          "any%2520%252B%2520here%253F"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2Bthere%2Bany%2B%252B%2Bhere%253F",
+        "https://kiwix.app/foo/part/file%3Fquestion%3DIs%2Bthere%2Bany%2B%252B%2B" +
+          "here%253F"
+      ),
+      EncodedUrl(
+        "https://kiwix.app/%F0%9F%A5%B3%F0%9F%A5%B0%F0%9F%98%98%F0%9F%A4%A9%F0%9F%98%8D%F0%9F" +
+          "%A4%8D%F0%9F%8E%80%F0%9F%A7%B8%F0%9F%8C%B7%F0%9F%8D%AD",
+        "https://kiwix.app/%F0%9F%A5%B3%F0%9F%A5%B0%F0%9F%98%98%F0%9F%A4%A9%F0%9F%98%8D" +
+          "%F0%9F%A4%8D%F0%9F%8E%80%F0%9F%A7%B8%F0%9F%8C%B7%F0%9F%8D%AD"
+      )
+    )
+    encodedUrls.forEach { encodedUrl ->
+      Assert.assertEquals(
+        encodedUrl.expectedUrl,
+        zimFileReader.getRedirect(encodedUrl.url)
+      )
     }
+    // dispose the ZimFileReader
+    zimFileReader.dispose()
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -22,7 +22,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
@@ -33,7 +32,7 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
 import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Assert
@@ -133,23 +132,19 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
   }
 
   @Test
-  fun testWithExtraZeroSizeFile() {
+  fun testWithExtraZeroSizeFile() = runBlocking {
     createAndGetSplitedZimFile(true)?.let { zimFile ->
       // test the articleCount and mediaCount of this zim file.
       val zimReaderSource = ZimReaderSource(zimFile)
-      activityScenario.onActivity {
-        it.lifecycleScope.launch {
-          val archive = zimReaderSource.createArchive()
-          val zimFileReader = ZimFileReader(
-            zimReaderSource,
-            archive!!,
-            DarkModeConfig(SharedPreferenceUtil(context), context),
-            SuggestionSearcher(archive)
-          )
-          Assert.assertEquals(zimFileReader.mediaCount, 16)
-          Assert.assertEquals(zimFileReader.articleCount, 4)
-        }
-      }
+      val archive = zimReaderSource.createArchive()
+      val zimFileReader = ZimFileReader(
+        zimReaderSource,
+        archive!!,
+        DarkModeConfig(SharedPreferenceUtil(context), context),
+        SuggestionSearcher(archive)
+      )
+      Assert.assertEquals(zimFileReader.mediaCount, 16)
+      Assert.assertEquals(zimFileReader.articleCount, 4)
     } ?: kotlin.run {
       // error in creating the zim file chunk
       fail("Couldn't create the zim file chunk")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetRobot.kt
@@ -1,0 +1,136 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.widgets
+
+import android.graphics.Point
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import applyWithViewHierarchyPrinting
+import org.hamcrest.core.AllOf.allOf
+import org.kiwix.kiwixmobile.BaseRobot
+import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+
+fun searchWidget(func: SearchWidgetRobot.() -> Unit) =
+  SearchWidgetRobot().applyWithViewHierarchyPrinting(func)
+
+class SearchWidgetRobot : BaseRobot() {
+
+  fun removeWidgetIfAlreadyAdded(uiDevice: UiDevice) {
+    try {
+      val widget = uiDevice.findObject(By.text("Search Kiwix"))
+      widget.click(1000L)
+      uiDevice.waitForIdle()
+      val center = getScreenCenter(uiDevice)
+      val widgetBounds = widget.visibleBounds
+
+      uiDevice.swipe(
+        widgetBounds.centerX(),
+        widgetBounds.centerY(),
+        center.x,
+        100,
+        150
+      )
+
+      uiDevice.waitForIdle()
+    } catch (ignore: Exception) {
+      // nothing to do since widget is not added
+    }
+  }
+
+  fun addWidgetToHomeScreen(uiDevice: UiDevice) {
+    val center = getScreenCenter(uiDevice)
+    longPressInCenterOfScreen(uiDevice, center)
+    clickOnWidgetsText(uiDevice)
+    var widget = uiDevice.findObject(By.text("Kiwix"))
+    var maxSwipes = 30
+    while (widget == null && maxSwipes > 0) {
+      uiDevice.swipe(center.x, center.y, center.x, 0, 200)
+      uiDevice.waitForIdle()
+      widget = uiDevice.findObject(By.text("Kiwix"))
+      maxSwipes--
+    }
+    uiDevice.swipe(center.x, center.y, center.x, 0, 200)
+    val b = widget.visibleBounds
+    val c = Point(b.left + 150, b.bottom + 150)
+    val dest = Point(c.x + 250, c.y + 250)
+    uiDevice.swipe(arrayOf(c, c, dest), 150)
+  }
+
+  private fun clickOnWidgetsText(uiDevice: UiDevice) {
+    try {
+      // Different according to the devices
+      uiDevice.findObject(By.text("Widgets")).click()
+    } catch (ignore: Exception) {
+      uiDevice.findObject(By.text("WIDGETS")).click()
+    }
+    uiDevice.waitForIdle()
+  }
+
+  fun assertSearchWidgetAddedToHomeScreen(uiDevice: UiDevice) {
+    uiDevice.findObject(By.text("Search Kiwix"))
+  }
+
+  private fun longPressInCenterOfScreen(uiDevice: UiDevice, center: Point) {
+    uiDevice.swipe(arrayOf(center, center), 150)
+  }
+
+  private fun getScreenCenter(device: UiDevice): Point {
+    val size = device.displaySizeDp
+    return Point(size.x / 2, size.y / 2)
+  }
+
+  fun clickOnBookmarkIcon(uiDevice: UiDevice, kiwixMainActivity: KiwixMainActivity) {
+    uiDevice.findObject(
+      By.res("${kiwixMainActivity.packageName}:id/search_widget_star")
+    ).click()
+  }
+
+  fun assertBookmarkScreenVisible() {
+    testFlakyView({
+      onView(allOf(withText(R.string.bookmarks), isDescendantOfA(withId(R.id.toolbar))))
+        .check(matches(isDisplayed()))
+    })
+  }
+
+  fun clickOnMicIcon(uiDevice: UiDevice, kiwixMainActivity: KiwixMainActivity) {
+    uiDevice.findObject(
+      By.res("${kiwixMainActivity.packageName}:id/search_widget_mic")
+    ).click()
+  }
+
+  fun assertSearchScreenVisible() {
+    testFlakyView({
+      onView(withText(R.string.menu_search_in_text)).check(matches(isDisplayed()))
+    })
+  }
+
+  fun clickOnSearchText(uiDevice: UiDevice, kiwixMainActivity: KiwixMainActivity) {
+    uiDevice.findObject(
+      By.res("${kiwixMainActivity.packageName}:id/search_widget_text")
+    ).click()
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2024 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.widgets
+
+import android.os.Build
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
+import org.hamcrest.Matchers.allOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
+
+class SearchWidgetTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+  private lateinit var kiwixMainActivity: KiwixMainActivity
+  private lateinit var uiDevice: UiDevice
+
+  init {
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(TouchTargetSizeCheck::class.java),
+          matchesViews(withContentDescription("More options"))
+        )
+      )
+    }
+  }
+
+  @Before
+  override fun waitForIdle() {
+    uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
+        TestUtils.closeSystemDialogs(context, this)
+      }
+      waitForIdle()
+    }
+    context.let {
+      SharedPreferenceUtil(it).apply {
+        setIntroShown()
+        putPrefWifiOnly(false)
+        setIsPlayStoreBuildType(true)
+        prefIsTest = true
+        putPrefLanguage("en")
+        lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
+      }
+    }
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+    }
+  }
+
+  @Test
+  fun testSearchWidget() {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
+      activityScenario.onActivity {
+        kiwixMainActivity = it
+      }
+      searchWidget {
+        pressHome()
+        removeWidgetIfAlreadyAdded(uiDevice)
+        addWidgetToHomeScreen(uiDevice)
+        assertSearchWidgetAddedToHomeScreen(uiDevice)
+        clickOnBookmarkIcon(uiDevice, kiwixMainActivity)
+        assertBookmarkScreenVisible()
+        pressBack()
+        pressHome()
+        clickOnMicIcon(uiDevice, kiwixMainActivity)
+        assertSearchScreenVisible()
+        pressBack()
+        pressHome()
+        clickOnSearchText(uiDevice, kiwixMainActivity)
+        assertSearchScreenVisible()
+        pressHome()
+        removeWidgetIfAlreadyAdded(uiDevice)
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -89,7 +89,6 @@ class SearchWidgetTest : BaseActivityTest() {
       }
       searchWidget {
         pressHome()
-        removeWidgetIfAlreadyAdded(uiDevice)
         addWidgetToHomeScreen(uiDevice)
         assertSearchWidgetAddedToHomeScreen(uiDevice)
         clickOnBookmarkIcon(uiDevice, kiwixMainActivity)
@@ -97,6 +96,7 @@ class SearchWidgetTest : BaseActivityTest() {
         pressBack()
         pressHome()
         clickOnMicIcon(uiDevice, kiwixMainActivity)
+        closeIfGoogleSearchVisible(uiDevice)
         assertSearchScreenVisible()
         pressBack()
         pressHome()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreSearchWidget.kt
@@ -35,10 +35,13 @@ abstract class CoreSearchWidget : AppWidgetProvider() {
     appWidgetManager: AppWidgetManager,
     appWidgetIds: IntArray
   ) {
-    val appName = (activityKClass as CoreMainActivity).appName
+    val searchWidgetText = when (val activity = activityKClass) {
+      is CoreMainActivity -> "${activity.getString(R.string.search_label)} ${activity.appName}"
+      else -> context.getString(R.string.search_widget_text)
+    }
     appWidgetIds.forEach { appWidgetId ->
       val views = RemoteViews(context.packageName, R.layout.kiwix_search_widget)
-      views.setTextViewText(R.id.search_widget_text, "Search $appName")
+      views.setTextViewText(R.id.search_widget_text, searchWidgetText)
       idsToActions.forEach { (id, action) ->
         views.setOnClickPendingIntent(id, pendingIntent(context, action))
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -72,6 +72,7 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnOpenInNewTabClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchOrigin.FromWebView
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchState
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchViewModel
+import org.kiwix.kiwixmobile.core.utils.EXTRA_IS_WIDGET_VOICE
 import org.kiwix.kiwixmobile.core.utils.SimpleTextListener
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import javax.inject.Inject
@@ -277,6 +278,12 @@ class SearchFragment : BaseFragment() {
             searchView?.setQuery(searchStringFromArguments, false)
           }
           searchViewModel.actions.trySend(Action.CreatedWithArguments(arguments)).isSuccess
+          arguments?.remove(EXTRA_IS_WIDGET_VOICE)
+          searchViewModel.voiceSearchResult.observe(viewLifecycleOwner) { searchTerm ->
+            searchTerm?.let {
+              searchView?.setQuery(it, false)
+            }
+          }
         }
 
         override fun onMenuItemSelected(menuItem: MenuItem) = true

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/Action.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/Action.kt
@@ -38,4 +38,6 @@ sealed class Action {
   data class CreatedWithArguments(val arguments: Bundle?) : Action()
   data class ActivityResultReceived(val requestCode: Int, val resultCode: Int, val data: Intent?) :
     Action()
+
+  data class VoiceSearchResult(val term: String) : Action()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.search.viewmodel
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,6 +49,7 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnOpenInNewTabClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ReceivedPromptForSpeechInput
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ScreenWasStartedFrom
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.StartSpeechInputFailed
+import org.kiwix.kiwixmobile.core.search.viewmodel.Action.VoiceSearchResult
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchOrigin.FromWebView
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.DeleteRecentSearch
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.OpenSearchItem
@@ -87,6 +89,7 @@ class SearchViewModel @Inject constructor(
   val actions = Channel<Action>(Channel.UNLIMITED)
   private val filter = MutableStateFlow("")
   private val searchOrigin = MutableStateFlow(FromWebView)
+  val voiceSearchResult: MutableLiveData<String?> = MutableLiveData(null)
 
   init {
     viewModelScope.launch { reducer() }
@@ -148,6 +151,7 @@ class SearchViewModel @Inject constructor(
         ).isSuccess
 
       is ScreenWasStartedFrom -> searchOrigin.tryEmit(it.searchOrigin)
+      is VoiceSearchResult -> voiceSearchResult.value = it.term
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/ProcessActivityResult.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/ProcessActivityResult.kt
@@ -25,7 +25,7 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.channels.Channel
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
-import org.kiwix.kiwixmobile.core.search.viewmodel.Action.Filter
+import org.kiwix.kiwixmobile.core.search.viewmodel.Action.VoiceSearchResult
 
 data class ProcessActivityResult(
   private val requestCode: Int,
@@ -40,7 +40,7 @@ data class ProcessActivityResult(
     ) {
       data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)?.apply {
         first()?.let {
-          actions.trySend(Filter(it)).isSuccess
+          actions.trySend(VoiceSearchResult(it)).isSuccess
         }
       }
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/ProcessActivityResultTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/ProcessActivityResultTest.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.channels.Channel
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
-import org.kiwix.kiwixmobile.core.search.viewmodel.Action.Filter
+import org.kiwix.kiwixmobile.core.search.viewmodel.Action.VoiceSearchResult
 
 internal class ProcessActivityResultTest {
 
@@ -72,6 +72,6 @@ internal class ProcessActivityResultTest {
   fun `invoke with sends filter action with data`() {
     every { data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS) } returns arrayListOf("")
     successfulResult.invokeWith(activity)
-    verify { actions.trySend(Filter("")).isSuccess }
+    verify { actions.trySend(VoiceSearchResult("")).isSuccess }
   }
 }


### PR DESCRIPTION
Fixes #4059 

* Fixed: `SearchWidget` was not properly working, it was due to the direct casting of `kClass` not working, so we have improved our code to get the `appName`(which we are showing in the search widget).
* Also, previously, the "Search" text was hardcoded in the `SearchWidget`, which can not be translated into other languages. So, to fix this, we are starting to use this from our string file so that the sentence can easily be translated into other languages.


https://github.com/user-attachments/assets/3b61107d-2e0c-4b24-8c1d-4ad3d9ea437b


* Fixed: When we click on the mic icon in the `SearchWidget` it opens the `searchFragment` but after searching through voice search it again opens the voice search(It does not search my voice search, same for if I press the back button the voice search again visible). It was due to the `fragmentArguments` we are passing for voice search was not clear, so due to this, it opened the voice search again and again. Also, the voice search was not working. So to fix this we have refactored our code.

**Before Fix**


https://github.com/user-attachments/assets/562c197e-1755-4d91-83c5-c1225a1f0662


**After Fix**


https://github.com/user-attachments/assets/ced77e57-4e73-4ef5-b7b4-18a3d7002011

* Added the UI test cases for testing this scenario.
* Improved MimeTypeTest, ZimFileReaderWithSplittedZimFileTest, and EncodedUrlTest test which sometimes failing on CI.