### PR TITLE
Refactored `RxJava` to `Coroutines` in `LanguageViewModel`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -71,7 +71,7 @@ class LanguageFragment : BaseFragment() {
       fun resetSearchState() {
         // clears the search text and resets the filter
         searchText = ""
-        languageViewModel.actions.offer(Action.Filter(searchText))
+        languageViewModel.actions.tryEmit(Action.Filter(searchText))
       }
 
       KiwixTheme {
@@ -83,13 +83,13 @@ class LanguageFragment : BaseFragment() {
             isSearchActive = isSearchActive,
             onSearchClick = { isSearchActive = true },
             onSaveClick = {
-              languageViewModel.actions.offer(Action.SaveAll)
+              languageViewModel.actions.tryEmit(Action.SaveAll)
             }
           ),
           onClearClick = { resetSearchState() },
           onAppBarValueChange = {
             searchText = it
-            languageViewModel.actions.offer(Action.Filter(it))
+            languageViewModel.actions.tryEmit(Action.Filter(it))
           },
           navigationIcon = {
             NavigationIcon(
@@ -113,18 +113,6 @@ class LanguageFragment : BaseFragment() {
         )
       }
     }
-    compositeAdd(activity)
-  }
-
-  private fun compositeAdd(activity: CoreMainActivity) {
-    compositeDisposable.add(
-      languageViewModel.effects.subscribe(
-        {
-          it.invokeWith(activity)
-        },
-        Throwable::printStackTrace
-      )
-    )
   }
 
   private fun appBarActionMenuList(

--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageScreen.kt
@@ -30,14 +30,15 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.extensions.CollectSideEffectWithActivity
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSearchView
@@ -60,10 +61,12 @@ fun LanguageScreen(
   onAppBarValueChange: (String) -> Unit,
   navigationIcon: @Composable() () -> Unit = {}
 ) {
-  val state by languageViewModel.state.observeAsState(State.Loading)
+  val state by languageViewModel.state.collectAsState(State.Loading)
   val listState: LazyListState = rememberLazyListState()
   val context = LocalContext.current
-
+  languageViewModel.effects.CollectSideEffectWithActivity { effect, activity ->
+    effect.invokeWith(activity)
+  }
   Scaffold(topBar = {
     KiwixAppBar(
       titleId = R.string.select_languages,
@@ -106,7 +109,7 @@ fun LanguageScreen(
             context = context,
             listState = listState,
             selectLanguageItem = { languageItem ->
-              languageViewModel.actions.offer(Action.Select(languageItem))
+              languageViewModel.actions.tryEmit(Action.Select(languageItem))
             }
           )
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -285,7 +285,7 @@ class ZimManageViewModel @Inject constructor(
     val downloads = downloadDao.downloads().asFlowable()
     val booksFromDao = books().asFlowable()
     val networkLibrary = PublishProcessor.create<LibraryNetworkEntity>()
-    val languages = languageDao.languages()
+    val languages = languageDao.languages().asFlowable()
     return arrayOf(
       updateLibraryItems(booksFromDao, downloads, networkLibrary, languages),
       updateLanguagesInDao(networkLibrary, languages),
@@ -451,7 +451,7 @@ class ZimManageViewModel @Inject constructor(
     booksFromDao: io.reactivex.rxjava3.core.Flowable<List<BookOnDisk>>,
     downloads: io.reactivex.rxjava3.core.Flowable<List<DownloadModel>>,
     library: Flowable<LibraryNetworkEntity>,
-    languages: Flowable<List<Language>>
+    languages: io.reactivex.rxjava3.core.Flowable<List<Language>>
   ) = Flowable.combineLatest(
     booksFromDao,
     downloads,
@@ -481,7 +481,7 @@ class ZimManageViewModel @Inject constructor(
 
   private fun updateLanguagesInDao(
     library: Flowable<LibraryNetworkEntity>,
-    languages: Flowable<List<Language>>
+    languages: io.reactivex.rxjava3.core.Flowable<List<Language>>
   ) = library
     .subscribeOn(Schedulers.io())
     .map(LibraryNetworkEntity::book)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -121,7 +121,7 @@ class ZimManageViewModelTest {
   private val downloads = MutableStateFlow<List<DownloadModel>>(emptyList())
   private val booksOnFileSystem = MutableStateFlow<List<BookOnDisk>>(emptyList())
   private val books = MutableStateFlow<List<BookOnDisk>>(emptyList())
-  private val languages: PublishProcessor<List<Language>> = PublishProcessor.create()
+  private val languages = MutableStateFlow<List<Language>>(emptyList())
   private val fileSystemStates: BehaviorProcessor<FileSystemState> = BehaviorProcessor.create()
   private val networkStates: PublishProcessor<NetworkState> = PublishProcessor.create()
   private val booksOnDiskListItems = MutableStateFlow<List<BooksOnDiskListItem>>(emptyList())
@@ -382,7 +382,7 @@ class ZimManageViewModelTest {
       every { application.getString(any(), any()) } returns ""
       every { kiwixService.library } returns Single.just(libraryNetworkEntity(networkBooks))
       every { defaultLanguageProvider.provide() } returns defaultLanguage
-      languages.onNext(dbBooks)
+      languages.value = dbBooks
       testScheduler.triggerActions()
       networkStates.onNext(CONNECTED)
       testScheduler.triggerActions()
@@ -420,12 +420,11 @@ class ZimManageViewModelTest {
     networkStates.onNext(CONNECTED)
     downloads.value = listOf(downloadModel(book = bookDownloading))
     books.value = listOf(bookOnDisk(book = bookAlreadyOnDisk))
-    languages.onNext(
+    languages.value =
       listOf(
         language(isActive = true, occurencesOfLanguage = 1, languageCode = "activeLanguage"),
         language(isActive = false, occurencesOfLanguage = 1, languageCode = "inactiveLanguage")
       )
-    )
     fileSystemStates.onNext(CanWrite4GbFile)
     testScheduler.advanceTimeBy(500, MILLISECONDS)
     testScheduler.triggerActions()
@@ -458,11 +457,10 @@ class ZimManageViewModelTest {
     networkStates.onNext(CONNECTED)
     downloads.value = listOf()
     books.value = listOf()
-    languages.onNext(
+    languages.value =
       listOf(
         language(isActive = true, occurencesOfLanguage = 1, languageCode = "activeLanguage")
       )
-    )
     fileSystemStates.onNext(CannotWrite4GbFile)
     testScheduler.advanceTimeBy(500, MILLISECONDS)
     testScheduler.triggerActions()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
@@ -43,13 +43,10 @@ abstract class DownloadRoomDao {
   lateinit var newBookDao: NewBookDao
 
   @Query("SELECT * FROM DownloadRoomEntity")
-  abstract fun downloadRoomEntity(): Flow<List<DownloadRoomEntity>>
-
-  @Query("SELECT * FROM DownloadRoomEntity")
   abstract fun getAllDownloads(): Flow<List<DownloadRoomEntity>>
 
   fun downloads(): Flow<List<DownloadModel>> =
-    downloadRoomEntity()
+    getAllDownloads()
       .distinctUntilChanged()
       .onEach(::moveCompletedToBooksOnDiskDao)
       .map { it.map(::DownloadModel) }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewLanguagesDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewLanguagesDao.kt
@@ -36,7 +36,7 @@ import javax.inject.Singleton
 @Singleton
 class NewLanguagesDao @Inject constructor(private val box: Box<LanguageEntity>) {
   fun languages() =
-    box.asFlowable()
+    box.asFlow()
       .map { it.map(LanguageEntity::toLanguageModel) }
 
   fun insert(languages: List<Language>) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FlowExtension.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FlowExtension.kt
@@ -1,0 +1,37 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.flow.Flow
+import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+
+@Composable
+fun <T> Flow<T>.CollectSideEffectWithActivity(
+  invokeWithActivity: (T, CoreMainActivity) -> Unit
+) {
+  val activity = LocalActivity.current as? CoreMainActivity
+  LaunchedEffect(Unit) {
+    collect { effect ->
+      activity?.let { invokeWithActivity(effect, it) }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4305 

* Removed duplicate method in `DownloadRoomDao` for fetching all downloads.
* Refactored `DownloadManagerMonitor` to use `Coroutines` instead of `RxJava`.
* Improved coroutine usage in `DownloadMonitorService`.
* Updated `LanguageViewModel` to use `Coroutine Flows` instead of `RxJava`.
* Refactored `NewLanguagesDao` to expose Coroutine Flows instead of `RxJava` observables.
* Updated `SaveLanguagesAndFinish` to use coroutines instead of `RxJava`.
* Created a `FlowExtension` utility class to add custom flow-related extensions. In this PR, added the `collectSideEffectWithActivity` extension function, which allows collecting `SideEffects` and handling them with the current Activity in a Compose UI. This also moved the `SideEffect` collection from the Fragment layer to the Compose screen, improving separation of concerns.
* Refactored the unit test cases according to this change.