### PR TITLE
Fixed: Unclean opening local ZIM file in library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -89,7 +89,9 @@ class KiwixReaderFragment : CoreReaderFragment() {
     openPageInBookFromNavigationArguments()
   }
 
+  @Suppress("MagicNumber")
   private fun openPageInBookFromNavigationArguments() {
+    showProgressBarWithProgress(30)
     val args = KiwixReaderFragmentArgs.fromBundle(requireArguments())
     lifecycleScope.launch {
       if (args.pageUrl.isNotEmpty()) {
@@ -102,6 +104,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
           // See https://github.com/kiwix/kiwix-android/issues/3541
           zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
         }
+        hideProgressBar()
         loadUrlWithCurrentWebview(args.pageUrl)
       } else {
         if (args.zimFileUri.isNotEmpty()) {
@@ -217,9 +220,6 @@ class KiwixReaderFragment : CoreReaderFragment() {
 
   override fun onResume() {
     super.onResume()
-    if (zimReaderContainer?.zimReaderSource == null) {
-      exitBook()
-    }
     if (isFullScreenVideo || isInFullScreenMode()) {
       hideNavBar()
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -121,6 +121,7 @@ import org.kiwix.kiwixmobile.core.main.DocumentParser.SectionsListener
 import org.kiwix.kiwixmobile.core.main.KiwixTextToSpeech.OnInitSucceedListener
 import org.kiwix.kiwixmobile.core.main.KiwixTextToSpeech.OnSpeakingListener
 import org.kiwix.kiwixmobile.core.main.MainMenu.MenuClickListener
+import org.kiwix.kiwixmobile.core.main.RestoreOrigin.FromExternalLaunch
 import org.kiwix.kiwixmobile.core.main.TableDrawerAdapter.DocumentSection
 import org.kiwix.kiwixmobile.core.main.TableDrawerAdapter.TableClickListener
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
@@ -174,7 +175,6 @@ import java.util.Date
 import javax.inject.Inject
 import kotlin.math.abs
 import kotlin.math.max
-import org.kiwix.kiwixmobile.core.main.RestoreOrigin.FromExternalLaunch
 
 const val SEARCH_ITEM_TITLE_KEY = "searchItemTitle"
 
@@ -1382,12 +1382,28 @@ abstract class CoreReaderFragment :
     bottomToolbar?.visibility = View.GONE
     actionBar?.title = getString(R.string.reader)
     contentFrame?.visibility = View.GONE
+    hideProgressBar()
     mainMenu?.hideBookSpecificMenuItems()
     closeZimBook()
   }
 
   fun closeZimBook() {
     zimReaderContainer?.setZimReaderSource(null)
+  }
+
+  protected fun showProgressBarWithProgress(progress: Int) {
+    progressBar?.apply {
+      visibility = VISIBLE
+      show()
+      this.progress = progress
+    }
+  }
+
+  protected fun hideProgressBar() {
+    progressBar?.apply {
+      visibility = View.GONE
+      hide()
+    }
   }
 
   private fun restoreDeletedTab(index: Int) {
@@ -2331,14 +2347,10 @@ abstract class CoreReaderFragment :
   override fun webViewProgressChanged(progress: Int, webView: WebView) {
     if (isAdded) {
       updateUrlProcessor()
-      progressBar?.apply {
-        visibility = View.VISIBLE
-        show()
-        this.progress = progress
-        if (progress == 100) {
-          hide()
-          Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView()?.url)
-        }
+      showProgressBarWithProgress(progress)
+      if (progress == 100) {
+        hideProgressBar()
+        Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView()?.url)
       }
       (webView.context as AppCompatActivity).invalidateOptionsMenu()
     }


### PR DESCRIPTION
Fixes #4065 

A flash was showing on the reader screen (with the blue button "Open library") when we were opening the ZIM file from the "Local library screen" because we had moved the `canReadFile` method to the IO thread. We have fixed this issue in this PR. Now, a `progress` will show until the `ZimFileReader` is created on the IO thread to notify users that the ZIM file is in the process of opening.


https://github.com/user-attachments/assets/a89d24fa-3973-448c-9a82-0528a8d0f6d5



