### PR TITLE
Showing a warning dialog when copying/moving the ZIM chunks in PS version.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -52,6 +52,7 @@ import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
+import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker.Companion.FOUR_GIGABYTES_IN_KILOBYTES
@@ -405,6 +406,9 @@ class CopyMoveFileHandler @Inject constructor(
     }
   }
 
+  suspend fun isValidZimFile(destinationFile: File): Boolean =
+    FileUtils.isSplittedZimFile(destinationFile.name) || validateZimFileValid(destinationFile)
+
   fun handleInvalidZimFile(destinationFile: File, sourceUri: Uri) {
     val errorMessage = activity.getString(R.string.error_file_invalid)
     if (isMoveOperation) {
@@ -428,7 +432,7 @@ class CopyMoveFileHandler @Inject constructor(
     }
   }
 
-  suspend fun isValidZimFile(destinationFile: File): Boolean {
+  private suspend fun validateZimFileValid(destinationFile: File): Boolean {
     var archive: Archive? = null
     return try {
       // create archive object, and check if it has the mainEntry or not to validate the ZIM file.

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -44,7 +44,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
@@ -709,28 +708,6 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
   }
 
   private fun showWarningDialogForSplittedZimFile() {
-    dialogShower.show(
-      KiwixDialog.ShowWarningAboutSplittedZimFile,
-      ::openCopiedMovedDirectory
-    )
-  }
-
-  private fun openCopiedMovedDirectory() {
-    val downloadedDirectoryPath = FileProvider.getUriForFile(
-      requireActivity(),
-      requireActivity().applicationContext.packageName + ".fileprovider",
-      File(sharedPreferenceUtil.prefStorage)
-    )
-    val intent = Intent(Intent.ACTION_VIEW).apply {
-      setDataAndType(downloadedDirectoryPath, "*/*")
-      addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-      addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    }
-    try {
-      requireActivity().startActivity(intent)
-    } catch (ignore: Exception) {
-      // TODO change the message
-      activity.toast(org.kiwix.kiwixmobile.core.R.string.no_reader_application_installed)
-    }
+    dialogShower.show(KiwixDialog.ShowWarningAboutSplittedZimFile)
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -93,6 +93,7 @@ import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener.Compani
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
+import org.kiwix.kiwixmobile.core.utils.files.FileUtils.isSplittedZimFile
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BookOnDiskDelegate
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskAdapter
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter.BooksOnDiskListItem
@@ -633,11 +634,11 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       !shouldShowRationalePermission()
 
   override fun onFileCopied(file: File) {
-    navigateToReaderFragment(file = file)
+    validateAndOpenZimInReader(file)
   }
 
   override fun onFileMoved(file: File) {
-    navigateToReaderFragment(file = file)
+    validateAndOpenZimInReader(file)
   }
 
   override fun onError(errorMessage: String) {
@@ -693,5 +694,20 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       // after selecting the storage try to copy/move the zim file.
       copyMoveFileHandler?.copyMoveZIMFileInSelectedStorage(storageDevice)
     }
+  }
+
+  private fun validateAndOpenZimInReader(file: File) {
+    if (isSplittedZimFile(file.path)) {
+      showWarningDialogForSplittedZimFile()
+    } else {
+      navigateToReaderFragment(file = file)
+    }
+  }
+
+  private fun showWarningDialogForSplittedZimFile() {
+    dialogShower.show(
+      KiwixDialog.ShowWarningAboutSplittedZimFile,
+      {}
+    )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -121,7 +121,7 @@ sealed class KiwixDialog(
   data object ShowWarningAboutSplittedZimFile : KiwixDialog(
     null,
     R.string.verify_zim_chunk_copied_moved_properly,
-    android.R.string.ok,
+    R.string.view,
     android.R.string.ok,
     cancelable = false
   )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -120,7 +120,7 @@ sealed class KiwixDialog(
 
   data object ShowWarningAboutSplittedZimFile : KiwixDialog(
     null,
-    R.string.verify_zim_chunk_copied_moved_properly,
+    R.string.ensure_zim_chunk_copied_moved_properly,
     R.string.view,
     android.R.string.ok,
     cancelable = false

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -119,8 +119,8 @@ sealed class KiwixDialog(
   )
 
   data object ShowWarningAboutSplittedZimFile : KiwixDialog(
-    null,
-    R.string.ensure_zim_chunk_copied_moved_properly,
+    R.string.verify_zim_chunk_dialog_title,
+    R.string.verify_zim_chunks_dialog_message,
     R.string.view,
     android.R.string.ok,
     cancelable = false

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -118,6 +118,14 @@ sealed class KiwixDialog(
     cancelable = false
   )
 
+  data object ShowWarningAboutSplittedZimFile : KiwixDialog(
+    null,
+    R.string.verify_zim_chunk_copied_moved_properly,
+    android.R.string.ok,
+    android.R.string.ok,
+    cancelable = false
+  )
+
   object SaveOrOpenUnsupportedFiles : KiwixDialog(
     R.string.save_or_open_unsupported_files_dialog_title,
     R.string.save_or_open_unsupported_files_dialog_message,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -121,8 +121,8 @@ sealed class KiwixDialog(
   data object ShowWarningAboutSplittedZimFile : KiwixDialog(
     R.string.verify_zim_chunk_dialog_title,
     R.string.verify_zim_chunks_dialog_message,
-    R.string.view,
     android.R.string.ok,
+    null,
     cancelable = false
   )
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -490,6 +490,19 @@ object FileUtils {
     filePath.endsWith(".zim") || filePath.endsWith(".zimaa")
 
   /**
+   * Determines whether the given file path corresponds to a split ZIM file.
+   *
+   * A split ZIM file has an extension that starts with ".zima" followed by a single character,
+   * such as ".zimaa", ".zimab", etc. This method checks if the file path ends with this specific pattern.
+   *
+   * @param filePath The file path to evaluate.
+   * @return `true` if the file path corresponds to a split ZIM file, `false` otherwise.
+   */
+  @JvmStatic
+  fun isSplittedZimFile(filePath: String): Boolean =
+    filePath.matches(Regex(".*\\.zima.$"))
+
+  /**
    * Get the main storage path for a given storage name (SD card or USB stick).
    *
    * @param context The application context.

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -334,7 +334,7 @@
   <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
-  <string name="verify_zim_chunk_copied_moved_properly">Be cautious: verify that all the ZIM chunks have been moved/copied properly! \nAfter copying/moving all the ZIM chunks please refresh the library screen by swipe down. The Split ZIM file will add in library.</string>
+  <string name="ensure_zim_chunk_copied_moved_properly">Be cautious: Ensure all ZIM chunks have been properly moved or copied. You can verify them by clicking the “View” button. Once done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
   <string name="view">View</string>
   <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -334,7 +334,8 @@
   <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
-  <string name="verify_zim_chunk_copied_moved_properly">Be cautious: verify that all the ZIM chunks have been moved/copied properly!</string>
+  <string name="verify_zim_chunk_copied_moved_properly">Be cautious: verify that all the ZIM chunks have been moved/copied properly! \nAfter copying/moving all the ZIM chunks please refresh the library screen by swipe down. The Split ZIM file will add in library.</string>
+  <string name="view">View</string>
   <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>
   <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -334,7 +334,8 @@
   <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
-  <string name="ensure_zim_chunk_copied_moved_properly">Be cautious: Ensure all ZIM chunks have been properly moved or copied. You can verify them by clicking the “View” button. Once done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
+  <string name="verify_zim_chunk_dialog_title">Be cautious: Ensure all ZIM chunks have been properly moved/copied!</string>
+  <string name="verify_zim_chunks_dialog_message">You can verify them by clicking the “View” button. Once done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
   <string name="view">View</string>
   <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -335,8 +335,7 @@
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
   <string name="verify_zim_chunk_dialog_title">Be cautious: Ensure all ZIM chunks have been properly moved/copied!</string>
-  <string name="verify_zim_chunks_dialog_message">You can verify them by clicking the “View” button. Once done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
-  <string name="view">View</string>
+  <string name="verify_zim_chunks_dialog_message">You can verify them inside “Android/media/org.kiwix…/” folder.\nOnce done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
   <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>
   <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -334,6 +334,7 @@
   <string name="moving_zim_file">Moving ZIM file…</string>
   <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
+  <string name="verify_zim_chunk_copied_moved_properly">Be cautious: verify that all the ZIM chunks have been moved/copied properly!</string>
   <string name="why_copy_move_files_to_app_directory">Why copy/move files to app public directory?</string>
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>
   <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>


### PR DESCRIPTION
Fixes #4045 

* Showing a warning dialog when copying/moving the ZIM chunks in the PS version.
* Improved the copying/moving of ZIM chunks, and improved the validation of ZIM chunks.
* The warning dialog will only show for the ZIM chunks, for normal ZIM files it will directly open the ZIM file in the reader like it was working.

https://github.com/user-attachments/assets/82cd6fb5-dbc1-4bc0-92b1-c065f1b04056


