### PR TITLE
Fixed: The ZIM file was displayed on the library screen but failed to open (the ZIM file was located in the SD card's trash folder).

### DIFF
--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -20,6 +20,7 @@ package eu.mhutti1.utils.storage
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.os.Build
 import android.os.Environment
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -52,7 +53,9 @@ object StorageDeviceUtils {
       // In the Play Store variant, we can only access app-specific directories,
       // so scanning other directories is unnecessary, wastes resources,
       // and increases the scanning time.
-      if (sharedPreferenceUtil?.isNotPlayStoreBuildWithAndroid11OrAbove() == true) {
+      if (sharedPreferenceUtil?.isPlayStoreBuild == false ||
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+      ) {
         addAll(externalMountPointDevices())
         addAll(externalFilesDirsDevices(context, false))
       }


### PR DESCRIPTION
Fixes #4175

* Improved the scanning process for ZIM files to reduce scan time by excluding hidden folders, which are unnecessary and caused delays in scanning.
* Updated MediaStore to exclude ZIM files located in the SD card's trash folder, addressing the issue.
* Refactored the NewBookDao to remove any ZIM files from the library screen if they are located in the trash folder.
* Added a new unit test to verify that books located in the trash folder do not appear on the library screen.