### PR TITLE
Minor improvement in showing the directory path in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This separation ensures clarity for users and prevents undesirable behavior.
 
 **Bookmarks**: Export and reimport them via the "Settings" menu.
 **ZIM files**: Move them to or from the reserved app directories `Android/media/org.kiwix.kiwixmobile/` or
-`Android/data/org.kiwix.kiwixmobile/. This might have to be done for both internal storage and SD card. Kiwix can detect automatically all ZIM files available in your storage. You just need to swipe down in the local "Library" screen and
+`Android/data/org.kiwix.kiwixmobile/`. This might have to be done for both internal storage and SD card. Kiwix can detect automatically all ZIM files available in your storage. You just need to swipe down in the local "Library" screen and
 it will scan your storage and recognize all your ZIM files.
 
 ## Android permissions needed


### PR DESCRIPTION
~* Updated the playStore link in the README file. The previous link https://android.kiwix.org/ was not working and it is not the Play Store link.~


* Minor improvement in showing the directory path. See the image below; the second directory path does not look correct.

![Screenshot from 2025-02-03 12-27-29](https://github.com/user-attachments/assets/bad80b67-77fc-4be3-9140-6a40fd379c66)


