### PR TITLE
Add zim scheme deep link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ By default, `ABI` splitting is disabled. In newer Gradle versions, when uploadin
 However, if you need to generate separate APKs for different ABIs, you can enable `ABI` splitting by setting the `APK_BUILD="true"` environment variable.
 This variable should only be set when building an APK. If you set this variable and attempt to generate a `.aab` file, the build will fail due to Gradle's new enhancements.
 
+## Deep links
+
+Kiwix can open URLs in the form `zim://<archive-id>/<article-path>` when the
+referenced archive is already present on the device. Tapping such a link in
+another app jumps straight to the requested page in Kiwix.
+
 ## Libraries Used
 
 - 📚 [Libkiwix](https://github.com/kiwix/java-libkiwix) - Kotlin/Java binding for the core Kiwix library.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -124,6 +124,14 @@
           android:host="search"
           android:scheme="kiwix" />
       </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="zim" />
+      </intent-filter>
       <intent-filter android:label="@string/app_search_string">
         <action android:name="android.intent.action.PROCESS_TEXT" />
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -300,6 +300,23 @@ class KiwixMainActivity : CoreMainActivity() {
           }, OPENING_ZIM_FILE_DELAY)
         }
 
+        "zim" -> {
+          val zimId = it.host
+          val page = it.encodedPath?.removePrefix("/") ?: ""
+          if (zimId != null && page.isNotEmpty()) {
+            lifecycleScope.launch {
+              newBookDao.bookById(zimId)?.let { entity ->
+                Handler(Looper.getMainLooper()).postDelayed({
+                  openPage(page, entity.zimReaderSource)
+                  clearIntentDataAndAction()
+                }, OPENING_ZIM_FILE_DELAY)
+              } ?: toast(R.string.cannot_open_file)
+            }
+          } else {
+            toast(R.string.cannot_open_file)
+          }
+        }
+
         else -> toast(R.string.cannot_open_file)
       }
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewBookDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NewBookDao.kt
@@ -150,6 +150,15 @@ class NewBookDao @Inject constructor(private val box: Box<BookOnDiskEntity>) {
       endsWith(
         BookOnDiskEntity_.zimReaderSource,
         downloadTitle,
+      QueryBuilder.StringOrder.CASE_INSENSITIVE
+      )
+    }.findFirst()
+
+  fun bookById(bookId: String) =
+    box.query {
+      equal(
+        BookOnDiskEntity_.bookId,
+        bookId,
         QueryBuilder.StringOrder.CASE_INSENSITIVE
       )
     }.findFirst()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NewBookDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NewBookDaoTest.kt
@@ -253,6 +253,25 @@ internal class NewBookDaoTest {
     every { query.findFirst() } returns bookOnDiskEntity
     assertThat(newBookDao.bookMatching(downloadTitle)).isEqualTo(bookOnDiskEntity)
   }
+
+  @Test
+  fun `bookById queries file by id`() {
+    val bookId = "id"
+    val queryBuilder: QueryBuilder<BookOnDiskEntity> = mockk()
+    every { box.query() } returns queryBuilder
+    every {
+      queryBuilder.equal(
+        BookOnDiskEntity_.bookId,
+        bookId,
+        QueryBuilder.StringOrder.CASE_INSENSITIVE
+      )
+    } returns queryBuilder
+    val query: Query<BookOnDiskEntity> = mockk()
+    every { queryBuilder.build() } returns query
+    val bookOnDiskEntity: BookOnDiskEntity = bookOnDiskEntity()
+    every { query.findFirst() } returns bookOnDiskEntity
+    assertThat(newBookDao.bookById(bookId)).isEqualTo(bookOnDiskEntity)
+  }
 }
 
 fun <T> mockBoxAsFlow(box: Box<T>, result: List<T>) {


### PR DESCRIPTION
## Summary
- support `zim://` scheme deep links in the manifest
- allow looking up a book by its ID
- handle `zim` links to open specific pages
- document zim deep linking
- test new DAO lookup helper

## Fixes: #4277
## Testing
- `gradle --offline testDebugUnitTest --stacktrace` *(fails: No route to host when downloading Gradle)*
