### PR TITLE
Fixed: Virtual keyboard reset the search (in library).

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragment.kt
@@ -68,6 +68,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificat
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
+import org.kiwix.kiwixmobile.core.extensions.isKeyboardVisible
 import org.kiwix.kiwixmobile.core.extensions.setBottomMarginToFragmentContainerView
 import org.kiwix.kiwixmobile.core.extensions.setUpSearchView
 import org.kiwix.kiwixmobile.core.extensions.snack
@@ -327,8 +328,11 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   }
 
   override fun onBackPressed(activity: AppCompatActivity): FragmentActivityExtensions.Super {
-    getActivity()?.finish()
-    return FragmentActivityExtensions.Super.ShouldNotCall
+    if (isKeyboardVisible()) {
+      closeKeyboard()
+      return FragmentActivityExtensions.Super.ShouldNotCall
+    }
+    return FragmentActivityExtensions.Super.ShouldCall
   }
 
   private fun onRefreshStateChange(isRefreshing: Boolean?) {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -55,7 +55,6 @@
     android:fullBackupContent="@xml/backup_rules"
     android:dataExtractionRules = "@xml/data_extraction_rules"
     android:hardwareAccelerated="true"
-    android:enableOnBackInvokedCallback="true"
     android:largeHeap="true"
     android:requestLegacyExternalStorage="true"
     android:resizeableActivity="true"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FragmentExtensions.kt
@@ -22,6 +22,8 @@ import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -34,6 +36,11 @@ inline fun <reified T : ViewModel> Fragment.viewModel(
 
 fun Fragment.toast(stringId: Int, length: Int = Toast.LENGTH_LONG) {
   requireActivity().toast(stringId, length)
+}
+
+fun Fragment.isKeyboardVisible(): Boolean {
+  val insets = ViewCompat.getRootWindowInsets(requireView()) ?: return false
+  return insets.isVisible(WindowInsetsCompat.Type.ime())
 }
 
 fun Fragment.closeKeyboard() {


### PR DESCRIPTION
Fixes #4112 

* Improved the back press handling in CoreMainActivity using the latest `onBackPressedDispatcher` API, to properly work with the latest versions of Android.
* Enhanced the back press behavior in OnlineLibraryFragment while searching for ZIM files, so the SearchView will not close when the user presses the back button to simply dismiss the keyboard.


https://github.com/user-attachments/assets/39983cb1-fd90-4418-b014-8249e9fc13ee

