### PR TITLE
#4236 Improved download notification strings replacing default Fetch

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -33,7 +33,6 @@ import com.tonyodev.fetch2.Download
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Fetch
 import com.tonyodev.fetch2.FetchListener
-import com.tonyodev.fetch2.R
 import com.tonyodev.fetch2.Status
 import com.tonyodev.fetch2.util.DEFAULT_NOTIFICATION_TIMEOUT_AFTER_RESET
 import com.tonyodev.fetch2core.DownloadBlock
@@ -47,6 +46,8 @@ import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.DOWNLOAD_NOTIFICATION_CHANNEL_ID
 import javax.inject.Inject
+
+const val THIRTY_TREE = 33
 
 class DownloadMonitorService : Service() {
   private val updater = PublishSubject.create<() -> Unit>()
@@ -265,7 +266,6 @@ class DownloadMonitorService : Service() {
     }
   }
 
-  @Suppress("MagicNumber")
   private fun showDownloadCompletedNotification(download: Download) {
     downloadNotificationChannel()
     val notificationBuilder = getNotificationBuilder(download.id)
@@ -275,7 +275,7 @@ class DownloadMonitorService : Service() {
     notificationBuilder.setPriority(NotificationCompat.PRIORITY_DEFAULT)
       .setSmallIcon(android.R.drawable.stat_sys_download_done)
       .setContentTitle(notificationTitle)
-      .setContentText(getString(R.string.fetch_notification_download_complete))
+      .setContentText(getString(string.complete))
       .setOngoing(false)
       .setGroup(download.id.toString())
       .setGroupSummary(false)
@@ -287,7 +287,10 @@ class DownloadMonitorService : Service() {
     // notification. If we use the same ID, changing the foreground notification for another
     // ongoing download cancels the previous notification for that id, preventing the download
     // complete notification from being displayed.
-    val downloadCompleteNotificationId = download.id + 33
+    val downloadCompleteNotificationId = download.id + THIRTY_TREE
+    // Cancel the complete download notification if already shown due to the application's
+    // lifecycle fetch. See #4237 for more details.
+    cancelNotificationForId(download.id - THIRTY_TREE)
     notificationManager.notify(downloadCompleteNotificationId, notificationBuilder.build())
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
@@ -111,6 +111,20 @@ class FetchDownloadNotificationManager @Inject constructor(
     }
   }
 
+  override fun getSubtitleText(
+    context: Context,
+    downloadNotification: DownloadNotification
+  ): String {
+    return when {
+      downloadNotification.isCompleted -> context.getString(R.string.fetch_notification_download_complete)
+      downloadNotification.isFailed -> context.getString(R.string.fetch_notification_download_failed)
+      downloadNotification.isPaused -> context.getString(R.string.fetch_notification_download_paused)
+      downloadNotification.isQueued -> context.getString(R.string.fetch_notification_download_resuming)
+      downloadNotification.etaInMilliSeconds < 0 -> context.getString(R.string.fetch_notification_download_downloading)
+      else -> super.getSubtitleText(context, downloadNotification)
+    }
+  }
+
   @RequiresApi(Build.VERSION_CODES.O)
   private fun createChannel(channelId: String, context: Context) =
     NotificationChannel(

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -329,9 +329,7 @@
   <string name="go_to_settings_label">This is a text label, by clicking on this text user navigates to the app settings on their device.</string>
   <string name="request_notification_permission_message">This message appears in the “Android Dialog” as an information message. When the user tries to run any functionality which requires notification access but the app does not have that access, then this message shows to the user to give notification access.</string>
   <string name="empty_string">{{Ignored}}</string>
-  <string name="fetch_notification_download_complete">This appears in the "Android Notification" as a notification description message indicating the download is complete.</string>
-  <string name="fetch_notification_download_failed">This appears in the "Android Notification" as a notification description message indicating the download failed.</string>
-  <string name="fetch_notification_download_paused">This appears in the "Android Notification" as a notification description message indicating the download has been paused.</string>
-  <string name="fetch_notification_download_resuming">This appears in the "Android Notification" as a notification description message indicating a paused download is resuming.</string>
-  <string name="fetch_notification_download_downloading">This appears in the "Android Notification" as a notification description message indicating that a download is in progress.</string>
+  <string name="resuming_state">This text is shown to inform the user that the current state of download is resuming.</string>
+  <string name="downloading_state">This text is shown to inform the user that the current state of download is actively in progress.</string>
+  <string name="download_failed_state">This text is shown to inform the user when a download has been failed.</string>
 </resources>

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -329,4 +329,9 @@
   <string name="go_to_settings_label">This is a text label, by clicking on this text user navigates to the app settings on their device.</string>
   <string name="request_notification_permission_message">This message appears in the “Android Dialog” as an information message. When the user tries to run any functionality which requires notification access but the app does not have that access, then this message shows to the user to give notification access.</string>
   <string name="empty_string">{{Ignored}}</string>
+  <string name="fetch_notification_download_complete">This appears in the "Android Notification" as a notification description message indicating the download is complete.</string>
+  <string name="fetch_notification_download_failed">This appears in the "Android Notification" as a notification description message indicating the download failed.</string>
+  <string name="fetch_notification_download_paused">This appears in the "Android Notification" as a notification description message indicating the download has been paused.</string>
+  <string name="fetch_notification_download_resuming">This appears in the "Android Notification" as a notification description message indicating a paused download is resuming.</string>
+  <string name="fetch_notification_download_downloading">This appears in the "Android Notification" as a notification description message indicating that a download is in progress.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -177,7 +177,7 @@
   <string name="pref_external_link_popup_title">Warn when entering external links</string>
   <string name="pref_external_link_popup_summary">Display popup to warn about additional costs or not working in offline links.</string>
   <string name="external_link_popup_dialog_title">Entering External Link!</string>
-  <string name="external_link_popup_dialog_message">You are entering an external link. This could lead to additional costs for data transfer or will just not work when you are offline. Do you want to continue?</string>
+  <string name="external_link_popup_dialog_message">You are entering an external link. This could lead to additional costs for data transfer or will just not work when you are offline.\nDo you want to continue?</string>
   <string name="do_not_ask_anymore">Do not ask anymore</string>
   <string name="your_languages" tools:keep="@string/your_languages">Selected languages:</string>
   <string name="other_languages" tools:keep="@string/other_languages">Other languages:</string>
@@ -335,7 +335,7 @@
   <string name="move">Move</string>
   <string name="copying_zim_file">Copying ZIM file…</string>
   <string name="moving_zim_file">Moving ZIM file…</string>
-  <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory. Do you want to copy or move it there?</string>
+  <string name="copy_move_files_dialog_description">Kiwix requires the ZIM file to be in its own data directory.\nDo you want to copy or move it there?</string>
   <string name="copy_file_error_message">Error in copying the ZIM file: %s.</string>
   <string name="verify_zim_chunk_dialog_title">Be cautious: Ensure all ZIM chunks have been properly moved/copied!</string>
   <string name="verify_zim_chunks_dialog_message">You can verify them inside “Android/media/org.kiwix…/” folder.\nOnce done, refresh the library screen by swiping down. The split ZIM file will then appear in your library.</string>
@@ -402,9 +402,7 @@
   <string name="donation_dialog_title">Donate Today</string>
   <string name="donation_dialog_description">%s needs your help.</string>
   <string name="make_donation">Make a donation</string>
-  <string name="fetch_notification_download_complete">Complete</string>
-  <string name="fetch_notification_download_failed">Failed</string>
-  <string name="fetch_notification_download_paused">Paused</string>
-  <string name="fetch_notification_download_resuming">Resuming</string>
-  <string name="fetch_notification_download_downloading">Downloading</string>
+  <string name="resuming_state">Resuming</string>
+  <string name="downloading_state">Downloading</string>
+  <string name="download_failed_state">Failed</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -402,4 +402,9 @@
   <string name="donation_dialog_title">Donate Today</string>
   <string name="donation_dialog_description">%s needs your help.</string>
   <string name="make_donation">Make a donation</string>
+  <string name="fetch_notification_download_complete">Complete</string>
+  <string name="fetch_notification_download_failed">Failed</string>
+  <string name="fetch_notification_download_paused">Paused</string>
+  <string name="fetch_notification_download_resuming">Resuming</string>
+  <string name="fetch_notification_download_downloading">Downloading</string>
 </resources>


### PR DESCRIPTION
Fixes #4236 
Apologies for the confusion! I accidentally closed the previous PR #4241 , so I'm resubmitting the changes here. 
This PR includes all requested changes. Please review again. Thank you!


### 📌 Summary

1. Improving notification wording by replacing "starting" with "resuming" when a paused download is resuming
2. Replacing Default Fetch library strings with our own string resources to handle translation in other languages.