### PR TITLE
Fixed: File size unit / calculation differs from Kiwix-Server.

### DIFF
--- a/core/detekt_baseline.xml
+++ b/core/detekt_baseline.xml
@@ -20,7 +20,7 @@
     <ID>MagicNumber:DownloaderModule.kt$DownloaderModule$5</ID>
     <ID>MagicNumber:FileUtils.kt$FileUtils$3</ID>
     <ID>MagicNumber:JNIInitialiser.kt$JNIInitialiser$1024</ID>
-    <ID>MagicNumber:Byte.kt$Byte$1024.0</ID>
+    <ID>MagicNumber:Byte.kt$Byte$1000.0</ID>
     <ID>MagicNumber:MainMenu.kt$MainMenu$99</ID>
     <ID>MagicNumber:ReaderMenuState.kt$ReaderMenuState$99</ID>
     <ID>MagicNumber:OnSwipeTouchListener.kt$OnSwipeTouchListener.GestureListener$100</ID>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/Byte.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/zim_manager/Byte.kt
@@ -27,9 +27,9 @@ value class Byte(private val byteString: String?) {
   val humanReadable
     get() = byteString?.toLongOrNull()?.let {
       val units = arrayOf("B", "KB", "MB", "GB", "TB")
-      val conversion = (log10(it.toDouble()) / log10(1024.0)).toInt()
-      DecimalFormat("#,##0.#")
-        .format(it / 1024.0.pow(conversion.toDouble())) +
+      val conversion = (log10(it.toDouble()) / log10(1000.0)).toInt()
+      DecimalFormat("#,##0.##")
+        .format(it / 1000.0.pow(conversion.toDouble())) +
         " " +
         units[conversion]
     }.orEmpty()


### PR DESCRIPTION
Fixes #4368 

* Changed the size calculation from GiB (binary format) to GB (decimal format).
* Removed the unused `OnSwipeTouchListener` class.

| Before(binary foramt)  |  After(decimal format) |
| ------------- | ------------- |
| <img width="464" height="807" alt="Screenshot from 2025-08-08 14-33-43" src="https://github.com/user-attachments/assets/0d29c894-0275-4aad-94a8-4d0ef3b6da52" /> |  <img width="464" height="807" alt="Screenshot from 2025-08-08 16-17-50" src="https://github.com/user-attachments/assets/0c600223-99af-4e50-b258-1d1ba5cf962d" /> |
| <img width="464" height="807" alt="Screenshot from 2025-08-08 16-14-06" src="https://github.com/user-attachments/assets/1bc063a3-93fe-441b-beb8-9b7cf67253f9" /> |  <img width="464" height="807" alt="Screenshot from 2025-08-08 16-17-56" src="https://github.com/user-attachments/assets/58fe7aac-159a-430c-9602-ed53ce1ded79" /> |
