### PR TITLE
Fixed: Navigation drawer showing while reading a book in fullscreen mode.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -308,6 +308,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     } else {
       showNavBar()
     }
+    super.onFullscreenVideoToggled(isFullScreen)
   }
 
   override fun openFullScreen() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -283,11 +283,16 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     }
   }
 
-  open fun disableDrawer() {
+  open fun disableDrawer(disableRightDrawer: Boolean = true) {
     drawerToggle?.isDrawerIndicatorEnabled = false
     drawerContainerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
-    // Disable the right drawer
-    drawerContainerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED, GravityCompat.END)
+    if (disableRightDrawer) {
+      // Disable the right drawer
+      drawerContainerLayout.setDrawerLockMode(
+        DrawerLayout.LOCK_MODE_LOCKED_CLOSED,
+        GravityCompat.END
+      )
+    }
   }
 
   open fun onNavigationItemSelected(item: MenuItem): Boolean {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1643,12 +1643,29 @@ abstract class CoreReaderFragment :
     return true
   }
 
+  /**
+   * Handles the toggling of fullscreen video mode and adjusts the drawer's behavior accordingly.
+   * - If a video is playing in fullscreen mode, the drawer is disabled to restrict interactions.
+   * - When fullscreen mode is exited, the drawer is re-enabled unless the reader is still
+   *   in fullscreen mode.
+   * - Specifically, if the reader is in fullscreen mode and the user plays a video in
+   *   fullscreen, then exits the video's fullscreen mode, the drawer remains disabled
+   *   because the reader is still in fullscreen mode.
+   */
   override fun onFullscreenVideoToggled(isFullScreen: Boolean) {
-    // does nothing because custom doesn't have a nav bar
+    if (isFullScreen) {
+      (requireActivity() as CoreMainActivity).disableDrawer(false)
+    } else {
+      if (!isInFullScreenMode()) {
+        toolbar?.let(::setUpDrawerToggle)
+        setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
+      }
+    }
   }
 
   @Suppress("MagicNumber")
   protected open fun openFullScreen() {
+    (requireActivity() as CoreMainActivity).disableDrawer(false)
     toolbarContainer?.visibility = View.GONE
     bottomToolbar?.visibility = View.GONE
     exitFullscreenButton?.visibility = View.VISIBLE
@@ -1664,6 +1681,8 @@ abstract class CoreReaderFragment :
 
   @Suppress("MagicNumber")
   open fun closeFullScreen() {
+    toolbar?.let(::setUpDrawerToggle)
+    setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
     sharedPreferenceUtil?.putPrefFullScreen(false)
     toolbarContainer?.visibility = View.VISIBLE
     updateBottomToolbarVisibility()


### PR DESCRIPTION
Fixes #4184 

* Disabled the right drawer when the user is reading a book in fullscreen mode to ensure uninterrupted reading.
* Also disabled the drawer while a video is playing in fullscreen mode to avoid interruptions during video playback.


https://github.com/user-attachments/assets/07756576-1fdb-4a86-92c6-7c8f286f6a3e

