### PR TITLE
Fixed: If storage permission is permanently denied on Android 11 or below, the selected file via the file picker does not open.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -437,7 +437,9 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
         )
       } else {
         zimFileUri = uri
-        if (requestExternalStorageWritePermission()) {
+        if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
+          showManageExternalStoragePermissionDialog()
+        } else if (requestExternalStorageWritePermission()) {
           getZimFileFromUri(uri)?.let(::navigateToReaderFragment)
         }
       }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -132,6 +132,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
   private var fragmentDestinationLibraryBinding: FragmentDestinationLibraryBinding? = null
   private var permissionDeniedLayoutShowing = false
   private var fileSelectListState: FileSelectListState? = null
+  private var zimFileUri: Uri? = null
 
   private val zimManageViewModel by lazy {
     requireActivity().viewModel<ZimManageViewModel>(viewModelFactory)
@@ -371,7 +372,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
     fragmentDestinationLibraryBinding?.selectFile?.setOnClickListener {
       if (!requireActivity().isManageExternalStoragePermissionGranted(sharedPreferenceUtil)) {
         showManageExternalStoragePermissionDialog()
-      } else {
+      } else if (requestExternalStorageWritePermission()) {
         showFileChooser()
       }
     }
@@ -435,7 +436,10 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
           parentFragmentManager
         )
       } else {
-        getZimFileFromUri(uri)?.let(::navigateToReaderFragment)
+        zimFileUri = uri
+        if (requestExternalStorageWritePermission()) {
+          getZimFileFromUri(uri)?.let(::navigateToReaderFragment)
+        }
       }
     }
   }
@@ -510,6 +514,9 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
     storagePermissionLauncher = null
     copyMoveFileHandler?.dispose()
     copyMoveFileHandler = null
+    readStoragePermissionLauncher?.unregister()
+    readStoragePermissionLauncher = null
+    zimFileUri = null
   }
 
   private fun sideEffects() = zimManageViewModel.sideEffects
@@ -709,5 +716,60 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
 
   private fun showWarningDialogForSplittedZimFile() {
     dialogShower.show(KiwixDialog.ShowWarningAboutSplittedZimFile)
+  }
+
+  private var readStoragePermissionLauncher: ActivityResultLauncher<Array<String>>? =
+    registerForActivityResult(
+      ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissionResult ->
+      val isGranted =
+        permissionResult.entries.all(
+          Map.Entry<String, @kotlin.jvm.JvmSuppressWildcards Boolean>::value
+        )
+      if (isGranted) {
+        zimFileUri?.let {
+          // open the selected ZIM file in reader.
+          lifecycleScope.launch {
+            getZimFileFromUri(it)?.let(::navigateToReaderFragment)
+          }
+        }
+      } else {
+        if (shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          /* shouldShowRequestPermissionRationale() returns false when:
+             *  1) User has previously checked on "Don't ask me again", and/or
+             *  2) Permission has been disabled on device
+             */
+          requireActivity().toast(string.request_storage, Toast.LENGTH_LONG)
+        } else {
+          dialogShower.show(
+            KiwixDialog.ReadPermissionRequired,
+            requireActivity()::navigateToAppSettings
+          )
+        }
+      }
+    }
+
+  @Suppress("NestedBlockDepth")
+  private fun requestExternalStorageWritePermission(): Boolean {
+    var isPermissionGranted = false
+    if (!sharedPreferenceUtil.isPlayStoreBuildWithAndroid11OrAbove() &&
+      Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+    ) {
+      if (requireActivity().checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        == PackageManager.PERMISSION_GRANTED
+      ) {
+        isPermissionGranted = true
+      } else {
+        readStoragePermissionLauncher?.launch(
+          arrayOf(
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+          )
+        )
+      }
+    } else {
+      isPermissionGranted = true
+    }
+    return isPermissionGranted
   }
 }


### PR DESCRIPTION
Fixes #4185

* Fixed: If storage permission is permanently denied on Android 11 or below, the selected file via the file picker does not open.
* The storage permission dialog is now shown when the user clicks the "File Picker" button, prompting them to grant the permission first before selecting a ZIM file via the file picker.
* If storage permission is denied or not granted, and the user opens a ZIM file by clicking on it in the file manager, the app will first prompt for permission. Once the permission is granted, the ZIM file will open in the reader. If the permission is not granted, the operation is canceled, and the selected ZIM file will not open.
* Fixed the scenario where, if the application does not have the `MANAGE_EXTERNAL_STORAGE` permission and the user tries to open a ZIM file from the file manager, the app now prompts for the required permission instead of showing an error.

https://github.com/user-attachments/assets/bf3482a2-b76c-4f46-88eb-0ed03de5997b



https://github.com/user-attachments/assets/e9cb2c57-b0dd-45db-9b39-5fd06ecbade9


