### PR TITLE
Corrected all the messages related to ZIM, and improved the message of copy/move ZIM file dialog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Bug Fixed:
 * Zimit2 Youtube video does not play in Android reader. (https://github.com/kiwix/kiwix-android/pull/3879)
 * Xapian crash scenarios(When searching for an article). (https://github.com/kiwix/kiwix-android/pull/3885)
 * ServiceWorker management seems unstable. (https://github.com/kiwix/kiwix-android/pull/3880)
-* Outdated text showing when a zim file could not open. (https://github.com/kiwix/kiwix-android/pull/3887)
+* Outdated text showing when a ZIM file could not open. (https://github.com/kiwix/kiwix-android/pull/3887)
 * Sometimes not all bookmarks are showing. (https://github.com/kiwix/kiwix-android/pull/3893)
 * Application crashes when loading the media in webView. (https://github.com/kiwix/kiwix-android/pull/3898)
 * Application crashes while migrating the history/notes. (https://github.com/kiwix/kiwix-android/pull/3900)
@@ -23,7 +23,7 @@ Bug Fixed:
 * Unable to restart download after pausing if application language is other than English. (https://github.com/kiwix/kiwix-android/pull/3847)
 * Can't open EPUB from Project Gutenberg in external app. (https://github.com/kiwix/kiwix-android/pull/3738)
 * Some EPUB files are not downloading. (https://github.com/kiwix/kiwix-android/pull/3738)
-* Saving bookmarks in the zim-split splitted ZIM files are crashing the application, when there is a 0 size extra zim chunk. (https://github.com/kiwix/kiwix-android/pull/3862)
+* Saving bookmarks in the zim-split splitted ZIM files are crashing the application, when there is a 0 size extra ZIM chunk. (https://github.com/kiwix/kiwix-android/pull/3862)
 * Suspended the application from F-droid store. (https://github.com/kiwix/kiwix-android/issues/3672)
 * New nightly APK signatures prevent easy update. (https://github.com/kiwix/kiwix-android/pull/3844)
 * Improved the article search. (https://github.com/kiwix/kiwix-android/pull/3849)
@@ -39,10 +39,10 @@ Compilation/CI/CD:
 
 3.10.1
 Bug Fixed:
-* Error on opening a split zim file. (https://github.com/kiwix/kiwix-android/pull/3803)
+* Error on opening a split ZIM file. (https://github.com/kiwix/kiwix-android/pull/3803)
 * Sometimes setting the org.kiwix.libzim.Archive.setNativeArchive crashes the application. (https://github.com/kiwix/kiwix-android/pull/3807)
-* Zim files are not opening with Kiwix when clicking on zim files in the storage. (https://github.com/kiwix/kiwix-android/pull/3834)
-* Main page is not loading for zim files. (https://github.com/kiwix/kiwix-android/pull/3817)
+* ZIM files are not opening with Kiwix when clicking on ZIM files in the storage. (https://github.com/kiwix/kiwix-android/pull/3834)
+* Main page is not loading for ZIM files. (https://github.com/kiwix/kiwix-android/pull/3817)
 * Fixed some issues reported by the playStore. (https://github.com/kiwix/kiwix-android/pull/3815, https://github.com/kiwix/kiwix-android/pull/3818, https://github.com/kiwix/kiwix-android/pull/3814, https://github.com/kiwix/kiwix-android/pull/3823, https://github.com/kiwix/kiwix-android/pull/3824)
 * The Delete icon is showing wrong content description on the notes and history screen. (https://github.com/kiwix/kiwix-android/pull/3826)
 
@@ -215,15 +215,15 @@ Compilation/CI/CD:
 
 
 3.5.0
-* FIX: Storing Zim/Book files inside the public Kiwix Directory on internal storage.
-* FIX: Storing Zim/Book files inside the public Kiwix Directory on external storage in android 11 and above.
+* FIX: Storing ZIM/Book files inside the public Kiwix Directory on internal storage.
+* FIX: Storing ZIM/Book files inside the public Kiwix Directory on external storage in android 11 and above.
 * FIX: Ability to save Notes in android 10 and above.
-* FIX: Ability to open externally downloaded Zim Files.
+* FIX: Ability to open externally downloaded ZIM Files.
 * FIX: MIME type fix for "*.js" titles.
 * FIX: CI/CD Pipeline fixed for android 21 & android 30.
 * FIX: Partial library migration from jcenter to jitpack & maven repo.
 * FIX: Add network permission dialog on download navigation.
-* NEW: File Selector for selecting any zim files from storage.
+* NEW: File Selector for selecting any ZIM files from storage.
 
 3.4.6
 * FIX: Added MANAGE_EXTERNAL_STORAGE permission for Android 11 and later
@@ -236,13 +236,13 @@ Compilation/CI/CD:
 3.4.5
 NEW: Supports Android 11
 NEW: Hotspot socket address better visible, clickable and shareable
-BUGFIX: Some zim-it files doesn't read anymore
+BUGFIX: Some zimit files doesn't read anymore
 BUGFIX: "Search in Kiwix" is just redirecting to Kiwix
 BUGFIX: Laggy input in search box
 + More
 
 3.4.4
-NEW: The Download of Zim in now more stable
+NEW: The Download of ZIM in now more stable
 NEW: Updated translations
 BUGFIX: In Search menu item recreates multiple times
 BUGFIX: Clicking the search result doesn't go anywhere
@@ -259,7 +259,7 @@ BUGFIX: Creating multiple tabs was causing `loading` in previously opened tabs
 BUGFIX: Messages displayed when no books are present were inconsistent typographically
 
 3.4.2
-NEW: Service worker support for war2c zim files
+NEW: Service worker support for war2c ZIM files
 NEW: Updated translations
 NEW: Online Library won't be downloaded on mobile data when wifi only preference is set
 BUGFIX: Text to Speech continues in background
@@ -299,19 +299,19 @@ BUGFIX: Crash on older devices due to OKHTTP
 
 3.3.2
 NEW: Better flow for hosting books
-NEW: Control text zoom for zim files
+NEW: Control text zoom for ZIM files
 NEW: Bookmarks/History internals rewrite
 NEW: Updated translations
 BUGFIX: Search results were inaccurate when typing too quickly
-BUGFIX: new zim scheme for addressing content
+BUGFIX: new ZIM scheme for addressing content
 BUGFIX: Native memory leaks fixed
 BUGFIX: fix crash on returning to webview from search result
-BUGFIX: some zim files could not be found after downloading
+BUGFIX: some ZIM files could not be found after downloading
 + Lots More
 
 3.3.1
 NEW: Send Diagnostic Reports
-BUGFIX: Loading older zim files could fail
+BUGFIX: Loading older ZIM files could fail
 BUGFIX: Some svgs were not loading
 + Lots More
 
@@ -357,12 +357,12 @@ NEW: Tags for books
 
 
 3.0.5
-BUGFIX: Some zim files could not be downloaded due to missing metadata
+BUGFIX: Some ZIM files could not be downloaded due to missing metadata
 BUGFIX: Some mirrors were not allowed to download via http
 
 3.0.4
 BUGFIX: Some users language was causing a crash due to unstable ISO codes
-BUGFIX: Some unstable zim files were crashing when opened
+BUGFIX: Some unstable ZIM files were crashing when opened
 BUGFIX: Long titles were rendering off screen on home page
 BUGFIX: Issues when opening a file externally
 
@@ -372,20 +372,20 @@ NEW: In app error reporting
 NEW: Improved bookmarks
 NEW: Help screen
 NEW: Home page
-NEW: Zim history
+NEW: ZIM history
 NEW: Introductory screen
 NEW: Improved language selection
 NEW: Add note to articles
 NEW: Tabs
-NEW: Share zim files to other Kiwix users
-NEW: Host zim files on your phone
+NEW: Share ZIM files to other Kiwix users
+NEW: Host ZIM files on your phone
 + Bugfixes & Lots More
 
 2.5.3
 BUGFIX: Fix IndexOutOfBounds in KiwixMobileActivity onResume
 
 2.5.2
-BUGFIX: Some zim files were not displaying
+BUGFIX: Some ZIM files were not displaying
 
 2.5.1
 NEW: Downloads are done over http

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ For an overview of how to make design changes to Kiwix Android, check out [DESIG
 The Kiwix app is split into 3 modules
 1. `core` - the "core" functionality of the app shared between different clients
 1. `app` - the main app Kiwix, Wikipedia Offline
-1. `custom` - this is for building custom applications that supply only 1 zim file and a custom skin
+1. `custom` - this is for building custom applications that supply only 1 ZIM file and a custom skin
 
 The default build is `debug`, with this variant you can use a debugger while developing. To install the application click the `run` button in Android Studio with the `app` configuration selected while you have a device connected. The `release` build is what gets uploaded to the Google Play store and can be built locally with the dummy credentials/keystore provided.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with the Play Store policies and ensure a smooth user experience.  We
 recommend using the official version of the app available on our
 website to access the complete set of features.
 
-Possible paths for play store version which supports for the scanning/reading zim files.
+Possible paths for play store version which supports for the scanning/reading ZIM files.
 
 | Storage path                                            | Viewable outside kiwix(in File manager) | Could be scanned by Kiwix |
 |---------------------------------------------------------|-----------------------------------------|---------------------------|

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -77,9 +77,9 @@ class CopyMoveFileHandler @Inject constructor(
 
   private val copyMoveTitle: String by lazy {
     if (isMoveOperation) {
-      activity.getString(R.string.file_moving_in_progress)
+      activity.getString(R.string.moving_zim_file)
     } else {
-      activity.getString(R.string.file_copying_in_progress)
+      activity.getString(R.string.copying_zim_file)
     }
   }
 

--- a/app/src/main/res/layout/copy_move_progress_bar.xml
+++ b/app/src/main/res/layout/copy_move_progress_bar.xml
@@ -28,7 +28,7 @@
     android:layout_height="wrap_content"
     android:layout_marginEnd="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_horizontal_margin"
-    android:text="@string/file_copying_in_progress"
+    android:text="@string/copying_zim_file"
     android:textSize="12sp"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/progressBar" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,6 @@
   <string name="cannot_open_file">Failed to open file\nPlease try looking for this file in your Library</string>
   <string name="send_files_title">Send Files</string>
   <string name="receive_files_title">Receive Files</string>
-  <string name="no_app_found_to_open">No app found to select zim file!</string>
-  <string name="select_zim_file">Select zim file to read</string>
+  <string name="no_app_found_to_open">No app found to select ZIM file!</string>
+  <string name="select_zim_file">Select ZIM file to read</string>
 </resources>

--- a/core/src/main/res/values-dag/strings.xml
+++ b/core/src/main/res/values-dag/strings.xml
@@ -305,8 +305,6 @@
   <string name="preparing_file_for_copy">Shili malibu zaŋ n-ti yaabu/kpɛhibu</string>
   <string name="action_copy">yaai</string>
   <string name="move">Kpɛhi</string>
-  <string name="file_copying_in_progress">Zim mazagali na yaarimi</string>
-  <string name="file_moving_in_progress">Zim mazagali na kpɛrimi</string>
   <string name="copy_move_files_dialog_description">A borimi ni a yaai bee a zaŋ kpɛhi mazagali ŋɔ ni?</string>
   <string name="copy_file_error_message">Chiriŋ niŋya a zim mazagali yaabu ni: %s.</string>
   <string name="move_files_permission_dialog_title">Kpɛhimi/yaami mazagaya niŋ app salo wuhibu ni?</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -341,8 +341,6 @@
   <string name="preparing_file_for_copy">Préparation de la copie/du déplacement</string>
   <string name="action_copy">Copier</string>
   <string name="move">Déplacer</string>
-  <string name="file_copying_in_progress">Copie du fichier Zim en cours</string>
-  <string name="file_moving_in_progress">Déplacement du fichier ZIM en cours</string>
   <string name="copy_move_files_dialog_description">Voulez-vous copier ou déplacer le fichier ?</string>
   <string name="copy_file_error_message">Erreur lors de la copie du fichier ZIM : %s.</string>
   <string name="move_files_permission_dialog_title">Déplacer/copier les fichiers vers le répertoire public de l’application ?</string>

--- a/core/src/main/res/values-ia/strings.xml
+++ b/core/src/main/res/values-ia/strings.xml
@@ -317,8 +317,6 @@
   <string name="preparing_file_for_copy">Preparation pro copiar/displaciar</string>
   <string name="action_copy">Copiar</string>
   <string name="move">Displaciar</string>
-  <string name="file_copying_in_progress">Copia del file ZIM in curso</string>
-  <string name="file_moving_in_progress">Displaciamento del file ZIM in curso</string>
   <string name="copy_move_files_dialog_description">Vole tu copiar o displaciar le file?</string>
   <string name="copy_file_error_message">Error durante le copia del file ZIM: %s.</string>
   <string name="move_files_permission_dialog_title">Displaciar/copiar files al directorio public del app?</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -304,8 +304,6 @@
   <string name="preparing_file_for_copy">Preparazione per la copia/spostamento</string>
   <string name="action_copy">Copia</string>
   <string name="move">Sposta</string>
-  <string name="file_copying_in_progress">Copia del file Zim in corso</string>
-  <string name="file_moving_in_progress">Spostamento del file Zim in corso</string>
   <string name="copy_move_files_dialog_description">Vuoi copiare o spostare il file?</string>
   <string name="copy_file_error_message">Errore nella copia del file zim: %s.</string>
   <string name="move_files_permission_dialog_title">Spostare/copiare i file nella directory pubblica dell’app?</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -322,8 +322,6 @@
   <string name="preparing_file_for_copy">הכנה להעתקה או העברה</string>
   <string name="action_copy">העתקה</string>
   <string name="move">העברה</string>
-  <string name="file_copying_in_progress">העתקת קובץ ZIM מתבצעת</string>
-  <string name="file_moving_in_progress">העברת קובץ ZIM מתבצעת</string>
   <string name="copy_move_files_dialog_description">האם ברצונך להעתיק או להעביר את הקובץ?</string>
   <string name="copy_file_error_message">שגיאה בהעתקת קובץ zim‏: %s.</string>
   <string name="move_files_permission_dialog_title">להעביר או להעתיק קבצים לספרייה ציבורית של היישום?</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -328,8 +328,6 @@
   <string name="preparing_file_for_copy">복사/이동 준비 중</string>
   <string name="action_copy">복사</string>
   <string name="move">이동</string>
-  <string name="file_copying_in_progress">Zim 파일 복사 진행 중</string>
-  <string name="file_moving_in_progress">Zim 파일 이동 진행 중</string>
   <string name="copy_move_files_dialog_description">파일을 복사하거나 이동하시겠습니까?</string>
   <string name="copy_file_error_message">zim 파일 복사 오류: %s.</string>
   <string name="move_files_permission_dialog_title">앱 공개 디렉토리로 파일을 이동/복사하시겠습니까?</string>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -314,8 +314,6 @@
   <string name="preparing_file_for_copy">Подготовка за копирање/преместување</string>
   <string name="action_copy">Копирај</string>
   <string name="move">Премести</string>
-  <string name="file_copying_in_progress">Копирањето на ZIM-податотеката е во тек</string>
-  <string name="file_moving_in_progress">Преместувањето на ZIM-податотеката е во тек</string>
   <string name="copy_move_files_dialog_description">Дали сакате да ја ископирате или преместите податотеката?</string>
   <string name="copy_file_error_message">Грешка при копирање на ZIM-податотеката: %s.</string>
   <string name="move_files_permission_dialog_title">Да се преместат/прекопираат податотеките во јавниот директориум на прилогот?</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -332,8 +332,6 @@
   <string name="preparing_file_for_copy">Preparando-se para copiar/mover</string>
   <string name="action_copy">Copiar</string>
   <string name="move">Mover</string>
-  <string name="file_copying_in_progress">Copiando arquivo zim</string>
-  <string name="file_moving_in_progress">Movendo arquivo zim</string>
   <string name="copy_move_files_dialog_description">Você quer copiar ou mover o arquivo?</string>
   <string name="copy_file_error_message">Erro ao copiar o arquivo zim: %s.</string>
   <string name="move_files_permission_dialog_title">Mover/Copiar arquivos para o diretório público do app?</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -343,8 +343,6 @@
   <string name="preparing_file_for_copy">Подготовка к копированию/перемещению</string>
   <string name="action_copy">Копировать</string>
   <string name="move">Переместить</string>
-  <string name="file_copying_in_progress">Копируем ZIM-файл</string>
-  <string name="file_moving_in_progress">Перемещаем ZIM-файл</string>
   <string name="copy_move_files_dialog_description">Вы хотите скопировать или переместить файл?</string>
   <string name="copy_file_error_message">Ошибка при копировании ZIM-файла: %s.</string>
   <string name="move_files_permission_dialog_title">Перемещение/копирование файлов в публичный каталог приложения?</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -325,8 +325,6 @@
   <string name="preparing_file_for_copy">準備拷貝/移動</string>
   <string name="action_copy">拷貝</string>
   <string name="move">移動</string>
-  <string name="file_copying_in_progress">正在進行 zim 檔案拷貝</string>
-  <string name="file_moving_in_progress">正在進行 zim 檔案移動</string>
   <string name="copy_move_files_dialog_description">您要拷貝或移動檔案嗎？</string>
   <string name="copy_file_error_message">拷貝 zim 檔案時發生錯誤：%s。</string>
   <string name="move_files_permission_dialog_title">將檔案移動/拷貝到應用程式公共目錄？</string>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -342,8 +342,6 @@
   <string name="preparing_file_for_copy">准备复制/移动</string>
   <string name="action_copy">复制</string>
   <string name="move">移动</string>
-  <string name="file_copying_in_progress">正在进行zim文件复制</string>
-  <string name="file_moving_in_progress">正在进行zim文件移动</string>
   <string name="copy_move_files_dialog_description">您要复制或移动文件吗？</string>
   <string name="copy_file_error_message">复制zim文件时出错：%s。</string>
   <string name="move_files_permission_dialog_title">将文件移动/复制到应用程序公共目录？</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -51,8 +51,8 @@
   <string name="qr_code">Rendered QR Code</string>
   <string name="share_host_address">Share URL via other applications</string>
   <string name="error_file_not_found">Error: The selected ZIM file could not be found.</string>
-  <string name="unable_to_read_zim_file">Unable to read this zim file!</string>
-  <string name="zim_not_opened">Unable to open zim file</string>
+  <string name="unable_to_read_zim_file">Unable to read this ZIM file!</string>
+  <string name="zim_not_opened">Unable to open ZIM file</string>
   <string name="error_file_invalid">Error: The selected file is not a valid ZIM file.</string>
   <string name="error_article_url_not_found">Error: Loading article (Url: %1$s) failed.</string>
   <string name="pref_display_title">Display</string>
@@ -72,7 +72,7 @@
   <string name="no_app_found_to_select_bookmark_file">No app found to select a bookmark file</string>
   <string name="no_section_info">No Content Headers Found</string>
   <string name="request_storage">To access offline content we need access to your storage</string>
-  <string name="request_write_storage">To download zim files we need write access to your storage</string>
+  <string name="request_write_storage">To download ZIM files we need write access to your storage</string>
   <string name="clear_recent_and_tabs_history_dialog">Are you sure you want to delete your search history and reset all active tabs?</string>
   <string name="delete_recent_search_item">Delete this item?</string>
   <string name="pref_clear_all_history_title">Clear history</string>
@@ -116,7 +116,7 @@
   <string name="local_zims" tools:keep="@string/local_zims">Device</string>
   <string name="remote_zims" tools:keep="@string/remote_zims">Online</string>
   <string name="library">Library</string>
-  <string name="delete_zim_body">The following zim file(s) will be deleted:\n\n%s</string>
+  <string name="delete_zim_body">The following ZIM file(s) will be deleted:\n\n%s</string>
   <string name="delete_zims_toast" tools:keep="@string/delete_zims_toast">Files deleted successfully</string>
   <string name="no_files_here" tools:keep="@string/no_files_here">No files here</string>
   <string name="download_no_space" tools:keep="@string/download_no_space">Insufficient space to download.</string>
@@ -181,7 +181,7 @@
   <string name="crash_title">Well… This is Embarrassing</string>
   <string name="crash_description">It looks like we crashed.\n\nWould you mind helping us fix this problem by sending the following information?</string>
   <string name="crash_checkbox_language">Your Language Settings</string>
-  <string name="crash_checkbox_zimfiles">A List of Your Zim Files</string>
+  <string name="crash_checkbox_zimfiles">A List of Your ZIM Files</string>
   <string name="crash_checkbox_exception">Details of The Crash</string>
   <string name="crash_checkbox_logs">Application Logs</string>
   <string name="crash_checkbox_device">Device Details</string>
@@ -231,7 +231,7 @@
   <string name="complete">Complete</string>
   <string name="paused_state">Paused</string>
   <string name="failed_state">Failed: %s</string>
-  <string name="custom_download_error_message_for_authentication_failed">The zim file could not be downloaded. Please try reinstalling the application from the Play store.</string>
+  <string name="custom_download_error_message_for_authentication_failed">The ZIM file could not be downloaded. Please try reinstalling the application from the Play store.</string>
   <string name="save">Save</string>
   <string name="note">Note</string>
   <string name="wiki_article_title">Wiki Article Title</string>
@@ -260,7 +260,7 @@
   <string name="permission_rationale_location">Location permission is required by Android to allow the app to detect peer devices</string>
   <string name="permission_rationale_nearby">Nearby devices permission is required by Android to allow the app to detect peer devices</string>
   <string name="permission_refused_location" tools:keep="@string/permission_refused_location">Cannot locate peer devices without location permissions</string>
-  <string name="permission_refused_storage" tools:keep="@string/permission_refused_storage">Cannot access zim files without storage permission</string>
+  <string name="permission_refused_storage" tools:keep="@string/permission_refused_storage">Cannot access ZIM files without storage permission</string>
   <string name="request_enable_location">Enable location to allow detection of peers</string>
   <string name="discovery_needs_location" tools:keep="@string/discovery_needs_location">Cannot discover peers without location services</string>
   <string name="request_enable_wifi">Enable WiFi P2P from system settings</string>
@@ -325,17 +325,17 @@
   <string name="preparing_file_for_copy">Preparing for copy/move</string>
   <string name="action_copy">Copy</string>
   <string name="move">Move</string>
-  <string name="file_copying_in_progress">Zim file copying in progress</string>
-  <string name="file_moving_in_progress">Zim file moving in progress</string>
+  <string name="copying_zim_file">Copying ZIM file…</string>
+  <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
-  <string name="copy_file_error_message">Error in copying the zim file: %s.</string>
+  <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
   <string name="move_files_permission_dialog_title">Move/Copy files to app public directory?</string>
   <string name="move_files_permission_dialog_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files. Do you agree to this?</string>
-  <string name="move_file_error_message">Error in moving the zim file: %s.</string>
+  <string name="move_file_error_message">Error in moving the ZIM file: %s.</string>
   <string name="how_to_update_content">How to update content?</string>
-  <string name="update_content_description">To update content (a zim file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
+  <string name="update_content_description">To update content (a ZIM file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>
-  <string name="all_files_permission_needed_message">In order to access all the zim files across device we need to have All Files Permission</string>
+  <string name="all_files_permission_needed_message">In order to access all the ZIM files across device we need to have All Files Permission</string>
   <string name="allowed">Allowed</string>
   <string name="not_allowed">Not allowed</string>
   <string name="denied_internet_permission_message">Please enable wifi to download content</string>

--- a/custom/src/main/res/values-qq/strings.xml
+++ b/custom/src/main/res/values-qq/strings.xml
@@ -4,5 +4,5 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="all">
   <string name="retry">{{Identical|Retry}}</string>
-  <string name="invalid_installation">* It is shown on the custom app’s download screen when there is no zim file available to read.\n* It is telling the user that the installation is invalid and user must download zim file.\n* It is also telling user to ensure that Wifi is on and user has enough storage.</string>
+  <string name="invalid_installation">* It is shown on the custom app’s download screen when there is no ZIM file available to read.\n* It is telling the user that the installation is invalid and user must download ZIM file.\n* It is also telling user to ensure that Wifi is on and user has enough storage.</string>
 </resources>

--- a/custom/src/main/res/values/strings.xml
+++ b/custom/src/main/res/values/strings.xml
@@ -2,5 +2,5 @@
 
 <resources>
   <string name="retry">Retry</string>
-  <string name="invalid_installation">Invalid Install. Please Download Zim.\n Ensure WiFi is on and you have enough storage</string>
+  <string name="invalid_installation">Invalid Install. Please Download ZIM.\n Ensure WiFi is on and you have enough storage</string>
 </resources>


### PR DESCRIPTION
Fixes #4066 

* Improved the message of the copy/move ZIM file dialog. Now the new messages will be shown on the dialog are:
  1. Copying ZIM file…
  2. Moving ZIM file…

| Copy Dialog  | Move Dialog |
| ------------- | ------------- |
| ![Screenshot_20241112-123419_Kiwix](https://github.com/user-attachments/assets/21acf3fe-0249-40e2-a550-2a513f751c85) |![Screenshot_20241112-123631_Kiwix](https://github.com/user-attachments/assets/fdd0bf43-53ee-4f34-b12f-29d8f6c1e6fe)  |

* Corrected all the messages related to ZIM.