### PR TITLE
Fixed: Input dispatching timed out at `DownloadMonitorService.cancelDownload`.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -100,7 +100,11 @@ class DownloadMonitorService : Service() {
         ACTION_PAUSE -> pauseDownload(downloadId.toLong())
         ACTION_RESUME -> resumeDownload(downloadId.toLong())
         ACTION_CANCEL -> cancelDownload(downloadId.toLong())
-        ACTION_QUERY_DOWNLOAD_STATUS -> queryDownloadStatus(downloadId.toLong())
+        ACTION_QUERY_DOWNLOAD_STATUS -> {
+          updater.onNext {
+            queryDownloadStatus(downloadId.toLong())
+          }
+        }
       }
     }
     return START_NOT_STICKY
@@ -569,8 +573,11 @@ class DownloadMonitorService : Service() {
 
   private fun cancelDownload(downloadId: Long) {
     synchronized(lock) {
-      downloadManager.remove(downloadId)
-      handleCancelledDownload(downloadId)
+      updater.onNext {
+        // Remove the download from DownloadManager on IO thread.
+        downloadManager.remove(downloadId)
+        handleCancelledDownload(downloadId)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4125 

* Moved the cancel download logic to the IO thread, ensuring that download-related tasks are performed on the IO thread while keeping the main thread free.
* Also moved the functionality to the IO thread for checking the status when we receive the ACTION_DOWNLOAD_COMPLETE broadcast from DownloadManager, to determine if the download was successful or canceled. This ensures it doesn't block the main thread, as cancelDownload is currently causing a blockage.