### PR TITLE
Fixed: Opening SearchItem and FindInPage triggers again when switching back to the reader fragment.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreReaderFragment.kt
@@ -1228,6 +1228,8 @@ abstract class CoreReaderFragment :
 
   override fun onDestroyView() {
     super.onDestroyView()
+    findInPageTitle = null
+    searchItemToOpen = null
     restoreTabsSnackbarCallback = null
     try {
       coreReaderLifeCycleScope?.cancel()


### PR DESCRIPTION
Fixes #4224 

* The issue occurred because when moving to another fragment, the `ReaderScreen` remained in the backstack and was not fully destroyed along with its data. Additionally, we were storing the `SearchItem` and `FIND_IN_PAGE` queries in variables to perform these actions after restoring tabs. As a result, when reopening the `ReaderScreen`, the tabs were restored, and these variables retained their values, triggering the related actions again.
* To fix this, we have cleared these variables when the fragment is destroyed, as keeping them is unnecessary when the user navigates away from the reader screen.


https://github.com/user-attachments/assets/63044513-8219-413d-bfce-c94e966b25b6


