### PR TITLE
Fixed: AAB file was not found when uploading to Play Store for custom apps.

### DIFF
--- a/custom/build.gradle.kts
+++ b/custom/build.gradle.kts
@@ -250,7 +250,7 @@ fun ProductFlavor.createPublishBundleWithAssetPlayDelivery(): TaskProvider<Task>
         .transactionWithCommit(packageName) {
           val generatedBundleFile =
             File(
-              "${layout.buildDirectory}/outputs/bundle/${capitalizedName.lowercase(Locale.getDefault())}" +
+              "${layout.buildDirectory.get()}/outputs/bundle/${capitalizedName.lowercase(Locale.getDefault())}" +
                 "Release/custom-${capitalizedName.lowercase(Locale.getDefault())}-release.aab"
             )
           if (generatedBundleFile.exists()) {


### PR DESCRIPTION
Since we upgraded Gradle, we switched to using `layout.buildDirectory` instead of `buildDir`, as the latter is now deprecated. The new approach returns a DirectoryProperty object instead of a direct build directory path. This caused our custom apps' CD pipeline to be unable to locate the generated `.aab` file. We have now updated the code to correctly retrieve the directory path from the `DirectoryProperty` object.

See uploading failure: https://github.com/kiwix/kiwix-android-custom/actions/runs/14241296835/job/39911608568