### PR TITLE
Fixed: Download notification disappears when pausing a download.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadManagerMonitor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadManagerMonitor.kt
@@ -41,7 +41,8 @@ const val DEFAULT_INT_VALUE = -1
 class DownloadManagerMonitor @Inject constructor(
   val fetch: Fetch,
   val context: Context,
-  val downloadRoomDao: DownloadRoomDao
+  val downloadRoomDao: DownloadRoomDao,
+  private val fetchDownloadNotificationManager: FetchDownloadNotificationManager
 ) : DownloadMonitor {
   private val updater = PublishSubject.create<() -> Unit>()
   private var updaterDisposable: Disposable? = null
@@ -122,7 +123,12 @@ class DownloadManagerMonitor @Inject constructor(
   }
 
   private fun update(download: Download) {
-    updater.onNext { downloadRoomDao.update(download) }
+    updater.onNext {
+      downloadRoomDao.update(download)
+      if (download.isPaused()) {
+        fetchDownloadNotificationManager.showDownloadPauseNotification(fetch, download)
+      }
+    }
   }
 
   private fun delete(download: Download) {


### PR DESCRIPTION
Fixes #4207 

* The Fetch library automatically removes the ongoing download notification when a download is paused. To improve the user experience, we have implemented custom logic to display a notification for paused downloads, allowing users to easily resume them.
* Additionally, Android 14 introduces a change that prevents non-dismissible notifications see for more details https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications. This means users can now dismiss notifications by swiping left or right. Since our app uses a foreground service for downloads, we must always display a notification. To handle this, we have implemented a mechanism that automatically adds the last notification to our foreground service to satisfy its need when no download is ongoing, and the user can still cancel it on Android 14 and above.

https://github.com/user-attachments/assets/4db20155-32fd-418a-b121-25ba51b6a4a8


