### PR TITLE
Fixed: Many problems at first side loading of a ZiM file

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -85,6 +85,7 @@ class DeepLinksTest : BaseActivityTest() {
         setIsPlayStoreBuildType(true)
         prefIsTest = true
         putPrefLanguage("en")
+        shouldShowStorageSelectionDialog = false
         lastDonationPopupShownInMilliSeconds = System.currentTimeMillis()
       }
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.help
 
+import android.os.Build
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.IdlingRegistry
@@ -50,15 +51,6 @@ class HelpFragmentTest : BaseActivityTest() {
       }
       waitForIdle()
     }
-    context.let {
-      sharedPreferenceUtil = SharedPreferenceUtil(it).apply {
-        setIntroShown()
-        putPrefWifiOnly(false)
-        setIsPlayStoreBuildType(true)
-        prefIsTest = true
-        putPrefLanguage("en")
-      }
-    }
     activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
       moveToState(Lifecycle.State.RESUMED)
       onActivity {
@@ -83,6 +75,7 @@ class HelpFragmentTest : BaseActivityTest() {
 
   @Test
   fun verifyHelpActivity() {
+    setShowCopyMoveToPublicDirectory(false)
     activityScenario.onActivity {
       it.navigate(R.id.helpFragment)
     }
@@ -96,8 +89,46 @@ class HelpFragmentTest : BaseActivityTest() {
       clickOnHowToUpdateContent()
       assertHowToUpdateContentIsExpanded()
       clickOnHowToUpdateContent()
+      assertWhyCopyMoveFilesToAppPublicDirectoryIsNotVisible()
     }
     LeakAssertions.assertNoLeaks()
+  }
+
+  @Test
+  fun verifyHelpActivityWithPlayStoreRestriction() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      setShowCopyMoveToPublicDirectory(true)
+      activityScenario.onActivity {
+        it.navigate(R.id.helpFragment)
+      }
+      help {
+        clickOnWhatDoesKiwixDo()
+        assertWhatDoesKiwixDoIsExpanded()
+        clickOnWhatDoesKiwixDo()
+        clickOnWhereIsContent()
+        assertWhereIsContentIsExpanded()
+        clickOnWhereIsContent()
+        clickOnHowToUpdateContent()
+        assertHowToUpdateContentIsExpanded()
+        clickOnHowToUpdateContent()
+        clickWhyCopyMoveFilesToAppPublicDirectory()
+        assertWhyCopyMoveFilesToAppPublicDirectoryIsExpanded()
+        clickWhyCopyMoveFilesToAppPublicDirectory()
+      }
+      LeakAssertions.assertNoLeaks()
+    }
+  }
+
+  private fun setShowCopyMoveToPublicDirectory(showRestriction: Boolean) {
+    context.let {
+      sharedPreferenceUtil = SharedPreferenceUtil(it).apply {
+        setIntroShown()
+        putPrefWifiOnly(false)
+        setIsPlayStoreBuildType(showRestriction)
+        prefIsTest = true
+        putPrefLanguage("en")
+      }
+    }
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpRobot.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.help
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.Findable.StringId.TextId
@@ -76,6 +77,19 @@ class HelpRobot : BaseRobot() {
 
   fun assertHowToUpdateContentIsExpanded() {
     isVisible(TextId(string.update_content_description))
+  }
+
+  fun clickWhyCopyMoveFilesToAppPublicDirectory() {
+    clickOn(TextId(string.why_copy_move_files_to_app_directory))
+  }
+
+  fun assertWhyCopyMoveFilesToAppPublicDirectoryIsExpanded() {
+    isVisible(Text(context.getString(string.copy_move_files_to_app_directory_description)))
+  }
+
+  fun assertWhyCopyMoveFilesToAppPublicDirectoryIsNotVisible() {
+    onView(withText(string.why_copy_move_files_to_app_directory))
+      .check(doesNotExist())
   }
 
   private fun helpTextFormat(vararg stringIds: Int) =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
@@ -37,6 +37,7 @@ import org.kiwix.kiwixmobile.R.id
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
 
 fun copyMoveFileHandler(func: CopyMoveFileHandlerRobot.() -> Unit) =
   CopyMoveFileHandlerRobot().applyWithViewHierarchyPrinting(func)
@@ -54,6 +55,23 @@ class CopyMoveFileHandlerRobot : BaseRobot() {
   fun assertCopyMoveDialogNotDisplayed() {
     testFlakyView({
       onView(withText(R.string.copy_move_files_dialog_description)).check(doesNotExist())
+    })
+  }
+
+  fun assertStorageSelectionDialogDisplayed() {
+    testFlakyView({
+      onView(withText(R.string.choose_storage_to_copy_move_zim_file))
+    })
+  }
+
+  fun clickOnInternalStorage() {
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      onView(
+        RecyclerViewMatcher(R.id.device_list).atPosition(
+          0
+        )
+      ).perform(click())
     })
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
@@ -44,10 +44,6 @@ fun copyMoveFileHandler(func: CopyMoveFileHandlerRobot.() -> Unit) =
 
 class CopyMoveFileHandlerRobot : BaseRobot() {
 
-  fun assertCopyMovePermissionDialogDisplayed() {
-    isVisible(TextId(R.string.move_files_permission_dialog_title))
-  }
-
   fun assertCopyMoveDialogDisplayed() {
     isVisible(TextId(R.string.copy_move_files_dialog_description))
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -113,12 +113,14 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       }
       copyMoveFileHandler(CopyMoveFileHandlerRobot::pauseForBetterTestPerformance)
       // test with first launch
-      sharedPreferenceUtil.copyMoveZimFilePermissionDialog = false
+      sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
       showMoveFileToPublicDirectoryDialog()
       // should show the permission dialog.
       copyMoveFileHandler {
-        assertCopyMovePermissionDialogDisplayed()
+        assertCopyMoveDialogDisplayed()
         clickOnCopy()
+        assertStorageSelectionDialogDisplayed()
+        clickOnInternalStorage()
         assertZimFileCopiedAndShowingIntoTheReader()
       }
       assertZimFileAddedInTheLocalLibrary()
@@ -150,12 +152,14 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       }
       copyMoveFileHandler(CopyMoveFileHandlerRobot::pauseForBetterTestPerformance)
       // test with first launch
-      sharedPreferenceUtil.copyMoveZimFilePermissionDialog = false
+      sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
       showMoveFileToPublicDirectoryDialog()
       // should show the permission dialog.
       copyMoveFileHandler {
-        assertCopyMovePermissionDialogDisplayed()
+        assertCopyMoveDialogDisplayed()
         clickOnMove()
+        assertStorageSelectionDialogDisplayed()
+        clickOnInternalStorage()
         assertZimFileCopiedAndShowingIntoTheReader()
       }
       assertZimFileAddedInTheLocalLibrary()
@@ -198,7 +202,8 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         navHostFragment.childFragmentManager.fragments[0] as LocalLibraryFragment
       localLibraryFragment.copyMoveFileHandler?.showMoveFileToPublicDirectoryDialog(
         Uri.fromFile(selectedFile),
-        DocumentFile.fromFile(selectedFile)
+        DocumentFile.fromFile(selectedFile),
+        fragmentManager = localLibraryFragment.parentFragmentManager
       )
     }
   }
@@ -307,7 +312,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       }
       copyMoveFileHandler(CopyMoveFileHandlerRobot::pauseForBetterTestPerformance)
       sharedPreferenceUtil.apply {
-        copyMoveZimFilePermissionDialog = true
+        shouldShowStorageSelectionDialog = false
         setIsPlayStoreBuildType(true)
       }
       // test opening images

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -110,14 +110,16 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       }
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        sharedPreferenceUtil.copyMoveZimFilePermissionDialog = false
+        sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
         // open file picker to select a file to test the real scenario.
         Espresso.onView(withId(R.id.select_file)).perform(ViewActions.click())
         uiDevice.findObject(By.textContains(fileName)).click()
 
         copyMoveFileHandler {
-          assertCopyMovePermissionDialogDisplayed()
+          assertCopyMoveDialogDisplayed()
           clickOnMove()
+          assertStorageSelectionDialogDisplayed()
+          clickOnInternalStorage()
           assertZimFileCopiedAndShowingIntoTheReader()
         }
       } catch (ignore: Exception) {
@@ -138,12 +140,14 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       }
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        sharedPreferenceUtil.copyMoveZimFilePermissionDialog = false
+        sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
         openFileManager()
         TestUtils.testFlakyView(uiDevice.findObject(By.textContains(fileName))::click, 10)
         copyMoveFileHandler {
-          assertCopyMovePermissionDialogDisplayed()
+          assertCopyMoveDialogDisplayed()
           clickOnMove()
+          assertStorageSelectionDialogDisplayed()
+          clickOnInternalStorage()
           assertZimFileCopiedAndShowingIntoTheReader()
         }
       } catch (ignore: Exception) {
@@ -175,12 +179,12 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
   }
 
   private fun testCopyMoveDialogShowing(uri: Uri) {
-    sharedPreferenceUtil.copyMoveZimFilePermissionDialog = false
+    sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
     ActivityScenario.launch<KiwixMainActivity>(
       createDeepLinkIntent(uri)
     ).onActivity {}
     copyMoveFileHandler {
-      assertCopyMovePermissionDialogDisplayed()
+      assertCopyMoveDialogDisplayed()
       clickOnCancel()
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/help/KiwixHelpFragment.kt
@@ -22,9 +22,21 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.help.HelpFragment
 
 class KiwixHelpFragment : HelpFragment() {
-  override fun rawTitleDescriptionMap() = listOf(
-    R.string.help_2 to R.array.description_help_2,
-    R.string.help_5 to R.array.description_help_5,
-    R.string.how_to_update_content to R.array.update_content_description
-  )
+  override fun rawTitleDescriptionMap() =
+    if (sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove()) {
+      listOf(
+        R.string.help_2 to R.array.description_help_2,
+        R.string.help_5 to R.array.description_help_5,
+        R.string.how_to_update_content to R.array.update_content_description,
+        R.string.why_copy_move_files_to_app_directory to getString(
+          R.string.copy_move_files_to_app_directory_description
+        )
+      )
+    } else {
+      listOf(
+        R.string.help_2 to R.array.description_help_2,
+        R.string.help_5 to R.array.description_help_5,
+        R.string.how_to_update_content to R.array.update_content_description
+      )
+    }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -162,6 +162,10 @@ class CopyMoveFileHandler @Inject constructor(
         else EXTERNAL_SELECT_POSITION
       )
     }
+    performCopyMoveOperation()
+  }
+
+  private fun performCopyMoveOperation() {
     if (validateZimFileCanCopyOrMove()) {
       if (isMoveOperation) {
         performMoveOperation()
@@ -198,7 +202,7 @@ class CopyMoveFileHandler @Inject constructor(
 
   fun handleDetectingFileSystemState() {
     if (isBookLessThan4GB()) {
-      showCopyMoveDialog()
+      performCopyMoveOperation()
     } else {
       showPreparingCopyMoveDialog()
       observeFileSystemState()
@@ -207,7 +211,7 @@ class CopyMoveFileHandler @Inject constructor(
 
   fun handleCannotWrite4GbFileState() {
     if (isBookLessThan4GB()) {
-      showCopyMoveDialog()
+      performCopyMoveOperation()
     } else {
       // Show an error dialog indicating the file system limitation
       fileCopyMoveCallback?.filesystemDoesNotSupportedCopyMoveFilesOver4GB()
@@ -221,7 +225,7 @@ class CopyMoveFileHandler @Inject constructor(
       .subscribe {
         hidePreparingCopyMoveDialog()
         if (validateZimFileCanCopyOrMove()) {
-          showCopyMoveDialog()
+          performCopyMoveOperation()
         }
       }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -82,7 +82,7 @@ class CopyMoveFileHandler @Inject constructor(
   var shouldValidateZimFile: Boolean = false
   private var fileSystemDisposable: Disposable? = null
   private lateinit var fragmentManager: FragmentManager
-  private val storageDeviceList by lazy {
+  val storageDeviceList by lazy {
     StorageDeviceUtils.getWritableStorage(activity)
   }
 
@@ -141,7 +141,7 @@ class CopyMoveFileHandler @Inject constructor(
     lifecycleScope = coroutineScope
   }
 
-  private fun showStorageSelectDialog() = StorageSelectDialog()
+  fun showStorageSelectDialog() = StorageSelectDialog()
     .apply {
       onSelectAction = ::copyMoveZIMFileInSelectedStorage
       titleSize = STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE
@@ -167,7 +167,7 @@ class CopyMoveFileHandler @Inject constructor(
     }
   }
 
-  fun performCopyMoveOperation() {
+  private fun performCopyMoveOperation() {
     if (isMoveOperation) {
       performMoveOperation()
     } else {
@@ -233,7 +233,7 @@ class CopyMoveFileHandler @Inject constructor(
       }
   }
 
-  private fun performCopyMoveOperationIfSufficientSpaceAvailable() {
+  fun performCopyMoveOperationIfSufficientSpaceAvailable() {
     val availableSpace = storageCalculator.availableBytes(File(sharedPreferenceUtil.prefStorage))
     if (hasNotSufficientStorageSpace(availableSpace)) {
       fileCopyMoveCallback?.insufficientSpaceInStorage(availableSpace)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -30,6 +30,11 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
+import androidx.fragment.app.FragmentManager
+import eu.mhutti1.utils.storage.STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE
+import eu.mhutti1.utils.storage.StorageDevice
+import eu.mhutti1.utils.storage.StorageDeviceUtils
+import eu.mhutti1.utils.storage.StorageSelectDialog
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +48,8 @@ import org.kiwix.kiwixmobile.core.extensions.deleteFile
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
+import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
+import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -74,6 +81,10 @@ class CopyMoveFileHandler @Inject constructor(
   var isMoveOperation = false
   var shouldValidateZimFile: Boolean = false
   private var fileSystemDisposable: Disposable? = null
+  private lateinit var fragmentManager: FragmentManager
+  private val storageDeviceList by lazy {
+    StorageDeviceUtils.getWritableStorage(activity)
+  }
 
   private val copyMoveTitle: String by lazy {
     if (isMoveOperation) {
@@ -93,13 +104,24 @@ class CopyMoveFileHandler @Inject constructor(
   fun showMoveFileToPublicDirectoryDialog(
     uri: Uri? = null,
     documentFile: DocumentFile? = null,
-    shouldValidateZimFile: Boolean = false
+    shouldValidateZimFile: Boolean = false,
+    fragmentManager: FragmentManager
   ) {
     this.shouldValidateZimFile = shouldValidateZimFile
+    this.fragmentManager = fragmentManager
     setSelectedFileAndUri(uri, documentFile)
-    if (!sharedPreferenceUtil.copyMoveZimFilePermissionDialog) {
-      showMoveToPublicDirectoryPermissionDialog()
+    if (sharedPreferenceUtil.shouldShowStorageSelectionDialog && storageDeviceList.size > 1) {
+      // Show dialog to select storage if more than one storage device is available, and user
+      // have not configured the storage yet.
+      showCopyMoveDialog(true)
     } else {
+      if (storageDeviceList.size == 1) {
+        // If only internal storage is currently available, set shouldShowStorageSelectionDialog
+        // to true. This allows the storage configuration dialog to be shown again if the
+        // user removes an external storage device (like an SD card) and then reinserts it.
+        // This ensures they are prompted to configure storage settings upon SD card reinsertion.
+        sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+      }
       if (validateZimFileCanCopyOrMove()) {
         showCopyMoveDialog()
       }
@@ -107,8 +129,8 @@ class CopyMoveFileHandler @Inject constructor(
   }
 
   fun setSelectedFileAndUri(uri: Uri?, documentFile: DocumentFile?) {
-    selectedFileUri = uri
-    selectedFile = documentFile
+    uri?.let { selectedFileUri = it }
+    documentFile?.let { selectedFile = it }
   }
 
   fun setFileCopyMoveCallback(fileCopyMoveCallback: FileCopyMoveCallback?) {
@@ -119,22 +141,34 @@ class CopyMoveFileHandler @Inject constructor(
     lifecycleScope = coroutineScope
   }
 
-  private fun showMoveToPublicDirectoryPermissionDialog() {
-    alertDialogShower.show(
-      KiwixDialog.MoveFileToPublicDirectoryPermissionDialog,
-      {
-        sharedPreferenceUtil.copyMoveZimFilePermissionDialog = true
-        if (validateZimFileCanCopyOrMove()) {
-          performCopyOperation()
-        }
-      },
-      {
-        sharedPreferenceUtil.copyMoveZimFilePermissionDialog = true
-        if (validateZimFileCanCopyOrMove()) {
-          performMoveOperation()
-        }
-      }
+  private fun showStorageSelectDialog() = StorageSelectDialog()
+    .apply {
+      onSelectAction = ::copyMoveZIMFileInSelectedStorage
+      titleSize = STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE
+      setStorageDeviceList(storageDeviceList)
+      setShouldShowCheckboxSelected(false)
+    }
+    .show(
+      fragmentManager,
+      activity.getString(R.string.choose_storage_to_copy_move_zim_file)
     )
+
+  fun copyMoveZIMFileInSelectedStorage(storageDevice: StorageDevice) {
+    sharedPreferenceUtil.apply {
+      shouldShowStorageSelectionDialog = false
+      putPrefStorage(sharedPreferenceUtil.getPublicDirectoryPath(storageDevice.name))
+      putStoragePosition(
+        if (storageDevice.isInternal) INTERNAL_SELECT_POSITION
+        else EXTERNAL_SELECT_POSITION
+      )
+    }
+    if (validateZimFileCanCopyOrMove()) {
+      if (isMoveOperation) {
+        performMoveOperation()
+      } else {
+        performCopyOperation()
+      }
+    }
   }
 
   fun isBookLessThan4GB(): Boolean =
@@ -192,22 +226,30 @@ class CopyMoveFileHandler @Inject constructor(
       }
   }
 
-  fun showCopyMoveDialog() {
+  fun showCopyMoveDialog(showStorageSelectionDialog: Boolean = false) {
     alertDialogShower.show(
       KiwixDialog.CopyMoveFileToPublicDirectoryDialog,
-      ::performCopyOperation,
-      ::performMoveOperation
+      { performCopyOperation(showStorageSelectionDialog) },
+      { performMoveOperation(showStorageSelectionDialog) }
     )
   }
 
-  fun performCopyOperation() {
+  fun performCopyOperation(showStorageSelectionDialog: Boolean = false) {
     isMoveOperation = false
-    copyZimFileToPublicAppDirectory()
+    if (showStorageSelectionDialog) {
+      showStorageSelectDialog()
+    } else {
+      copyZimFileToPublicAppDirectory()
+    }
   }
 
-  fun performMoveOperation() {
+  fun performMoveOperation(showStorageSelectionDialog: Boolean = false) {
     isMoveOperation = true
-    moveZimFileToPublicAppDirectory()
+    if (showStorageSelectionDialog) {
+      showStorageSelectDialog()
+    } else {
+      moveZimFileToPublicAppDirectory()
+    }
   }
 
   private fun copyZimFileToPublicAppDirectory() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -431,7 +431,8 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
         uri,
         documentFile,
         // pass if fileName is null then we will validate it after copying/moving
-        fileName == null
+        fileName == null,
+        parentFragmentManager
       )
     } else {
       getZimFileFromUri(uri)?.let(::navigateToReaderFragment)
@@ -669,6 +670,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
     .apply {
       onSelectAction = ::storeDeviceInPreferences
       setStorageDeviceList(storageDeviceList)
+      setShouldShowCheckboxSelected(true)
     }
     .show(parentFragmentManager, getString(string.pref_storage))
 
@@ -683,6 +685,6 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       else EXTERNAL_SELECT_POSITION
     )
     // after selecting the storage try to copy/move the zim file.
-    copyMoveFileHandler?.showMoveFileToPublicDirectoryDialog()
+    copyMoveFileHandler?.copyMoveZIMFileInSelectedStorage(storageDevice)
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -577,6 +577,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       onSelectAction = ::storeDeviceInPreferences
       titleSize = STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE
       setStorageDeviceList(storageDeviceList)
+      setShouldShowCheckboxSelected(false)
     }
     .show(parentFragmentManager, getString(string.choose_storage_to_download_book))
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -230,15 +230,15 @@ class CopyMoveFileHandlerTest {
 
     fileHandler.showMoveFileToPublicDirectoryDialog()
     every { fileHandler.validateZimFileCanCopyOrMove() } returns true
-    every { fileHandler.performCopyOperation() } just Runs
+    every { fileHandler.performCopyOperation(showStorageSelectionDialog) } just Runs
 
     positiveButtonClickSlot.captured.invoke()
-    verify { fileHandler.performCopyOperation() }
+    verify { fileHandler.performCopyOperation(showStorageSelectionDialog) }
     every { sharedPreferenceUtil.copyMoveZimFilePermissionDialog } returns false
-    every { fileHandler.performMoveOperation() } just Runs
+    every { fileHandler.performMoveOperation(showStorageSelectionDialog) } just Runs
     negativeButtonClickSlot.captured.invoke()
 
-    verify { fileHandler.performMoveOperation() }
+    verify { fileHandler.performMoveOperation(showStorageSelectionDialog) }
 
     verify { sharedPreferenceUtil.copyMoveZimFilePermissionDialog = true }
   }
@@ -275,14 +275,14 @@ class CopyMoveFileHandlerTest {
 
     every { fileHandler.validateZimFileCanCopyOrMove() } returns true
     fileHandler.showMoveFileToPublicDirectoryDialog()
-    every { fileHandler.performCopyOperation() } just Runs
+    every { fileHandler.performCopyOperation(showStorageSelectionDialog) } just Runs
 
     positiveButtonClickSlot.captured.invoke()
-    verify { fileHandler.performCopyOperation() }
-    every { fileHandler.performMoveOperation() } just Runs
+    verify { fileHandler.performCopyOperation(showStorageSelectionDialog) }
+    every { fileHandler.performMoveOperation(showStorageSelectionDialog) } just Runs
     negativeButtonClickSlot.captured.invoke()
 
-    verify { fileHandler.performMoveOperation() }
+    verify { fileHandler.performMoveOperation(showStorageSelectionDialog) }
   }
 
   private fun prepareFileSystemAndFileForMockk(

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
@@ -30,7 +30,6 @@ import androidx.recyclerview.widget.RecyclerView
 import eu.mhutti1.utils.storage.adapter.StorageAdapter
 import eu.mhutti1.utils.storage.adapter.StorageDelegate
 import org.kiwix.kiwixmobile.core.CoreApp
-import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.core.databinding.StorageSelectDialogBinding
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isLandScapeMode

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageSelectDialog.kt
@@ -50,13 +50,14 @@ class StorageSelectDialog : DialogFragment() {
   private var aTitle: String? = null
   private var storageSelectDialogViewBinding: StorageSelectDialogBinding? = null
   private val storageDeviceList = arrayListOf<StorageDevice>()
+  private var shouldShowCheckboxSelected: Boolean = true
 
   private val storageAdapter: StorageAdapter by lazy {
     StorageAdapter(
       StorageDelegate(
         storageCalculator,
         sharedPreferenceUtil,
-        aTitle == getString(R.string.choose_storage_to_download_book)
+        shouldShowCheckboxSelected
       ) {
         onSelectAction?.invoke(it)
         dismiss()
@@ -66,6 +67,10 @@ class StorageSelectDialog : DialogFragment() {
 
   fun setStorageDeviceList(storageDeviceList: List<StorageDevice>) {
     this.storageDeviceList.addAll(storageDeviceList)
+  }
+
+  fun setShouldShowCheckboxSelected(shouldShowCheckboxSelected: Boolean) {
+    this.shouldShowCheckboxSelected = shouldShowCheckboxSelected
   }
 
   override fun onCreateView(

--- a/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageDelegate.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageDelegate.kt
@@ -30,7 +30,7 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 class StorageDelegate(
   private val storageCalculator: StorageCalculator,
   private val sharedPreferenceUtil: SharedPreferenceUtil,
-  private val isShowingStorageOptionForFirstDownload: Boolean,
+  private val shouldShowCheckboxSelected: Boolean,
   private val onClickAction: (StorageDevice) -> Unit
 ) : AdapterDelegate<StorageDevice> {
   override fun createViewHolder(parent: ViewGroup): ViewHolder {
@@ -38,7 +38,7 @@ class StorageDelegate(
       parent.viewBinding(ItemStoragePreferenceBinding::inflate, false),
       storageCalculator,
       sharedPreferenceUtil,
-      isShowingStorageOptionForFirstDownload,
+      shouldShowCheckboxSelected,
       onClickAction
     )
   }

--- a/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageViewHolder.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/adapter/StorageViewHolder.kt
@@ -44,7 +44,7 @@ internal class StorageViewHolder(
   private val itemStoragePreferenceBinding: ItemStoragePreferenceBinding,
   private val storageCalculator: StorageCalculator,
   private val sharedPreferenceUtil: SharedPreferenceUtil,
-  private val isShowingStorageOptionForFirstDownload: Boolean,
+  private val shouldShowCheckboxSelected: Boolean,
   private val onClickAction: (StorageDevice) -> Unit
 ) : BaseViewHolder<StorageDevice>(itemStoragePreferenceBinding.root) {
 
@@ -60,7 +60,7 @@ internal class StorageViewHolder(
           )
         )
 
-      radioButton.isChecked = !isShowingStorageOptionForFirstDownload &&
+      radioButton.isChecked = shouldShowCheckboxSelected &&
         adapterPosition == sharedPreferenceUtil.storagePosition
       freeSpace.apply {
         text = item.getFreeSpace(root.context, storageCalculator)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -257,11 +257,11 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
       _textZooms.offer(textZoom)
     }
 
-  var copyMoveZimFilePermissionDialog: Boolean
-    get() = sharedPreferences.getBoolean(PREF_COPY_MOVE_PERMISSION, false)
+  var shouldShowStorageSelectionDialog: Boolean
+    get() = sharedPreferences.getBoolean(PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, true)
     set(value) {
       sharedPreferences.edit {
-        putBoolean(PREF_COPY_MOVE_PERMISSION, value)
+        putBoolean(PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, value)
       }
     }
 
@@ -329,7 +329,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_HISTORY_MIGRATED = "pref_history_migrated"
     const val PREF_NOTES_MIGRATED = "pref_notes_migrated"
     const val PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED = "pref_app_directory_to_public_migrated"
-    const val PREF_COPY_MOVE_PERMISSION = "pref_copy_move_permission"
+    const val PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG = "pref_show_copy_move_storage_dialog"
     private const val PREF_LATER_CLICKED_MILLIS = "pref_later_clicked_millis"
     const val PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS =
       "pref_last_donation_shown_in_milliseconds"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -109,15 +109,6 @@ sealed class KiwixDialog(
     cancelable = false
   )
 
-  data object MoveFileToPublicDirectoryPermissionDialog : KiwixDialog(
-    R.string.move_files_permission_dialog_title,
-    R.string.move_files_permission_dialog_description,
-    R.string.action_copy,
-    R.string.move,
-    neutralMessage = R.string.cancel,
-    cancelable = false
-  )
-
   data object CopyMoveFileToPublicDirectoryDialog : KiwixDialog(
     null,
     R.string.copy_move_files_dialog_description,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -123,6 +123,7 @@ sealed class KiwixDialog(
     R.string.copy_move_files_dialog_description,
     R.string.action_copy,
     R.string.move,
+    neutralMessage = R.string.cancel,
     cancelable = false
   )
 

--- a/core/src/main/res/values-dag/strings.xml
+++ b/core/src/main/res/values-dag/strings.xml
@@ -307,7 +307,6 @@
   <string name="move">Kpɛhi</string>
   <string name="copy_move_files_dialog_description">A borimi ni a yaai bee a zaŋ kpɛhi mazagali ŋɔ ni?</string>
   <string name="copy_file_error_message">Chiriŋ niŋya a zim mazagali yaabu ni: %s.</string>
-  <string name="move_files_permission_dialog_title">Kpɛhimi/yaami mazagaya niŋ app salo wuhibu ni?</string>
   <string name="how_to_update_content">Wula ka lahabali ni tooi maliniŋ?</string>
   <string name="update_content_description">A yi yɛn mali lahabali niŋ (zim fasara) n- to ni a deei niŋ lala yaɣili maa ni noo. A ni tooi niŋ lala deei niŋ yaɣili.</string>
   <string name="all_files_permission_needed">Fasara nima zaa soli tibu nyɛla din bora</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -343,8 +343,6 @@
   <string name="move">Déplacer</string>
   <string name="copy_move_files_dialog_description">Voulez-vous copier ou déplacer le fichier ?</string>
   <string name="copy_file_error_message">Erreur lors de la copie du fichier ZIM : %s.</string>
-  <string name="move_files_permission_dialog_title">Déplacer/copier les fichiers vers le répertoire public de l’application ?</string>
-  <string name="move_files_permission_dialog_description">En raison des politiques de Google Play sur Android 11 et versions ultérieures, notre application ne peut plus accéder directement aux fichiers stockés ailleurs sur votre appareil. Pour vous permettre de visualiser les fichiers sélectionnés, nous devons les déplacer ou les copier dans un dossier spécial dans notre répertoire d’applications. Cela nous permet d’accéder aux fichiers et de les ouvrir. Êtes-vous d’accord avec cela ?</string>
   <string name="move_file_error_message">Erreur lors du déplacement du fichier ZIM : %s.</string>
   <string name="how_to_update_content">Comment actualiser le contenu ?</string>
   <string name="update_content_description">Pour mettre à jour un contenu (un fichier zim), vous devez télécharger la dernière version complète de ce même contenu. Vous pouvez le faire via la section de téléchargement.</string>

--- a/core/src/main/res/values-ia/strings.xml
+++ b/core/src/main/res/values-ia/strings.xml
@@ -319,8 +319,6 @@
   <string name="move">Displaciar</string>
   <string name="copy_move_files_dialog_description">Vole tu copiar o displaciar le file?</string>
   <string name="copy_file_error_message">Error durante le copia del file ZIM: %s.</string>
-  <string name="move_files_permission_dialog_title">Displaciar/copiar files al directorio public del app?</string>
-  <string name="move_files_permission_dialog_description">A causa del politicas de Google Play sur Android 11 e plus recente, iste application non pote plus acceder directemente al files immagazinate in altere locos sur iste apparato. Pro permitter le accesso al files seligite, es necessari displaciar o copiar los in un dossier special in le directorio de iste application. Isto permittera acceder al files e aperir los. Es tu de accordo con isto?</string>
   <string name="move_file_error_message">Error durante le displaciamento del file ZIM: %s.</string>
   <string name="how_to_update_content">Como actualisar contento?</string>
   <string name="update_content_description">Pro actualisar le contento (un file ZIM) tu debe discargar le ultime version complete de iste mesme contento. Tu pote facer lo in le section de discargamento.</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -306,7 +306,6 @@
   <string name="move">Sposta</string>
   <string name="copy_move_files_dialog_description">Vuoi copiare o spostare il file?</string>
   <string name="copy_file_error_message">Errore nella copia del file zim: %s.</string>
-  <string name="move_files_permission_dialog_title">Spostare/copiare i file nella directory pubblica dell’app?</string>
   <string name="move_file_error_message">Errore nello spostamento del file zim: %s.</string>
   <string name="how_to_update_content">Come aggiornare i contenuti?</string>
   <string name="update_content_description">Per aggiornare un contenuto (un file ZIM), devi scaricare l’ultima versione completa di quello stesso contenuto. Puoi farlo nella sezione Scarica.</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -324,8 +324,6 @@
   <string name="move">העברה</string>
   <string name="copy_move_files_dialog_description">האם ברצונך להעתיק או להעביר את הקובץ?</string>
   <string name="copy_file_error_message">שגיאה בהעתקת קובץ zim‏: %s.</string>
-  <string name="move_files_permission_dialog_title">להעביר או להעתיק קבצים לספרייה ציבורית של היישום?</string>
-  <string name="move_files_permission_dialog_description">בשל מדיניות Google Play ב־Android 11 ומעלה, היישום שלנו אינו יכול יותר לגשת ישירות לקבצים המאוחסנים במקום אחר במכשיר שלך. כדי לאפשר לך להציג את הקבצים שבחרת, עלינו להעביר או להעתיק אותם לתיקייה מיוחדת בתוך תיקיית היישום שלנו. זה מאפשר לנו לגשת ולפתוח את הקבצים. האם זה בסדר מבחינתך?</string>
   <string name="move_file_error_message">שגיאה בהעברת קובץ zim‏: %s.</string>
   <string name="how_to_update_content">איך לעדכן תוכן?</string>
   <string name="update_content_description">כדי לעדכן תוכן (קובץ zim) עליך להוריד את הגרסה המלאה העדכנית ביותר של אותו התוכן בדיוק. ניתן לעשות זאת דרך סעיף ההורדה.</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -330,7 +330,6 @@
   <string name="move">이동</string>
   <string name="copy_move_files_dialog_description">파일을 복사하거나 이동하시겠습니까?</string>
   <string name="copy_file_error_message">zim 파일 복사 오류: %s.</string>
-  <string name="move_files_permission_dialog_title">앱 공개 디렉토리로 파일을 이동/복사하시겠습니까?</string>
   <string name="move_file_error_message">zim 파일 이동 오류: %s.</string>
   <string name="how_to_update_content">어떻게 콘텐츠를 업데이트합니까?</string>
   <string name="update_content_description">콘텐츠(zim 파일)을 업데이트하려면 매우 동일한 콘텐츠의 최신판 전체를 다운로드해야 합니다. 다운로드 부분에서 해당 작업을 할 수 있습니다.</string>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -316,8 +316,6 @@
   <string name="move">Премести</string>
   <string name="copy_move_files_dialog_description">Дали сакате да ја ископирате или преместите податотеката?</string>
   <string name="copy_file_error_message">Грешка при копирање на ZIM-податотеката: %s.</string>
-  <string name="move_files_permission_dialog_title">Да се преместат/прекопираат податотеките во јавниот директориум на прилогот?</string>
-  <string name="move_files_permission_dialog_description">Поради правилата на Google Play за Андроид 11 и поново, нашиот прилог повеќе нема непосреден пристап до податотеки складирани на други места на вашиот уред. За да ви овозможиме да ги гледате избраните податотеки ќе треба да ги преместиме или да ги прекопираме во специјална папка во директориумот на прилогот. Дали се сложувате со ова?</string>
   <string name="move_file_error_message">Грешка при преместување на ZIM-податотеката: %s.</string>
   <string name="how_to_update_content">Како се подновува содржината?</string>
   <string name="update_content_description">За да ја подновите содржината (ZIM-поатотека) ќе треба да ја преземете последната полна верзија на истава содржина. Ова се прави во одделот за преземање.</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -334,8 +334,6 @@
   <string name="move">Mover</string>
   <string name="copy_move_files_dialog_description">Você quer copiar ou mover o arquivo?</string>
   <string name="copy_file_error_message">Erro ao copiar o arquivo zim: %s.</string>
-  <string name="move_files_permission_dialog_title">Mover/Copiar arquivos para o diretório público do app?</string>
-  <string name="move_files_permission_dialog_description">Devido às políticas do Google Play no Android 11 e acima, nosso app não pode mais acessar arquivos armazenados em outro lugar do seu dispositivo. Para você poder ver seus arquivos selecionados, nós precisamos mover ou copiar eles em uma pasta especial no diretório do app. Isso permite acessar e abrir os arquivos. Você concorda com isso?</string>
   <string name="move_file_error_message">Erro ao mover o arquivo zim: %s.</string>
   <string name="how_to_update_content">Como atualizar o conteúdo?</string>
   <string name="update_content_description">Para atualizar o conteúdo (um arquivo zim), você precisa baixar a versão completa mais recente desse mesmo conteúdo. Você pode fazer isso através da seção de download.</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -345,8 +345,6 @@
   <string name="move">Переместить</string>
   <string name="copy_move_files_dialog_description">Вы хотите скопировать или переместить файл?</string>
   <string name="copy_file_error_message">Ошибка при копировании ZIM-файла: %s.</string>
-  <string name="move_files_permission_dialog_title">Перемещение/копирование файлов в публичный каталог приложения?</string>
-  <string name="move_files_permission_dialog_description">В соответствии с политикой Google Play для Android 11 и выше, наше приложение больше не может напрямую обращаться к файлам, хранящимся в других местах на вашем устройстве. Чтобы вы могли просматривать выбранные файлы, нам нужно переместить или скопировать их в специальную папку в каталоге приложения. Это позволит нам получить доступ к файлам и открыть их. Вы согласны с этим?</string>
   <string name="move_file_error_message">Ошибка при перемещении ZIM-файла: %s.</string>
   <string name="how_to_update_content">Как обновить содержимое?</string>
   <string name="update_content_description">Чтобы обновить содержимое (файл zim), вам нужно скачать последнюю версию того же содержимого. Вы можете это сделать в разделе загрузок.</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -327,8 +327,6 @@
   <string name="move">移動</string>
   <string name="copy_move_files_dialog_description">您要拷貝或移動檔案嗎？</string>
   <string name="copy_file_error_message">拷貝 zim 檔案時發生錯誤：%s。</string>
-  <string name="move_files_permission_dialog_title">將檔案移動/拷貝到應用程式公共目錄？</string>
-  <string name="move_files_permission_dialog_description">由於 Android 11（或更高版本）的 Google Play 政策，我們的應用程式已無法直接存取儲存在您設備上其他位置的檔案。為了讓您能查看所選檔案，我們需要將它們移動或拷貝到應用程式目錄中的特殊資料夾裡，這樣才能讓我們能夠存取並開啟檔案。請問您同意嗎？</string>
   <string name="move_file_error_message">移動 zim 檔案時發生錯誤：%s。</string>
   <string name="how_to_update_content">如何更新內容？</string>
   <string name="update_content_description">要更新內容（zim 檔案）的話，您需要下載這個相似內容的完整最新版本。您可以透過下載段落來進行。</string>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -344,8 +344,6 @@
   <string name="move">移动</string>
   <string name="copy_move_files_dialog_description">您要复制或移动文件吗？</string>
   <string name="copy_file_error_message">复制zim文件时出错：%s。</string>
-  <string name="move_files_permission_dialog_title">将文件移动/复制到应用程序公共目录？</string>
-  <string name="move_files_permission_dialog_description">由于Android 11及更高版本的Google Play政策，我们的应用无法再直接访问存储在您设备其他地方的文件。为了让您查看所选文件，我们需要将它们移动或复制到我们应用目录中的特殊文件夹中。这样我们才能访问和打开这些文件。您是否同意此操作？</string>
   <string name="move_file_error_message">移动zim文件时出错：%s。</string>
   <string name="how_to_update_content">如何更新内容？</string>
   <string name="update_content_description">要更新内容（ZIM 文件），您需要下载此相似内容的完整最新版本。您可以通过下载章节进行。</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -329,8 +329,8 @@
   <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
-  <string name="move_files_permission_dialog_title">Move/Copy files to app public directory?</string>
-  <string name="move_files_permission_dialog_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files. Do you agree to this?</string>
+  <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
+  <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>
   <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>
   <string name="move_file_error_message">Error in moving the ZIM file: %s.</string>
   <string name="how_to_update_content">How to update content?</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
   <string name="move_files_permission_dialog_title">Move/Copy files to app public directory?</string>
   <string name="move_files_permission_dialog_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files. Do you agree to this?</string>
+  <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>
   <string name="move_file_error_message">Error in moving the ZIM file: %s.</string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a ZIM file) you need to download the full latest version of this very same content. You can do that via the download section.</string>


### PR DESCRIPTION
Fixes #4067 

* Removed the initial dialog of copy/move. Now, we are showing the usual one "Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?" dialog every time(with a cancel button so that the user can have better control over this functionality).
* Showing the storage selection dialog when there is an SD card available, if not available, it will directly proceed with the copy/move operation. Also, when the SD card is inserted and the user tries to copy/move the ZIM file, at this point, it will show the storage selection dialog. Apart from this, it will also show the storage selection dialog on the reinsertion of the SD card.

https://github.com/user-attachments/assets/c332b4ae-9810-420e-a91e-eeb94759841b





* Added the explanation in the `Help screen` about this functionality. Also, added a UI test for this.

  ![Screenshot from 2024-11-14 12-47-12](https://github.com/user-attachments/assets/2dd8d951-3a2b-4d75-a738-d9a7add15909)

* Refactored the old instrumentation and unit test cases. Also, added some new unit test cases.
