### PR TITLE
Updated the README file to reflect the compatible version of Android Studio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Kiwix requires the following permissions to fully work:
 
 ## Build instructions
 1. Clone [this repository](https://github.com/kiwix/kiwix-android).
-2. Import the project with [Android Studio](https://developer.android.com/studio).
+2. Import the project with [Android Studio Narwhal Canary build](https://developer.android.com/studio/preview).
 3. Set the Gradle JDK to Java 17.
 4. Run ./gradlew build from the root directory.
 


### PR DESCRIPTION
See https://github.com/kiwix/kiwix-android/issues/4287

Since there's no official Android Studio IDE that supports Android 16 yet — it's currently in the final beta phase and is expected to launch in May or possibly June — we need to use the `Canary build` of the `Narwhal` version for now. Therefore, we're updating the README file accordingly. Once the official IDE is released, we'll update the README again.