### PR TITLE
Fixed: After upgrading Gradle, we were unable to upload the AAB because APK splitting was enabled.

### DIFF
--- a/.github/workflows/dummy_bundle_and_apk.yml
+++ b/.github/workflows/dummy_bundle_and_apk.yml
@@ -32,14 +32,24 @@ jobs:
           echo "KIWIX_ANDROID_RELEASE_DATE=$DATE" >> $GITHUB_ENV
         shell: bash
 
-      - name: Generate dummy Bundle and APKs
+      - name: Generate dummy Bundle
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
         run: |
-          ./gradlew bundlePlayStore assembleRelease --scan
+          ./gradlew bundlePlayStore --scan
+
+      - name: Generate dummy APKs
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
+          APK_BUILD: "true"
+        run: |
+          ./gradlew assembleRelease --scan
 
 
       - name: Get Bundle and APKs name and path

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,7 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          APK_BUILD: "true"
         run: ./gradlew assembleNightly
 
       - name: Set date variable

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -138,6 +138,8 @@ jobs:
           distribution: temurin
 
       - name: Build all configurations
+        env:
+          APK_BUILD: "true"
         run: ./gradlew assemble
 
       - name: Upload APK as Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           UNIVERSAL_RELEASE_APK: app/build/outputs/apk/standalone/*universal*.apk
           ARCHIVE_NAME: org.kiwix.kiwixmobile.standalone-${{ github.event.release.tag_name }}.apk
           KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
+          APK_BUILD: "true"
         run: |
           ./gradlew assembleStandalone
           cp ${UNIVERSAL_RELEASE_APK} ${ARCHIVE_NAME}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Kiwix Android is a multi-module project, in 99% of scenarios you will want to bu
 
 We have an [automatic version code generation](https://github.com/kiwix/kiwix-android/blob/main/buildSrc/src/main/kotlin/VersionCodeGenerator.kt) system based on the current date. However, you can override this by setting the environment variable `KIWIX_ANDROID_RELEASE_DATE` to a specific date in the `YYYY-MM-DD` format. This will use the provided date for the version code calculation instead of the current date.
 
+### ABI Splitting for APKs
+
+By default, `ABI` splitting is disabled. In newer Gradle versions, when uploading a `.aab` file, `ABI` splitting must remain disabled.
+However, if you need to generate separate APKs for different ABIs, you can enable `ABI` splitting by setting the `APK_BUILD="true"` environment variable.
+This variable should only be set when building an APK. If you set this variable and attempt to generate a `.aab` file, the build will fail due to Gradle's new enhancements.
+
 ## Libraries Used
 
 - 📚 [Libkiwix](https://github.com/kiwix/java-libkiwix) - Kotlin/Java binding for the core Kiwix library.

--- a/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
@@ -68,7 +68,20 @@ class AppConfigurer {
       val abiCodes = mapOf("arm64-v8a" to 6, "x86" to 3, "x86_64" to 4, "armeabi-v7a" to 5)
       splits {
         abi {
-          isEnable = true
+          // Enable ABI splits only when needed (e.g., when building APKs).
+          // This prevents unnecessary splits when generating an App Bundle (AAB),
+          // as AABs already handle ABI splits automatically.
+          //
+          // The environment variable `APK_BUILD` controls this behavior:
+          // - If set to `"true"`, ABI splits are **enabled** (for APK builds).
+          // - If `"false"` or unset, ABI splits are **disabled** (for App Bundles).
+          //
+          // This approach ensures that:
+          // - **App Bundles (AABs)** remain unaffected (since Google Play handles ABI splits).
+          // - **APK builds** get ABI splits when needed for direct distribution (e.g., custom deployments).
+          //
+          // See: https://github.com/kiwix/kiwix-android/issues/4273
+          isEnable = System.getenv("APK_BUILD")?.toBoolean() ?: false
           reset()
           include(*abiCodes.keys.toTypedArray())
           isUniversalApk = true


### PR DESCRIPTION
Fixes #4273 

* ABI splitting is now enabled only when needed (i.e., when building an APK) through an environment variable (APK_BUILD). By default, ABI splitting remains disabled for aab.
* Refactored the workflow to align with this change.
* Updated the README to document this change, ensuring that everyone is aware of this feature.