### PR TITLE
Fixed: Input dispatching timed out at `CopyMoveFileHandler.deleteSourceFile`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -432,7 +432,7 @@ class CopyMoveFileHandler @Inject constructor(
     }
   }
 
-  fun deleteSourceFile(uri: Uri) {
+  suspend fun deleteSourceFile(uri: Uri) = withContext(Dispatchers.IO) {
     try {
       DocumentsContract.deleteDocument(activity.applicationContext.contentResolver, uri)
     } catch (ignore: Exception) {


### PR DESCRIPTION
Fixes #4123 

Moved the delete logic to the IO thread to ensure the deletion operation does not block the main thread. This method was called from the `Main` dispatcher, but now, we ae calling from the `IO` dispatcher.