### PR TITLE
Fixed: `ZimFileRendering` test was failing.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -224,7 +224,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     Request.Builder()
       .url(
         URI.create(
-          "https://download.kiwix.org/zim/wikipedia_fr_climate_change_mini.zim"
+          "https://download.kiwix.org/zim/wikipedia/wikipedia_fr_climate_change_mini_2023-05.zim"
         ).toURL()
       ).build()
 


### PR DESCRIPTION
Fixes #4259 

* This was due to a new `climate_change_mini` ZIM file being uploaded yesterday. Our URL was now downloading this new ZIM file instead of the previous one, while our test case was written for the old ZIM file to check its rendering.


![Screenshot from 2025-03-07 10-54-51](https://github.com/user-attachments/assets/bee8e4b9-e346-4937-9737-1c108699c753)

* To fix this, we have provided the direct URL of our ZIM file so that it works correctly.