### PR TITLE
Fixed: When devices went to sleep mode, the search filter was reset of the online library.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -23,7 +23,9 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions.clearText
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -34,6 +36,8 @@ import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import com.adevinta.android.barista.interaction.BaristaSwipeRefreshInteractions.refresh
 import junit.framework.AssertionFailedError
+import junit.framework.TestCase.assertEquals
+import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.junit.Assert
 import org.kiwix.kiwixmobile.BaseRobot
@@ -43,6 +47,7 @@ import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.download.DownloadTest.Companion.KIWIX_DOWNLOAD_TEST
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.utils.RecyclerViewMatcher
@@ -258,5 +263,42 @@ class DownloadRobot : BaseRobot() {
         }
       }
     }
+  }
+
+  fun clickOnSearchIcon() {
+    pauseForBetterTestPerformance()
+    testFlakyView({ clickOn(ViewId(R.id.action_search)) })
+  }
+
+  fun clickOnClearSearchIcon() {
+    pauseForBetterTestPerformance()
+    testFlakyView({ clickOn(ViewId(androidx.appcompat.R.id.search_close_btn)) })
+  }
+
+  fun searchWikipediaZIMFiles() {
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      val searchView = onView(withId(androidx.appcompat.R.id.search_src_text))
+      searchView.perform(clearText())
+      searchView.perform(typeText("Wikipedia"))
+    })
+  }
+
+  fun assertPreviousSearchRemainsActive() {
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      val searchView = onView(withId(androidx.appcompat.R.id.search_src_text))
+      searchView.check(matches(withText(containsString("Wikipedia"))))
+    })
+  }
+
+  fun assertSearchViewIsNotActive(kiwixMainActivity: KiwixMainActivity) {
+    pauseForBetterTestPerformance()
+    testFlakyView({
+      assertEquals(
+        kiwixMainActivity.supportActionBar?.title,
+        kiwixMainActivity.getString(string.download)
+      )
+    })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.nav.destination.library
+
+import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import com.adevinta.android.barista.interaction.BaristaSleepInteractions
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesViews
+import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
+import org.hamcrest.Matchers.allOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
+import org.kiwix.kiwixmobile.R
+import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.download.downloadRobot
+import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
+import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+
+class OnlineLibraryFragmentTest : BaseActivityTest() {
+
+  @Rule
+  @JvmField
+  var retryRule = RetryRule()
+
+  private lateinit var kiwixMainActivity: KiwixMainActivity
+
+  init {
+    AccessibilityChecks.enable().apply {
+      setRunChecksFromRootView(true)
+      setSuppressingResultMatcher(
+        allOf(
+          matchesCheck(DuplicateClickableBoundsCheck::class.java),
+          matchesViews(ViewMatchers.withId(R.id.get_zim_nearby_device))
+        )
+      )
+    }
+  }
+
+  @Before
+  override fun waitForIdle() {
+    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
+      if (isSystemUINotRespondingDialogVisible(this)) {
+        closeSystemDialogs(context, this)
+      }
+      waitForIdle()
+    }
+    PreferenceManager.getDefaultSharedPreferences(
+      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+    ).edit {
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
+      putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
+      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
+      putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
+      putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
+      putString(SharedPreferenceUtil.PREF_LANG, "en")
+      putLong(
+        SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
+        System.currentTimeMillis()
+      )
+    }
+    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+      moveToState(Lifecycle.State.RESUMED)
+      onActivity {
+        handleLocaleChange(
+          it,
+          "en",
+          SharedPreferenceUtil(context)
+        )
+      }
+    }
+  }
+
+  @Test
+  fun searchPersistsAfterNavigatingAwayIfNotCleared() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      it.navigate(R.id.downloadsFragment)
+    }
+    downloadRobot {
+      waitForDataToLoad()
+      clickOnSearchIcon()
+      searchWikipediaZIMFiles()
+      pressBack()
+      clickLibraryOnBottomNav()
+      clickDownloadOnBottomNav()
+      assertPreviousSearchRemainsActive()
+    }
+  }
+
+  @Test
+  fun searchIsClearedIfUserExplicitlyResetsIt() {
+    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      it.navigate(R.id.downloadsFragment)
+    }
+    downloadRobot {
+      waitForDataToLoad()
+      clickOnSearchIcon()
+      searchWikipediaZIMFiles()
+      clickOnClearSearchIcon()
+      pressBack()
+      clickLibraryOnBottomNav()
+      clickDownloadOnBottomNav()
+      assertSearchViewIsNotActive(kiwixMainActivity)
+    }
+  }
+}

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -144,6 +144,7 @@ class ZimManageViewModel @Inject constructor(
   val fileSelectActions = PublishProcessor.create<FileSelectActions>()
   val requestDownloadLibrary = BehaviorProcessor.createDefault(Unit)
   val requestFiltering = BehaviorProcessor.createDefault("")
+  val onlineBooksSearchedQuery = MutableLiveData<String>()
 
   private var compositeDisposable: CompositeDisposable? = CompositeDisposable()
   val downloadProgress = MutableLiveData<String>()


### PR DESCRIPTION
Fixes #4205

* Preserved search query across lifecycle changes to restore it when the fragment becomes visible again.
* Previously, when the device went to sleep, `viewLifecycleOwner` closed the search view due to lifecycle events, resetting the search.
* Now, the query is stored in `ViewModel` (which is lifecycle-aware) and restored when the online library screen is reopened.
* Search is reset only when the user explicitly clears it.
* Added `OnlineLibraryFragmentTest` instrumentation (UI) test case to test this new functionality.

https://github.com/user-attachments/assets/8d3a0e81-7512-4d44-bcc5-72bb3e197cfa


