### PR TITLE
Keeping the downloading books always at the top.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -140,6 +140,8 @@ class DownloadTest : BaseActivityTest() {
         stopDownloadIfAlreadyStarted()
         downloadZimFile(smallestZimFileIndex)
         try {
+          // Scroll to the top because now the downloading ZIM files are showing on the top.
+          scrollToZimFileIndex(0)
           assertDownloadStart()
           pauseDownload()
           assertDownloadPaused()

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -384,7 +384,7 @@ class ZimManageViewModelTest {
       url = ""
     )
     val bookWithInactiveLanguage = book(
-      id = "3",
+      id = "4",
       language = "inactiveLanguage",
       url = ""
     )
@@ -415,10 +415,12 @@ class ZimManageViewModelTest {
     viewModel.libraryItems.test()
       .assertValue(
         listOf(
-          LibraryListItem.DividerItem(Long.MAX_VALUE, R.string.your_languages),
+          LibraryListItem.DividerItem(Long.MAX_VALUE, R.string.downloading),
+          LibraryListItem.LibraryDownloadItem(downloadModel(book = bookDownloading)),
+          LibraryListItem.DividerItem(Long.MAX_VALUE - 1, R.string.your_languages),
           LibraryListItem.BookItem(bookWithActiveLanguage, CanWrite4GbFile),
           LibraryListItem.DividerItem(Long.MIN_VALUE, R.string.other_languages),
-          LibraryListItem.LibraryDownloadItem(downloadModel(book = bookDownloading))
+          LibraryListItem.BookItem(bookWithInactiveLanguage, CanWrite4GbFile)
         )
       )
   }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
   <string name="do_not_ask_anymore">Do not ask anymore</string>
   <string name="your_languages" tools:keep="@string/your_languages">Selected languages:</string>
   <string name="other_languages" tools:keep="@string/other_languages">Other languages:</string>
+  <string name="downloading" tools:keep="@string/no_items_msg">Downloading:</string>
   <string name="no_items_msg" tools:keep="@string/no_items_msg">No items available</string>
   <string name="crash_title">Well… This is Embarrassing</string>
   <string name="crash_description">It looks like we crashed.\n\nWould you mind helping us fix this problem by sending the following information?</string>


### PR DESCRIPTION
Fixes #4206 

* Added a new "Downloading:" section in `OnlineFragment` to display currently downloading books at the top.
* The language and search filter will not affect this meaning if a user selects another language and searches any ZIM file via the search feature, the "Downloading:" section always shows on the top and the filter will be applied to the remaining books.


https://github.com/user-attachments/assets/8e22d92c-ebe1-4ee5-94b2-b6c20472685e

* Refactored the `ZimManageViewModelTest` according to this new change.
* Refactored the `DownloadTest` which was failing after making this change.

