### PR TITLE
Fixed: Transfer ZIM file freezes on tablet

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -147,37 +147,35 @@ class LocalFileTransferTest {
 
   @Test
   fun showCaseFeature() {
-    if (Build.VERSION.SDK_INT != Build.VERSION_CODES.TIRAMISU) {
-      shouldShowShowCaseFeatureToUser(true, isResetShowCaseId = true)
-      activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          handleLocaleChange(
-            it,
-            "en",
-            SharedPreferenceUtil(context)
-          )
-          it.navigate(R.id.libraryFragment)
-        }
+    shouldShowShowCaseFeatureToUser(true, isResetShowCaseId = true)
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+        it.navigate(R.id.libraryFragment)
       }
-      StandardActions.closeDrawer()
-      library {
-        assertGetZimNearbyDeviceDisplayed()
-        clickFileTransferIcon {
-          assertClickNearbyDeviceMessageVisible()
-          clickOnGotItButton()
-          assertDeviceNameMessageVisible()
-          clickOnGotItButton()
-          assertNearbyDeviceListMessageVisible()
-          clickOnGotItButton()
-          assertTransferZimFilesListMessageVisible()
-          clickOnGotItButton()
-          pressBack()
-          assertGetZimNearbyDeviceDisplayed()
-        }
-      }
-      LeakAssertions.assertNoLeaks()
     }
+    StandardActions.closeDrawer()
+    library {
+      assertGetZimNearbyDeviceDisplayed()
+      clickFileTransferIcon {
+        assertClickNearbyDeviceMessageVisible()
+        clickOnGotItButton()
+        assertDeviceNameMessageVisible()
+        clickOnGotItButton()
+        assertNearbyDeviceListMessageVisible()
+        clickOnGotItButton()
+        assertTransferZimFilesListMessageVisible()
+        clickOnGotItButton()
+        pressBack()
+        assertGetZimNearbyDeviceDisplayed()
+      }
+    }
+    LeakAssertions.assertNoLeaks()
   }
 
   @Test

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -36,7 +36,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -55,9 +54,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
-import org.kiwix.kiwixmobile.core.R.string
-import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.cachedComponent
+import org.kiwix.kiwixmobile.core.R.drawable
+import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
@@ -69,6 +68,7 @@ import org.kiwix.kiwixmobile.core.navigateToAppSettings
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.databinding.FragmentLocalFileTransferBinding
 import org.kiwix.kiwixmobile.localFileTransfer.WifiDirectManager.Companion.getDeviceStatus
 import org.kiwix.kiwixmobile.localFileTransfer.adapter.WifiP2pDelegate
@@ -193,12 +193,12 @@ class LocalFileTransferFragment :
           getString(string.got_it)
         )
         addSequenceItem(
-          fragmentLocalFileTransferBinding?.listPeerDevices,
+          fragmentLocalFileTransferBinding?.nearbyDeviceShowCaseView,
           getString(string.nearby_devices_list_message),
           getString(string.got_it)
         )
         addSequenceItem(
-          fragmentLocalFileTransferBinding?.recyclerViewTransferFiles,
+          fragmentLocalFileTransferBinding?.fileTransferShowCaseView,
           getString(string.transfer_zim_files_list_message),
           getString(string.got_it)
         )

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -42,6 +42,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
@@ -55,16 +56,20 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.cachedComponent
+import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isLandScapeMode
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isTablet
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
 import org.kiwix.kiwixmobile.core.extensions.getToolbarNavigationIcon
 import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
+import org.kiwix.kiwixmobile.core.utils.DimenUtils.getWindowWidth
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -143,10 +148,41 @@ class LocalFileTransferFragment :
     wifiDirectManager.callbacks = this
     wifiDirectManager.lifecycleCoroutineScope = lifecycleScope
     wifiDirectManager.startWifiDirectManager(filesForTransfer)
-    fragmentLocalFileTransferBinding
-      ?.textViewDeviceName
-      ?.setToolTipWithContentDescription(getString(string.your_device))
+    fragmentLocalFileTransferBinding?.apply {
+      textViewDeviceName.setToolTipWithContentDescription(getString(string.your_device))
+      fileTransferShowCaseView.apply {
+        val fileTransferShowViewParams = layoutParams
+        fileTransferShowViewParams.width = getShowCaseViewWidth()
+        fileTransferShowViewParams.height = getShowCaseViewHeight()
+        layoutParams = fileTransferShowViewParams
+      }
+      nearbyDeviceShowCaseView.apply {
+        val nearbyDeviceShowCaseViewParams = layoutParams
+        nearbyDeviceShowCaseViewParams.width = getShowCaseViewWidth()
+        nearbyDeviceShowCaseViewParams.height = getShowCaseViewHeight()
+        layoutParams = nearbyDeviceShowCaseViewParams
+      }
+    }
   }
+
+  private fun getShowCaseViewWidth(): Int {
+    return when {
+      requireActivity().isTablet() -> {
+        requireActivity().resources.getDimensionPixelSize(dimen.maximum_donation_popup_width)
+      }
+
+      requireActivity().isLandScapeMode() -> {
+        requireActivity().resources.getDimensionPixelSize(
+          dimen.showcase_view_maximum_width_in_landscape_mode
+        )
+      }
+
+      else -> FrameLayout.LayoutParams.MATCH_PARENT
+    }
+  }
+
+  private fun getShowCaseViewHeight(): Int =
+    requireActivity().resources.getDimensionPixelSize(dimen.showcase_view_maximum_height)
 
   private fun setupMenu() {
     (requireActivity() as MenuHost).addMenuProvider(

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -69,7 +69,6 @@ import org.kiwix.kiwixmobile.core.extensions.setToolTipWithContentDescription
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.navigateToAppSettings
-import org.kiwix.kiwixmobile.core.utils.DimenUtils.getWindowWidth
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog

--- a/app/src/main/res/layout/fragment_local_file_transfer.xml
+++ b/app/src/main/res/layout/fragment_local_file_transfer.xml
@@ -35,15 +35,15 @@
     android:layout_height="wrap_content"
     android:layout_marginStart="15dp"
     android:background="@android:color/transparent"
+    android:contentDescription="@string/device_name"
+    android:gravity="start|center"
+    android:minHeight="@dimen/material_minimum_height_and_width"
     android:paddingStart="5dp"
     android:paddingEnd="5dp"
     android:paddingBottom="5dp"
     android:textIsSelectable="true"
-    android:gravity="start|center"
-    android:minHeight="@dimen/material_minimum_height_and_width"
     android:textSize="17sp"
     android:textStyle="bold"
-    android:contentDescription="@string/device_name"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintHorizontal_bias="0.0"
     app:layout_constraintStart_toStartOf="parent"
@@ -98,6 +98,15 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/text_view_available_device" />
 
+  <View
+    android:id="@+id/nearby_device_show_case_view"
+    android:layout_width="@dimen/showcase_view_maximum_width"
+    android:layout_height="10dp"
+    android:layout_margin="50dp"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/text_view_available_device" />
+
   <ProgressBar
     android:id="@+id/progress_bar_searching_peers"
     android:layout_width="wrap_content"
@@ -138,8 +147,16 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@id/view_file_list_boundary" />
 
+  <View
+    android:id="@+id/file_transfer_show_case_view"
+    android:layout_width="@dimen/showcase_view_maximum_width"
+    android:layout_height="10dp"
+    android:layout_margin="50dp"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/text_view_files_for_transfer" />
+
   <androidx.recyclerview.widget.RecyclerView
-    tools:listitem="@layout/item_transfer_list"
     android:id="@+id/recycler_view_transfer_files"
     android:layout_width="match_parent"
     android:layout_height="0dp"
@@ -148,6 +165,7 @@
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/text_view_files_for_transfer" />
+    app:layout_constraintTop_toBottomOf="@id/text_view_files_for_transfer"
+    tools:listitem="@layout/item_transfer_list" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_local_file_transfer.xml
+++ b/app/src/main/res/layout/fragment_local_file_transfer.xml
@@ -100,7 +100,7 @@
 
   <View
     android:id="@+id/nearby_device_show_case_view"
-    android:layout_width="@dimen/showcase_view_maximum_width"
+    android:layout_width="10dp"
     android:layout_height="10dp"
     android:layout_margin="50dp"
     app:layout_constraintEnd_toEndOf="parent"
@@ -149,7 +149,7 @@
 
   <View
     android:id="@+id/file_transfer_show_case_view"
-    android:layout_width="@dimen/showcase_view_maximum_width"
+    android:layout_width="10dp"
     android:layout_height="10dp"
     android:layout_margin="50dp"
     app:layout_constraintEnd_toEndOf="parent"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -189,4 +189,14 @@ object ActivityExtensions {
 
   fun Activity.isLandScapeMode(): Boolean =
     resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+  @Suppress("MagicNumber")
+  fun Activity.isTablet(): Boolean {
+    val configuration = resources.configuration
+    val isLargeOrXLarge =
+      configuration.screenLayout and
+        Configuration.SCREENLAYOUT_SIZE_MASK >= Configuration.SCREENLAYOUT_SIZE_LARGE
+    val isWideEnough = configuration.smallestScreenWidthDp >= 600
+    return isLargeOrXLarge && isWideEnough
+  }
 }

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -26,5 +26,6 @@
   <dimen name="find_in_page_button_padding">13dp</dimen>
   <dimen name="donation_popup_bottom_margin">20dp</dimen>
   <dimen name="maximum_donation_popup_width">400dp</dimen>
-  <dimen name="showcase_view_maximum_width">200dp</dimen>
+  <dimen name="showcase_view_maximum_width_in_landscape_mode">150dp</dimen>
+  <dimen name="showcase_view_maximum_height">10dp</dimen>
 </resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -26,4 +26,5 @@
   <dimen name="find_in_page_button_padding">13dp</dimen>
   <dimen name="donation_popup_bottom_margin">20dp</dimen>
   <dimen name="maximum_donation_popup_width">400dp</dimen>
+  <dimen name="showcase_view_maximum_width">200dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #4085 

* It was due to our 3rd and 4th showCase since we are showing the showcase view on `recyclerView` which has the `match_parent` width(So as much as the device has the width our showCase view becomes bigger), and showCase view tries to show the given view inside a circle. So due to this, the circle was very big and the remaining content was going outside the screen.
* To fix this, we have added 2 views to show the showcase view, the width will be adjusted at runtime according to device width which prevents this type of error.


https://github.com/user-attachments/assets/d803245e-36e7-49c8-90a0-9bd1c5f98b77




![Screenshot from 2024-11-19 16-33-36](https://github.com/user-attachments/assets/abdd30d5-be39-42eb-92ad-016957ee740f)
![Screenshot from 2024-11-19 16-33-40](https://github.com/user-attachments/assets/875b6879-95fb-4263-9303-5efbfad66323)



