### PR TITLE
Added support for Android's per-app language setting.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"
     android:roundIcon="@mipmap/ic_launcher_round"
-    android:supportsRtl="true">
+    android:supportsRtl="true"
+    android:localeConfig="@xml/locales_config"
+    tools:targetApi="tiramisu">
 
     <activity
       android:name=".main.KiwixMainActivity"
@@ -155,5 +157,13 @@
     <service
       android:name=".webserver.wifi_hotspot.HotspotService"
       android:foregroundServiceType="dataSync" />
+    <service
+      android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+      android:enabled="false"
+      android:exported="false">
+      <meta-data
+        android:name="autoStoreLocales"
+        android:value="true" />
+    </service>
   </application>
 </manifest>

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -25,11 +25,13 @@ import android.os.Handler
 import android.os.Looper
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.view.ActionMode
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.os.ConfigurationCompat
+import androidx.core.os.LocaleListCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.drawerlayout.widget.DrawerLayout
@@ -142,6 +144,16 @@ class KiwixMainActivity : CoreMainActivity() {
     handleNotificationIntent(intent)
     handleGetContentIntent(intent)
     activityKiwixMainBinding.root.applyEdgeToEdgeInsets()
+    migratedToPerAppLanguage()
+  }
+
+  private fun migratedToPerAppLanguage() {
+    if (!sharedPreferenceUtil.perAppLanguageMigrated) {
+      AppCompatDelegate.setApplicationLocales(
+        LocaleListCompat.forLanguageTags(sharedPreferenceUtil.prefLanguage)
+      )
+      sharedPreferenceUtil.putPerAppLanguageMigration(true)
+    }
   }
 
   private suspend fun migrateInternalToPublicAppDirectory() {

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Kiwix Android
+  ~ Copyright (c) 2025 Kiwix <android.kiwix.org>
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+  <locale android:name="am" />
+  <locale android:name="oc" />
+  <locale android:name="vi" />
+  <locale android:name="nl" />
+  <locale android:name="uz" />
+  <locale android:name="hu" />
+  <locale android:name="cs" />
+  <locale android:name="da" />
+  <locale android:name="ko" />
+  <locale android:name="et" />
+  <locale android:name="ie" />
+  <locale android:name="bm" />
+  <locale android:name="hr" />
+  <locale android:name="ta" />
+  <locale android:name="id" />
+  <locale android:name="th" />
+  <locale android:name="cy" />
+  <locale android:name="nb" />
+  <locale android:name="nn" />
+  <locale android:name="ml" />
+  <locale android:name="ur" />
+  <locale android:name="sc" />
+  <locale android:name="or" />
+  <locale android:name="si" />
+  <locale android:name="ps" />
+  <locale android:name="gu" />
+  <locale android:name="it" />
+  <locale android:name="in" />
+  <locale android:name="so" />
+  <locale android:name="ba" />
+  <locale android:name="he" />
+  <locale android:name="lv" />
+  <locale android:name="su" />
+  <locale android:name="sv" />
+  <locale android:name="be" />
+  <locale android:name="ms" />
+  <locale android:name="yo" />
+  <locale android:name="as" />
+  <locale android:name="fi" />
+  <locale android:name="li" />
+  <locale android:name="lt" />
+  <locale android:name="sq" />
+  <locale android:name="eo" />
+  <locale android:name="fr" />
+  <locale android:name="km" />
+  <locale android:name="ru" />
+  <locale android:name="qu" />
+  <locale android:name="tl" />
+  <locale android:name="fa" />
+  <locale android:name="br" />
+  <locale android:name="sh" />
+  <locale android:name="my" />
+  <locale android:name="ja" />
+  <locale android:name="uk" />
+  <locale android:name="ia" />
+  <locale android:name="tr" />
+  <locale android:name="jv" />
+  <locale android:name="hi" />
+  <locale android:name="az" />
+  <locale android:name="cv" />
+  <locale android:name="pt" />
+  <locale android:name="rm" />
+  <locale android:name="es" />
+  <locale android:name="mn" />
+  <locale android:name="bn" />
+  <locale android:name="mg" />
+  <locale android:name="fo" />
+  <locale android:name="lb" />
+  <locale android:name="te" />
+  <locale android:name="sk" />
+  <locale android:name="yi" />
+  <locale android:name="mk" />
+  <locale android:name="ro" />
+  <locale android:name="ne" />
+  <locale android:name="iw" />
+  <locale android:name="af" />
+  <locale android:name="sw" />
+  <locale android:name="pl" />
+  <locale android:name="zh" />
+  <locale android:name="el" />
+  <locale android:name="ar" />
+  <locale android:name="sl" />
+  <locale android:name="gl" />
+  <locale android:name="sa" />
+  <locale android:name="ka" />
+  <locale android:name="ji" />
+  <locale android:name="kn" />
+  <locale android:name="de" />
+  <locale android:name="ky" />
+  <locale android:name="bg" />
+  <locale android:name="ca" />
+  <locale android:name="mt" />
+  <locale android:name="en" />
+</locale-config>
+

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -296,6 +296,8 @@ object Libs {
    */
   const val appcompat: String = "androidx.appcompat:appcompat:" + Versions.appcompat
 
+  const val appcompat_resource = "androidx.appcompat:appcompat-resources:" + Versions.appcompat
+
   /**
    * https://github.com/ReactiveX/RxAndroid
    */

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -198,6 +198,7 @@ class AllProjectConfigurer {
     target.dependencies {
       implementation(Libs.kotlin_stdlib_jdk8)
       implementation(Libs.appcompat)
+      implementation(Libs.appcompat_resource)
       implementation(Libs.material)
       implementation(Libs.constraintlayout)
       implementation(Libs.swipe_refresh_layout)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -106,6 +106,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefIsAppDirectoryMigrated: Boolean
     get() = sharedPreferences.getBoolean(PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, false)
 
+  val perAppLanguageMigrated: Boolean
+    get() = sharedPreferences.getBoolean(PER_APP_LANGUAGE_MIGRATION, false)
+
   val prefStorage: String
     get() {
       val storage = sharedPreferences.getString(PREF_STORAGE, null)
@@ -158,6 +161,9 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
 
   fun putPrefDeviceDefaultLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_DEVICE_DEFAULT_LANG, language) }
+
+  fun putPerAppLanguageMigration(isMigrated: Boolean) =
+    sharedPreferences.edit { putBoolean(PER_APP_LANGUAGE_MIGRATION, isMigrated) }
 
   fun putPrefIsFirstRun(isFirstRun: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_IS_FIRST_RUN, isFirstRun) }
@@ -334,5 +340,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     private const val PREF_LATER_CLICKED_MILLIS = "pref_later_clicked_millis"
     const val PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS =
       "pref_last_donation_shown_in_milliseconds"
+    const val PER_APP_LANGUAGE_MIGRATION = "per_app_language_migration"
   }
 }

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -51,4 +51,5 @@
   <issue id="CheckResult">
     <ignore path="**/androidTest/**.kt" />
   </issue>
+  <issue id="UnusedTranslation" severity="warning" />
 </lint>


### PR DESCRIPTION
Fixes#4222

* Introduced the per-app language feature in application.
* Added `androidx.appcompat:appcompat-resources` dependency.
* Setting the chosen language in AppCompatDelegate to update the selected language globally so that it is displayed in the system settings.
* Migrated the previously chosen language in AppCompatDelegate so that the previously selected language will remain active.