### PR TITLE
Fixed: Application crash while adding application shortcuts.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -77,6 +77,7 @@ const val FIND_IN_PAGE_SEARCH_STRING = "findInPageSearchString"
 const val ZIM_FILE_URI_KEY = "zimFileUri"
 const val KIWIX_INTERNAL_ERROR = 10
 const val ACTION_NEW_TAB = "NEW_TAB"
+const val NEW_TAB_SHORTCUT_ID = "new_tab_shortcut"
 
 abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
 

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -19,26 +19,27 @@
 package org.kiwix.kiwixmobile.custom.main
 
 import android.content.Intent
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
-import android.graphics.drawable.Icon
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.navigation.NavigationView
+import org.kiwix.kiwixmobile.core.R.drawable
+import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.extensions.applyEdgeToEdgeInsets
 import org.kiwix.kiwixmobile.core.extensions.browserIntent
 import org.kiwix.kiwixmobile.core.main.ACTION_NEW_TAB
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.main.NEW_TAB_SHORTCUT_ID
 import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.R
-import org.kiwix.kiwixmobile.core.R.string
-import org.kiwix.kiwixmobile.core.R.drawable
-import org.kiwix.kiwixmobile.core.extensions.applyEdgeToEdgeInsets
 import org.kiwix.kiwixmobile.custom.customActivityComponent
 import org.kiwix.kiwixmobile.custom.databinding.ActivityCustomMainBinding
 
@@ -192,12 +193,13 @@ class CustomMainActivity : CoreMainActivity() {
   override fun getIconResId() = R.mipmap.ic_launcher
 
   override fun createApplicationShortcuts() {
-    val shortcutManager = getSystemService(ShortcutManager::class.java)
+    // Remove previously added dynamic shortcuts for old ids if any found.
+    removeOutdatedIdShortcuts()
     // Create a shortcut for opening the "New tab"
-    val newTabShortcut = ShortcutInfo.Builder(this, "new_tab")
+    val newTabShortcut = ShortcutInfoCompat.Builder(this, NEW_TAB_SHORTCUT_ID)
       .setShortLabel(getString(string.new_tab_shortcut_label))
       .setLongLabel(getString(string.new_tab_shortcut_label))
-      .setIcon(Icon.createWithResource(this, drawable.ic_shortcut_new_tab))
+      .setIcon(IconCompat.createWithResource(this, drawable.ic_shortcut_new_tab))
       .setDisabledMessage(getString(string.shortcut_disabled_message))
       .setIntent(
         Intent(this, CustomMainActivity::class.java).apply {
@@ -205,6 +207,16 @@ class CustomMainActivity : CoreMainActivity() {
         }
       )
       .build()
-    shortcutManager.dynamicShortcuts = listOf(newTabShortcut)
+    ShortcutManagerCompat.addDynamicShortcuts(this, listOf(newTabShortcut))
+  }
+
+  // Outdated shortcut id(new_tab)
+  // Remove if the application has the outdated shortcut.
+  private fun removeOutdatedIdShortcuts() {
+    ShortcutManagerCompat.getDynamicShortcuts(this).forEach {
+      if (it.id == "new_tab") {
+        ShortcutManagerCompat.removeDynamicShortcuts(this, arrayListOf(it.id))
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #4166 

* The issue occurred because these shortcuts were defined in the manifest, which treated them as immutable and unable to be updated. We removed them from the manifest and added them as dynamic shortcuts. On some devices (e.g., Honor devices), it takes time to remove these shortcuts from the static shortcut list after the user updates the app, causing them to be treated as immutable and unable to be updated. This led to the crash. To fix this, we updated our shortcut IDs so that when the previous static shortcuts are removed by the OS, it will not affect the creation of the new dynamic shortcuts.
* For previously added dynamic shortcuts on other devices, we implemented a removeOutdatedIdShortcuts() method, which removes the old dynamic shortcuts.
* Using the `ShortcutManagerCompat` class to add dynamic shortcuts instead of directly using the `ShortcutManager` class, as it provides better handling for adding shortcuts.