### PR TITLE
Improved the message to copy/move ZIM

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -327,7 +327,7 @@
   <string name="move">Move</string>
   <string name="file_copying_in_progress">Zim file copying in progress</string>
   <string name="file_moving_in_progress">Zim file moving in progress</string>
-  <string name="copy_move_files_dialog_description">Do you want to copy or move the file?</string>
+  <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the zim file: %s.</string>
   <string name="move_files_permission_dialog_title">Move/Copy files to app public directory?</string>
   <string name="move_files_permission_dialog_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files. Do you agree to this?</string>


### PR DESCRIPTION
Fixes #4064

Improved the message to copy/move ZIM.

![Screenshot_20241112-111011_Kiwix](https://github.com/user-attachments/assets/931a1d2d-8f6b-482c-b166-05aa0a537de5)
