### PR TITLE
Changed the website, and Nightly APKs name.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           UNIVERSAL_RELEASE_APK: app/build/outputs/apk/standalone/*universal*.apk
-          ARCHIVE_NAME: kiwix-${{ github.event.release.tag_name }}.apk
+          ARCHIVE_NAME: org.kiwix.kiwixmobile.standalone-${{ github.event.release.tag_name }}.apk
           KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
         run: |
           ./gradlew assembleStandalone

--- a/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
@@ -103,7 +103,7 @@ class AppConfigurer {
   }
 
   private fun setNameForNightlyUniversalApk(): String =
-    "kiwix-universal-${getCurrentDate()}.apk"
+    "org.kiwix.kiwixmobile.standalone-universal-${getCurrentDate()}.apk"
 
   private fun getCurrentDate() =
     Date().let(SimpleDateFormat("yyyy-MM-dd", Locale.ROOT)::format)


### PR DESCRIPTION
Fixes #4128 

* Before the name was `kiwix-3.13.0.apk` for the release APK(with app id org.kiwix.kiwixmobile app id) we were uploading on the website. But now, we are uploading the standalone APK on the website(with org.kiwix.kiwixmobile.standalone app id) it is a breaking change, and users are not aware of it. So we are changing the APK name so that users can understand this change. See https://github.com/kiwix/kiwix-android/issues/4128#issuecomment-2565693850.
* Renamed the nightly APK since there also we are uploading the standalone APK.