### PR TITLE
Using java-libkiwix `2.2.4` to fix native crashes happens while getting the `getEntryByPath`, and `getData()` methods.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -92,7 +92,7 @@ object Versions {
 
   const val androidx_activity: String = "1.9.3"
 
-  const val libkiwix: String = "2.2.3"
+  const val libkiwix: String = "2.2.4"
 
   const val material: String = "1.12.0"
 


### PR DESCRIPTION
Fixes #3956

We have fixed this issue on `java-libkiwix` side see https://github.com/kiwix/java-libkiwix/pull/116 for full details.
