### PR TITLE
Fixed: D&D description is not displayed correctly.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/libraryView/adapter/LibraryViewHolder.kt
@@ -103,8 +103,8 @@ sealed class LibraryViewHolder<in T : LibraryListItem>(containerView: View) :
     @Suppress("MagicNumber")
     override fun bind(item: LibraryDownloadItem) {
       itemDownloadBinding.libraryDownloadFavicon.setBitmap(item.favIcon)
-      itemDownloadBinding.libraryDownloadTitle.text = item.title
-      itemDownloadBinding.libraryDownloadDescription.text = item.description
+      itemDownloadBinding.libraryDownloadTitle.setTextAndVisibility(item.title)
+      itemDownloadBinding.libraryDownloadDescription.setTextAndVisibility(item.description)
       itemDownloadBinding.downloadProgress.progress = item.progress
       itemDownloadBinding.stop.apply {
         setToolTipWithContentDescription(itemDownloadBinding.root.context.getString(string.stop))

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/TextViewExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/TextViewExtensions.kt
@@ -20,10 +20,11 @@ package org.kiwix.kiwixmobile.core.extensions
 
 import android.view.View
 import android.widget.TextView
+import org.kiwix.kiwixmobile.core.utils.StyleUtils.fromHtml
 
 fun TextView.setTextAndVisibility(nullableText: String?) =
-  if (nullableText != null && nullableText.isNotEmpty()) {
-    text = nullableText
+  if (!nullableText.isNullOrEmpty()) {
+    text = nullableText.fromHtml().toString()
     visibility = View.VISIBLE
   } else {
     visibility = View.GONE


### PR DESCRIPTION
Fixes #4087 

* The issue was caused by an HTML entity in the description of the "D&D" ZIM file. The description was displayed as "D\&amp;D Wiki" because it was not properly decoded before being set in the TextView.
* We have now implemented proper decoding of any HTML entities present in the title or description before setting them to the TextView, ensuring the description is displayed correctly.

![Screenshot_20241127-163113_Kiwix](https://github.com/user-attachments/assets/4aaa3945-408a-4490-baf4-573debee9137)
