### PR TITLE
Fixed: `FIND_IN_PAGE` feature only works with first tab page.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -220,7 +220,7 @@ object TestUtils {
 
   @JvmStatic
   fun deleteTemporaryFilesOfTestCases(context: Context) {
-    ContextCompat.getExternalFilesDirs(context, null).filterNotNull()
+    context.getExternalFilesDirs(null).filterNotNull()
       .map(::deleteAllFilesInDirectory)
     ContextWrapper(context).externalMediaDirs.filterNotNull()
       .map(::deleteAllFilesInDirectory)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -505,16 +505,6 @@ abstract class CoreReaderFragment :
         readAloudService?.registerCallBack(this@CoreReaderFragment)
       }
     }
-    requireActivity().observeNavigationResult<String>(
-      FIND_IN_PAGE_SEARCH_STRING,
-      viewLifecycleOwner,
-      Observer(::findInPage)
-    )
-    requireActivity().observeNavigationResult<SearchItemToOpen>(
-      TAG_FILE_SEARCHED,
-      viewLifecycleOwner,
-      Observer(::openSearchItem)
-    )
     handleClicks()
   }
 
@@ -2617,6 +2607,28 @@ abstract class CoreReaderFragment :
       Log.w(TAG_KIWIX, "Kiwix shared preferences corrupted", e)
       activity.toast(R.string.could_not_restore_tabs, Toast.LENGTH_LONG)
     }
+    // After restoring the tabs, observe any search actions that the user might have triggered.
+    // Since the ZIM file opening functionality has been moved to a background thread,
+    // we ensure that all necessary actions are completed before observing these search actions.
+    observeSearchActions()
+  }
+
+  /**
+   * Observes any search-related actions triggered by the user, such as "Find in Page" or
+   * opening a specific search item.
+   * This method sets up observers for navigation results related to search functionality.
+   */
+  private fun observeSearchActions() {
+    requireActivity().observeNavigationResult<String>(
+      FIND_IN_PAGE_SEARCH_STRING,
+      viewLifecycleOwner,
+      Observer(::findInPage)
+    )
+    requireActivity().observeNavigationResult<SearchItemToOpen>(
+      TAG_FILE_SEARCHED,
+      viewLifecycleOwner,
+      Observer(::openSearchItem)
+    )
   }
 
   override fun onReadAloudPauseOrResume(isPauseTTS: Boolean) {

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
@@ -131,7 +131,7 @@ class SearchFragmentTestForCustomApp {
       customMainActivity = it
     }
     // test with a large ZIM file to properly test the scenario
-    downloadingZimFile = getDownloadingZimFile()
+    downloadingZimFile = getDownloadingZimFileFromDataFolder()
     getOkkHttpClientForTesting().newCall(downloadRequest()).execute().use { response ->
       if (response.isSuccessful) {
         response.body?.let { responseBody ->
@@ -147,7 +147,7 @@ class SearchFragmentTestForCustomApp {
     UiThreadStatement.runOnUiThread {
       customMainActivity.navigate(customMainActivity.readerFragmentResId)
     }
-    openZimFileInReaderWithAssetFileDescriptor(downloadingZimFile)
+    openZimFileInReader(zimFile = downloadingZimFile)
     openSearchWithQuery()
     val searchTerm = "gard"
     val searchedItem = "Gardanta Spirito"

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
@@ -100,14 +100,16 @@ class SearchRobot {
   }
 
   fun searchAndClickOnArticle(searchString: String) {
-    // wait a bit to properly load the ZIM file in the reader
+    // Wait a bit to properly load the ZIM file in the reader.
     BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     openSearchScreen()
+    // Wait a bit to properly visible the search screen.
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
     searchWithFrequentlyTypedWords(searchString)
     clickOnSearchItemInSearchList()
   }
 
-  fun clickOnSearchItemInSearchList() {
+  private fun clickOnSearchItemInSearchList() {
     testFlakyView({
       BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
       Espresso.onView(ViewMatchers.withId(R.id.search_list)).perform(

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchRobot.kt
@@ -19,19 +19,31 @@
 package org.kiwix.kiwixmobile.custom.search
 
 import android.view.KeyEvent
+import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.getText
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.uiautomator.UiDevice
+import com.adevinta.android.barista.interaction.BaristaDrawerInteractions.openDrawerWithGravity
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.internal.matcher.HelperMatchers
+import org.hamcrest.CoreMatchers.containsString
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.custom.R.id
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.testFlakyView
 
@@ -117,5 +129,44 @@ class SearchRobot {
           )
         )
     })
+  }
+
+  fun clickOnHomeButton() {
+    testFlakyView({
+      Espresso.onView(ViewMatchers.withId(R.id.bottom_toolbar_home))
+        .perform(ViewActions.click())
+    })
+  }
+
+  fun clickOnAFoolForYouArticle() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    testFlakyView({
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'A Fool for You')]"
+          )
+        ).perform(webClick())
+    })
+  }
+
+  fun assertAFoolForYouArticleLoaded() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    testFlakyView({
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), '\"A Fool for You\"')]"
+          )
+        ).check(webMatches(getText(), containsString("\"A Fool for You\"")))
+    })
+  }
+
+  fun openNoteFragment() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    openDrawerWithGravity(id.custom_drawer_container, GravityCompat.START)
+    testFlakyView({ onView(withText(R.string.pref_notes)).perform(click()) })
   }
 }

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/testutils/TestUtils.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/testutils/TestUtils.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.custom.testutils
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
-import androidx.core.content.ContextCompat
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
@@ -32,6 +31,7 @@ import java.io.File
 object TestUtils {
   private const val TAG = "TESTUTILS"
   var TEST_PAUSE_MS_FOR_SEARCH_TEST = 1000
+  var TEST_PAUSE_MS = 3000
 
   @JvmStatic
   fun isSystemUINotRespondingDialogVisible(uiDevice: UiDevice) =
@@ -92,7 +92,7 @@ object TestUtils {
 
   @JvmStatic
   fun deleteTemporaryFilesOfTestCases(context: Context) {
-    ContextCompat.getExternalFilesDirs(context, null).filterNotNull()
+    context.getExternalFilesDirs(null).filterNotNull()
       .map(::deleteAllFilesInDirectory)
     ContextWrapper(context).externalMediaDirs.filterNotNull()
       .map(::deleteAllFilesInDirectory)

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -144,7 +144,6 @@ class CustomReaderFragment : CoreReaderFragment() {
       zimReaderContainer?.zimFileReader?.let(::setUpBookmarks)
     } else {
       openObbOrZim()
-      manageExternalLaunchAndRestoringViewState()
     }
     requireArguments().clear()
   }
@@ -207,11 +206,15 @@ class CustomReaderFragment : CoreReaderFragment() {
                 val bookOnDisk = BookOnDisk(zimFileReader)
                 repositoryActions?.saveBook(bookOnDisk)
               }
+              // Open the previous loaded pages after ZIM file loads.
+              manageExternalLaunchAndRestoringViewState()
             }
 
             is ValidationState.HasBothFiles -> {
               it.zimFile.delete()
               openZimFile(ZimReaderSource(it.obbFile), true)
+              // Open the previous loaded pages after ZIM file loads.
+              manageExternalLaunchAndRestoringViewState()
             }
 
             else -> {}


### PR DESCRIPTION
Fixes #4200 

* The previously loaded article was not loading in custom apps when switching to another fragment and then returning to the reader screen. Instead, the home page of the ZIM file was loading. A fix has been implemented to resolve this issue.
* Added test cases for custom apps to cover this scenario and prevent future errors.
* Refactored some deprecated methods used in test cases.
* Improved the logic for handling search-related operations to ensure they are performed after tabs are fully restored.
* Previously, the search observation was initiated before the tabs were restored, causing the `FIND_IN_PAGE` feature to only work in the first tab. This happened because the webView list was empty at the time of observation.
* With the ZIM file opening and tab restoration now moved to background threads, the search observation logic has been moved to after the tabs are restored. This ensures that all webViews are properly initialized before observing search actions.
* This approach is more robust and aligns with the correct lifecycle of tab restoration and search functionality.
* Fixed: The `SearchFragmentTestForCustomApp` was failing sometimes. See https://github.com/kiwix/kiwix-android/actions/runs/13069386299/job/36467529496

https://github.com/user-attachments/assets/2c4c55f4-1923-4c71-a070-20cd8c522413




