### PR TITLE
Fixed: `Input dispatching timed out` error while creating the application shortcuts.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -36,6 +36,7 @@ import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_LOCKED_CLOSED
 import androidx.drawerlayout.widget.DrawerLayout.LOCK_MODE_UNLOCKED
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
@@ -136,7 +137,9 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     CoroutineScope(Dispatchers.IO).launch {
       objectBoxToRoomMigrator.migrateObjectBoxDataToRoom()
     }
-    createApplicationShortcuts()
+    lifecycleScope.launch(Dispatchers.IO) {
+      createApplicationShortcuts()
+    }
     handleBackPressed()
   }
 


### PR DESCRIPTION
Fixes #4213 

Moved shortcut creation to `lifecycleScope` to free up the main thread. This ensures the UI remains responsive while shortcuts are being created.


https://github.com/user-attachments/assets/d36b1305-10f5-4030-a883-6cfce970574b


https://github.com/user-attachments/assets/4b63f09d-87f7-4041-b8db-e337779b00e5

