### PR TITLE
Fixed: `Send diagnostic` report does not attach the device logs in `Google Pixel 7a`.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -140,22 +140,22 @@ open class ErrorActivity : BaseActivity() {
 
   // List of supported email apps
   private val supportedEmailPackages = listOf(
-    "com.google.android.gm",               // Gmail
-    "com.zoho.mail",                       // Zoho Mail
-    "com.microsoft.office.outlook",        // Outlook
-    "com.yahoo.mobile.client.android.mail",// Yahoo Mail
-    "me.bluemail.mail",                    // BlueMail
-    "ch.protonmail.android",               // ProtonMail
-    "com.fsck.k9",                         // K-9 Mail
-    "com.maildroid",                       // Maildroid
-    "org.kman.AquaMail",                   // Aqua Mail
-    "com.edison.android.mail",              // Edison Mail
-    "com.readdle.spark",                   // Spark
-    "com.gmx.mobile.android.mail",          // GMX Mail
-    "com.fastmail",                        // FastMail
-    "ru.mail.mailapp",                     // Mail.ru
-    "ru.yandex.mail",                      // Yandex.Mail
-    "de.tutao.tutanota"                    // Tutanota
+    "com.google.android.gm", // Gmail
+    "com.zoho.mail", // Zoho Mail
+    "com.microsoft.office.outlook", // Outlook
+    "com.yahoo.mobile.client.android.mail", // Yahoo Mail
+    "me.bluemail.mail", // BlueMail
+    "ch.protonmail.android", // ProtonMail
+    "com.fsck.k9", // K-9 Mail
+    "com.maildroid", // Maildroid
+    "org.kman.AquaMail", // Aqua Mail
+    "com.edison.android.mail", // Edison Mail
+    "com.readdle.spark", // Spark
+    "com.gmx.mobile.android.mail", // GMX Mail
+    "com.fastmail", // FastMail
+    "ru.mail.mailapp", // Mail.ru
+    "ru.yandex.mail", // Yandex.Mail
+    "de.tutao.tutanota" // Tutanota
   )
 
   private val sendEmailLauncher =


### PR DESCRIPTION
Fixes #4095 

Introduced a new way of attaching the log file in the email body without showing other apps in the suggestion list. Since there was a `TransactionTooLargeException` error while resolving the email apps when there are large logs available. So to fix this, we have introduced a way to attach the log file in the email body that solves this problem. Also, ensuring that other apps could not show in the suggestion list when sharing.

https://github.com/user-attachments/assets/c49e4e43-d2a3-4512-aa89-cb389ceb8b60


https://github.com/user-attachments/assets/bc225d53-a1b2-4756-b43f-5302117fc1c8



