### PR TITLE
Bumped the `upload-artifact` action from version 3 to version 4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           script: bash contrib/instrumentation.sh
 
       - name: Upload screenshot result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.api-level }}
@@ -107,7 +107,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Coverage to GH-Actions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.api-level==30 }}
         with:
           name: Tests Coverage Report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload ktlint Reports
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
          name: ktlint-report
          path: '**/build/reports/ktlint'
@@ -74,7 +74,7 @@ jobs:
       - name: Static Analysis
         run: ./gradlew detektDebug detektCustomExampleDebug
       - name: Upload Lint Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: detekt-report
@@ -112,7 +112,7 @@ jobs:
         run: ./gradlew app:lintDebug custom:lintCustomexampleDebug
 
       - name: Upload Lint Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: lint-report
@@ -141,7 +141,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Upload APK as Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
             name: kiwix-android


### PR DESCRIPTION
Fixes #4203 

* The CI pipeline failed due to the deprecated version of `upload-artifact` (v3).
* Upgrading to version 4 resolves the deprecation error and ensures compatibility with the latest features and improvements. Apart from this, the other `actions` are using the latest versions.