### PR TITLE
Fixed: Application crash caused by "Input dispatching timed out" while retrieving storageDeviceList information in the online library.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -58,7 +58,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import eu.mhutti1.utils.storage.Bytes
 import eu.mhutti1.utils.storage.StorageDevice
-import eu.mhutti1.utils.storage.StorageDeviceUtils
 import eu.mhutti1.utils.storage.StorageSelectDialog
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -99,6 +98,7 @@ import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDis
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem.BookOnDisk
 import org.kiwix.kiwixmobile.databinding.FragmentDestinationLibraryBinding
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.zimManager.MAX_PROGRESS
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions
@@ -134,9 +134,6 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
 
   private val zimManageViewModel by lazy {
     requireActivity().viewModel<ZimManageViewModel>(viewModelFactory)
-  }
-  private val storageDeviceList by lazy {
-    StorageDeviceUtils.getWritableStorage(requireActivity())
   }
 
   private var storagePermissionLauncher: ActivityResultLauncher<Array<String>>? =
@@ -665,17 +662,22 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       message,
       requireActivity().findViewById(R.id.bottom_nav_view),
       string.download_change_storage,
-      ::showStorageSelectDialog
+      {
+        lifecycleScope.launch {
+          showStorageSelectDialog((requireActivity() as KiwixMainActivity).getStorageDeviceList())
+        }
+      }
     )
   }
 
-  private fun showStorageSelectDialog() = StorageSelectDialog()
-    .apply {
-      onSelectAction = ::storeDeviceInPreferences
-      setStorageDeviceList(storageDeviceList)
-      setShouldShowCheckboxSelected(true)
-    }
-    .show(parentFragmentManager, getString(string.pref_storage))
+  private fun showStorageSelectDialog(storageDeviceList: List<StorageDevice>) =
+    StorageSelectDialog()
+      .apply {
+        onSelectAction = ::storeDeviceInPreferences
+        setStorageDeviceList(storageDeviceList)
+        setShouldShowCheckboxSelected(true)
+      }
+      .show(parentFragmentManager, getString(string.pref_storage))
 
   private fun storeDeviceInPreferences(
     storageDevice: StorageDevice

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -21,6 +21,8 @@ package eu.mhutti1.utils.storage
 import android.content.Context
 import android.content.ContextWrapper
 import android.os.Environment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import java.io.File
 import java.io.FileFilter
@@ -28,8 +30,9 @@ import java.io.RandomAccessFile
 
 object StorageDeviceUtils {
   @JvmStatic
-  fun getWritableStorage(context: Context) =
+  suspend fun getWritableStorage(context: Context) = withContext(Dispatchers.IO) {
     validate(externalMediaFilesDirsDevices(context), true)
+  }
 
   @JvmStatic
   fun getReadableStorage(context: Context): List<StorageDevice> {

--- a/core/src/main/res/layout/item_storage_preference.xml
+++ b/core/src/main/res/layout/item_storage_preference.xml
@@ -55,7 +55,7 @@
     android:layout_marginTop="8dp"
     android:indeterminate="false"
     android:max="100"
-    android:progress="50"
+    android:progress="0"
     android:progressDrawable="@drawable/progress_bar_state"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/radioButton"


### PR DESCRIPTION
Fixes #4163 

* Moved the storage device retrieval to the IO thread.
* Updated the StorageDeviceUtils.getWritableStorage method to a suspend function to ensure execution on the IO thread.
* Refactored CopyMoveFileHandler, OnlineLibraryFragment, KiwixPrefsFragment, and LocalLibraryFragment to adapt to this change.
* Optimized storage device retrieval by caching it in the main activity and reusing it across fragments to enhance performance, especially with large SD cards. Because getting it in fragments again and again is quite expensive because when we switch to other screens the previous saved state will lost, and it again tries(when it requires) to get the list of storage devices if we again come back to that fragment.
* Refactored the CopyMoveFileHandlerTest.
* Improved the showing of the storage device list.
