### PR TITLE
Fixed: Input dispatching timed out in `CoreReaderFragment.toggleBookmark`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
@@ -45,7 +45,7 @@ class WebServerHelper @Inject constructor(
   private var isServerStarted = false
   private var validIpAddressDisposable: Disposable? = null
 
-  fun startServerHelper(
+  suspend fun startServerHelper(
     selectedBooksPath: ArrayList<String>,
     restartServer: Boolean
   ): ServerStatus? {
@@ -64,7 +64,7 @@ class WebServerHelper @Inject constructor(
     }
   }
 
-  private fun startAndroidWebServer(
+  private suspend fun startAndroidWebServer(
     selectedBooksPath: ArrayList<String>,
     restartServer: Boolean
   ): ServerStatus? {
@@ -78,7 +78,7 @@ class WebServerHelper @Inject constructor(
     return serverStatus
   }
 
-  private fun startKiwixServer(selectedBooksPath: ArrayList<String>): ServerStatus {
+  private suspend fun startKiwixServer(selectedBooksPath: ArrayList<String>): ServerStatus {
     var errorMessage: Int? = null
     ServerUtils.port = DEFAULT_PORT
     kiwixServer = kiwixServerFactory.createKiwixServer(selectedBooksPath).also {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -42,8 +42,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
-import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.R.layout
+import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
@@ -443,6 +443,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
     Intent(requireActivity(), HotspotService::class.java).setAction(action)
 
   override fun onServerStarted(ip: String) {
+    dialog?.dismiss() // Dismiss dialog when server started.
     this.ip = ip
     layoutServerStarted()
   }
@@ -452,6 +453,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   }
 
   override fun onServerFailedToStart(errorMessage: Int?) {
+    dialog?.dismiss() // Dismiss dialog if there is some error in starting the server.
     errorMessage?.let {
       toast(errorMessage)
     }
@@ -514,7 +516,6 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   }
 
   override fun onIpAddressValid() {
-    dialog?.dismiss()
     startWifiHotspot(false)
   }
 


### PR DESCRIPTION
Fixes #4127 

* Moved the `Book()` object creation to `lifeCycleScope` instead of running it on the main thread. Earlier, it was blocking the UI, especially with large ZIM files. Now, by using `lifeCycleScope`, it won't block the main thread.
* Improved the KiwixServer creation process. Server creation was previously happening on the main thread, which could cause the same issue we are facing with adding bookmarks. Because we are creating the same book object while creating the server, which is required for `server` creation.
* Updated the behavior of the "Starting server" dialog. Before, the dialog disappeared after validating the IP address, even though server creation was still in progress. Now, the server creation process is moved to the IO thread. For large ZIM files, server creation can take some time, so the dialog will only dismiss once the server is successfully created or if an error occurs. This ensures users are aware that server creation is in progress.


https://github.com/user-attachments/assets/afb784fc-41bf-4272-aa57-824d28ceeef3


