### PR TITLE
Fixed: Kiwix cannot import ZIM files from the filesystem.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -136,7 +135,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     val loadFileStream =
       ObjectBoxToLibkiwixMigratorTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.localLibrary
 
 import android.net.Uri
 import android.os.Build
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.Lifecycle
@@ -227,7 +226,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     val loadFileStream =
       CopyMoveFileHandlerTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()
@@ -247,7 +246,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
 
   private fun getInvalidZimFileUri(extension: String): Uri {
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim$extension"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -26,7 +26,6 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -228,7 +227,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
     val loadFileStream =
       CopyMoveFileHandlerTest::class.java.classLoader.getResourceAsStream(fileName)
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       fileName
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/DarkModeViewPainterTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.main
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -161,7 +160,7 @@ class DarkModeViewPainterTest : BaseActivityTest() {
     val loadFileStream =
       DarkModeViewPainterTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.mimetype
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -72,7 +71,7 @@ class MimeTypeTest : BaseActivityTest() {
   fun testMimeType() = runBlocking {
     val loadFileStream = MimeTypeTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -122,7 +121,7 @@ class LocalLibraryTest : BaseActivityTest() {
       LocalLibraryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile =
       File(
-        ContextCompat.getExternalFilesDirs(context, null)[0],
+        context.getExternalFilesDirs(null)[0],
         "testzim.zim"
       )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.note
 
 import android.os.Build
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -267,7 +266,7 @@ class NoteFragmentTest : BaseActivityTest() {
 
     val loadFileStream =
       NoteFragmentTest::class.java.classLoader.getResourceAsStream(zimFileName)
-    val zimFile = File(ContextCompat.getExternalFilesDirs(context, null)[0], zimFileName)
+    val zimFile = File(context.getExternalFilesDirs(null)[0], zimFileName)
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     loadFileStream.use { inputStream ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -204,7 +203,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
     val loadFileStream =
       LibkiwixBookmarkTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.page.history
 
 import android.os.Build
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -115,7 +114,7 @@ class NavigationHistoryTest : BaseActivityTest() {
     val loadFileStream =
       NavigationHistoryTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
@@ -79,7 +78,7 @@ class EncodedUrlTest : BaseActivityTest() {
     val loadFileStream =
       EncodedUrlTest::class.java.classLoader.getResourceAsStream("characters_encoding.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "characters_encoding.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -19,7 +19,6 @@
 package org.kiwix.kiwixmobile.reader
 
 import android.os.Build
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -113,7 +112,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     val loadFileStream =
       KiwixReaderFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -154,7 +153,7 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
   private fun createAndGetSplitedZimFile(shouldCreateExtraZeroSizeFile: Boolean = false): File? {
     val loadFileStream =
       EncodedUrlTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val storageDir = ContextCompat.getExternalFilesDirs(context, null)[0]
+    val storageDir = context.getExternalFilesDirs(null)[0]
 
     // Delete existing parts if they exist
     (1..3)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -18,7 +18,6 @@
 package org.kiwix.kiwixmobile.search
 
 import android.os.Build
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
@@ -342,7 +341,7 @@ class SearchFragmentTest : BaseActivityTest() {
     val loadFileStream =
       SearchFragmentTest::class.java.classLoader.getResourceAsStream("testzim.zim")
     val zimFile = File(
-      ContextCompat.getExternalFilesDirs(context, null)[0],
+      context.getExternalFilesDirs(null)[0],
       "testzim.zim"
     )
     if (zimFile.exists()) zimFile.delete()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/files/FileUtilsInstrumentationTest.kt
@@ -340,7 +340,7 @@ class FileUtilsInstrumentationTest {
     // get the SD card path
     val sdCardPath = context?.getExternalFilesDirs("")
       ?.get(1)?.path?.substringBefore("/Android")
-    val dummyUriData = listOf(
+    val dummyUriData = arrayListOf(
       // test the download uri on older devices
       DummyUrlData(
         null,
@@ -385,14 +385,6 @@ class FileUtilsInstrumentationTest {
             "%3A$commonUri"
         )
       ),
-      // test with USB stick uri
-      DummyUrlData(
-        null,
-        null,
-        "/mnt/media_rw/USB/$commonPath",
-        null,
-        Uri.parse("${primaryStorageUriPrefix}USB%3A$commonUri")
-      ),
       // test with invalid uri
       DummyUrlData(
         null,
@@ -421,6 +413,18 @@ class FileUtilsInstrumentationTest {
         )
       )
     )
+    // test with USB stick uri
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
+      dummyUriData.add(
+        DummyUrlData(
+          null,
+          null,
+          "/mnt/media_rw/USB/$commonPath",
+          null,
+          Uri.parse("${primaryStorageUriPrefix}USB%3A$commonUri")
+        )
+      )
+    }
     context?.let { context ->
       CoroutineScope(Dispatchers.Main).launch {
         dummyUriData.forEach { dummyUrlData ->

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -410,7 +410,7 @@ class CopyMoveFileHandler @Inject constructor(
     FileUtils.isSplittedZimFile(destinationFile.name) || validateZimFileValid(destinationFile)
 
   fun handleInvalidZimFile(destinationFile: File, sourceUri: Uri) {
-    val errorMessage = activity.getString(R.string.error_file_invalid)
+    val errorMessage = activity.getString(R.string.error_file_invalid, destinationFile.path)
     if (isMoveOperation) {
       val moveSuccessful = tryMoveWithDocumentContract(
         destinationFile.toUri(),

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -425,7 +425,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
         // and we will handle this later.
         val fileName = documentFile?.name
         if (fileName != null && !isValidZimFile(fileName)) {
-          activity.toast(string.error_file_invalid)
+          activity.toast(getString(string.error_file_invalid, "$uri"))
           return@launch
         }
         copyMoveFileHandler?.showMoveFileToPublicDirectoryDialog(
@@ -456,12 +456,12 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       requireActivity().applicationContext, uri
     )
     if (filePath == null || !File(filePath).isFileExist()) {
-      activity.toast(string.error_file_not_found)
+      activity.toast(getString(string.error_file_not_found, "$uri"))
       return null
     }
     val file = File(filePath)
     return if (!FileUtils.isValidZimFile(file.path)) {
-      activity.toast(string.error_file_invalid)
+      activity.toast(getString(string.error_file_invalid, file.path))
       null
     } else {
       file

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -27,6 +27,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -90,6 +91,7 @@ import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener
 import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener.Companion.SCROLL_DOWN
 import org.kiwix.kiwixmobile.core.utils.SimpleRecyclerViewScrollListener.Companion.SCROLL_UP
+import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
@@ -456,11 +458,17 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       requireActivity().applicationContext, uri
     )
     if (filePath == null || !File(filePath).isFileExist()) {
+      Log.e(
+        TAG_KIWIX,
+        "The Selected ZIM file not found in the storage. File Uri = $uri\n" +
+          "Retrieved Path = $filePath"
+      )
       activity.toast(getString(string.error_file_not_found, "$uri"))
       return null
     }
     val file = File(filePath)
     return if (!FileUtils.isValidZimFile(file.path)) {
+      Log.e(TAG_KIWIX, "Selected ZIM file is not a valid ZIM file. File path = ${file.path}")
       activity.toast(getString(string.error_file_invalid, file.path))
       null
     } else {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -144,7 +144,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
       // it will attempt to open the last opened ZIM file with the last loaded URL,
       // which is inside the non-existing ZIM file. This leads to unexpected behavior.
       exitBook()
-      activity.toast(string.error_file_not_found)
+      activity.toast(getString(string.error_file_not_found, zimFileUri))
       return
     }
     val zimReaderSource = ZimReaderSource(File(filePath))

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
@@ -41,7 +41,9 @@ data class OpenFileWithNavigation(private val bookOnDisk: BooksOnDiskListItem.Bo
         zimReaderSource.canOpenInLibkiwix()
       }
       if (!canOpenInLibkiwix) {
-        activity.toast(R.string.error_file_not_found)
+        activity.toast(
+          activity.getString(R.string.error_file_not_found, zimReaderSource.toDatabase())
+        )
       } else {
         activity.navigate(
           actionNavigationLibraryToNavigationReader().apply {

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -350,17 +350,26 @@ class CopyMoveFileHandlerTest {
     fileHandler = spyk(fileHandler)
     every { fileHandler.tryMoveWithDocumentContract(any(), any(), any()) } returns true
     every { destinationFile.parentFile } returns mockk()
+    every { destinationFile.path } returns ""
     fileHandler.isMoveOperation = true
 
     fileHandler.handleInvalidZimFile(destinationFile, sourceUri)
 
     verify { fileHandler.dismissProgressDialog() }
-    verify { fileCopyMoveCallback.onError(activity.getString(R.string.error_file_invalid)) }
+    verify {
+      fileCopyMoveCallback.onError(
+        activity.getString(
+          R.string.error_file_invalid,
+          destinationFile.path
+        )
+      )
+    }
   }
 
   @Test
   fun `handleInvalidZimFile should delete file and show error if move fails`() {
     fileHandler = spyk(fileHandler)
+    every { destinationFile.path } returns ""
     every { fileHandler.tryMoveWithDocumentContract(any(), any(), any()) } returns false
     every { destinationFile.parentFile } returns mockk()
     fileHandler.isMoveOperation = true
@@ -369,7 +378,7 @@ class CopyMoveFileHandlerTest {
 
     verify {
       fileHandler.handleFileOperationError(
-        activity.getString(R.string.error_file_invalid),
+        activity.getString(R.string.error_file_invalid, destinationFile.path),
         destinationFile
       )
     }

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -339,6 +339,7 @@ class CopyMoveFileHandlerTest {
   fun `notifyFileOperationSuccess should handle invalid ZIM file`() = runTest {
     fileHandler = spyk(fileHandler)
     fileHandler.shouldValidateZimFile = true
+    every { destinationFile.path } returns ""
     coEvery { fileHandler.isValidZimFile(destinationFile) } returns false
     fileHandler.notifyFileOperationSuccess(destinationFile, sourceUri)
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -167,7 +167,7 @@ class AddNoteDialog : DialogFragment() {
   private fun isZimFileExist() = zimFileName != null
 
   private fun onFailureToCreateAddNoteDialog() {
-    context.toast(R.string.error_file_not_found, Toast.LENGTH_LONG)
+    context.toast(getString(R.string.error_file_not_found, zimFileName), Toast.LENGTH_LONG)
     parentFragmentManager.beginTransaction().remove(this).commit()
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1774,7 +1774,10 @@ abstract class CoreReaderFragment :
       } else {
         exitBook()
         Log.w(TAG_KIWIX, "ZIM file doesn't exist at " + zimReaderSource.toDatabase())
-        requireActivity().toast(R.string.error_file_not_found, Toast.LENGTH_LONG)
+        requireActivity().toast(
+          getString(R.string.error_file_not_found, zimReaderSource.toDatabase()),
+          Toast.LENGTH_LONG
+        )
       }
     } else {
       this.zimReaderSource = zimReaderSource
@@ -1818,7 +1821,10 @@ abstract class CoreReaderFragment :
         // disable all controls for this ZIM file. This prevents potential crashes.
         // See issue #4161 for more details.
         exitBook()
-        requireActivity().toast(R.string.error_file_invalid, Toast.LENGTH_LONG)
+        requireActivity().toast(
+          getString(R.string.error_file_invalid, zimReaderSource.toDatabase()),
+          Toast.LENGTH_LONG
+        )
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -88,8 +88,14 @@ class ZimFileReader constructor(
               null
             }
           } catch (ignore: JNIKiwixException) {
+            Log.e(
+              TAG,
+              "Error in creating ZimFileReader," +
+                " there is an JNI exception happens: $ignore"
+            )
             null
           } catch (ignore: Exception) { // for handing the error, if any zim file is corrupted
+            Log.e(TAG, "Error in creating ZimFileReader: $ignore")
             null
           }
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -22,7 +22,6 @@ import android.content.ContextWrapper
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.content.ContextCompat.getExternalFilesDirs
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import io.reactivex.Flowable

--- a/core/src/main/res/values-af/strings.xml
+++ b/core/src/main/res/values-af/strings.xml
@@ -24,8 +24,8 @@
   <string name="search_label">Soek</string>
   <string name="choose_file">Kies ’n inhoudslêer (*.zim)</string>
   <string name="open_in_new_tab">Open skakel in nuwe oortjie?</string>
-  <string name="error_file_not_found">Fout: die geselekteerde ZIM-lêer kon nie gevind word nie.</string>
-  <string name="error_file_invalid">Fout: die geselekteerde lêer is nie ’n geldige ZIM-lêer nie.</string>
+  <string name="error_file_not_found">Fout: die geselekteerde ZIM-lêer kon nie gevind word nie. %s</string>
+  <string name="error_file_invalid">Fout: die geselekteerde lêer is nie ’n geldige ZIM-lêer nie. %s</string>
   <string name="error_article_url_not_found">Fout: Laai van bladsy (URL: %1$s) het gefaal.</string>
   <string name="pref_display_title">Wys</string>
   <string name="pref_info_title">Inligting</string>

--- a/core/src/main/res/values-ar/strings.xml
+++ b/core/src/main/res/values-ar/strings.xml
@@ -70,10 +70,10 @@
   <string name="server_started_message">أدخل عنوان الآيبي هذا في متصفحك للوصول إلى الخادم %s</string>
   <string name="qr_code">رمز QR المقدَم</string>
   <string name="share_host_address">مشاركة URL عبر تطبيقات أخرى</string>
-  <string name="error_file_not_found">خطأ: تعذر العثور على الملف زيم (ZIM) المحدد</string>
+  <string name="error_file_not_found">خطأ: تعذر العثور على الملف زيم (ZIM) المحدد %s</string>
   <string name="unable_to_read_zim_file">غير قادر على قراءة هذا الملف ZIM!</string>
   <string name="zim_not_opened">غير قادر على فتح ملف ZIM</string>
-  <string name="error_file_invalid">خطأ: ملف زيم (ZIM) المحدد ليس صالحًا.</string>
+  <string name="error_file_invalid">%s خطأ: ملف زيم (ZIM) المحدد ليس صالحًا.</string>
   <string name="error_article_url_not_found">خطأ: لم ينجح تحميل المقالة (Url: %1$s).</string>
   <string name="pref_display_title">العرض</string>
   <string name="pref_info_title">معلومات</string>

--- a/core/src/main/res/values-ast/strings.xml
+++ b/core/src/main/res/values-ast/strings.xml
@@ -47,9 +47,9 @@
   <string name="start_server_label">Aniciar el sirvidor</string>
   <string name="stop_server_label">Parar el sirvidor</string>
   <string name="server_started_message">Escribi esta direición ip nel restolador pa tener accesu al sirvidor %s</string>
-  <string name="error_file_not_found">Error: Nun pudo alcontrase ficheru ZIM seleicionáu.</string>
+  <string name="error_file_not_found">Error: Nun pudo alcontrase ficheru ZIM seleicionáu. %s</string>
   <string name="zim_not_opened" fuzzy="true">Nun pudo abrise l ficheru zim</string>
-  <string name="error_file_invalid">Error: El ficheru seleicionáu nun ye un ficheru ZIM válidu.</string>
+  <string name="error_file_invalid">Error: El ficheru seleicionáu nun ye un ficheru ZIM válidu. %s</string>
   <string name="error_article_url_not_found">Error: Falló la carga del artículu (Url: %1$s).</string>
   <string name="pref_display_title">Amosar</string>
   <string name="pref_info_title">Información</string>

--- a/core/src/main/res/values-az/strings.xml
+++ b/core/src/main/res/values-az/strings.xml
@@ -18,8 +18,8 @@
   <string name="search_label">Axtar</string>
   <string name="choose_file" fuzzy="true">ZIM məzmunlu fayl seç (*.zim)</string>
   <string name="open_in_new_tab">Linki yeni pəncərədə aç?</string>
-  <string name="error_file_not_found">Xəta: Seçilmiş ZIM fayl mövcud deyil.</string>
-  <string name="error_file_invalid">Xəta: Seçilmiş ZIM faylı yararlı deyil.</string>
+  <string name="error_file_not_found">Xəta: Seçilmiş ZIM fayl mövcud deyil. %s</string>
+  <string name="error_file_invalid">Xəta: Seçilmiş ZIM faylı yararlı deyil. %s</string>
   <string name="error_article_url_not_found">Xəta: Məqalənin (Url: %1$s) yüklənməsi alınmadı.</string>
   <string name="pref_display_title">Ekran</string>
   <string name="pref_info_title">Məlumat</string>

--- a/core/src/main/res/values-b+be+tarask/strings.xml
+++ b/core/src/main/res/values-b+be+tarask/strings.xml
@@ -34,8 +34,8 @@
   <string name="server_failed_message">Немагчыма запусьціць сэрвэр. Калі ласка, уключыце ваш пункт доступу</string>
   <string name="server_failed_toast_message">Немагчыма запусьціць сэрвэр.</string>
   <string name="hotspot_details_message">Дэталі вашага лякальнага пункту досягу. \nSSID: %1$s \nСпокліч: %2$s</string>
-  <string name="error_file_not_found">Памылка: абраны ZIM-файл ня знойдзены.</string>
-  <string name="error_file_invalid">Памылка: абраны файл не зьяўляецца слушным ZIM-файлам.</string>
+  <string name="error_file_not_found">Памылка: абраны ZIM-файл ня знойдзены. %s</string>
+  <string name="error_file_invalid">Памылка: абраны файл не зьяўляецца слушным ZIM-файлам. %s</string>
   <string name="error_article_url_not_found">Памылка: загрузка артыкула (Url: %1$s) не атрымалася.</string>
   <string name="pref_info_title">Інфармацыя</string>
   <string name="pref_info_version">Вэрсія</string>

--- a/core/src/main/res/values-be/strings.xml
+++ b/core/src/main/res/values-be/strings.xml
@@ -25,8 +25,8 @@
   <string name="search_label">Пошук</string>
   <string name="choose_file" fuzzy="true">Абярыце ZIM-файл (*.zim)</string>
   <string name="open_in_new_tab">Адкрыць спасылку ў новым вакенцы?</string>
-  <string name="error_file_not_found">Памылка: абраны ZIM-файл не знойдзены.</string>
-  <string name="error_file_invalid">Памылка: абраны файл не з’яўляецца слушным ZIM-файлам.</string>
+  <string name="error_file_not_found">Памылка: абраны ZIM-файл не знойдзены. %s</string>
+  <string name="error_file_invalid">Памылка: абраны файл не з’яўляецца слушным ZIM-файлам. %s</string>
   <string name="error_article_url_not_found">Памылка: загрузка артыкула не атрымалася (Url: %1$s).</string>
   <string name="pref_display_title">Паказаць</string>
   <string name="pref_info_title">Інфармацыя</string>

--- a/core/src/main/res/values-bg/strings.xml
+++ b/core/src/main/res/values-bg/strings.xml
@@ -28,8 +28,8 @@
   <string name="search_label">Търсене</string>
   <string name="choose_file">Изберете файл със съдържание (*.zim)</string>
   <string name="open_in_new_tab">Отваряне на препратката в нов раздел?</string>
-  <string name="error_file_not_found">Грешка: Избраният ZIM файл не е намерен.</string>
-  <string name="error_file_invalid">Грешка: Избраният файл не е валиден ZIM файл.</string>
+  <string name="error_file_not_found">Грешка: Избраният ZIM файл не е намерен. %s</string>
+  <string name="error_file_invalid">Грешка: Избраният файл не е валиден ZIM файл. %s</string>
   <string name="error_article_url_not_found">Грешка: Зареждането на статия (Url: %1$s) е неуспешно.</string>
   <string name="pref_display_title">Покажете</string>
   <string name="pref_info_title">Информация</string>

--- a/core/src/main/res/values-bm/strings.xml
+++ b/core/src/main/res/values-bm/strings.xml
@@ -15,8 +15,8 @@
   <string name="menu_exit_full_screen">Bɔ ekaran falen na</string>
   <string name="search_label">Ɲinini kɛ</string>
   <string name="choose_file" fuzzy="true">I mago bɛ fisiye min na ZIMU kɔnɔ, o suganti yan.</string>
-  <string name="error_file_not_found">Fili: Fisiye sugantilen ma se ka ye fan si.</string>
-  <string name="error_file_invalid">Fili: fisiye sugantilen tɛ fisiye yamaruyalen ye.</string>
+  <string name="error_file_not_found">Fili: Fisiye sugantilen ma se ka ye fan si. %s</string>
+  <string name="error_file_invalid">Fili: fisiye sugantilen tɛ fisiye yamaruyalen ye. %s</string>
   <string name="error_article_url_not_found">Fili: Kunnafoni (Url: %1$s)  sariziyeli tigɛra sira la.</string>
   <string name="pref_display_title">Jirayɔrɔ</string>
   <string name="pref_info_title">Kunnafoni</string>

--- a/core/src/main/res/values-bn/strings.xml
+++ b/core/src/main/res/values-bn/strings.xml
@@ -38,8 +38,8 @@
   <string name="connection_refused">সংযোগ প্রত্যাখান করা হয়েছে।</string>
   <string name="error_server_already_running">সার্ভার ইতিমধ্যেই চলছে। দয়া করে এটি বন্ধ করে আবার চেষ্টা করুন।</string>
   <string name="error_ip_address_not_found">আইপি ঠিকানা খুঁজে পাওয়া যায়নি।</string>
-  <string name="error_file_not_found">ত্রুটি: নির্বাচিত ZIM ফাইলটি খুঁজে পাওয়া যায় নি।</string>
-  <string name="error_file_invalid">ত্রুটি: নির্বাচিত ফাইলটি বৈধ ZIM ফাইল নয়।</string>
+  <string name="error_file_not_found">ত্রুটি: নির্বাচিত ZIM ফাইলটি খুঁজে পাওয়া যায় নি। %s</string>
+  <string name="error_file_invalid">ত্রুটি: নির্বাচিত ফাইলটি বৈধ ZIM ফাইল নয়। %s</string>
   <string name="error_article_url_not_found">ত্রুটি: নিবন্ধ লোডে (Url: %1$s) ব্যর্থ।</string>
   <string name="pref_display_title">প্রদর্শন</string>
   <string name="pref_info_title">তথ্য</string>

--- a/core/src/main/res/values-br/strings.xml
+++ b/core/src/main/res/values-br/strings.xml
@@ -39,10 +39,10 @@
   <string name="error_ip_address_not_found">N’haller ket kavout ar chomlec’h IP.</string>
   <string name="server_started_message">Enankit ar chomlec’h IP-mañ e-barzh ho merdeer evit kaout ar servijer %s</string>
   <string name="share_host_address">Rannañ an URL war-bouez arloadoù all</string>
-  <string name="error_file_not_found">Fazi : N’eus ket bet gallet kavout ar restr ZIM diuzet.</string>
+  <string name="error_file_not_found">Fazi : N’eus ket bet gallet kavout ar restr ZIM diuzet. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">N’haller ket lenn ar restr ZIM-mañ!</string>
   <string name="zim_not_opened" fuzzy="true">Dibosupl digeriñ ar restr zim</string>
-  <string name="error_file_invalid">Fazi : Ar restr diuzet n’eo ket ur restr ZIM reizh.</string>
+  <string name="error_file_invalid">Fazi : Ar restr diuzet n’eo ket ur restr ZIM reizh. %s</string>
   <string name="error_article_url_not_found">Fazi : N’eus ket bet gallet kargañ ar pennad “%1$s”</string>
   <string name="pref_display_title">Diskwel</string>
   <string name="pref_info_title">Titouroù</string>

--- a/core/src/main/res/values-ca/strings.xml
+++ b/core/src/main/res/values-ca/strings.xml
@@ -31,8 +31,8 @@
   <string name="hotspot_dialog_neutral_button">CONTINUA</string>
   <string name="start_server_label">Inicia el servidor</string>
   <string name="stop_server_label">Atura el servidor</string>
-  <string name="error_file_not_found">Error: no s’ha trobat el fitxer ZIM.</string>
-  <string name="error_file_invalid">Error: el fitxer seleccionat no és un fitxer ZIM vàlid.</string>
+  <string name="error_file_not_found">Error: no s’ha trobat el fitxer ZIM. %s</string>
+  <string name="error_file_invalid">Error: el fitxer seleccionat no és un fitxer ZIM vàlid. %s</string>
   <string name="error_article_url_not_found">Error: no s’ha pogut carregar l’article (Url: %1$s).</string>
   <string name="pref_display_title">Visualitzar</string>
   <string name="pref_info_title">Informació</string>

--- a/core/src/main/res/values-cs/strings.xml
+++ b/core/src/main/res/values-cs/strings.xml
@@ -60,10 +60,10 @@
   <string name="stop_server_label">Zastavit server</string>
   <string name="server_started_message">Vložte tuto IP adresu do svého prohlížeče pro přístup na server %s</string>
   <string name="share_host_address">Sdílet URL přes jiné aplikace</string>
-  <string name="error_file_not_found">Chyba: Nelze najít vybraný soubor ZIM.</string>
+  <string name="error_file_not_found">Chyba: Nelze najít vybraný soubor ZIM. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Tento soubor zim nelze přečíst!</string>
   <string name="zim_not_opened" fuzzy="true">Nelze otevřít soubor zim</string>
-  <string name="error_file_invalid">Chyba: Vybraný soubor není platným souborem ZIM.</string>
+  <string name="error_file_invalid">Chyba: Vybraný soubor není platným souborem ZIM. %s</string>
   <string name="error_article_url_not_found">Chyba: Načtení článku (Url: %1$s ) se nezdařilo.</string>
   <string name="pref_display_title">Zobrazení</string>
   <string name="pref_info_title">Informace</string>

--- a/core/src/main/res/values-cy/strings.xml
+++ b/core/src/main/res/values-cy/strings.xml
@@ -20,8 +20,8 @@
   <string name="search_label">Chwilio</string>
   <string name="choose_file">Dewisiwch Ffeil Gynnwys (*.zim)</string>
   <string name="open_in_new_tab">Agor y ddolen mewn tab newydd?</string>
-  <string name="error_file_not_found">Gwall: Doedd dim modd canfod y ffeil ZIM dan sylw.</string>
-  <string name="error_file_invalid">Gwall: Dydy yr ffeil dan sylw ddim yn ffeil ZIM dilys.</string>
+  <string name="error_file_not_found">Gwall: Doedd dim modd canfod y ffeil ZIM dan sylw. %s</string>
+  <string name="error_file_invalid">Gwall: Dydy yr ffeil dan sylw ddim yn ffeil ZIM dilys. %s</string>
   <string name="error_article_url_not_found">Gwall: Methwyd a llwytho yr erthygl: (Url: %1$s).</string>
   <string name="pref_display_title">Golwg</string>
   <string name="pref_info_title">Gwybodaeth</string>

--- a/core/src/main/res/values-da/strings.xml
+++ b/core/src/main/res/values-da/strings.xml
@@ -37,10 +37,10 @@
   <string name="progress_dialog_starting_server">Starter serveren</string>
   <string name="start_server_label">Start server</string>
   <string name="stop_server_label">Stop server</string>
-  <string name="error_file_not_found">Fejl: Den valgte ZIM fil blev ikke fundet.</string>
+  <string name="error_file_not_found">Fejl: Den valgte ZIM fil blev ikke fundet. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Kan ikke åbne den zim fil!</string>
   <string name="zim_not_opened" fuzzy="true">Kan ikke åbne zim fil</string>
-  <string name="error_file_invalid">Fejl: Den valgte fil er ikke en gyldig ZIM fil.</string>
+  <string name="error_file_invalid">Fejl: Den valgte fil er ikke en gyldig ZIM fil. %s</string>
   <string name="error_article_url_not_found">Fejl: Indlæsning af artikel (Url: %1$s) mislykkedes.</string>
   <string name="pref_display_title">Visning</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-dag/strings.xml
+++ b/core/src/main/res/values-dag/strings.xml
@@ -60,10 +60,10 @@
   <string name="error_ip_address_not_found">N bi nya ip addreesi</string>
   <string name="server_started_message">Kpɛhimi a ip fasara a browzɛr ni din yɛn chɛ ka a  nya niŋsim niŋda %s</string>
   <string name="share_host_address">Shiriki URL kupitia programu zingine</string>
-  <string name="error_file_not_found">Chiriŋ: ZIM mazagali shɛli bɛ ni daa piigi ŋɔ bi tooi nya.</string>
+  <string name="error_file_not_found">Chiriŋ: ZIM mazagali shɛli bɛ ni daa piigi ŋɔ bi tooi nya. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Di bi tooi karim zim mazagali ŋɔ!</string>
   <string name="zim_not_opened" fuzzy="true">Di bi tooi yoogi zim mazagali</string>
-  <string name="error_file_invalid">Chiriŋ: Mazagali shɛli bɛ ni daa piigi ŋɔ pala ZIM mazagali din niŋ viɛnyɛla.</string>
+  <string name="error_file_invalid">Chiriŋ: Mazagali shɛli bɛ ni daa piigi ŋɔ pala ZIM mazagali din niŋ viɛnyɛla. %s</string>
   <string name="error_article_url_not_found">Chiriŋ: Yaɣ’shɛli dini yoori a (Url: %1$s) bi yooi</string>
   <string name="pref_display_title">Zaŋ wuhi</string>
   <string name="pref_info_title">Lahabali</string>

--- a/core/src/main/res/values-de/strings.xml
+++ b/core/src/main/res/values-de/strings.xml
@@ -82,10 +82,10 @@
   <string name="server_started_message">Geben Sie diese IP-Adresse in Ihren Browser ein, um auf den Server %s zuzugreifen</string>
   <string name="qr_code">Gerenderter QR-Code</string>
   <string name="share_host_address">URL mit anderen Applikationen teilen</string>
-  <string name="error_file_not_found">Fehler: Die ausgewählte ZIM-Datei konnte nicht gefunden werden.</string>
+  <string name="error_file_not_found">Fehler: Die ausgewählte ZIM-Datei konnte nicht gefunden werden. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Diese Zim-Datei konnte nicht gelesen werden!</string>
   <string name="zim_not_opened" fuzzy="true">Konnte die ZIM-Datei nicht öffnen</string>
-  <string name="error_file_invalid">Fehler: Die ausgewählte Datei ist keine gültige ZIM-Datei.</string>
+  <string name="error_file_invalid">Fehler: Die ausgewählte Datei ist keine gültige ZIM-Datei. %s</string>
   <string name="error_article_url_not_found">Fehler: Das Laden des Artikels (URL: %1$s) ist fehlgeschlagen.</string>
   <string name="pref_display_title">Anzeige</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-diq/strings.xml
+++ b/core/src/main/res/values-diq/strings.xml
@@ -53,9 +53,9 @@
   <string name="stop_server_label">Serveri vındardış</string>
   <string name="server_started_message">Seba resayışê serverê %s re browseri rê ena adresê ip cı kerê</string>
   <string name="share_host_address">URL’yi be aplikasyonanê binan ra bare ke</string>
-  <string name="error_file_not_found">Xeta: Dosyaya ZIMia weçinıtiye nêvêniye.</string>
+  <string name="error_file_not_found">Xeta: Dosyaya ZIMia weçinıtiye nêvêniye. %s</string>
   <string name="zim_not_opened" fuzzy="true">Dosyay Zimi nêabiyena</string>
-  <string name="error_file_invalid">Xeta: Dosyaya weçinıtiye yew dosyaya ZIMia vêrdiye niya.</string>
+  <string name="error_file_invalid">Xeta: Dosyaya weçinıtiye yew dosyaya ZIMia vêrdiye niya. %s</string>
   <string name="error_article_url_not_found">Xeta: Barkerdışê meqaleyê (Url: %1$s) nêbi.</string>
   <string name="pref_display_title">Bımocne</string>
   <string name="pref_info_title">Melumat</string>

--- a/core/src/main/res/values-el/strings.xml
+++ b/core/src/main/res/values-el/strings.xml
@@ -51,9 +51,9 @@
   <string name="start_server_label">Έναρξη διακομιστή</string>
   <string name="stop_server_label">Τερματισμός διακομιστή</string>
   <string name="server_started_message">Εισάγετε την διεύθυνση ip στον περιηγητής σας, για πρόσβαση στον διακομιστή %s</string>
-  <string name="error_file_not_found">Σφάλμα: Το επιλεγμένο ZIM αρχείο δεν μπόρεσε να βρεθεί.</string>
+  <string name="error_file_not_found">Σφάλμα: Το επιλεγμένο ZIM αρχείο δεν μπόρεσε να βρεθεί. %s</string>
   <string name="zim_not_opened" fuzzy="true">Δεν μπόρεσε να ανοιχθεί το αρχείο zim</string>
-  <string name="error_file_invalid">Σφάλμα: Το επιλεγμένο αρχείο δεν είναι έγκυρο αρχείο ZIM.</string>
+  <string name="error_file_invalid">Σφάλμα: Το επιλεγμένο αρχείο δεν είναι έγκυρο αρχείο ZIM. %s</string>
   <string name="error_article_url_not_found">Σφάλμα:το Ανέβασμα του λήμματος (Url: %1$s) απέτυχε.</string>
   <string name="pref_display_title">Εμφάνιση</string>
   <string name="pref_info_title">Πληροφορίες</string>

--- a/core/src/main/res/values-eo/strings.xml
+++ b/core/src/main/res/values-eo/strings.xml
@@ -31,8 +31,8 @@
   <string name="choose_file">Elektu Dosieron de Enhavo (*.zim)</string>
   <string name="open_in_new_tab">Ĉu malfermi ligilon en nova langeto?</string>
   <string name="hotspot_dialog_neutral_button">DAŬRIGI</string>
-  <string name="error_file_not_found">Eraro: Ne eblis trovi la elektitan ZIM-dosieron.</string>
-  <string name="error_file_invalid">Eraro: La elektita dosiero ne estas valida ZIM-dosiero.</string>
+  <string name="error_file_not_found">Eraro: Ne eblis trovi la elektitan ZIM-dosieron. %s</string>
+  <string name="error_file_invalid">Eraro: La elektita dosiero ne estas valida ZIM-dosiero. %s</string>
   <string name="error_article_url_not_found">Eraro: Ŝargado de la artikolo (Url: %1$s) fiaskis.</string>
   <string name="pref_display_title">Montrado</string>
   <string name="pref_info_title">Informo</string>

--- a/core/src/main/res/values-es/strings.xml
+++ b/core/src/main/res/values-es/strings.xml
@@ -77,10 +77,10 @@
   <string name="server_started_message">Introduce esta dirección IP en tu navegador para acceder al servidor %s</string>
   <string name="qr_code">Código QR renderizado</string>
   <string name="share_host_address">Compartir URL a través de otras aplicaciones</string>
-  <string name="error_file_not_found">Error: no se encontró el archivo ZIM seleccionado.</string>
+  <string name="error_file_not_found">Error: no se encontró el archivo ZIM seleccionado. %s</string>
   <string name="unable_to_read_zim_file">¡No se puede leer este archivo zim!</string>
   <string name="zim_not_opened">No se pudo abrir el archivo .zim</string>
-  <string name="error_file_invalid">Error: el archivo seleccionado no es un archivo ZIM válido.</string>
+  <string name="error_file_invalid">Error: el archivo seleccionado no es un archivo ZIM válido. %s</string>
   <string name="error_article_url_not_found">Error: falló la carga del artículo (URL: %1$s).</string>
   <string name="pref_display_title">Mostrar</string>
   <string name="pref_info_title">Información</string>

--- a/core/src/main/res/values-eu/strings.xml
+++ b/core/src/main/res/values-eu/strings.xml
@@ -62,10 +62,10 @@
   <string name="server_started_message">Sartu IP helbide hau arakatzailean %s zerbitzaria atzitzeko.</string>
   <string name="qr_code">Errendaturiko QR kodea</string>
   <string name="share_host_address">Partekatu URLa beste aplikazioen bitartez</string>
-  <string name="error_file_not_found">Akatsa: Hautatutako ZIM artxiboa ezin izan da aurkitu.</string>
+  <string name="error_file_not_found">Akatsa: Hautatutako ZIM artxiboa ezin izan da aurkitu. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Ezin da irakurri ZIM fitxategi hau.</string>
   <string name="zim_not_opened" fuzzy="true">Ezin da ireki ZIM fitxategia</string>
-  <string name="error_file_invalid">Akatsa: Hautatutako artikulua ez da baliozko ZIM artxiboa.</string>
+  <string name="error_file_invalid">Akatsa: Hautatutako artikulua ez da baliozko ZIM artxiboa. %s</string>
   <string name="error_article_url_not_found">Akatsa: (Url: %1$s) artikuluaren kargatzea eten da.</string>
   <string name="pref_display_title">Erakutsi</string>
   <string name="pref_info_title">Informazioa</string>

--- a/core/src/main/res/values-fa/strings.xml
+++ b/core/src/main/res/values-fa/strings.xml
@@ -32,8 +32,8 @@
   <string name="open_in_new_tab">بازکردن پیوند در زبانهٔ جدید؟</string>
   <string name="go_to_wifi_settings_label">برو به تنظیمات وای‌فای</string>
   <string name="no_books_selected_toast_message">لطفاً نخست کتاب‌ها را انتخاب کنید</string>
-  <string name="error_file_not_found">خطا: پروندهٔ ZIM انتخاب شده پیدا نشد.</string>
-  <string name="error_file_invalid">خطا: پروندهٔ انتخاب‌شده یک پروندهٔ ZIM معتبر نیست.</string>
+  <string name="error_file_not_found">خطا: پروندهٔ ZIM انتخاب شده پیدا نشد. %s</string>
+  <string name="error_file_invalid">خطا: پروندهٔ انتخاب‌شده یک پروندهٔ ZIM معتبر نیست. %s</string>
   <string name="error_article_url_not_found">حطا: بارگیری مقالهٔ (نشانی: %1$s) شکست خورد.</string>
   <string name="pref_display_title">نمایش</string>
   <string name="pref_info_title">اطلاعات</string>

--- a/core/src/main/res/values-fi/strings.xml
+++ b/core/src/main/res/values-fi/strings.xml
@@ -47,10 +47,10 @@
   <string name="start_server_label">Käynnistä palvelin</string>
   <string name="stop_server_label">Pysäytä palvelin</string>
   <string name="error_ip_address_not_found">IP-osoitetta ei löytynyt.</string>
-  <string name="error_file_not_found">Virhe: valittua ZIM-tiedostoa ei löytynyt.</string>
+  <string name="error_file_not_found">Virhe: valittua ZIM-tiedostoa ei löytynyt. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Zim-tiedostoa ei voitu lukea!</string>
   <string name="zim_not_opened" fuzzy="true">Zim-tiedostoa ei voi avata</string>
-  <string name="error_file_invalid">Virhe: valittu tiedosto ei ole kelvollinen ZIM-tiedosto.</string>
+  <string name="error_file_invalid">Virhe: valittu tiedosto ei ole kelvollinen ZIM-tiedosto. %s</string>
   <string name="error_article_url_not_found">Virhe: Artikkelin (Url: %1$s) lataus epäonnistui.</string>
   <string name="pref_display_title">Näytä</string>
   <string name="pref_info_title">Tiedot</string>

--- a/core/src/main/res/values-fr/strings.xml
+++ b/core/src/main/res/values-fr/strings.xml
@@ -82,10 +82,10 @@
   <string name="server_started_message">Entrez cette adresse IP dans votre navigateur pour accéder au serveur %s</string>
   <string name="qr_code">Rendu du QR Code</string>
   <string name="share_host_address">Partager l’URL via d’autres applications</string>
-  <string name="error_file_not_found">Erreur : le fichier ZIM sélectionné est introuvable.</string>
+  <string name="error_file_not_found">Erreur : le fichier ZIM sélectionné est introuvable. %s</string>
   <string name="unable_to_read_zim_file">Impossible de lire ce fichier ZIM !</string>
   <string name="zim_not_opened">Impossible d’ouvrir le fichier ZIM</string>
-  <string name="error_file_invalid">Erreur : le fichier sélectionné n’est pas un fichier ZIM valide.</string>
+  <string name="error_file_invalid">Erreur : le fichier sélectionné n’est pas un fichier ZIM valide. %s</string>
   <string name="error_article_url_not_found">Erreur : le chargement de l’article (URL : %1$s) a échoué.</string>
   <string name="pref_display_title">Affichage</string>
   <string name="pref_info_title">Informations</string>

--- a/core/src/main/res/values-gl/strings.xml
+++ b/core/src/main/res/values-gl/strings.xml
@@ -25,8 +25,8 @@
   <string name="search_label">Procurar</string>
   <string name="choose_file">Seleccione un ficheiro de contido (*.zim)</string>
   <string name="open_in_new_tab">Quere abrir a ligazón nunha nova lapela?</string>
-  <string name="error_file_not_found">Erro: Non se puido atopar o ficheiro ZIM seleccionado.</string>
-  <string name="error_file_invalid">Erro: O ficheiro seleccionado non é un ficheiro ZIM válido.</string>
+  <string name="error_file_not_found">Erro: Non se puido atopar o ficheiro ZIM seleccionado. %s</string>
+  <string name="error_file_invalid">Erro: O ficheiro seleccionado non é un ficheiro ZIM válido. %s</string>
   <string name="error_article_url_not_found">Erro: Non se puido cargar o artigo (URL: %1$s).</string>
   <string name="pref_display_title">Visualización</string>
   <string name="pref_info_title">Información</string>

--- a/core/src/main/res/values-gpe/strings.xml
+++ b/core/src/main/res/values-gpe/strings.xml
@@ -53,10 +53,10 @@
   <string name="error_ip_address_not_found">Eno fi find ip address.</string>
   <string name="server_started_message">Make you Enter dis ip address for your browser insyd so say you go fi access de server %s</string>
   <string name="share_host_address">Make you Share URL via oda applications</string>
-  <string name="error_file_not_found">Error: Eno fi find de selected ZIM file.</string>
+  <string name="error_file_not_found">Error: Eno fi find de selected ZIM file. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Eno fi read dis zim file!</string>
   <string name="zim_not_opened" fuzzy="true">Eno fi open zim file</string>
-  <string name="error_file_invalid">Error: De file wey you select no be valid ZIM file.</string>
+  <string name="error_file_invalid">Error: De file wey you select no be valid ZIM file. %s</string>
   <string name="error_article_url_not_found">Error: Loading article (Url: %1$s) fail.</string>
   <string name="pref_display_title">Display</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-gsw/strings.xml
+++ b/core/src/main/res/values-gsw/strings.xml
@@ -43,9 +43,9 @@
   <string name="start_server_label">Server schtartä</string>
   <string name="stop_server_label">Server schtoppe</string>
   <string name="server_started_message">Gäbed Si diä IP Adrässe i ihräm Browser i um uf de Server %s zuezgrifä</string>
-  <string name="error_file_not_found">Fehler: Di usgwählti ZIM-Datei isch nit gfunde worde.</string>
+  <string name="error_file_not_found">Fehler: Di usgwählti ZIM-Datei isch nit gfunde worde. %s</string>
   <string name="zim_not_opened" fuzzy="true">Cha zim Datei nid uftue</string>
-  <string name="error_file_invalid">Fehler: Di usgwählti Datei isch chei gültigi ZIM-Datei.</string>
+  <string name="error_file_invalid">Fehler: Di usgwählti Datei isch chei gültigi ZIM-Datei. %s</string>
   <string name="error_article_url_not_found">Fehler: S’ Lade vom Artikel (URL: %1$s) het nit gchlappt.</string>
   <string name="pref_display_title">Azeig</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-gu/strings.xml
+++ b/core/src/main/res/values-gu/strings.xml
@@ -16,8 +16,8 @@
   <string name="search_label">શોધો</string>
   <string name="choose_file" fuzzy="true">ZIM માહિતી ફાઇલ (*.zim) પસંદ કરો</string>
   <string name="open_in_new_tab">કડી નવી ટેબમાં ખોલશો?</string>
-  <string name="error_file_not_found">ક્ષતિ: પસંદ કરેલ ZIM ફાઇલ મળી શકી નહી.</string>
-  <string name="error_file_invalid">ક્ષતિ: પસંદ કરેલ ફાઇલ યોગ્ય ZIM ફાઇલ નથી.</string>
+  <string name="error_file_not_found">ક્ષતિ: પસંદ કરેલ ZIM ફાઇલ મળી શકી નહી. %s</string>
+  <string name="error_file_invalid">ક્ષતિ: પસંદ કરેલ ફાઇલ યોગ્ય ZIM ફાઇલ નથી. %s</string>
   <string name="error_article_url_not_found">ક્ષતિ: લેખ (Url: %1$s) લાવવાનું નિષ્ફળ થયું.</string>
   <string name="pref_display_title">દર્શાવો</string>
   <string name="pref_info_title">માહિતી</string>

--- a/core/src/main/res/values-ha/strings.xml
+++ b/core/src/main/res/values-ha/strings.xml
@@ -56,10 +56,10 @@
   <string name="error_ip_address_not_found">An kasa samun ip address.</string>
   <string name="server_started_message">Shigar da wannan adireshin ip a cikin burauzarka don samun damar sabar %s</string>
   <string name="share_host_address">Raba URL ta hanyar wasu aikace-aikace</string>
-  <string name="error_file_not_found">Kuskure: Ba a iya samun fayil din ZIM da aka zaba ba</string>
+  <string name="error_file_not_found">Kuskure: Ba a iya samun fayil din ZIM da aka zaba ba %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">An kasa karanta wannan fayil na zim!</string>
   <string name="zim_not_opened" fuzzy="true">An kasa buɗe fayil na zim</string>
-  <string name="error_file_invalid">Kuskure: Fayil ɗin da aka zaɓa ba ingantaccen fayil na ZIM bane.</string>
+  <string name="error_file_invalid">Kuskure: Fayil ɗin da aka zaɓa ba ingantaccen fayil na ZIM bane. %s</string>
   <string name="error_article_url_not_found">Kuskure: Loading labarin (Url: %1$s) ya gaza</string>
   <string name="pref_display_title">Nunawa</string>
   <string name="pref_info_title">Bayani</string>

--- a/core/src/main/res/values-hi/strings.xml
+++ b/core/src/main/res/values-hi/strings.xml
@@ -60,10 +60,10 @@
   <string name="stop_server_label">सर्वर बंद करें।</string>
   <string name="server_started_message">सर्वर %s प्रयोग करने के लिए इस आईपी पते को अपने ब्राउज़र में दर्ज करें</string>
   <string name="share_host_address">अन्य एप्लिकेशन के माध्यम से यूआरएल साझा करें</string>
-  <string name="error_file_not_found">त्रुटि: चुनी गयी ZIM फ़ाइल नही मिल सकी।</string>
+  <string name="error_file_not_found">त्रुटि: चुनी गयी ZIM फ़ाइल नही मिल सकी। %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">इस ज़िम फ़ाइल को पढ़ने में असमर्थ!</string>
   <string name="zim_not_opened" fuzzy="true">ज़िम फ़ाइल खोलने में असमर्थ</string>
-  <string name="error_file_invalid">त्रुटि: चुनी गयी फ़ाइल एक वैध ZIM फ़ाइल नहीं है।</string>
+  <string name="error_file_invalid">त्रुटि: चुनी गयी फ़ाइल एक वैध ZIM फ़ाइल नहीं है। %s</string>
   <string name="error_article_url_not_found">त्रुटि: आलेख (Url:  %1$s ) लोड करना विफल रहा।</string>
   <string name="pref_display_title">प्रदर्शन</string>
   <string name="pref_info_title">जानकारी</string>

--- a/core/src/main/res/values-hu/strings.xml
+++ b/core/src/main/res/values-hu/strings.xml
@@ -33,8 +33,8 @@
   <string name="choose_file">Tartalomfájl kiválasztása (*.zim)</string>
   <string name="open_in_new_tab">Hivatkozás megnyitása új lapon?</string>
   <string name="connection_refused">Csatlakozás elutasítva.</string>
-  <string name="error_file_not_found">Hiba: A kijelölt ZIM-fájl nem található.</string>
-  <string name="error_file_invalid">Hiba: A kijelölt fájl nem érvényes ZIM-fájl.</string>
+  <string name="error_file_not_found">Hiba: A kijelölt ZIM-fájl nem található. %s</string>
+  <string name="error_file_invalid">Hiba: A kijelölt fájl nem érvényes ZIM-fájl. %s</string>
   <string name="error_article_url_not_found">Hiba: A cikk (URL: %1$s) betöltése nem sikerült.</string>
   <string name="pref_display_title">Megjelenítés</string>
   <string name="pref_info_title">Információ</string>

--- a/core/src/main/res/values-ia/strings.xml
+++ b/core/src/main/res/values-ia/strings.xml
@@ -56,10 +56,10 @@
   <string name="server_started_message">Entra iste adresse IP in tu navigator pro acceder al servitor %s</string>
   <string name="qr_code">Codice QR rendite</string>
   <string name="share_host_address">Condivider le URL via altere applicationes</string>
-  <string name="error_file_not_found">Error: Le file ZIM seligite non poteva esser trovate.</string>
+  <string name="error_file_not_found">Error: Le file ZIM seligite non poteva esser trovate. %s</string>
   <string name="unable_to_read_zim_file">Impossibile leger iste file ZIM!</string>
   <string name="zim_not_opened">Impossibile aperir le file ZIM</string>
-  <string name="error_file_invalid">Error: Le file seligite non es un file ZIM valide.</string>
+  <string name="error_file_invalid">Error: Le file seligite non es un file ZIM valide. %s</string>
   <string name="error_article_url_not_found">Error: Le cargamento del articulo (Url: %1$s) ha fallite.</string>
   <string name="pref_display_title">Visualisation</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-ig/strings.xml
+++ b/core/src/main/res/values-ig/strings.xml
@@ -61,10 +61,10 @@
   <string name="server_started_message">Tinye adreesị IP a n’ime ihe nchọgharị gị iji nweta ihe nkesa %s</string>
   <string name="qr_code">Emepụtara Koodu QR</string>
   <string name="share_host_address">Kesaa URL site na ngwa ndị ọzọ</string>
-  <string name="error_file_not_found">Njehie: Enweghi ike ịchọta faịlụ ZIM ahọpụtara.</string>
+  <string name="error_file_not_found">Njehie: Enweghi ike ịchọta faịlụ ZIM ahọpụtara. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Enweghị ike ịgụ faịlụ zim a!</string>
   <string name="zim_not_opened" fuzzy="true">Enweghị ike imepe faịlụ zim</string>
-  <string name="error_file_invalid">Njehie: faịlụ ahọpụtara abụghị faịlụ ZIM ziri ezi.</string>
+  <string name="error_file_invalid">Njehie: faịlụ ahọpụtara abụghị faịlụ ZIM ziri ezi. %s</string>
   <string name="error_article_url_not_found">Njehie: Ịbute akụkọ (URl: %1$s ) dara.</string>
   <string name="pref_display_title">Ngosipụta</string>
   <string name="pref_info_title">Ozi</string>

--- a/core/src/main/res/values-igl/strings.xml
+++ b/core/src/main/res/values-igl/strings.xml
@@ -55,10 +55,10 @@
   <string name="error_ip_address_not_found">Ineke li IP address no</string>
   <string name="server_started_message">Dí únyí kí ip dë tefú ẹnwú ķẹdú búraúze atodú kẹneke lotígbo ẹńwú agbúćhẹ dẹ %s</string>
   <string name="share_host_address">Kpí URL pkáyí ápplícásiọn omúnẹ</string>
-  <string name="error_file_not_found">Faìlú: ZIM mádú málíñ úgbodúń</string>
+  <string name="error_file_not_found">Faìlú: ZIM mádú málíñ úgbodúń %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Ineke gbi Zim file no</string>
   <string name="zim_not_opened" fuzzy="true">Unekén bi Zim filuñ</string>
-  <string name="error_file_invalid">Inyọno: File kẹtu chi Zim file Kuma dẹn</string>
+  <string name="error_file_invalid">Inyọno: File kẹtu chi Zim file Kuma dẹn %s</string>
   <string name="pref_display_title">Dutẹ</string>
   <string name="pref_info_title">Inabali</string>
   <string name="pref_info_version">Enwñ ojioji</string>

--- a/core/src/main/res/values-in/strings.xml
+++ b/core/src/main/res/values-in/strings.xml
@@ -64,10 +64,10 @@
   <string name="server_started_message">Masukkan alamat IP ini ke browser Anda untuk mengakses server %s</string>
   <string name="qr_code">Kode QR yang Dirender</string>
   <string name="share_host_address">Bagikan URL melalui aplikasi lain</string>
-  <string name="error_file_not_found">Galat: Berkas ZIM yang dipilih tidak ditemukan.</string>
+  <string name="error_file_not_found">Galat: Berkas ZIM yang dipilih tidak ditemukan. %s</string>
   <string name="unable_to_read_zim_file">Tidak bisa membaca berkas ZIM ini!</string>
   <string name="zim_not_opened">ZIM file tidak dapat dibuka</string>
-  <string name="error_file_invalid">Galat: Berkas yang dipilih bukan berkas ZIM yang sah.</string>
+  <string name="error_file_invalid">Galat: Berkas yang dipilih bukan berkas ZIM yang sah. %s</string>
   <string name="error_article_url_not_found">Galat: Pemuatan artikel (Url: %1$s) gagal.</string>
   <string name="pref_display_title">Tampilan</string>
   <string name="pref_info_title">Informasi</string>

--- a/core/src/main/res/values-it/strings.xml
+++ b/core/src/main/res/values-it/strings.xml
@@ -64,10 +64,10 @@
   <string name="server_started_message">Inserisci questo indirizzo IP nel tuo browser per accedere al server: %s</string>
   <string name="qr_code">Codice QR renderizzato</string>
   <string name="share_host_address">Condividi URL con altre applicazioni</string>
-  <string name="error_file_not_found">Errore: il file ZIM selezionato non è stato trovato.</string>
+  <string name="error_file_not_found">Errore: il file ZIM selezionato non è stato trovato. %s</string>
   <string name="unable_to_read_zim_file">Impossibile leggere questo file ZIM!</string>
   <string name="zim_not_opened">Impossibile aprire il file ZIM</string>
-  <string name="error_file_invalid">Errore: il file selezionato non è un file ZIM valido.</string>
+  <string name="error_file_invalid">Errore: il file selezionato non è un file ZIM valido. %s</string>
   <string name="error_article_url_not_found">Errore: caricamento della voce (URL: %1$s) non riuscito.</string>
   <string name="pref_display_title">Aspetto</string>
   <string name="pref_info_title">Informazioni</string>

--- a/core/src/main/res/values-iw/strings.xml
+++ b/core/src/main/res/values-iw/strings.xml
@@ -61,10 +61,10 @@
   <string name="server_started_message">יש להזין את כתובת ה־IP הזאת לדפדפן שלך כדי לגשת לשרת %s</string>
   <string name="qr_code">קוד QR מתוצג</string>
   <string name="share_host_address">שיתוף URL דרך יישומים אחרים</string>
-  <string name="error_file_not_found">שגיאה: קובץ ה־ZIM שנבחר לא נמצא.</string>
+  <string name="error_file_not_found">%s שגיאה: קובץ ה־ZIM שנבחר לא נמצא.</string>
   <string name="unable_to_read_zim_file">לא ניתן לקרוא מקובץ ה־ZIM הזה!</string>
   <string name="zim_not_opened">לא ניתן לפתוח את קובץ ה־ZIM</string>
-  <string name="error_file_invalid">שגיאה: הקובץ שנבחר אינו קובץ ZIM תקין.</string>
+  <string name="error_file_invalid">שגיאה: הקובץ שנבחר אינו קובץ ZIM תקין. %s</string>
   <string name="error_article_url_not_found">שגיאה: טעינת הערך נכשלה (כתובת: %1$s).</string>
   <string name="pref_display_title">תצוגה</string>
   <string name="pref_info_title">מידע</string>

--- a/core/src/main/res/values-ja/strings.xml
+++ b/core/src/main/res/values-ja/strings.xml
@@ -62,10 +62,10 @@
   <string name="error_ip_address_not_found">IPアドレスが見つかりませんでした。</string>
   <string name="server_started_message">サーバー %s にアクセスするには、この IP アドレスをブラウザに入力してください</string>
   <string name="share_host_address">他のアプリケーション経由で URL を共有する</string>
-  <string name="error_file_not_found">エラー: 選択した ZIM ファイルが見つかりませんでした。</string>
+  <string name="error_file_not_found">エラー: 選択した ZIM ファイルが見つかりませんでした。 %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">この zim ファイルは読み込めません！</string>
   <string name="zim_not_opened" fuzzy="true">zim ファイルを開けません</string>
-  <string name="error_file_invalid">エラー: 選択したファイルは有効な ZIM ファイルではありません。</string>
+  <string name="error_file_invalid">エラー: 選択したファイルは有効な ZIM ファイルではありません。 %s</string>
   <string name="error_article_url_not_found">エラー: 記事 (URL: %1$s) を読み込めませんでした。</string>
   <string name="pref_display_title">表示</string>
   <string name="pref_info_title">情報</string>

--- a/core/src/main/res/values-ka/strings.xml
+++ b/core/src/main/res/values-ka/strings.xml
@@ -22,8 +22,8 @@
   <string name="search_label">ძიება</string>
   <string name="choose_file" fuzzy="true">აირჩიეთ ZIM-ფაილი (*.zim)</string>
   <string name="open_in_new_tab">ბმული ახალ ჩანართში გაიხსნას?</string>
-  <string name="error_file_not_found">შეცდომა: არჩეული ZIM ფაილი ვერ მოიძებნა.</string>
-  <string name="error_file_invalid">შეცდომა: არჩეული ფაილი არ არის სწორი ZIM ფაილი.</string>
+  <string name="error_file_not_found">შეცდომა: არჩეული ZIM ფაილი ვერ მოიძებნა. %s</string>
+  <string name="error_file_invalid">შეცდომა: არჩეული ფაილი არ არის სწორი ZIM ფაილი. %s</string>
   <string name="error_article_url_not_found">შეცდომა: სტატია (Url: %1$s) ვერ ჩაიტვირთა.</string>
   <string name="pref_display_title">ჩვენება</string>
   <string name="pref_info_title">ინფორმაცია</string>

--- a/core/src/main/res/values-km/strings.xml
+++ b/core/src/main/res/values-km/strings.xml
@@ -16,8 +16,8 @@
   <string name="search_label">ស្វែងរក</string>
   <string name="choose_file" fuzzy="true">ជ្រើសរើសឯកសារមាតិកា ZIM (*.zim)</string>
   <string name="open_in_new_tab">បើក​តំណ​ក្នុង​ផ្ទាំង​ថ្មី?</string>
-  <string name="error_file_not_found">កំហុស៖ ឯកសារ ZIM ដែលបានជ្រើសនេះ រកមិនឃើញទេ។</string>
-  <string name="error_file_invalid">កំហុស៖ ឯកសារ ZIM ដែលបានជ្រើសនេះ មិនមែនជាឯកសារ ZIM ត្រឹមត្រូវ។</string>
+  <string name="error_file_not_found">កំហុស៖ ឯកសារ ZIM ដែលបានជ្រើសនេះ រកមិនឃើញទេ។ %s</string>
+  <string name="error_file_invalid">កំហុស៖ ឯកសារ ZIM ដែលបានជ្រើសនេះ មិនមែនជាឯកសារ ZIM ត្រឹមត្រូវ។ %s</string>
   <string name="error_article_url_not_found">កំហុស៖ ទាញយកអត្ថបទ (Url: %1$s) បានបរាជ័យ។</string>
   <string name="pref_display_title">ការ​បង្ហាញ</string>
   <string name="pref_info_title">ព័ត៌មាន</string>

--- a/core/src/main/res/values-kn/strings.xml
+++ b/core/src/main/res/values-kn/strings.xml
@@ -34,7 +34,7 @@
   <string name="hotspot_running">ಹಾಟ್‌ಸ್ಪಾಟ್ ರನ್ ಆಗುತ್ತಿದೆ</string>
   <string name="no_books_selected_toast_message">ದಯವಿಟ್ಟು ಮೊದಲು ಪುಸ್ತಕಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
   <string name="hotspot_dialog_neutral_button">ಮುಂದುವರಿಸಿ</string>
-  <string name="error_file_invalid">ದೋಷ: ಆರಿಸಿದ ಫೈಲು ಸರಿಯಾದ ZIM ಫೈಲು ಅಲ್ಲ</string>
+  <string name="error_file_invalid">ದೋಷ: ಆರಿಸಿದ ಫೈಲು ಸರಿಯಾದ ZIM ಫೈಲು ಅಲ್ಲ %s</string>
   <string name="error_article_url_not_found">ದೋಷ: ಲೇಖನ (Url: %1$s) ತರುವುದು ವಿಫಲವಾಗಿದೆ.</string>
   <string name="pref_display_title">ಪ್ರದರ್ಶಿಸು</string>
   <string name="pref_info_title">ಮಾಹಿತಿ</string>

--- a/core/src/main/res/values-ko/strings.xml
+++ b/core/src/main/res/values-ko/strings.xml
@@ -69,10 +69,10 @@
   <string name="server_started_message">%s 서버에 접속하려면 브라우저에 이 IP 주소를 입력하십시오</string>
   <string name="qr_code">표시된 QR 코드</string>
   <string name="share_host_address">다른 애플리케이션을 통해 URL 공유</string>
-  <string name="error_file_not_found">오류: 선택된 ZIM 파일을 찾을 수 없습니다.</string>
+  <string name="error_file_not_found">오류: 선택된 ZIM 파일을 찾을 수 없습니다. %s</string>
   <string name="unable_to_read_zim_file">이 ZIM 파일을 읽을 수 없습니다!</string>
   <string name="zim_not_opened">ZIM 파일을 열 수 없습니다</string>
-  <string name="error_file_invalid">오류: 선택한 파일은 올바른 ZIM 파일이 아닙니다.</string>
+  <string name="error_file_invalid">오류: 선택한 파일은 올바른 ZIM 파일이 아닙니다. %s</string>
   <string name="error_article_url_not_found">오류: 문서(Url: %1$s)를 불러오는 데 실패했습니다.</string>
   <string name="pref_display_title">표시</string>
   <string name="pref_info_title">정보</string>

--- a/core/src/main/res/values-ku/strings.xml
+++ b/core/src/main/res/values-ku/strings.xml
@@ -53,10 +53,10 @@
   <string name="stop_server_label">Serverê bide sekinandin</string>
   <string name="server_started_message">Vê adresa IPyê di geroka xwe de binivîsîne ji bo ku xwe bigihînî servera %s</string>
   <string name="share_host_address">URLyê bi riya sepanên din parve bike</string>
-  <string name="error_file_not_found">Çewtîː Peldanka ZIM’ê ya bijartî nehate dîtin.</string>
+  <string name="error_file_not_found">Çewtîː Peldanka ZIM’ê ya bijartî nehate dîtin. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Nebû ku vê dosyeya zimê bixwîne!</string>
   <string name="zim_not_opened" fuzzy="true">Nikare dosyeya zim-ê veke</string>
-  <string name="error_file_invalid">Çewtîː Peldanka bijartî ne peldankeke ZIMê ya derbasdar e.</string>
+  <string name="error_file_invalid">Çewtîː Peldanka bijartî ne peldankeke ZIMê ya derbasdar e. %s</string>
   <string name="error_article_url_not_found">Çewtîː Barkirina gotara (Url: %1$s) têk çû.</string>
   <string name="pref_display_title">Nîşan bide</string>
   <string name="pref_info_title">Agahî</string>

--- a/core/src/main/res/values-lb/strings.xml
+++ b/core/src/main/res/values-lb/strings.xml
@@ -44,10 +44,10 @@
   <string name="error_ip_address_not_found">IP-Adress konnt net fonnt ginn.</string>
   <string name="server_started_message">Gitt dës IP-Adress an Äre Browser a fir op de Server %s zouzegräifen</string>
   <string name="share_host_address">URL mat aneren Applikatiounen deelen</string>
-  <string name="error_file_not_found">Feeler: Déi ausgewielten ZIM-Datei konnt net fonnt ginn.</string>
+  <string name="error_file_not_found">Feeler: Déi ausgewielten ZIM-Datei konnt net fonnt ginn. %s</string>
   <string name="unable_to_read_zim_file">Dëse ZIM-Fichier konnt net gelies ginn!</string>
   <string name="zim_not_opened">De ZIM-Fichier konnt net opgemaach ginn</string>
-  <string name="error_file_invalid">Feeler: Déi ausgewielten Datei ass keng gülteg ZIM-Datei.</string>
+  <string name="error_file_invalid">Feeler: Déi ausgewielten Datei ass keng gülteg ZIM-Datei. %s</string>
   <string name="error_article_url_not_found">Feeler: D’Luede vum Artikel (URL: %1$s) huet net funktionéiert.</string>
   <string name="pref_display_title">Weisen</string>
   <string name="pref_info_title">Informatioun</string>

--- a/core/src/main/res/values-li/strings.xml
+++ b/core/src/main/res/values-li/strings.xml
@@ -17,8 +17,8 @@
   <string name="search_label">Zeuk</string>
   <string name="choose_file">Sillekteer ’n Inhawdsbestandj (*.zim)</string>
   <string name="open_in_new_tab">Äöpen link in nuuj tabblaad?</string>
-  <string name="error_file_not_found">Fout: ’t geselecteerd ZIM-bestandj kós neet waere gevónje.</string>
-  <string name="error_file_invalid">Fout: ’t geselecteerd bestandj is gei geldig ZIM-bestandj.</string>
+  <string name="error_file_not_found">Fout: ’t geselecteerd ZIM-bestandj kós neet waere gevónje. %s</string>
+  <string name="error_file_invalid">Fout: ’t geselecteerd bestandj is gei geldig ZIM-bestandj. %s</string>
   <string name="error_article_url_not_found">Fout: ’t laje van de pagina (URL: %1$s) is mislök.</string>
   <string name="pref_display_title">Waergaaf</string>
   <string name="pref_info_title">Infermasie</string>

--- a/core/src/main/res/values-ln/strings.xml
+++ b/core/src/main/res/values-ln/strings.xml
@@ -52,10 +52,10 @@
   <string name="error_ip_address_not_found">Nakokaki te kozwa adrɛsi ya IP.</string>
   <string name="server_started_message">Tyá adresi IP oyo na navigateur na yo mpo na kokɔta na serveur %s</string>
   <string name="share_host_address">Kabola URL na nzela ya ba applications misusu</string>
-  <string name="error_file_not_found">Mabunga: Fisyé ZIM oyo oponi ezwami te.</string>
+  <string name="error_file_not_found">Mabunga: Fisyé ZIM oyo oponi ezwami te. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Epesameli nzela te ya kotanga fisyé ZIM oyo!</string>
   <string name="zim_not_opened" fuzzy="true">Ekoki te kofungola fisyé ZIM</string>
-  <string name="error_file_invalid">Libunga: Fisyé oyo oponi ezali fisyé ZIM ya malamu te.</string>
+  <string name="error_file_invalid">Libunga: Fisyé oyo oponi ezali fisyé ZIM ya malamu te. %s</string>
   <string name="error_article_url_not_found">Libunga: Kokɔtisa lisolo (Url: %1$s ) elongi te.</string>
   <string name="pref_display_title">Kolakisa</string>
   <string name="pref_info_title">Nsango</string>

--- a/core/src/main/res/values-lt/strings.xml
+++ b/core/src/main/res/values-lt/strings.xml
@@ -26,8 +26,8 @@
   <string name="choose_file" fuzzy="true">Pasirinkite ZIM Turinio Failą (*.zim)</string>
   <string name="open_in_new_tab">Atidaryti nuorodą naujame skirtuke?</string>
   <string name="stop_server_label">Sustabdyti serverį</string>
-  <string name="error_file_not_found">Klaida: pasirinktas ZIM failas nerastas.</string>
-  <string name="error_file_invalid">Klaida: pasirinktas failas nėra galiojantis ZIM failas.</string>
+  <string name="error_file_not_found">Klaida: pasirinktas ZIM failas nerastas. %s</string>
+  <string name="error_file_invalid">Klaida: pasirinktas failas nėra galiojantis ZIM failas. %s</string>
   <string name="error_article_url_not_found">Klaida: nepavyko įkelti straipsnio (Url: %1$s).</string>
   <string name="pref_display_title">Rodyti</string>
   <string name="pref_info_title">Informacija</string>

--- a/core/src/main/res/values-mg/strings.xml
+++ b/core/src/main/res/values-mg/strings.xml
@@ -20,8 +20,8 @@
   <string name="search_label">Hikaroka</string>
   <string name="choose_file" fuzzy="true">Hisafidy rakitra misy votoatiny (*.zim)</string>
   <string name="open_in_new_tab">Hanokatra rohy anaty sasa-joro vaovao?</string>
-  <string name="error_file_not_found">Hadisoana: Tsy nahita ilay rakitra ZIM voafidinao.</string>
-  <string name="error_file_invalid">Hadisoana: Rakitra ZIM tsy azo raisina ilay voafidinao.</string>
+  <string name="error_file_not_found">Hadisoana: Tsy nahita ilay rakitra ZIM voafidinao. %s</string>
+  <string name="error_file_invalid">Hadisoana: Rakitra ZIM tsy azo raisina ilay voafidinao. %s</string>
   <string name="error_article_url_not_found">Hadisoana: tsy nahafahana ilay lahatsoratra (Url: %1$s).</string>
   <string name="pref_display_title">Fiseho</string>
   <string name="pref_info_title">Fampahalalana</string>

--- a/core/src/main/res/values-mk/strings.xml
+++ b/core/src/main/res/values-mk/strings.xml
@@ -54,10 +54,10 @@
   <string name="server_started_message">Внесете ја оваа IP-адреса во прелистувачот за да пристапите на опслужувачот %s</string>
   <string name="qr_code">Испишан QR-код</string>
   <string name="share_host_address">Сподели URL преку други прилози</string>
-  <string name="error_file_not_found">Грешка: Не ја најдов избраната ZIM-податотека.</string>
+  <string name="error_file_not_found">Грешка: Не ја најдов избраната ZIM-податотека. %s</string>
   <string name="unable_to_read_zim_file">Не можам да ја прочитам оваа ZIM-податотека!</string>
   <string name="zim_not_opened">Не можам да ја отворам ZIM-податотеката</string>
-  <string name="error_file_invalid">Грешка: Одбраната податотека не е вежачка ZIM-податотека.</string>
+  <string name="error_file_invalid">Грешка: Одбраната податотека не е вежачка ZIM-податотека. %s</string>
   <string name="error_article_url_not_found">Грешка: Не успеав да ја вчитам статијата (URL: %1$s).</string>
   <string name="pref_display_title">Приказник</string>
   <string name="pref_info_title">Информации</string>

--- a/core/src/main/res/values-ml/strings.xml
+++ b/core/src/main/res/values-ml/strings.xml
@@ -39,9 +39,9 @@
   <string name="hotspot_notification_content_title">കിവിക്സ് ഹോട്ട്സ്പോട്ട്</string>
   <string name="start_server_label">സെർവർ തുടങ്ങുക</string>
   <string name="stop_server_label">സെർവർ നിർത്തുക</string>
-  <string name="error_file_not_found">പിഴവ്: തിരഞ്ഞെടുത്ത സിം ഫയൽ കണ്ടെത്താനായില്ല</string>
+  <string name="error_file_not_found">പിഴവ്: തിരഞ്ഞെടുത്ത സിം ഫയൽ കണ്ടെത്താനായില്ല %s</string>
   <string name="zim_not_opened" fuzzy="true">zim ഫയൽ തുറക്കുവാൻ സാധിച്ചില്ല</string>
-  <string name="error_file_invalid">പിഴവ്: തിരഞ്ഞെടുത്ത സിം ഫയൽ സാധുവല്ല.</string>
+  <string name="error_file_invalid">പിഴവ്: തിരഞ്ഞെടുത്ത സിം ഫയൽ സാധുവല്ല. %s</string>
   <string name="error_article_url_not_found">പിഴവ്: (Url: %1$s) എന്ന ലേഖനം ലോഡ് ചെയ്യുന്നത് പരാജയപ്പെട്ടു.</string>
   <string name="pref_display_title">കാഴ്ച</string>
   <string name="pref_info_title">വിവരം</string>

--- a/core/src/main/res/values-mn/strings.xml
+++ b/core/src/main/res/values-mn/strings.xml
@@ -17,8 +17,8 @@
   <string name="search_label">Хайлт</string>
   <string name="choose_file" fuzzy="true">ZIM  агуулгын файлыг сонгох (*.zim)</string>
   <string name="open_in_new_tab">Холбоосыг өөр табд нээ</string>
-  <string name="error_file_not_found">Алдаа: Сонгосон ZIM файл олдсонгүй.</string>
-  <string name="error_file_invalid">Алдаа: Сонгосон ZIM файл алдаатай байна.</string>
+  <string name="error_file_not_found">Алдаа: Сонгосон ZIM файл олдсонгүй. %s</string>
+  <string name="error_file_invalid">Алдаа: Сонгосон ZIM файл алдаатай байна. %s</string>
   <string name="error_article_url_not_found">Алдаа: (Url: %1$s) нийтлэлийг уншихад алдаа.</string>
   <string name="pref_display_title">Үзүүлэх</string>
   <string name="pref_info_title">Мэдээлэл</string>

--- a/core/src/main/res/values-ms/strings.xml
+++ b/core/src/main/res/values-ms/strings.xml
@@ -39,8 +39,8 @@
   <string name="hotspot_notification_content_title">Kawasan Khas Kiwix</string>
   <string name="start_server_label">Mula pelayan</string>
   <string name="stop_server_label">Hentikan pelayan</string>
-  <string name="error_file_not_found">Ralat: Fail ZIM yang terpilih tidak dapat ditemui.</string>
-  <string name="error_file_invalid">Ralat: Fail yang terpilih bukan fail ZIM yang sah.</string>
+  <string name="error_file_not_found">Ralat: Fail ZIM yang terpilih tidak dapat ditemui. %s</string>
+  <string name="error_file_invalid">Ralat: Fail yang terpilih bukan fail ZIM yang sah. %s</string>
   <string name="error_article_url_not_found">Ralat: Rencana (Url: %1$s) gagal dimuatkan.</string>
   <string name="pref_display_title">Paparan</string>
   <string name="pref_info_title">Maklumat</string>

--- a/core/src/main/res/values-my/strings.xml
+++ b/core/src/main/res/values-my/strings.xml
@@ -31,8 +31,8 @@
   <string name="wifi_dialog_title">ဝိုင်ဖိုင် ကွန်နက်ရှင် ခြေရာခံမိသည်</string>
   <string name="start_server_label">ဆာဗာ စတင်ရန်</string>
   <string name="stop_server_label">ဆာဗာ ရပ်တန့်ရန်</string>
-  <string name="error_file_not_found">အမှားသတိပေးချက် − ရွေးချယ်ထားသော ZIM ဖိုင်ကို ရှာမတွေ့ပါ။</string>
-  <string name="error_file_invalid">အမှားသတိပေးချက် − ရွေးချယ်ထားသောဖိုင်သည် တရားဝင် ZIM ဖိုင် မဟုတ်ပါ။</string>
+  <string name="error_file_not_found">အမှားသတိပေးချက် − ရွေးချယ်ထားသော ZIM ဖိုင်ကို ရှာမတွေ့ပါ။ %s</string>
+  <string name="error_file_invalid">အမှားသတိပေးချက် − ရွေးချယ်ထားသောဖိုင်သည် တရားဝင် ZIM ဖိုင် မဟုတ်ပါ။ %s</string>
   <string name="error_article_url_not_found">အမှားသတိပေးချက် − (Url: %1$s) ဆောင်းပါးထည့်သွင်းခြင်း မအောင်မြင်ပါ။</string>
   <string name="pref_display_title">မြင်ကွင်း</string>
   <string name="pref_info_title">သတင်းအချက်အလက်</string>

--- a/core/src/main/res/values-nb/strings.xml
+++ b/core/src/main/res/values-nb/strings.xml
@@ -28,8 +28,8 @@
   <string name="open_in_new_tab">Åpne lenke i ny fane?</string>
   <string name="start_server_label">Start tjener</string>
   <string name="stop_server_label">Stopp tjener</string>
-  <string name="error_file_not_found">Feil: Den valgte ZIM-filen ble ikke funnet</string>
-  <string name="error_file_invalid">Feil: Den valgte filen er ikke en gyldig ZIM-fil</string>
+  <string name="error_file_not_found">Feil: Den valgte ZIM-filen ble ikke funnet %s</string>
+  <string name="error_file_invalid">Feil: Den valgte filen er ikke en gyldig ZIM-fil %s</string>
   <string name="error_article_url_not_found">Feil: Kunne ikke laste inn artikkelen (Url: %1$s).</string>
   <string name="pref_display_title">Skjerm</string>
   <string name="pref_info_title">Informasjon</string>

--- a/core/src/main/res/values-ne/strings.xml
+++ b/core/src/main/res/values-ne/strings.xml
@@ -25,8 +25,8 @@
   <string name="search_label">खोज्नुहोस्</string>
   <string name="choose_file">सामग्री फाइल छान्नुहोस् (*.zim)</string>
   <string name="open_in_new_tab">लिङ्कलाई नयाँ ट्याबमा खोल्ने?</string>
-  <string name="error_file_not_found">त्रुटी: छानिएको ZIM फाइल भेटाउन सकिएन।</string>
-  <string name="error_file_invalid">त्रुटी: छानिएको फाइल मान्य ZIM फाइल होइन।</string>
+  <string name="error_file_not_found">त्रुटी: छानिएको ZIM फाइल भेटाउन सकिएन। %s</string>
+  <string name="error_file_invalid">त्रुटी: छानिएको फाइल मान्य ZIM फाइल होइन। %s</string>
   <string name="error_article_url_not_found">त्रुटी: लेख खोल्न असफल । (Url: %1$s)</string>
   <string name="pref_display_title">देखाउनुहोस्</string>
   <string name="pref_info_title">जानकारी</string>

--- a/core/src/main/res/values-nl/strings.xml
+++ b/core/src/main/res/values-nl/strings.xml
@@ -63,10 +63,10 @@
   <string name="server_started_message">Voer dit IP-adres in uw browser in om toegang te krijgen tot de server %s</string>
   <string name="qr_code">Gemaakte QR-code</string>
   <string name="share_host_address">URL delen via andere applicaties</string>
-  <string name="error_file_not_found">Fout: het geselecteerde ZIM-bestand kon niet gevonden worden.</string>
+  <string name="error_file_not_found">Fout: het geselecteerde ZIM-bestand kon niet gevonden worden. %s</string>
   <string name="unable_to_read_zim_file">Kan dit ZIM-bestand niet lezen!</string>
   <string name="zim_not_opened">Kan ZIM-bestand niet openen</string>
-  <string name="error_file_invalid">Fout: het geselecteerde bestand is geen geldig ZIM-bestand.</string>
+  <string name="error_file_invalid">Fout: het geselecteerde bestand is geen geldig ZIM-bestand. %s</string>
   <string name="error_article_url_not_found">Fout: Het laden van de pagina (URL: %1$s) is mislukt.</string>
   <string name="pref_display_title">Weergave</string>
   <string name="pref_info_title">Informatie</string>

--- a/core/src/main/res/values-nqo/strings.xml
+++ b/core/src/main/res/values-nqo/strings.xml
@@ -51,10 +51,10 @@
   <string name="stop_server_label">ߡߊ߬ߛߐ߬ߟߊ߲ ߟߊߟߐ߬</string>
   <string name="server_started_message">IP ߢߌ߲߬ ߠߊߘߏ߲߬ ߌ ߟߊ߫ ߛߏ߲߯ߓߊߟߊ߲ ߠߊ߫ ߞߊ߬ ߡߊ߬ߛߐ߬ߟߊ߲ ߠߊߛߐ߬ߘߐ߲߬ %s</string>
   <string name="share_host_address">URL ߟߊߖߍ߲ߛߍ߲߫ ߟߥߊ߬ߟߌ߬ߟߊ߲ ߜߘߍ ߟߎ߬ ߛߌߟߊ ߝߍ߬</string>
-  <string name="error_file_not_found">ߝߌ߬ߟߌ: ZIM ߞߐߕߐ߯ ߡߊߡߌ߬ߘߊ߬ߣߍ߲ ߕߍߣߊ߬ ߡߊߛߐ߬ߘߐ߲߫ ߠߊ߫.</string>
+  <string name="error_file_not_found">ߝߌ߬ߟߌ: ZIM ߞߐߕߐ߯ ߡߊߡߌ߬ߘߊ߬ߣߍ߲ ߕߍߣߊ߬ ߡߊߛߐ߬ߘߐ߲߫ ߠߊ߫. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">ߊ߬ ߕߴߛߋ߫ ߞߊ߬ ZIM ߞߐߕߐ߮ ߣߌ߲߬ ߘߐߞߊ߬ߙߊ߲߬߹</string>
   <string name="zim_not_opened" fuzzy="true">ZIM ߞߐߕߐ߮ ߕߍ߫ ߛߐ߲߬ ߠߊߞߊ߬ ߟߊ߫</string>
-  <string name="error_file_invalid">ߝߌ߬ߟߌ: ߞߐߕߐ߯ ߓߊߕߐ߬ߡߐ߲߬ߣߍ߲ ߣߌ߲߬ ߕߍ߫ ZIM ߞߐߕߐ߯ ߓߍ߲߬ߣߍ߲ ߝߋ߲߫ ߘߌ߫.</string>
+  <string name="error_file_invalid">ߝߌ߬ߟߌ: ߞߐߕߐ߯ ߓߊߕߐ߬ߡߐ߲߬ߣߍ߲ ߣߌ߲߬ ߕߍ߫ ZIM ߞߐߕߐ߯ ߓߍ߲߬ߣߍ߲ ߝߋ߲߫ ߘߌ߫. %s</string>
   <string name="error_article_url_not_found">ߝߎ߬ߕߎ߲߬ߕߌ: ߞߎߡߘߊ ߟߊߢߎ߲ߠߌ߲ (Url: %1$s) ߓߘߊ߫ ߗߌߙߏ߲߫.</string>
   <string name="pref_display_title">ߦߌ߬ߘߊ߬ߟߌ</string>
   <string name="pref_info_title">ߞߎ߲߬ߠߊ߬ߝߏߣߌ߲</string>

--- a/core/src/main/res/values-oc/strings.xml
+++ b/core/src/main/res/values-oc/strings.xml
@@ -22,8 +22,8 @@
   <string name="search_label">Recercar</string>
   <string name="choose_file">Seleccionar un fichièr de contengut (*.zim)</string>
   <string name="open_in_new_tab">Dobrir lo ligam dins un onglet novèl ?</string>
-  <string name="error_file_not_found">Error : Lo fichièr ZIM seleccionat es introbable.</string>
-  <string name="error_file_invalid">Error : Lo fichièr seleccionat es pas un fichièr ZIM valid.</string>
+  <string name="error_file_not_found">Error : Lo fichièr ZIM seleccionat es introbable. %s</string>
+  <string name="error_file_invalid">Error : Lo fichièr seleccionat es pas un fichièr ZIM valid. %s</string>
   <string name="error_article_url_not_found">Error : Lo cargament de l’article (Url: %1$s) a fracassat.</string>
   <string name="pref_display_title">Afichatge</string>
   <string name="pref_info_title">Informacion</string>

--- a/core/src/main/res/values-or/strings.xml
+++ b/core/src/main/res/values-or/strings.xml
@@ -51,10 +51,10 @@
   <string name="stop_server_label">ସର୍ଭର ବନ୍ଦ କରନ୍ତୁ</string>
   <string name="server_started_message">ସର୍ଭର %s ପ୍ରବେଶ କରିବାକୁ ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଏହି ip ଠିକଣା ପ୍ରବେଶ କରନ୍ତୁ</string>
   <string name="share_host_address">ଅନ୍ୟ ପ୍ରୟୋଗଗୁଡ଼ିକ ମାଧ୍ୟମରେ URL ଅଂଶୀଦାର କରନ୍ତୁ</string>
-  <string name="error_file_not_found">ଅସୁବିଧା: ବଛାଯାଇଥିବା ଜିମ ଫାଇଲ ମିଳିଲାନାହିଁ ।</string>
+  <string name="error_file_not_found">ଅସୁବିଧା: ବଛାଯାଇଥିବା ଜିମ ଫାଇଲ ମିଳିଲାନାହିଁ । %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">ଏହି zim ଫାଇଲକୁ ପଢ଼ିବାରେ ଅସମର୍ଥ</string>
   <string name="zim_not_opened" fuzzy="true">ଜିମ୍ ଫାଇଲ୍ ଖୋଲିବାକୁ ଅସମର୍ଥ</string>
-  <string name="error_file_invalid">ଅସୁବିଧା: ବଛାଯାଇଥିବା ଜିମ ଫାଇଲଟି ବୈଧ ନୁହେଁ ।</string>
+  <string name="error_file_invalid">ଅସୁବିଧା: ବଛାଯାଇଥିବା ଜିମ ଫାଇଲଟି ବୈଧ ନୁହେଁ । %s</string>
   <string name="error_article_url_not_found">ଅସୁବିଧା: (Url: %1$s) ପ୍ରସଙ୍ଗ ଖୋଲିବାରେ ବିଫଳ ହେଲୁ ।</string>
   <string name="pref_display_title">ଦେଖଣା</string>
   <string name="pref_info_title">ସୂଚନା</string>

--- a/core/src/main/res/values-pl/strings.xml
+++ b/core/src/main/res/values-pl/strings.xml
@@ -65,10 +65,10 @@
   <string name="error_ip_address_not_found">Nie udało się znaleźć adresu IP.</string>
   <string name="server_started_message">Wpisz ten adres IP w przeglądarce, aby uzyskać dostęp do serwera %s</string>
   <string name="share_host_address">Udostępnij adres URL za pośrednictwem innych aplikacji</string>
-  <string name="error_file_not_found">Błąd: Wybrany plik ZIM nie został znaleziony.</string>
+  <string name="error_file_not_found">Błąd: Wybrany plik ZIM nie został znaleziony. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Nie można odczytać tego pliku zim!</string>
   <string name="zim_not_opened" fuzzy="true">Nie można otworzyć pliku zim</string>
-  <string name="error_file_invalid">Błąd: Wybrany plik nie jest prawidłowym plikiem ZIM.</string>
+  <string name="error_file_invalid">Błąd: Wybrany plik nie jest prawidłowym plikiem ZIM. %s</string>
   <string name="error_article_url_not_found">Błąd: Ładowanie artykułu (Url:  %1$s ) się nie powiodło.</string>
   <string name="pref_display_title">Wyświetl</string>
   <string name="pref_info_title">Informacje</string>

--- a/core/src/main/res/values-ps/strings.xml
+++ b/core/src/main/res/values-ps/strings.xml
@@ -21,8 +21,8 @@
   <string name="search_label">پلټل</string>
   <string name="choose_file" fuzzy="true">د ZIM مېنځپانگې يوه دوتنه ټاکل (*.zim)</string>
   <string name="open_in_new_tab">تړنه په نوې کړکۍ کې پرانيستل</string>
-  <string name="error_file_not_found">تېروتنه: ستاسې ټاکلې ZIM دوتنه و نه موندل شوه.</string>
-  <string name="error_file_invalid">تېروتنه: ستاسې ټاکلې دوتنه يوه کره ZIM دوتنه نه ده.</string>
+  <string name="error_file_not_found">تېروتنه: ستاسې ټاکلې ZIM دوتنه و نه موندل شوه. %s</string>
+  <string name="error_file_invalid">تېروتنه: ستاسې ټاکلې دوتنه يوه کره ZIM دوتنه نه ده. %s</string>
   <string name="error_article_url_not_found">تېروتنه: ليکنه برسېرېدنه (يو آر ال: %1$s) نابريالئ شوه.</string>
   <string name="pref_display_title">ښکارېدنه</string>
   <string name="pref_info_title">مالومات</string>

--- a/core/src/main/res/values-pt-rBR/strings.xml
+++ b/core/src/main/res/values-pt-rBR/strings.xml
@@ -71,10 +71,10 @@
   <string name="server_started_message">Digite este endereço IP no seu navegador para acessar o servidor %s</string>
   <string name="qr_code">QR Code renderizado</string>
   <string name="share_host_address">Compartir URL a través de outras aplicações</string>
-  <string name="error_file_not_found">Erro: O arquivo ZIM selecionado não pode ser encontrado.</string>
+  <string name="error_file_not_found">Erro: O arquivo ZIM selecionado não pode ser encontrado. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">\nNão é possível ler este arquivo zim!</string>
   <string name="zim_not_opened" fuzzy="true">Não foi possível abrir o arquivo zim</string>
-  <string name="error_file_invalid">Erro: O arquivo selecionado não é um arquivo ZIM válido.</string>
+  <string name="error_file_invalid">Erro: O arquivo selecionado não é um arquivo ZIM válido. %s</string>
   <string name="error_article_url_not_found">Erro: Falha no carregamento do artigo (Url: %1$s).</string>
   <string name="pref_display_title">Exibição</string>
   <string name="pref_info_title">Informação</string>

--- a/core/src/main/res/values-pt/strings.xml
+++ b/core/src/main/res/values-pt/strings.xml
@@ -67,10 +67,10 @@
   <string name="server_started_message">Digite este endereço IP no seu navegador para aceder ao servidor %s</string>
   <string name="qr_code">Código QR renderizado</string>
   <string name="share_host_address">Compartilhar URL através de outros aplicativos</string>
-  <string name="error_file_not_found">Erro: não foi possível encontrar o ficheiro ZIM selecionado.</string>
+  <string name="error_file_not_found">Erro: não foi possível encontrar o ficheiro ZIM selecionado. %s</string>
   <string name="unable_to_read_zim_file">Não é possível ler este arquivo ZIM!</string>
   <string name="zim_not_opened">Não é possível abrir o arquivo ZIM</string>
-  <string name="error_file_invalid">Erro: o ficheiro selecionado não é um ficheiro ZIM válido.</string>
+  <string name="error_file_invalid">Erro: o ficheiro selecionado não é um ficheiro ZIM válido. %s</string>
   <string name="error_article_url_not_found">Erro: o carregamento do artigo falhou (URL: %1$s).</string>
   <string name="pref_display_title">Mostrar</string>
   <string name="pref_info_title">Informação</string>

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -61,10 +61,10 @@
   <string name="stop_server_label">This message shows as the button text, by clicking on this button “Kiwix server” stops.</string>
   <string name="server_started_message">This message appears in “Android TextView” as a text message. When the “Kiwix server” is successfully started, in this message %s will be replaced with the IP address on which the server is running. It shows the details of the server IP address to the user.</string>
   <string name="share_host_address">This message is the content description of “Android ImageView”, this appears when the “Kiwix server” is running and the IP address is visible to the user on which server is running. By clicking on this it will share the IP address with other applications.</string>
-  <string name="error_file_not_found">This message appears in “Android Toast” as an error message when the user tries to open a Zim file but the file was moved to another directory or deleted. So this message informs the user this file could not be found.</string>
+  <string name="error_file_not_found">This message appears in “Android Toast” as an error message when the user tries to open a Zim file but the file was moved to another directory or deleted. So this message informs the user this file could not be found. Here %s will be replaced with the ZIM file path which is failed to open.</string>
   <string name="unable_to_read_zim_file">This message appears in “Android Toast” as a error message when our application is unable to read the zim file.</string>
   <string name="zim_not_opened">This message appears in “Android Toast” as an error message when the user opens the application and the previously opened zim file was deleted from the phone storage, then we are showing this error message to the user.</string>
-  <string name="error_file_invalid">The message appears in “Android Toast” as a warning message when the user tries to open a file and that file is not the zim file.</string>
+  <string name="error_file_invalid">The message appears in “Android Toast” as a warning message when the user tries to open a file and that file is not the zim file.\n Here %s will be replaced by the ZIM file path which is failed to open.</string>
   <string name="error_article_url_not_found">* This message appears in “Android Toast” as an error message when “Kiwix Reader” is unable to load the given URL.\n* Here %1$s will be replaced by the URL which is failed to load.</string>
   <string name="pref_display_title">{{Identical|Display}}</string>
   <string name="pref_info_title">{{Identical|Information}}</string>

--- a/core/src/main/res/values-rm/strings.xml
+++ b/core/src/main/res/values-rm/strings.xml
@@ -15,8 +15,8 @@
   <string name="search_label">Tschertgar</string>
   <string name="choose_file" fuzzy="true">Selecziunar ina datoteca da cuntegn ZIM (*.zim)</string>
   <string name="open_in_new_tab">Avrir il link en in nov tab?</string>
-  <string name="error_file_not_found">Errur: la datoteca ZIM selecziunada è betg vegnida chattada.</string>
-  <string name="error_file_invalid">Errur: la datoteca selecziunada è betg ina datoteca ZIM valida.</string>
+  <string name="error_file_not_found">Errur: la datoteca ZIM selecziunada è betg vegnida chattada. %s</string>
+  <string name="error_file_invalid">Errur: la datoteca selecziunada è betg ina datoteca ZIM valida. %s</string>
   <string name="error_article_url_not_found">Errur: chargiar il artitgel (Url: %1$s) n’a betg funcziunà.</string>
   <string name="pref_display_title">Vista</string>
   <string name="pref_info_title">Infurmaziun</string>

--- a/core/src/main/res/values-ro/strings.xml
+++ b/core/src/main/res/values-ro/strings.xml
@@ -53,9 +53,9 @@
   <string name="stop_server_label">Oprește server</string>
   <string name="server_started_message">Introduceți această adresă ip în browserul dvs. pentru a accesa serverul %s</string>
   <string name="share_host_address">Distribuie URL prin alte aplicaţii</string>
-  <string name="error_file_not_found">Eroare: Fișierul ZIM selectat nu poate fi găsit.</string>
+  <string name="error_file_not_found">Eroare: Fișierul ZIM selectat nu poate fi găsit. %s</string>
   <string name="zim_not_opened" fuzzy="true">Imposibil de deschis fișierul zim</string>
-  <string name="error_file_invalid">Eroare: Fișierul selectat nu este un fișier ZIM valid.</string>
+  <string name="error_file_invalid">Eroare: Fișierul selectat nu este un fișier ZIM valid. %s</string>
   <string name="error_article_url_not_found">Eroare: Încărcarea articolului (Url: %1$s) nu a reușit.</string>
   <string name="pref_display_title">Afișaj</string>
   <string name="pref_info_title">Informații</string>

--- a/core/src/main/res/values-ru/strings.xml
+++ b/core/src/main/res/values-ru/strings.xml
@@ -83,10 +83,10 @@
   <string name="server_started_message">Введите этот IP адрес в ваш браузер чтобы получить доступ к серверу %s</string>
   <string name="qr_code">Отобразить QR-код</string>
   <string name="share_host_address">Поделиться URL через другие приложения</string>
-  <string name="error_file_not_found">Ошибка: выбранный ZIM-файл не найден.</string>
+  <string name="error_file_not_found">Ошибка: выбранный ZIM-файл не найден. %s</string>
   <string name="unable_to_read_zim_file">Не удается прочитать этот ZIM-файл!</string>
   <string name="zim_not_opened">Не удается открыть ZIM-файл</string>
-  <string name="error_file_invalid">Ошибка: Выбранный файл не является пригодным ZIM-файлом.</string>
+  <string name="error_file_invalid">Ошибка: Выбранный файл не является пригодным ZIM-файлом. %s</string>
   <string name="error_article_url_not_found">Ошибка: Загрузка статьи (Url: %1$s) не удалась.</string>
   <string name="pref_display_title">Экран</string>
   <string name="pref_info_title">Информация</string>

--- a/core/src/main/res/values-sa/strings.xml
+++ b/core/src/main/res/values-sa/strings.xml
@@ -19,8 +19,8 @@
   <string name="search_label">अन्विष्यताम्</string>
   <string name="choose_file" fuzzy="true">एतस्याः ZIM पूर्वलिखितसञ्चिकायाः चयनं करोतु (*.zim)</string>
   <string name="open_in_new_tab">एतत् परिसन्धिं नवीन-टेब्-मध्ये उद्घाटयतु</string>
-  <string name="error_file_not_found">दोषः : चितसञ्चिका ZIM न प्राप्ता ।</string>
-  <string name="error_file_invalid">दोषः : चितसञ्चिका योग्या ZIM-सञ्चिका नस्ति ।</string>
+  <string name="error_file_not_found">दोषः : चितसञ्चिका ZIM न प्राप्ता । %s</string>
+  <string name="error_file_invalid">दोषः : चितसञ्चिका योग्या ZIM-सञ्चिका नस्ति । %s</string>
   <string name="error_article_url_not_found">दोषः : (Url: %1$s) लेखस्य अवारोपणं विफलम् अभवत् ।</string>
   <string name="pref_display_title">प्रदर्श्यताम्</string>
   <string name="pref_info_title">सूचना</string>

--- a/core/src/main/res/values-sc/strings.xml
+++ b/core/src/main/res/values-sc/strings.xml
@@ -51,10 +51,10 @@
   <string name="error_ip_address_not_found">Non apo pòdidu agatare s’indiritzu IP.</string>
   <string name="server_started_message">Inserta custu indiritzu ip in su navigadore tuo pro intrare in su servidore %s</string>
   <string name="share_host_address">Cumpartzi s’URL cun àteras aplicatziones</string>
-  <string name="error_file_not_found">Errore: su documentu ZIM ischertadu no est istadu agatadu.</string>
+  <string name="error_file_not_found">Errore: su documentu ZIM ischertadu no est istadu agatadu. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Non faghet a lèghere custu archìviu zim!</string>
   <string name="zim_not_opened" fuzzy="true">Impossìbile abèrrere su documentu zim</string>
-  <string name="error_file_invalid">Errore: su documentu ischertadu no est unu documentu ZIM vàlidu.</string>
+  <string name="error_file_invalid">Errore: su documentu ischertadu no est unu documentu ZIM vàlidu. %s</string>
   <string name="error_article_url_not_found">Errore: carrigamentu de s’artìculu (Url: %1$s) non resèssidu.</string>
   <string name="pref_display_title">Ischermu</string>
   <string name="pref_info_title">Informatziones</string>

--- a/core/src/main/res/values-si/strings.xml
+++ b/core/src/main/res/values-si/strings.xml
@@ -22,8 +22,8 @@
   <string name="search_label">ගවේෂණය</string>
   <string name="choose_file" fuzzy="true">ZIM වර්ගයේ ගොනුවක් තෝරාගන්න (*.zim)</string>
   <string name="open_in_new_tab">සබැඳිය නව තීරුවක විවෘත කරන්න?</string>
-  <string name="error_file_not_found">දෝෂය: තෝරාගත් ZIM ගොනුව සොයා ගැනීමට නොහැකි විය.</string>
-  <string name="error_file_invalid">දෝෂය: තෝරාගත් ගොනුව වලංගු ZIM ගොනුවක් නොවේ.</string>
+  <string name="error_file_not_found">දෝෂය: තෝරාගත් ZIM ගොනුව සොයා ගැනීමට නොහැකි විය. %s</string>
+  <string name="error_file_invalid">දෝෂය: තෝරාගත් ගොනුව වලංගු ZIM ගොනුවක් නොවේ. %s</string>
   <string name="error_article_url_not_found">දෝෂය: (Url: %1$s) ලිපිය පූරණය වීම අසාර්ථකයි.</string>
   <string name="pref_display_title">පෙන්වීම</string>
   <string name="pref_info_title">තොරතුරු</string>

--- a/core/src/main/res/values-sk/strings.xml
+++ b/core/src/main/res/values-sk/strings.xml
@@ -52,10 +52,10 @@
   <string name="stop_server_label">Zastaviť server</string>
   <string name="server_started_message">Zadajte túto ip adresu to vášho prehliadača pre prístup na server %s</string>
   <string name="share_host_address">Zdieľať URL cez iné aplikácie</string>
-  <string name="error_file_not_found">Chyba: Vybraný súbor ZIM sa nenašiel.</string>
+  <string name="error_file_not_found">Chyba: Vybraný súbor ZIM sa nenašiel. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Nepodarilo sa prečítať súbor zim!</string>
   <string name="zim_not_opened" fuzzy="true">Nepodarilo sa otvoriť súbor zim</string>
-  <string name="error_file_invalid">Chyba: Vybraný súbor nie je platný ZIM súbor.</string>
+  <string name="error_file_invalid">Chyba: Vybraný súbor nie je platný ZIM súbor. %s</string>
   <string name="error_article_url_not_found">Chyba: Načítavanie článku (Url: %1$s) sa nepodarilo.</string>
   <string name="pref_display_title">Zobrazenie</string>
   <string name="pref_info_title">Informácie</string>

--- a/core/src/main/res/values-sl/strings.xml
+++ b/core/src/main/res/values-sl/strings.xml
@@ -59,10 +59,10 @@
   <string name="error_ip_address_not_found">IP-naslova ni bilo mogoče najti.</string>
   <string name="server_started_message">Za dostop do strežnika %s vnesite v brskalnik ta lP-naslov</string>
   <string name="share_host_address">Delite URL z drugimi aplikacijami</string>
-  <string name="error_file_not_found">Napaka: izbrane datoteke ZIM ni bilo mogoče najti.</string>
+  <string name="error_file_not_found">Napaka: izbrane datoteke ZIM ni bilo mogoče najti. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Te datoteke ZIM ni mogoče prebrati!</string>
   <string name="zim_not_opened" fuzzy="true">Datoteke ZIM ni mogoče odpreti</string>
-  <string name="error_file_invalid">Napaka: izbrana datoteka ni veljavna datoteka ZIM.</string>
+  <string name="error_file_invalid">Napaka: izbrana datoteka ni veljavna datoteka ZIM. %s</string>
   <string name="error_article_url_not_found">Napaka: Nalaganje članka (url: %1$s) ni uspelo.</string>
   <string name="pref_display_title">Prikaz</string>
   <string name="pref_info_title">Informacije</string>

--- a/core/src/main/res/values-so/strings.xml
+++ b/core/src/main/res/values-so/strings.xml
@@ -20,8 +20,8 @@
   <string name="search_label">Raadi</string>
   <string name="choose_file" fuzzy="true">Dooro galka ZIM ee ka samaysan (*.zim)</string>
   <string name="open_in_new_tab">Fur webka qaab cusub</string>
-  <string name="error_file_not_found">Qalad: Galka ZIM ee aad dooratay lama helin.</string>
-  <string name="error_file_invalid">Qalad: Galka ZIM ee aad dooratay maaha mid shaqaynaya.</string>
+  <string name="error_file_not_found">Qalad: Galka ZIM ee aad dooratay lama helin. %s</string>
+  <string name="error_file_invalid">Qalad: Galka ZIM ee aad dooratay maaha mid shaqaynaya. %s</string>
   <string name="error_article_url_not_found">Qalad: Galinta maqaalka (Url: %1$s) ma galin.</string>
   <string name="pref_display_title">Qaab aragga</string>
   <string name="pref_info_title">Macluumaad</string>

--- a/core/src/main/res/values-sq/strings.xml
+++ b/core/src/main/res/values-sq/strings.xml
@@ -54,10 +54,10 @@
   <string name="server_started_message">Që të hyni te shërbyesi %s, jepni këtë adresë IP te shfletuesi juaj</string>
   <string name="qr_code">Kodi QR i vizatuar</string>
   <string name="share_host_address">Jepeni URL-në përmes aplikacionesh të tjera</string>
-  <string name="error_file_not_found">Gabim: S’u gjet dot kartela ZIM e përzgjedhur.</string>
+  <string name="error_file_not_found">Gabim: S’u gjet dot kartela ZIM e përzgjedhur. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">S’arrihet të lexohet kjo kartelë zim!</string>
   <string name="zim_not_opened" fuzzy="true">S’arrihet të hapet kartelë zim</string>
-  <string name="error_file_invalid">Gabim: Kartela e përzgjedhur s’është kartelë ZIM e vlefshme.</string>
+  <string name="error_file_invalid">Gabim: Kartela e përzgjedhur s’është kartelë ZIM e vlefshme. %s</string>
   <string name="error_article_url_not_found">Gabim: Dështoi ngarkimi i artikullit (Url: %1$s).</string>
   <string name="pref_display_title">Ekran</string>
   <string name="pref_info_title">Informacione</string>

--- a/core/src/main/res/values-sr/strings.xml
+++ b/core/src/main/res/values-sr/strings.xml
@@ -25,8 +25,8 @@
   <string name="choose_file">Изаберите датотеку са садржајем (*.zim)</string>
   <string name="open_in_new_tab">Отворити везу у новој картици?</string>
   <string name="server_stopped_successfully_toast_message">Сервер је успешно заустављен.</string>
-  <string name="error_file_not_found">Грешка: изабрана ZIM датотека се не може наћи.</string>
-  <string name="error_file_invalid">Грешка: изабрана датотека није важећа ZIM датотека.</string>
+  <string name="error_file_not_found">Грешка: изабрана ZIM датотека се не може наћи. %s</string>
+  <string name="error_file_invalid">Грешка: изабрана датотека није важећа ZIM датотека. %s</string>
   <string name="error_article_url_not_found">Грешка: учитавање чланка (Url: %1$s) није успело.</string>
   <string name="pref_display_title">Приказ</string>
   <string name="pref_info_title">Информације</string>

--- a/core/src/main/res/values-su/strings.xml
+++ b/core/src/main/res/values-su/strings.xml
@@ -14,7 +14,7 @@
   <string name="menu_exit_full_screen">Kaluar ti modeu layar pinuh</string>
   <string name="search_label">Paluruh</string>
   <string name="choose_file">Pilih Berkas Kontén (*.zim)</string>
-  <string name="error_file_invalid">Kasalahan: Berkas nu dipilih lain berkas ZIM nu sah.</string>
+  <string name="error_file_invalid">Kasalahan: Berkas nu dipilih lain berkas ZIM nu sah. %s</string>
   <string name="error_article_url_not_found">Kasalahan: Pamuatan artikel (Url: %1$s) gagal.</string>
   <string name="pref_display_title">Panémbong</string>
   <string name="pref_info_title">Émbaran</string>

--- a/core/src/main/res/values-sv/strings.xml
+++ b/core/src/main/res/values-sv/strings.xml
@@ -63,10 +63,10 @@
   <string name="server_started_message">Ange denna IP-adress i din webbläsare för att komma åt servern %s</string>
   <string name="qr_code">Renderad QR-kod</string>
   <string name="share_host_address">Dela webbadress med andra appar</string>
-  <string name="error_file_not_found">Fel: Den valda ZIM-filen kunde inte hittas.</string>
+  <string name="error_file_not_found">Fel: Den valda ZIM-filen kunde inte hittas. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Kunde inte läsa denna zim-fil!</string>
   <string name="zim_not_opened" fuzzy="true">Kunde inte öppna zip-fil</string>
-  <string name="error_file_invalid">Fel: Den valda filen är inte en giltig ZIM-fil.</string>
+  <string name="error_file_invalid">Fel: Den valda filen är inte en giltig ZIM-fil. %s</string>
   <string name="error_article_url_not_found">Fel: Inläsning av artikel (url: %1$s) misslyckades.</string>
   <string name="pref_display_title">Visning</string>
   <string name="pref_info_title">Information</string>

--- a/core/src/main/res/values-sw/strings.xml
+++ b/core/src/main/res/values-sw/strings.xml
@@ -63,10 +63,10 @@
   <string name="error_ip_address_not_found">Sikuweza kupata anwani ya IP.</string>
   <string name="server_started_message">Ingiza anwani hii ya ip kwenye kivinjari chako ili kufikia seva %s</string>
   <string name="share_host_address">Kushiriki URL kupitia programu nyingine</string>
-  <string name="error_file_not_found">Hitilafu: Faili ya ZIM iliyochaguliwa haija patikana.</string>
+  <string name="error_file_not_found">Hitilafu: Faili ya ZIM iliyochaguliwa haija patikana. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Haiwezi kusoma faili hii zim!</string>
   <string name="zim_not_opened" fuzzy="true">Haiwezi kufungua faili ya zim</string>
-  <string name="error_file_invalid">Hitilafu:Faili iliyochaguliwa sio faili sahihi ya ZIM.</string>
+  <string name="error_file_invalid">Hitilafu:Faili iliyochaguliwa sio faili sahihi ya ZIM. %s</string>
   <string name="error_article_url_not_found">Hitilafu:Upakiaji wa makala umefeli (Url: %1$s)</string>
   <string name="pref_display_title">Onesha</string>
   <string name="pref_info_title">Maarifa</string>

--- a/core/src/main/res/values-ta/strings.xml
+++ b/core/src/main/res/values-ta/strings.xml
@@ -53,10 +53,10 @@
   <string name="stop_server_label">சேவையகத்தை நிறுத்து</string>
   <string name="server_started_message">%s சேவையகத்தை அணுக உங்கள் உலாவியில் இந்த ஐபி முகவரியை உள்ளிடவும்</string>
   <string name="share_host_address">பிற பயன்பாடுகள் வழியாக URL ஐப் பகிரவும்</string>
-  <string name="error_file_not_found">பிழை: தேர்வு செய்யப்பட்ட ZIM கோப்பு காணப்படவில்லை</string>
+  <string name="error_file_not_found">பிழை: தேர்வு செய்யப்பட்ட ZIM கோப்பு காணப்படவில்லை %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">இந்த ஜிம் கோப்பைப் படிக்க முடியவில்லை!</string>
   <string name="zim_not_opened" fuzzy="true">ZIM கோப்பைத் திறக்க முடியவில்லை</string>
-  <string name="error_file_invalid">பிழை: தேர்வு செய்யப்பட்ட கோப்பு, ஏற்புடைய ZIM கோப்பு அல்ல</string>
+  <string name="error_file_invalid">பிழை: தேர்வு செய்யப்பட்ட கோப்பு, ஏற்புடைய ZIM கோப்பு அல்ல %s</string>
   <string name="error_article_url_not_found">பிழை: (Url: %1$s) கட்டுரையை ஏற்றித்துவங்க தவறிவிட்டது</string>
   <string name="pref_display_title">காண்பி</string>
   <string name="pref_info_title">தகவல்</string>

--- a/core/src/main/res/values-te/strings.xml
+++ b/core/src/main/res/values-te/strings.xml
@@ -57,10 +57,10 @@
   <string name="error_ip_address_not_found">ip చిరునామా కనుగొనబడలేదు.</string>
   <string name="server_started_message">%s సర్వర్‌ని యాక్సెస్ చేయడానికి మీ బ్రౌజర్‌లో ఈ ip చిరునామాను నమోదు చేయండి</string>
   <string name="share_host_address">ఇతర అప్లికేషన్ల ద్వారా URLని భాగస్వామ్యం చేయండి</string>
-  <string name="error_file_not_found">దోషం‌ :‌ మీరు ఎంపిక చేసిన ZIM దస్త్రం దొరకలేదు.</string>
+  <string name="error_file_not_found">దోషం‌ :‌ మీరు ఎంపిక చేసిన ZIM దస్త్రం దొరకలేదు. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">ఈ జిమ్ ఫైల్‌ని చదవడం సాధ్యం కాలేదు!</string>
   <string name="zim_not_opened" fuzzy="true">జిమ్ ఫైల్‌ను తెరవడం సాధ్యం కాలేదు</string>
-  <string name="error_file_invalid">దోషం : మీరు ఎంపిక చేసిన దస్త్రం సరియైన ZIM దస్త్రం కాదు.</string>
+  <string name="error_file_invalid">దోషం : మీరు ఎంపిక చేసిన దస్త్రం సరియైన ZIM దస్త్రం కాదు. %s</string>
   <string name="error_article_url_not_found">దోషం : వ్యాసం (Url: %1$s) ను లోడ్ చెయ్యడం విఫలమయింది.</string>
   <string name="pref_display_title">వీక్షణం</string>
   <string name="pref_info_title">సమాచారం</string>

--- a/core/src/main/res/values-th/strings.xml
+++ b/core/src/main/res/values-th/strings.xml
@@ -28,9 +28,9 @@
   <string name="open_in_new_tab">ต้องการเปิดลิงก์ในแท็บใหม่หรือไม่</string>
   <string name="no_books_selected_toast_message">กรุณาเลือกหน้งสือก่อน</string>
   <string name="hotspot_dialog_neutral_button">ดำเนินการต่อ</string>
-  <string name="error_file_not_found">ข้อผิดพลาด:ไม่พบไฟล์ ZIM ที่เลือก</string>
+  <string name="error_file_not_found">ข้อผิดพลาด:ไม่พบไฟล์ ZIM ที่เลือก %s</string>
   <string name="zim_not_opened" fuzzy="true">ไม่สามารถเปิดไฟล์ zim ได้</string>
-  <string name="error_file_invalid">ข้อผิดพลาด:ไฟล์ที่เลือกไม่ได้เป็นไฟล์ ZIM ที่ถูกต้อง</string>
+  <string name="error_file_invalid">ข้อผิดพลาด:ไฟล์ที่เลือกไม่ได้เป็นไฟล์ ZIM ที่ถูกต้อง %s</string>
   <string name="error_article_url_not_found">ข้อผิดพลาด:ไม่สามารถดาวน์โหลดบทความได้ (URL:%1$s)</string>
   <string name="pref_display_title">แสดงผล</string>
   <string name="pref_info_title">ข้อมูล</string>

--- a/core/src/main/res/values-tn/strings.xml
+++ b/core/src/main/res/values-tn/strings.xml
@@ -52,10 +52,10 @@
   <string name="error_ip_address_not_found">Go batla ip adress go retetse.</string>
   <string name="server_started_message">Tsenya aterese eno ya ip mo browser ya gago go fitlhelela server %s</string>
   <string name="share_host_address">Abelana URL ka ditselna tse dingwe</string>
-  <string name="error_file_not_found">Phoso: Faele ya ZIM e e tlhophilweng ga e a ka ya bonwa.</string>
+  <string name="error_file_not_found">Phoso: Faele ya ZIM e e tlhophilweng ga e a ka ya bonwa. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Go batla faele ye ya ZIM ga go kgonege!</string>
   <string name="zim_not_opened" fuzzy="true">Go bula faele ya ZIM go a retela</string>
-  <string name="error_file_invalid">Phoso: Faele e e tlhophilweng ga se faele ya ZIM e e siameng.</string>
+  <string name="error_file_invalid">Phoso: Faele e e tlhophilweng ga se faele ya ZIM e e siameng. %s</string>
   <string name="error_article_url_not_found">Phoso:Tsebe ye e letetsweng (Url:%1$s) e retetse.</string>
   <string name="pref_display_title">Pontsho</string>
   <string name="pref_info_title">Tshedimosetso</string>

--- a/core/src/main/res/values-tr/strings.xml
+++ b/core/src/main/res/values-tr/strings.xml
@@ -68,10 +68,10 @@
   <string name="error_ip_address_not_found">IP adresi bulunamadı.</string>
   <string name="server_started_message">%s sunucusuna erişmek için tarayıcınıza bu ip adresini girin.</string>
   <string name="share_host_address">URL’yi diğer uygulamalar aracılığıyla paylaşın</string>
-  <string name="error_file_not_found">Hata: Seçili ZIM dosyası bulunamadı.</string>
+  <string name="error_file_not_found">Hata: Seçili ZIM dosyası bulunamadı. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Bu zim dosyası okunamıyor!</string>
   <string name="zim_not_opened" fuzzy="true">Zim dosyası açılamıyor</string>
-  <string name="error_file_invalid">Hata: Seçili dosya geçerli bir ZIM dosyası değil.</string>
+  <string name="error_file_invalid">Hata: Seçili dosya geçerli bir ZIM dosyası değil. %s</string>
   <string name="error_article_url_not_found">Hata: (Url: %1$s) makalesinin yüklemesi başarısız.</string>
   <string name="pref_display_title">Görüntüle</string>
   <string name="pref_info_title">Bilgi</string>

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -60,10 +60,10 @@
   <string name="stop_server_label">Зупинити сервер</string>
   <string name="server_started_message">Уведіть цю IP адресу у ваш браузер, аби отримати доступ до серверу %s</string>
   <string name="share_host_address">Поділіться URL-адресою за допомогою інших програм</string>
-  <string name="error_file_not_found">Помилка: вибраний ZIM файл неможливо знайти.</string>
+  <string name="error_file_not_found">Помилка: вибраний ZIM файл неможливо знайти. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Неможливо прочитати цей файл zim!</string>
   <string name="zim_not_opened" fuzzy="true">Неможливо відкрити файл zim</string>
-  <string name="error_file_invalid">Помилка: вибраний файл не є вірним файлом ZIM.</string>
+  <string name="error_file_invalid">Помилка: вибраний файл не є вірним файлом ZIM. %s</string>
   <string name="error_article_url_not_found">Помилка: завантаження статті (Url: %1$s) не вдалося.</string>
   <string name="pref_display_title">Дисплей</string>
   <string name="pref_info_title">Інформація</string>

--- a/core/src/main/res/values-ur/strings.xml
+++ b/core/src/main/res/values-ur/strings.xml
@@ -50,10 +50,10 @@
   <string name="error_ip_address_not_found">آئی پی ایڈریس نہیں مل سکا۔</string>
   <string name="server_started_message">سرور تک رسائی حاصل کرنے کے لیے اس آئی پی کو اپنے براؤزر میں درج کریں %s</string>
   <string name="share_host_address">دوسرے ایپلیکیشنز کے ذریعے یو آر ایل شیئر کریں۔</string>
-  <string name="error_file_not_found">خرابی: منتخب کردہ ZIM فائل نہیں مل سکی۔</string>
+  <string name="error_file_not_found">خرابی: منتخب کردہ ZIM فائل نہیں مل سکی۔ %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">اس zim فائل کو پڑھنے سے قاصر!</string>
   <string name="zim_not_opened" fuzzy="true">zim فائل کو کھولنے سے قاصر</string>
-  <string name="error_file_invalid">خرابی: منتخب فائل ایک درست ZIM فائل نہیں ہے۔</string>
+  <string name="error_file_invalid">خرابی: منتخب فائل ایک درست ZIM فائل نہیں ہے۔ %s</string>
   <string name="error_article_url_not_found">خرابی: مضمون لوڈ کرنا (Url: %1$s ) ناکام ہو گیا۔</string>
   <string name="pref_display_title">تظاہرہ</string>
   <string name="pref_info_title">معلومات</string>

--- a/core/src/main/res/values-vi/strings.xml
+++ b/core/src/main/res/values-vi/strings.xml
@@ -25,8 +25,8 @@
   <string name="choose_file">Chọn một Tập tin Nội dung (*.zim)</string>
   <string name="open_in_new_tab">Mở liên kết trong thẻ mới?</string>
   <string name="share_host_address">Chia sẻ URL thông qua phần mềm khác</string>
-  <string name="error_file_not_found">Lỗi: Không tìm thấy tập tin ZIM đã chọn</string>
-  <string name="error_file_invalid">Lỗi: Tập tin đã chọn không phải là tập tin ZIM hợp lệ.</string>
+  <string name="error_file_not_found">Lỗi: Không tìm thấy tập tin ZIM đã chọn %s</string>
+  <string name="error_file_invalid">Lỗi: Tập tin đã chọn không phải là tập tin ZIM hợp lệ. %s</string>
   <string name="error_article_url_not_found">Lỗi: Việc tải bài (URL: %1$s) bị thất bại.</string>
   <string name="pref_display_title">Hiển thị</string>
   <string name="pref_info_title">Thông tin</string>

--- a/core/src/main/res/values-xal/strings.xml
+++ b/core/src/main/res/values-xal/strings.xml
@@ -36,8 +36,8 @@
   <string name="stop_server_label">Сервериг зогсах</string>
   <string name="error_server_already_running">Сервер негнт аҗллҗ эклсмн. Үүг унтраһад, дәкн орлдтн.</string>
   <string name="error_ip_address_not_found">IP хайгиг олҗ чадсн уга.</string>
-  <string name="error_file_not_found">Эндү: Суңһсн файл олдсн уга.</string>
-  <string name="error_file_invalid">Эндү: Суңһсн ZIM файл эндүтә бәәнә.</string>
+  <string name="error_file_not_found">Эндү: Суңһсн файл олдсн уга. %s</string>
+  <string name="error_file_invalid">Эндү: Суңһсн ZIM файл эндүтә бәәнә. %s</string>
   <string name="error_article_url_not_found">Эндү: (Url: %1$s) ниитллиг умшхд эндү һарв.</string>
   <string name="pref_display_title">Үзүлх</string>
   <string name="pref_info_title">Медәлл</string>

--- a/core/src/main/res/values-xmf/strings.xml
+++ b/core/src/main/res/values-xmf/strings.xml
@@ -46,8 +46,8 @@
   <string name="stop_server_label">სერვერიშ გაჩემება</string>
   <string name="error_server_already_running">სერვერი ასე მუშენს. ქორთხინთ, გოთიშით თინა დო კჷნე ახალშო ქოცადით.</string>
   <string name="error_ip_address_not_found">IP-მიოწურაფუქ ვეგორჷ.</string>
-  <string name="error_file_not_found">ჩილათა: გიშაგორილი ZIM-ფაილქ ვეგორუ.</string>
-  <string name="error_file_invalid">ჩილათა: გიშაგორილი ფაილი ვა რე თინი ZIM-ფაილი.</string>
+  <string name="error_file_not_found">ჩილათა: გიშაგორილი ZIM-ფაილქ ვეგორუ. %s</string>
+  <string name="error_file_invalid">ჩილათა: გიშაგორილი ფაილი ვა რე თინი ZIM-ფაილი. %s</string>
   <string name="error_article_url_not_found">ჩილათა: სტატიაშ (Url: %1$s) გიმოხარგუაქ ვემიხუჯინუ.</string>
   <string name="pref_display_title">ეკრანი</string>
   <string name="pref_info_title">ინფორმაცია</string>

--- a/core/src/main/res/values-yo/strings.xml
+++ b/core/src/main/res/values-yo/strings.xml
@@ -56,10 +56,10 @@
   <string name="error_ip_address_not_found">Ko le ri adiresi ip.</string>
   <string name="server_started_message">Tẹ adiresi IP yii sinu ẹrọ aṣawakiri rẹ lati wọle si olupin %s</string>
   <string name="share_host_address">Pin URL nipasẹ awọn ohun elo miiran</string>
-  <string name="error_file_not_found">Aṣiṣe: Faili ZIM ti o yan ko ṣee ri.</string>
+  <string name="error_file_not_found">Aṣiṣe: Faili ZIM ti o yan ko ṣee ri. %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">Ko le ka faili zim yii!</string>
   <string name="zim_not_opened" fuzzy="true">Ko le ṣi faili zim</string>
-  <string name="error_file_invalid">Aṣiṣe: Faili ti o yan kii ṣe faili ZIM to wulo.</string>
+  <string name="error_file_invalid">Aṣiṣe: Faili ti o yan kii ṣe faili ZIM to wulo. %s</string>
   <string name="error_article_url_not_found">Aṣiṣe: Nkojọpọ nkan (Url: %1$s ) kuna.</string>
   <string name="pref_display_title">Ìmúhàn</string>
   <string name="pref_info_title">Ìfitọ́nilétí</string>

--- a/core/src/main/res/values-zh-rTW/strings.xml
+++ b/core/src/main/res/values-zh-rTW/strings.xml
@@ -66,10 +66,10 @@
   <string name="server_started_message">在您的瀏覽器輸入 IP 位址來存取伺服器%s</string>
   <string name="qr_code">呈現 QR 碼</string>
   <string name="share_host_address">透過別種應用程式分享 URL</string>
-  <string name="error_file_not_found">錯誤：找不到所選的 ZIM 檔案。</string>
+  <string name="error_file_not_found">錯誤：找不到所選的 ZIM 檔案。 %s</string>
   <string name="unable_to_read_zim_file" fuzzy="true">無法讀取這個 zim 檔案！</string>
   <string name="zim_not_opened" fuzzy="true">無法打開 zim 檔案</string>
-  <string name="error_file_invalid">錯誤：所選檔案不是有效的 ZIM 檔。</string>
+  <string name="error_file_invalid">錯誤：所選檔案不是有效的 ZIM 檔。 %s</string>
   <string name="error_article_url_not_found">錯誤：載入條目(網址：%1$s)失敗。</string>
   <string name="pref_display_title">顯示</string>
   <string name="pref_info_title">資訊</string>

--- a/core/src/main/res/values-zh/strings.xml
+++ b/core/src/main/res/values-zh/strings.xml
@@ -82,10 +82,10 @@
   <string name="server_started_message">将这个 IP 地址输入到你的浏览器中来连接服务器 %s</string>
   <string name="qr_code">显示二维码</string>
   <string name="share_host_address">通过其他应用程序分享 URL</string>
-  <string name="error_file_not_found">错误：找不到选定的 ZIM 文件。</string>
+  <string name="error_file_not_found">错误：找不到选定的 ZIM 文件。 %s</string>
   <string name="unable_to_read_zim_file">无法读取此 ZIM 文件！</string>
   <string name="zim_not_opened">无法打开 ZIM 文件</string>
-  <string name="error_file_invalid">错误：选定的文件不是有效的 ZIM 文件。</string>
+  <string name="error_file_invalid">错误：选定的文件不是有效的 ZIM 文件。 %s</string>
   <string name="error_article_url_not_found">错误：加载条目（网址：%1$s）失败。</string>
   <string name="pref_display_title">显示</string>
   <string name="pref_info_title">信息</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -50,10 +50,10 @@
   <string name="server_started_message" tools:keep="@string/server_started_message">Enter this ip address into your browser to access the server %s</string>
   <string name="qr_code">Rendered QR Code</string>
   <string name="share_host_address">Share URL via other applications</string>
-  <string name="error_file_not_found">Error: The selected ZIM file could not be found.</string>
+  <string name="error_file_not_found">Error: The selected ZIM file could not be found. %s</string>
   <string name="unable_to_read_zim_file">Unable to read this ZIM file!</string>
   <string name="zim_not_opened">Unable to open ZIM file</string>
-  <string name="error_file_invalid">Error: The selected file is not a valid ZIM file.</string>
+  <string name="error_file_invalid">Error: The selected file is not a valid ZIM file. %s</string>
   <string name="error_article_url_not_found">Error: Loading article (Url: %1$s) failed.</string>
   <string name="error_loading_random_article_zim_not_loaded">Unable to load article. The ZIM file is not properly loaded.</string>
   <string name="could_not_find_random_article">Unable to find a random article. Please try again later.</string>

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.custom.search
 import android.Manifest
 import android.content.Context
 import android.content.res.AssetFileDescriptor
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.NavHostFragment
@@ -350,7 +349,7 @@ class SearchFragmentTestForCustomApp {
       .build()
 
   private fun getDownloadingZimFile(): File {
-    val zimFile = File(ContextCompat.getExternalFilesDirs(context, null)[0], "ray_charles.zim")
+    val zimFile = File(context.getExternalFilesDirs(null)[0], "ray_charles.zim")
     if (zimFile.exists()) zimFile.delete()
     zimFile.createNewFile()
     return zimFile

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -110,7 +110,7 @@ class CustomFileValidator @Inject constructor(private val context: Context) {
         // Check if the directory's parent is not null
         dir.parent?.let { parentPath ->
           // Add the parent directory to the list, so we can scan all the files contained in the folder.
-          // We are doing this because ContextCompat.getExternalFilesDirs(context, null) method returns the path to the
+          // We are doing this because context.getExternalFilesDirs(null) method returns the path to the
           // "files" folder, which is specific to the app's package name, both for internal and SD card storage.
           // By obtaining the parent directory, we can scan files from the app-specific directory itself.
           directoryList.add(File(parentPath))

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.content.res.AssetManager
-import androidx.core.content.ContextCompat
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -189,10 +188,10 @@ class CustomFileValidatorTest {
 
     if (extension == "zim") {
       every {
-        ContextCompat.getExternalFilesDirs(context, null)
+        context.getExternalFilesDirs(null)
       } returns arrayOf(storageDirectory)
     } else {
-      every { ContextCompat.getObbDirs(context) } returns arrayOf(storageDirectory)
+      every { context.obbDirs } returns arrayOf(storageDirectory)
     }
   }
 }


### PR DESCRIPTION
Fixes #4216 

* On Android 9 (API 28) and below, `getExternalFilesDirs` correctly returns USB paths. However, on Android 10 (API 29) and above, it returns null for external storage like USB sticks. Previously, we appended `/mnt/media_rw/` as a workaround which works in most of the devices, but this was unreliable due to varying mount paths across devices.
* Android 11 (API 30) introduced the `StorageService` API, which accurately retrieves mount paths for SD cards, USB sticks, and external hard drives [See](https://developer.android.com/reference/android/os/storage/StorageVolume#getDirectory()). We now use this API on Android 10+ while keeping `getExternalFilesDirs` for Android 9 and below since it is correctly working on those devices. This ensures reliable USB and SD card path detection on modern devices. Additionally, we've added debugging logs to capture errors when opening files in the reader.
* Displaying a proper error message with the full ZIM path when there is an issue opening the ZIM file or if the selected file is not a valid ZIM file.
* Refactored `CopyMoveFileHandlerTest` to align with this change.
* Updated the string documentation to help translators understand this update.
* To resolve the lint error, and if the user uses the application in other languages then to avoid crashing the application, all string files have been updated. These files will be automatically updated in the latest TranslateWiki PR.
* Refactored the deprecated method used in our test cases.