### PR TITLE
Fixed: A crash reported by Play Store for the `org.kiwix.libzim.Item.getSize` method.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -199,7 +199,7 @@ class ZimFileReader constructor(
   private fun loadContent(uri: String, extension: String): InputStream? {
     val item = getItem(uri)
     if (compressedExtensions.any { it != extension }) {
-      item?.size?.let {
+      item?.itemSize()?.let {
         // Check if the item size exceeds 1 MB
         if (it / Kb > 1024) {
           // Retrieve direct access information for the item
@@ -293,7 +293,7 @@ class ZimFileReader constructor(
     file: File,
     infoPair: DirectAccessInfo
   ): InputStream? =
-    item?.size?.let {
+    item?.itemSize()?.let {
       AssetFileDescriptor(
         infoPair.parcelFileDescriptor(file),
         infoPair.offset,
@@ -455,3 +455,14 @@ const val ILLUSTRATION_SIZE = 48
 // add content prefix to url since searched items return the url inside of zim without content prefix.
 val String.addContentPrefix: String
   get() = if (startsWith(CONTENT_PREFIX)) this else CONTENT_PREFIX + this
+
+/**
+ * Handling the any error thrown by this method. Devs should handle the flow if this methods
+ * returns null. See https://github.com/kiwix/kiwix-android/issues/4157 for more details.
+ */
+fun Item.itemSize(): Long? = try {
+  size
+} catch (ignore: Exception) {
+  Log.e(TAG, "Could not get the item size.\n Original exception = $ignore")
+  null
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -58,7 +58,7 @@ class ZimReaderContainer @Inject constructor(private val zimFileReaderFactory: F
         val headers = mutableMapOf("Accept-Ranges" to "bytes")
         if ("Range" in requestHeaders.keys) {
           setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = zimFileReader?.getItem(url)?.size ?: 0L
+          val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
           val lastByte = fullSize - 1
           val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
           headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"


### PR DESCRIPTION
Fixes #4157 

Created an extension function to safely retrieve the item's size and handle any potential errors within this function. This method was used in three places, and since we are already handling cases where this method returns null, the existing functionality remains unaffected.