### PR TITLE
Added the hasFragileUserData tag in the manifest to display the "Keep app data" checkbox in the uninstall dialog.

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
     android:largeHeap="true"
     android:requestLegacyExternalStorage="true"
     android:resizeableActivity="true"
+    android:hasFragileUserData="true"
     android:supportsRtl="true"
     android:theme="@style/KiwixTheme"
     tools:targetApi="tiramisu">


### PR DESCRIPTION
Fixes #4150 

* When users attempt to uninstall the app, the "Keep app data" checkbox will appear in the uninstall dialog. By enabling it, the app's data will not be deleted upon uninstallation, allowing users to access the data again if they reinstall the app. Additionally, this is a good way to notify users that uninstalling the app can delete all app-related data, such as ZIM files.

![Image](https://github.com/user-attachments/assets/ac0ac729-c63b-4e72-91a3-3dfe66eb6654)