### PR TITLE
#4236 Improved download notification strings replacing default Fetch

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
@@ -111,6 +111,20 @@ class FetchDownloadNotificationManager @Inject constructor(
     }
   }
 
+  override fun getSubtitleText(
+    context: Context,
+    downloadNotification: DownloadNotification
+  ): String {
+    return when {
+      downloadNotification.isCompleted -> context.getString(R.string.fetch_notification_download_complete)
+      downloadNotification.isFailed -> context.getString(R.string.fetch_notification_download_failed)
+      downloadNotification.isPaused -> context.getString(R.string.fetch_notification_download_paused)
+      downloadNotification.isQueued -> context.getString(R.string.fetch_notification_download_resuming)
+      downloadNotification.etaInMilliSeconds < 0 -> context.getString(R.string.fetch_notification_download_downloading)
+      else -> super.getSubtitleText(context, downloadNotification)
+    }
+  }
+
   @RequiresApi(Build.VERSION_CODES.O)
   private fun createChannel(channelId: String, context: Context) =
     NotificationChannel(

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -329,4 +329,9 @@
   <string name="go_to_settings_label">This is a text label, by clicking on this text user navigates to the app settings on their device.</string>
   <string name="request_notification_permission_message">This message appears in the “Android Dialog” as an information message. When the user tries to run any functionality which requires notification access but the app does not have that access, then this message shows to the user to give notification access.</string>
   <string name="empty_string">{{Ignored}}</string>
+  <string name="fetch_notification_download_complete">This appears in the "Android Notification" as a notification description message indicating the download is complete.</string>
+  <string name="fetch_notification_download_failed">This appears in the "Android Notification" as a notification description message indicating the download failed.</string>
+  <string name="fetch_notification_download_paused">This appears in the "Android Notification" as a notification description message indicating the download has been paused.</string>
+  <string name="fetch_notification_download_resuming">This appears in the "Android Notification" as a notification description message indicating a paused download is resuming.</string>
+  <string name="fetch_notification_download_downloading">This appears in the "Android Notification" as a notification description message indicating that a download is in progress.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -402,4 +402,9 @@
   <string name="donation_dialog_title">Donate Today</string>
   <string name="donation_dialog_description">%s needs your help.</string>
   <string name="make_donation">Make a donation</string>
+  <string name="fetch_notification_download_complete">Complete</string>
+  <string name="fetch_notification_download_failed">Failed</string>
+  <string name="fetch_notification_download_paused">Paused</string>
+  <string name="fetch_notification_download_resuming">Resuming</string>
+  <string name="fetch_notification_download_downloading">Downloading</string>
 </resources>


### PR DESCRIPTION
Fixes #4236

### 📌 Summary

1. Improving notification wording by replacing "starting" with "resuming" when a paused download is resuming
2. Replacing Default `Fetch` library strings with our own string resources to handle translation in other languages.
