### PR TITLE
Fixed: Application crashes when opening the random article.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1735,6 +1735,10 @@ abstract class CoreReaderFragment :
         mainMenu?.onFileOpened(urlIsValid())
         setUpBookmarks(zimFileReader)
       } ?: kotlin.run {
+        // If the ZIM file is not opened properly (especially for ZIM chunks), exit the book to
+        // disable all controls for this ZIM file. This prevents potential crashes.
+        // See issue #4161 for more details.
+        exitBook()
         requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1691,7 +1691,8 @@ abstract class CoreReaderFragment :
       if (zimReaderSource.canOpenInLibkiwix()) {
         // Show content if there is `Open Library` button showing
         // and we are opening the ZIM file
-        reopenBook()
+        hideNoBookOpenViews()
+        contentFrame?.visibility = View.VISIBLE
         openAndSetInContainer(zimReaderSource)
         updateTitle()
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -109,6 +109,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.databinding.FragmentReaderBinding
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.ZERO
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.consumeObservable
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isLandScapeMode
@@ -2173,13 +2174,39 @@ abstract class CoreReaderFragment :
     }
   }
 
-  private fun openRandomArticle() {
+  /**
+   * Attempts to open a random article from the ZIM file. If the article URL cannot be retrieved
+   * due to internal errors or a missing ZIM file reader, the method will retry up to a certain
+   * number of times (default: 2). If the article URL is still unavailable after retries,
+   * an error message will be displayed to the user. The method ensures that the user does not
+   * see a blank or previously loaded page, but instead receives an appropriate error message
+   * if the random article cannot be fetched.
+   *
+   * @param retryCount The number of attempts left to retry fetching the random article.
+   *                   Default is 2. The method decreases this count with each retry attempt.
+   */
+  private fun openRandomArticle(retryCount: Int = 2) {
+    // Check if the ZIM file reader is available, if not show an error and exit.
+    if (zimReaderContainer?.zimFileReader == null) {
+      toast(R.string.error_loading_random_article_zim_not_loaded)
+      return
+    }
     val articleUrl = zimReaderContainer?.getRandomArticleUrl()
     if (articleUrl == null) {
       // Check if the random url is null due to some internal error in libzim(See #3926)
-      // then again try to get the random article. So that the user can see the random article
-      // instead of a (blank/same page) currently loaded in the webView.
-      openRandomArticle()
+      // then try one more time to get the random article. So that the user can see the
+      // random article instead of a (blank/same page) currently loaded in the webView.
+      if (retryCount > ZERO) {
+        Log.e(
+          TAG_KIWIX,
+          "Random article URL is null, retrying... Remaining attempts: $retryCount"
+        )
+        openRandomArticle(retryCount - 1)
+      } else {
+        // if it is failed to find the random article two times then show a error to user.
+        Log.e(TAG_KIWIX, "Failed to load random article after multiple attempts")
+        toast(R.string.could_not_find_random_article)
+      }
       return
     }
     Log.d(TAG_KIWIX, "openRandomArticle: $articleUrl")

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
   <string name="zim_not_opened">Unable to open ZIM file</string>
   <string name="error_file_invalid">Error: The selected file is not a valid ZIM file.</string>
   <string name="error_article_url_not_found">Error: Loading article (Url: %1$s) failed.</string>
+  <string name="error_loading_random_article_zim_not_loaded">Unable to load article. The ZIM file is not properly loaded.</string>
+  <string name="could_not_find_random_article">Unable to find a random article. Please try again later.</string>
   <string name="pref_display_title">Display</string>
   <string name="pref_info_title">Information</string>
   <string name="pref_info_version">Version</string>


### PR DESCRIPTION
Fixes #4161 

* The issue occurred in the Play Store variant, specifically with the copy/move functionality for ZIM files. After copying or moving a ZIM file, the application attempts to open it in the reader. However, if the application tries to open a split ZIM file with only one chunk, it throws an error indicating that the file is not a valid ZIM file (which is expected, as not all ZIM chunks have been copied/moved). When this error occurs, the menu buttons remain enabled, allowing the user to interact with them. If the user then attempts to open a random article, the application enters an infinite loop and crashes. To resolve this, we now disable the menu controls whenever an error occurs while opening a ZIM file, preventing the user from using them in such scenarios.

**Before fix**


https://github.com/user-attachments/assets/6701b120-fc8c-4bea-8903-e3f910e04004



**After fix**


https://github.com/user-attachments/assets/9bf98a31-3119-4d00-9a3e-8b73bf97ec00




* Added a retry mechanism to attempt fetching the random article twice in case of an internal error in libzim to prevent going into an infinite loop.
* After two failed attempts, an error message is displayed to the user if the random article is not found.
* Previously, when a ZIM file was in the process of opening, the reopenBook method was used to hide the "Open Library" button if it was visible. However, this method also enabled the menu buttons. If an error occurred while loading the ZIM file, the controls remained enabled, which was not desirable. Now, the "Open Library" button is hidden, and the menu buttons are shown only after the ZIM file has successfully loaded. If an error occurs during loading, an error message is displayed (as it was previously), and the UI is updated accordingly. 
