### PR TITLE
Uploading `release` APK in Github release instead of `standalone` APK.

### DIFF
--- a/.github/workflows/dummy_bundle_and_apk.yml
+++ b/.github/workflows/dummy_bundle_and_apk.yml
@@ -1,4 +1,4 @@
-name: Generate dummy bundle
+name: Generate dummy bundle and APK
 
 # The workflow will trigger when the `dummy_bundle` tag is pushed.
 on:
@@ -7,7 +7,7 @@ on:
       - 'dummy_bundle' # dummy_bundle Tag
 
 jobs:
-  publish_dummy_bundle:
+  publish_dummy_bundle_and_apk:
     runs-on: ubuntu-22.04
 
     steps:
@@ -25,26 +25,33 @@ jobs:
         run: |
           echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
 
-      - name: Generate dummy Bundle
+      - name: Generate dummy Bundle and APKs
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
         run: |
-          ./gradlew bundlePlayStore --scan
+          ./gradlew bundlePlayStore assembleRelease --scan
 
-
-      - name: Get Bundle name and path
-        id: bundle-path
+      - name: Get Bundle and APKs name and path
+        id: get-bundle-and-apk-paths
         run: |
           BUNDLE_PATH="app/build/outputs/bundle/playStore/kiwix-playStore.aab"
           BUNDLE_NAME="PlayStoreDummyBundle.aab"
           echo "bundle_path=$BUNDLE_PATH" >> $GITHUB_ENV
           echo "bundle_name=$BUNDLE_NAME" >> $GITHUB_ENV
+          APK_DIR="app/build/outputs/apk/release/"
+          echo "apk_dir=$APK_DIR" >> $GITHUB_ENV
 
       - name: Upload Bundle as an artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.bundle_name }}
           path: ${{ env.bundle_path }}
+
+      - name: Upload All Release APKs as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReleaseApks
+          path: ${{ env.apk_dir }}*.apk
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           UNIVERSAL_RELEASE_APK: app/build/outputs/apk/standalone/*universal*.apk
           ARCHIVE_NAME: kiwix-${{ github.event.release.tag_name }}.apk
         run: |
-          ./gradlew assembleStandalone
+          ./gradlew assembleStandalone assembleRelease
           cp ${UNIVERSAL_RELEASE_APK} ${ARCHIVE_NAME}
           scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no "$ARCHIVE_NAME" ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
@@ -52,7 +52,7 @@ jobs:
       - name: Upload APKs to Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "app/build/outputs/apk/standalone/**"
+          artifacts: "app/build/outputs/apk/release/**"
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.TAG }}
           allowUpdates: true


### PR DESCRIPTION
Fixes #4114 

* To resolve the publishing issue on `IzzyOnDroid`, we are now uploading the `Release` APK(with `org.kiwix.kiwixmobile` package name) to the GitHub release, so that `IzzyOnDroid` can retrieve the APK and upload it to their platform easily.
* Generated dummy release APKs along with the dummy bundle to have them readily available if needed. For example, in the current scenario, we need to manually generate the release APKs and upload them to the 3.12.0 GitHub release so that IzzyOnDroid can fetch and update the application on their platform. See it is uploaded the Release APKs https://github.com/kiwix/kiwix-android/actions/runs/12063880435
