### PR TITLE
Added support for Android 16.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,13 +28,17 @@ android {
   // This is now specified in the Gradle configuration instead of declaring
   // it directly in the AndroidManifest file.
   namespace = "org.kiwix.kiwixmobile"
+  compileSdkPreview = Config.compileSdk
   defaultConfig {
+    minSdk = Config.minSdk
     base.archivesName.set(apkPrefix)
+    targetSdkPreview = Config.targetSdk
     resValue("string", "app_name", "Kiwix")
     resValue("string", "app_search_string", "Search Kiwix")
     versionCode = "".getVersionCode()
     versionName = generateVersionName()
     manifestPlaceholders["permission"] = "android.permission.MANAGE_EXTERNAL_STORAGE"
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
   lint {
     checkDependencies = true

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/CustomPageIndicator.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/CustomPageIndicator.kt
@@ -21,6 +21,7 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.database.DataSetObserver
 import android.graphics.Canvas
@@ -767,7 +768,8 @@ class CustomPageIndicator @JvmOverloads constructor(
   init {
     val density = context.resources.displayMetrics.density.toInt()
 
-    // Load attributes
+    // Load
+    @SuppressLint("UseKtx")
     val a = getContext().obtainStyledAttributes(
       attrs, R.styleable.CustomPageIndicator, defStyle, 0
     )

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryFragment.kt
@@ -388,7 +388,7 @@ class LocalLibraryFragment : BaseFragment(), CopyMoveFileHandler.FileCopyMoveCal
       if (sharedPreferenceUtil.prefIsTest) {
         putExtra(
           "android.provider.extra.INITIAL_URI",
-          Uri.parse("content://com.android.externalstorage.documents/document/primary:Download")
+          "content://com.android.externalstorage.documents/document/primary:Download".toUri()
         )
       }
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.nav.destination.reader
 
-import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -30,6 +29,7 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.coroutines.launch
@@ -135,7 +135,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
     // when creating the new archive object.
     updateTitle()
     val filePath = FileUtils.getLocalFilePathByUri(
-      requireActivity().applicationContext, Uri.parse(zimFileUri)
+      requireActivity().applicationContext, zimFileUri.toUri()
     )
     if (filePath == null || !File(filePath).isFileExist()) {
       // Close the previously opened book in the reader. Since this file is not found,
@@ -158,7 +158,7 @@ class KiwixReaderFragment : CoreReaderFragment() {
 
   override fun openHomeScreen() {
     Handler(Looper.getMainLooper()).postDelayed({
-      if (webViewList.size == 0) {
+      if (webViewList.isEmpty()) {
         hideTabSwitcher(false)
       }
     }, HIDE_TAB_SWITCHER_DELAY)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,5 +28,5 @@ allprojects {
 }
 
 tasks.create<Delete>("clean") {
-  delete(rootProject.buildDir)
+  delete(rootProject.layout.buildDirectory)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:8.7.2")
+  implementation("com.android.tools.build:gradle:8.10.0-alpha05")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
   implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.0.0-1.0.24")
   implementation("org.jacoco:org.jacoco.core:0.8.12")

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -22,9 +22,9 @@ object Config {
 
   // Here is a list of all Android versions with their corresponding API
   // levels: https://apilevels.com/
-  const val compileSdk = 35 // SDK version used by Gradle to compile our app.
+  const val compileSdk = "Baklava" // SDK version used by Gradle to compile our app.
   const val minSdk = 25 // Minimum SDK (Minimum Support Device) is 25 (Android 7.1 Nougat).
-  const val targetSdk = 35 // Target SDK (Maximum Support Device) is 34 (Android 14).
+  const val targetSdk = "Baklava" // Target SDK (Maximum Support Device) is Baklava (Android 16).
 
   val javaVersion = JavaVersion.VERSION_17
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -48,7 +48,7 @@ object Versions {
 
   const val android_arch_lifecycle_extensions: String = "1.1.1"
 
-  const val com_android_tools_build_gradle: String = "8.7.2"
+  const val com_android_tools_build_gradle: String = "8.10.0-alpha05"
 
   const val de_fayard_buildsrcversions_gradle_plugin: String = "0.7.0"
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -57,12 +57,6 @@ class AllProjectConfigurer {
       if (isLibrary) {
         namespace = "org.kiwix.kiwixmobile.core"
       }
-      setCompileSdkVersion(Config.compileSdk)
-      defaultConfig {
-        minSdk = Config.minSdk
-        setTargetSdkVersion(Config.targetSdk)
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-      }
 
       buildTypes {
         getByName("debug") {

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -153,6 +153,7 @@ class AllProjectConfigurer {
           add("UnusedResources")
           add("NonConstantResourceId")
           add("NotifyDataSetChanged")
+          add("Aligned16KB") // TODO: Remove when properly migrated to Android 16.
         }
         lintConfig = target.rootProject.file("lintConfig.xml")
       }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,8 +18,12 @@ plugins.apply(KiwixConfigurationPlugin::class)
 apply(plugin = "io.objectbox")
 
 android {
+  compileSdkPreview = Config.compileSdk
   defaultConfig {
+    minSdk = Config.minSdk
+    targetSdkPreview = Config.targetSdk
     buildConfigField("long", "VERSION_CODE", "".getVersionCode().toString())
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
   buildTypes {
     getByName("release") {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/Compat.kt
@@ -23,6 +23,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.ConnectivityManager
+import java.util.Locale
 
 /**
  * This interface defines a set of functions that are not available on all platforms.
@@ -76,4 +77,6 @@ interface Compat {
   fun isNetworkAvailable(connectivity: ConnectivityManager): Boolean
 
   fun isWifi(connectivity: ConnectivityManager): Boolean
+
+  fun convertToLocal(language: String): Locale
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -28,17 +28,14 @@ import android.os.Build
 class CompatHelper private constructor() {
   // Note: Needs ": Compat" or the type system assumes `Compat21`
   private val compatValue: Compat = when {
-    sdkVersion >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA -> CompatV36()
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
     else -> CompatV25()
   }
 
   companion object {
     /** Singleton instance of [CompatHelper] */
     private val instance by lazy(::CompatHelper)
-
-    /** Get the current Android API level.  */
-    val sdkVersion: Int
-      get() = Build.VERSION.SDK_INT
 
     val compat get() = instance.compatValue
 
@@ -79,5 +76,7 @@ class CompatHelper private constructor() {
 
     fun ConnectivityManager.isWifi(): Boolean =
       compat.isWifi(this)
+
+    fun String.convertToLocal() = compat.convertToLocal(this)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV25.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV25.kt
@@ -26,6 +26,7 @@ import android.content.pm.ResolveInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
+import java.util.Locale
 
 open class CompatV25 : Compat {
 
@@ -62,4 +63,6 @@ open class CompatV25 : Compat {
     return connectivity.getNetworkCapabilities(connectivity.activeNetwork)
       ?.hasTransport(TRANSPORT_WIFI) == true
   }
+
+  override fun convertToLocal(language: String): Locale = Locale(language)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV36.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatV36.kt
@@ -1,6 +1,6 @@
 /*
  * Kiwix Android
- * Copyright (c) 2023 Kiwix <android.kiwix.org>
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -21,37 +21,33 @@ package org.kiwix.kiwixmobile.core.compat
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.content.pm.PackageManager.PackageInfoFlags
 import android.content.pm.ResolveInfo
 import android.net.ConnectivityManager
-import android.os.Build.VERSION_CODES.TIRAMISU
+import android.os.Build.VERSION_CODES.BAKLAVA
 import androidx.annotation.RequiresApi
 import java.util.Locale
 
-@RequiresApi(TIRAMISU)
-open class CompatV33 : Compat {
-  private val compatV25 = CompatV25()
+@RequiresApi(BAKLAVA)
+open class CompatV36 : Compat {
+  private val compatV33 = CompatV33()
   override fun queryIntentActivities(
     packageManager: PackageManager,
     intent: Intent,
     flags: ResolveInfoFlagsCompat
-  ): List<ResolveInfo> = packageManager.queryIntentActivities(
-    intent,
-    PackageManager.ResolveInfoFlags.of(flags.value)
-  )
+  ): List<ResolveInfo> = compatV33.queryIntentActivities(packageManager, intent, flags)
 
   override fun getPackageInformation(
     packageName: String,
     packageManager: PackageManager,
     flag: Int
   ): PackageInfo =
-    packageManager.getPackageInfo(packageName, PackageInfoFlags.of(flag.toLong()))
+    compatV33.getPackageInformation(packageName, packageManager, flag)
 
   override fun isNetworkAvailable(connectivity: ConnectivityManager): Boolean =
-    compatV25.isNetworkAvailable(connectivity)
+    compatV33.isNetworkAvailable(connectivity)
 
   override fun isWifi(connectivity: ConnectivityManager): Boolean =
-    compatV25.isWifi(connectivity)
+    compatV33.isWifi(connectivity)
 
-  override fun convertToLocal(language: String): Locale = compatV25.convertToLocal(language)
+  override fun convertToLocal(language: String): Locale = Locale.of(language)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/LanguageEntity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/entities/LanguageEntity.kt
@@ -22,6 +22,7 @@ import io.objectbox.annotation.Convert
 import io.objectbox.annotation.Entity
 import io.objectbox.annotation.Id
 import io.objectbox.converter.PropertyConverter
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import org.kiwix.kiwixmobile.core.zim_manager.Language
 import java.util.Locale
 
@@ -36,7 +37,7 @@ data class LanguageEntity(
 
   constructor(language: Language) : this(
     0,
-    Locale(language.languageCode),
+    language.languageCode.convertToLocal(),
     language.active,
     language.occurencesOfLanguage
   )
@@ -50,5 +51,5 @@ class StringToLocaleConverter : PropertyConverter<Locale, String> {
     entityProperty?.isO3Language ?: Locale.ENGLISH.isO3Language
 
   override fun convertToEntityProperty(databaseValue: String?): Locale =
-    databaseValue?.let(::Locale) ?: Locale.ENGLISH
+    databaseValue?.convertToLocal() ?: Locale.ENGLISH
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/DownloadRequest.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/model/DownloadRequest.kt
@@ -20,10 +20,11 @@ package org.kiwix.kiwixmobile.core.downloader.model
 import android.net.Uri
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.StorageUtils
+import androidx.core.net.toUri
 
 data class DownloadRequest(val urlString: String) {
 
-  val uri: Uri get() = Uri.parse(urlString)
+  val uri: Uri get() = urlString.toUri()
 
   fun getDestination(sharedPreferenceUtil: SharedPreferenceUtil): String =
     "${sharedPreferenceUtil.prefStorage}/Kiwix/${StorageUtils.getFileNameFromUrl(urlString)}"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ContextExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ContextExtensions.kt
@@ -33,6 +33,9 @@ import android.util.TypedValue
 import android.widget.Toast
 import androidx.annotation.AttrRes
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.graphics.scale
 import org.kiwix.kiwixmobile.core.base.BaseBroadcastReceiver
 import java.util.Locale
 
@@ -84,14 +87,9 @@ fun Context.getResizedDrawable(resourceId: Int, width: Int, height: Int): Drawab
   val drawable = ContextCompat.getDrawable(this, resourceId)
 
   return if (drawable != null) {
-    val bitmap = Bitmap.createScaledBitmap(
-      getBitmapFromDrawable(drawable),
-      width,
-      height,
-      false
-    )
+    val bitmap = getBitmapFromDrawable(drawable).scale(width, height, false)
 
-    BitmapDrawable(resources, bitmap).apply {
+    bitmap.toDrawable(resources).apply {
       bounds = drawable.bounds
     }
   } else {
@@ -104,11 +102,7 @@ fun Context.getBitmapFromDrawable(drawable: Drawable): Bitmap {
     return drawable.bitmap
   }
 
-  val bitmap = Bitmap.createBitmap(
-    drawable.intrinsicWidth,
-    drawable.intrinsicHeight,
-    Bitmap.Config.ARGB_8888
-  )
+  val bitmap = createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight)
   val canvas = Canvas(bitmap)
   drawable.setBounds(0, 0, canvas.width, canvas.height)
   drawable.draw(canvas)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpAdapter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpAdapter.kt
@@ -20,8 +20,8 @@ package org.kiwix.kiwixmobile.core.help
 import android.animation.ObjectAnimator
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isGone
 import androidx.recyclerview.widget.RecyclerView
 import org.kiwix.kiwixmobile.core.base.adapter.BaseViewHolder
 import org.kiwix.kiwixmobile.core.databinding.ItemHelpBinding
@@ -51,7 +51,7 @@ internal class HelpAdapter(titleDescriptionMap: Map<String, String>) :
 
     @SuppressWarnings("MagicNumber")
     fun toggleDescriptionVisibility() {
-      if (itemHelpBinding.itemHelpDescription.visibility == View.GONE) {
+      if (itemHelpBinding.itemHelpDescription.isGone) {
         ObjectAnimator.ofFloat(itemHelpBinding.itemHelpToggleExpand, "rotation", 0f, 180f).start()
         itemHelpBinding.itemHelpDescription.expand()
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -18,18 +18,18 @@
 package org.kiwix.kiwixmobile.core.main
 
 import android.content.Intent
-import android.net.Uri
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import android.webkit.MimeTypeMap
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.net.toUri
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
+import org.kiwix.kiwixmobile.core.utils.files.Log
 
 open class CoreWebViewClient(
   protected val callback: WebViewCallback,
@@ -64,7 +64,7 @@ open class CoreWebViewClient(
     }
 
     // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+    val intent = Intent(Intent.ACTION_VIEW, url.toUri())
     callback.openExternalUrl(intent)
     return true
   }
@@ -144,7 +144,7 @@ open class CoreWebViewClient(
     }
     private val LEGACY_CONTENT_PREFIXES = arrayOf(
       "zim://content/",
-      Uri.parse("content://" + instance.packageName + ".zim.base/").toString()
+      "content://${instance.packageName}.zim.base/".toUri().toString()
     )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/qr/GenerateQR.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/qr/GenerateQR.kt
@@ -18,12 +18,15 @@
 
 package org.kiwix.kiwixmobile.core.qr
 
+import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Color
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
 import javax.inject.Inject
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.set
 
 /**
  * Utility class to generate QR codes.
@@ -37,6 +40,7 @@ class GenerateQR @Inject constructor() {
    * @param foregroundColor The color of the QR code.
    * @param backgroundColor The background color of the QR code.
    */
+  @SuppressLint("UseKtx")
   fun createQR(
     code: String,
     size: Int = 512,
@@ -47,7 +51,7 @@ class GenerateQR @Inject constructor() {
       it[EncodeHintType.MARGIN] = 1
     }
     val bits = QRCodeWriter().encode(code, BarcodeFormat.QR_CODE, size, size, hints)
-    return Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565).also {
+    return createBitmap(size, size, Bitmap.Config.RGB_565).also {
       for (x in 0 until size) {
         for (y in 0 until size) {
           it.setPixel(x, y, if (bits[x, y]) foregroundColor else backgroundColor)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -401,7 +401,7 @@ class ZimFileReader constructor(
     * Uri.parse returns null without android dependencies loaded
     */
     @JvmField
-    val UI_URI: Uri? = Uri.parse("content://org.kiwix.ui/")
+    val UI_URI: Uri? = "content://org.kiwix.ui/".toUri()
 
     const val CONTENT_PREFIX = "https://kiwix.app/"
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CorePrefsFragment.kt
@@ -46,6 +46,7 @@ import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.DarkModeConfig
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInformation
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
@@ -169,9 +170,7 @@ abstract class CorePrefsFragment :
         languagePref.title =
           if (selectedLang == Locale.ROOT.toString())
             getString(R.string.device_default)
-          else Locale(
-            selectedLang
-          ).displayLanguage
+          else selectedLang.convertToLocal().displayLanguage
         languagePref.onPreferenceChangeListener =
           Preference.OnPreferenceChangeListener { _, newValue ->
             val languageCode = newValue as String?
@@ -205,7 +204,7 @@ abstract class CorePrefsFragment :
     val entries = arrayOfNulls<String>(languageCodeList.size)
     entries[0] = getString(R.string.device_default)
     for (i in 1 until languageCodeList.size) {
-      val locale = Locale(languageCodeList[i])
+      val locale = languageCodeList[i].convertToLocal()
       entries[i] = locale.displayLanguage + " (" + locale.getDisplayLanguage(locale) + ") "
     }
     return entries

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/LanguageContainer.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.utils
 
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import java.util.Locale
 
 class LanguageContainer private constructor(val languageCode: String, val languageName: String) {
@@ -25,7 +26,7 @@ class LanguageContainer private constructor(val languageCode: String, val langua
 
   companion object {
     private fun chooseLanguageName(languageCode: String): String {
-      val displayLanguage = Locale(languageCode).displayLanguage
+      val displayLanguage = languageCode.convertToLocal().displayLanguage
       return if (displayLanguage.length == 2 || displayLanguage.isEmpty())
         Locale.ENGLISH.displayLanguage
       else

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ZimReaderContainerUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ZimReaderContainerUtils.kt
@@ -18,7 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.utils
 
-import android.net.Uri
+import androidx.core.net.toUri
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 
@@ -26,7 +26,7 @@ private fun ZimReaderContainer.redirectOrOriginal(contentUrl: String): String =
   if (isRedirect(contentUrl)) getRedirect(contentUrl) else contentUrl
 
 private fun contentUrl(articleUrl: String): String =
-  Uri.parse(ZimFileReader.CONTENT_PREFIX + articleUrl).toString()
+  "${ZimFileReader.CONTENT_PREFIX}$articleUrl".toUri().toString()
 
 fun ZimReaderContainer.urlSuffixToParsableUrl(suffixUrl: String): String =
   redirectOrOriginal(contentUrl(suffixUrl))

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
@@ -20,8 +20,8 @@ package org.kiwix.kiwixmobile.core.utils.dialog
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import androidx.annotation.IdRes
+import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.BuildConfig
@@ -102,9 +102,9 @@ class RateDialogHandler @Inject constructor(
 
   private fun goToRateApp(activity: Activity) {
     val kiwixLocalMarketUri =
-      Uri.parse("market://details?id=${activity.packageName}")
+      "market://details?id=${activity.packageName}".toUri()
     val kiwixBrowserMarketUri =
-      Uri.parse("http://play.google.com/store/apps/details?id=${activity.packageName}")
+      "http://play.google.com/store/apps/details?id=${activity.packageName}".toUri()
     val goToMarket = Intent(Intent.ACTION_VIEW, kiwixLocalMarketUri)
     goToMarket.addFlags(
       Intent.FLAG_ACTIVITY_NO_HISTORY or

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -51,6 +51,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
+import androidx.core.net.toUri
 
 object FileUtils {
 
@@ -405,7 +406,7 @@ object FileUtils {
       for (prefix in contentUriPrefixes) {
         contentQuery(
           context,
-          ContentUris.withAppendedId(Uri.parse(prefix), documentId),
+          ContentUris.withAppendedId(prefix.toUri(), documentId),
           documentsContractWrapper
         )?.let {
           return@queryForActualPath it

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/Language.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/Language.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.core.zim_manager
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import java.util.Locale
 
 @Parcelize
@@ -52,7 +53,7 @@ data class Language constructor(
     languageCode: String,
     active: Boolean,
     occurrencesOfLanguage: Int
-  ) : this(Locale(languageCode), active, occurrencesOfLanguage)
+  ) : this(languageCode.convertToLocal(), active, occurrencesOfLanguage)
 
   override fun equals(other: Any?): Boolean =
     (other as Language).language == language && other.active == active

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/fileselect_view/adapter/BooksOnDiskListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/fileselect_view/adapter/BooksOnDiskListItem.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.adapter
 
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import org.kiwix.kiwixmobile.core.dao.entities.BookOnDiskEntity
 import org.kiwix.kiwixmobile.core.dao.entities.DownloadRoomEntity
 import org.kiwix.kiwixmobile.core.entity.LibraryNetworkEntity.Book
@@ -51,7 +52,7 @@ sealed class BooksOnDiskListItem {
   ) : BooksOnDiskListItem() {
 
     val locale: Locale by lazy {
-      Locale(book.language)
+      book.language.convertToLocal()
     }
 
     constructor(bookOnDiskEntity: BookOnDiskEntity) : this(

--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -4,16 +4,16 @@ import com.android.build.gradle.internal.dsl.ProductFlavor
 import custom.CustomApps
 import custom.createPublisher
 import custom.transactionWithCommit
-import plugin.KiwixConfigurationPlugin
-import java.net.URI
-import java.net.URLDecoder
-import java.util.Locale
-import java.util.Base64
-import java.io.FileOutputStream
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
+import plugin.KiwixConfigurationPlugin
 import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.net.URI
+import java.net.URLDecoder
+import java.util.Base64
+import java.util.Locale
 
 plugins {
   android
@@ -22,8 +22,12 @@ plugins {
 plugins.apply(KiwixConfigurationPlugin::class)
 
 android {
+  compileSdkPreview = Config.compileSdk
   defaultConfig {
     applicationId = "org.kiwix"
+    minSdk = Config.minSdk
+    targetSdkPreview = Config.targetSdk
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
   flavorDimensions += "default"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 19 16:13:45 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -51,4 +51,5 @@
   <issue id="CheckResult">
     <ignore path="**/androidTest/**.kt" />
   </issue>
+  <issue id="AnnotateVersionCheck" severity="warning" />
 </lint>


### PR DESCRIPTION
Fixes #4165 

* Added support for Android 16.
* Upgraded AGP to `8.10.0-alpha05`, which supports Android 16.
* Replaced `targetSdkVersion` and `compileSdkVersion` with `targetSdkPreview` and `compileSdkPreview` to add support for Android 16.
* Refactored the `java.util.Locale` constructor, which is deprecated in Android 16. For this, we have created `CompatV36` to utilize the methods introduced in this Android version.
* After upgrading the gradle lint showed some new errors so we have fixed those lint errors that required us to use the `KTX` extension functions, as they internally utilize the same functions we were using.
