### PR TITLE
Fixed: The bottom bar disappears when reopening the app from the background.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -84,7 +84,6 @@ class KiwixReaderFragment : CoreReaderFragment() {
     }
     activity.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     toolbar?.let { activity.setupDrawerToggle(it, true) }
-    setFragmentContainerBottomMarginToSizeOfNavBar()
     openPageInBookFromNavigationArguments()
   }
 
@@ -237,6 +236,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
 
   override fun onResume() {
     super.onResume()
+    setFragmentContainerBottomMarginToSizeOfNavBar()
     if (isFullScreenVideo || isInFullScreenMode()) {
       hideNavBar()
     }


### PR DESCRIPTION
Fixes #4196 

* The issue was that we were setting the bottom margin to `0` when the fragment was moved to the background (i.e., when switching fragments) to prevent the bottom margin from affecting other screens. This was applied to the `NavHostContainer`, which hosts the reader fragment. Enabling the bottom margin when the fragment view is created worked in most cases. However, on Android 15, the system saves the fragment state and does not recreate the view, which means our margin-setting logic was not executed. As a result, the `bottomAppBar` appeared to disappear, but in reality, it was rendering behind the `BottomNavigationView` (the three options at the bottom).
* To fix this, we now set the bottom margin in the `onResume` method so that whenever the reader screen becomes visible, the bottom margin is automatically adjusted.


https://github.com/user-attachments/assets/f8439045-1602-4c68-b65b-4fea6e015989

