### PR TITLE
Fixed: When a note is deleted, the corresponding file remained in storage.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -129,17 +129,7 @@ class NoteFragmentTest : BaseActivityTest() {
 
   @Test
   fun testUserCanSeeNotesForDeletedFiles() {
-    // delete the notes if any saved to properly run the test scenario
-    note {
-      openNoteFragment()
-      assertToolbarExist()
-      assertNoteRecyclerViewExist()
-      clickOnTrashIcon()
-      assertDeleteNoteDialogDisplayed()
-      clickOnDeleteButton()
-      assertNoNotesTextDisplayed()
-      pressBack()
-    }
+    deletePreviouslySavedNotes()
     loadZimFileInReader("testzim.zim")
     StandardActions.closeDrawer() // close the drawer if open before running the test cases.
     note {
@@ -188,17 +178,7 @@ class NoteFragmentTest : BaseActivityTest() {
 
   @Test
   fun testZimFileOpenedAfterOpeningNoteOnNotesScreen() {
-    // delete the notes if any saved to properly run the test scenario
-    note {
-      openNoteFragment()
-      assertToolbarExist()
-      assertNoteRecyclerViewExist()
-      clickOnTrashIcon()
-      assertDeleteNoteDialogDisplayed()
-      clickOnDeleteButton()
-      assertNoNotesTextDisplayed()
-      pressBack()
-    }
+    deletePreviouslySavedNotes()
     loadZimFileInReader("testzim.zim")
     note {
       assertHomePageIsLoadedOfTestZimFile()
@@ -216,6 +196,65 @@ class NoteFragmentTest : BaseActivityTest() {
       // to close the note dialog.
       pressBack()
       // to close the notes fragment.
+      pressBack()
+    }
+  }
+
+  @Test
+  fun testNoteEntryIsRemovedFromDatabaseWhenDeletedInAddNoteDialog() {
+    deletePreviouslySavedNotes()
+    loadZimFileInReader("testzim.zim")
+    note {
+      clickOnNoteMenuItem(context)
+      assertNoteDialogDisplayed()
+      writeDemoNote()
+      saveNote()
+      pressBack()
+      openNoteFragment()
+      assertToolbarExist()
+      assertNoteRecyclerViewExist()
+      clickOnSavedNote()
+      clickOnOpenNote()
+      assertNoteSaved()
+      clickOnDeleteIcon()
+      pressBack()
+      assertNoNotesTextDisplayed()
+    }
+  }
+
+  @Test
+  fun testNoteFileIsDeletedWhenNoteIsRemovedFromNotesScreen() {
+    deletePreviouslySavedNotes()
+    loadZimFileInReader("testzim.zim")
+    // Save a note.
+    note {
+      clickOnNoteMenuItem(context)
+      assertNoteDialogDisplayed()
+      writeDemoNote()
+      saveNote()
+      pressBack()
+    }
+    // Delete that note from "Note" screen.
+    deletePreviouslySavedNotes()
+    // Test the note file is deleted or not.
+    note {
+      clickOnNoteMenuItem(context)
+      assertNoteDialogDisplayed()
+      assertNotDoesNotExist()
+      pressBack()
+    }
+  }
+
+  private fun deletePreviouslySavedNotes() {
+    // delete the notes if any saved to properly run the test scenario
+    note {
+      openNoteFragment()
+      assertToolbarExist()
+      assertNoteRecyclerViewExist()
+      clickOnTrashIcon()
+      assertDeleteNoteDialogDisplayed()
+      clickOnDeleteButton()
+      assertNoNotesTextDisplayed()
       pressBack()
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -26,6 +26,7 @@ import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
@@ -109,6 +110,15 @@ class NoteRobot : BaseRobot() {
     // This is flaky since it is shown in a dialog and sometimes
     // UIDevice does not found the view immediately due to rendering process.
     testFlakyView({ isVisible(Text(noteText)) })
+  }
+
+  fun assertNotDoesNotExist() {
+    testFlakyView({ onView(withText(noteText)).check(doesNotExist()) })
+  }
+
+  fun clickOnDeleteIcon() {
+    pauseForBetterTestPerformance()
+    testFlakyView({ clickOn(ViewId(R.id.delete_note)) })
   }
 
   fun clickOnTrashIcon() {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -436,7 +436,7 @@ class AddNoteDialog : DialogFragment() {
     val noteText = dialogNoteAddNoteBinding?.addNoteEditText?.text.toString()
     if (noteDeleted) {
       dialogNoteAddNoteBinding?.addNoteEditText?.text?.clear()
-      mainRepositoryActions.deleteNote(articleNoteFileName)
+      mainRepositoryActions.deleteNote(getNoteTitle())
       disableMenuItems()
       view?.snack(
         stringId = R.string.note_delete_successful,


### PR DESCRIPTION
Fixes #4194 

* The note file is now deleted from storage when the user selects multiple notes and deletes them from the "Notes" screen.
* Improved note deletion in the "Note Dialog." Previously, when deleting a note from the `AddNoteDialog` on the Notes screen, the file was removed from storage, but its entry remained in the database, causing the note to still appear on the "Notes" screen after deletion. This issue has now been fixed.
* Added the UI test cases for both scenarios to avoid future errors.


https://github.com/user-attachments/assets/8ed5213a-a62d-4319-a4a0-1ca2fda81adb

