### PR TITLE
Fixed: Transparent images were not visible in "Dark mode".

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -93,12 +93,17 @@ class ZimFileReader constructor(
             Log.e(
               TAG,
               "Error in creating ZimFileReader," +
-                " there is an JNI exception happens: $ignore"
+                " there is an JNI exception happens: $ignore\n" +
+                "For ZIM file = ${zimReaderSource.toDatabase()}"
             )
             null
           } catch (ignore: Exception) {
             // for handing the error, if any zim file is corrupted
-            Log.e(TAG, "Error in creating ZimFileReader: $ignore")
+            Log.e(
+              TAG,
+              "Error in creating ZimFileReader: $ignore\n" +
+                "For ZIM file = ${zimReaderSource.toDatabase()}"
+            )
             null
           }
         }
@@ -433,6 +438,9 @@ class ZimFileReader constructor(
       div[poster] img, div[poster] video {
         -webkit-filter: invert(0); 
         filter: invert(0); 
+      }
+      img {
+          background-color: white !important;
       }
       """.trimIndent()
     private val assetExtensions =


### PR DESCRIPTION
Fixes #4234 

Added a white background to transparent images so that when reading a ZIM file in "Dark mode," the content of transparent images displays properly. It will not affect the image that does not have a transparent background, see in below videos.



https://github.com/user-attachments/assets/98e3612e-7912-4418-a4de-76c747645e2c


https://github.com/user-attachments/assets/a657a166-be1a-4acc-886c-9283cce3ee7b

