### PR TITLE
Fixed: Search was not working when closing a tab and immediately opening the search screen.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1220,6 +1220,7 @@ abstract class CoreReaderFragment :
 
   override fun onDestroyView() {
     super.onDestroyView()
+    restoreTabsSnackbarCallback = null
     try {
       coreReaderLifeCycleScope?.cancel()
       readerLifeCycleScope?.cancel()
@@ -1394,17 +1395,7 @@ abstract class CoreReaderFragment :
         .setAction(R.string.undo) { undoButton ->
           undoButton.isEnabled = false
           restoreDeletedTab(index)
-        }.addCallback(object : Snackbar.Callback() {
-          override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-            super.onDismissed(transientBottomBar, event)
-            // If the undo button is not clicked and no tabs are left, exit the book and
-            // clean up resources.
-            if (event != DISMISS_EVENT_ACTION && webViewList.isEmpty()) {
-              closeZimBook()
-            }
-          }
-        })
-        .show()
+        }.addCallback(restoreTabsSnackbarCallback).show()
     }
     openHomeScreen()
   }
@@ -1895,16 +1886,18 @@ abstract class CoreReaderFragment :
           setIsCloseAllTabButtonClickable(true)
           restoreDeletedTabs()
         }
-      }.addCallback(object : Snackbar.Callback() {
-        override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-          super.onDismissed(transientBottomBar, event)
-          // If the undo button is not clicked and no tabs are left, exit the book and
-          // clean up resources.
-          if (event != DISMISS_EVENT_ACTION && webViewList.isEmpty()) {
-            closeZimBook()
-          }
-        }
-      }).show()
+      }.addCallback(restoreTabsSnackbarCallback).show()
+    }
+  }
+
+  private var restoreTabsSnackbarCallback: Snackbar.Callback? = object : Snackbar.Callback() {
+    override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+      super.onDismissed(transientBottomBar, event)
+      // If the undo button is not clicked and no tabs are left, exit the book and
+      // clean up resources.
+      if (event != DISMISS_EVENT_ACTION && webViewList.isEmpty() && isAdded) {
+        closeZimBook()
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4198 

* The issue occurred because, after closing a tab and quickly navigating to the search screen, the snackbar callback was still running in the background. When switching to the search screen, the WebView list was empty because we cleared it when the fragment's view was destroyed. As a result, the book was closed, and the SearchScreen could not find the ZIM file for searching.
* To fix this, we now dismiss the snackbar callback when the fragment's view is destroyed.



https://github.com/user-attachments/assets/6936ac0b-59b9-4bc8-bfa5-0ab51af20582

