### PR TITLE
Improved the Note label in the OverFlowMenu for more clarity

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -67,7 +67,7 @@ class NoteRobot : BaseRobot() {
     // overFlowOptionMenu so that we can easily click on it.
     pauseForBetterTestPerformance()
     openActionBarOverflowOrOptionsMenu(context)
-    clickOn(Text("Note"))
+    clickOn(TextId(R.string.take_notes))
   }
 
   fun assertNoteDialogDisplayed() {

--- a/core/src/main/res/menu/menu_main.xml
+++ b/core/src/main/res/menu/menu_main.xml
@@ -20,7 +20,7 @@
   <item
     android:id="@+id/menu_add_note"
     android:icon="@drawable/ic_add_note"
-    android:title="@string/note"
+    android:title="@string/take_notes"
     android:visible="false"
     app:showAsAction="never" />
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -233,6 +233,7 @@
   <string name="custom_download_error_message_for_authentication_failed">The ZIM file could not be downloaded. Please try reinstalling the application from the Play store.</string>
   <string name="save">Save</string>
   <string name="note">Note</string>
+  <string name="take_notes">Take notes</string>
   <string name="wiki_article_title">Wiki Article Title</string>
   <string name="ext_storage_permission_rationale_export_bookmark">Storage access is required for exporting Bookmarks</string>
   <string name="ext_storage_write_permission_denied_export_bookmark">Bookmarks can’t export without access of storage</string>


### PR DESCRIPTION
Fixes #4093 



![417f978c-13c8-4067-aee8-bdbf47c70a3b](https://github.com/user-attachments/assets/8cf101f2-509a-44eb-b978-95a4df4e30a8)
