### PR TITLE
Fixed: Background downloading of ZIM files not working.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
@@ -255,7 +255,7 @@ class FetchDownloadNotificationManager @Inject constructor(
   }
 
   @Suppress("InjectDispatcher")
-  fun getCancelNotification(
+  private fun getCancelNotification(
     fetch: Fetch,
     download: Download,
     notificationBuilder: Builder

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -49,6 +49,7 @@ import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToLibkiwixMigrator
 import org.kiwix.kiwixmobile.core.data.remote.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.downloader.DownloadMonitor
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.APP_NAME_KEY
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService.Companion.STOP_DOWNLOAD_SERVICE
 import org.kiwix.kiwixmobile.core.error.ErrorActivity
@@ -247,7 +248,11 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
    */
   private fun startMonitoringDownloads() {
     if (!isServiceRunning(DownloadMonitorService::class.java)) {
-      startService(Intent(this, DownloadMonitorService::class.java))
+      startService(
+        Intent(this, DownloadMonitorService::class.java).apply {
+          putExtra(APP_NAME_KEY, appName)
+        }
+      )
     }
   }
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
   <string name="download_no_space" tools:keep="@string/download_no_space">Insufficient space to download.</string>
   <string name="download">Download</string>
   <string name="download_notification_channel_name" tools:keep="@string/download_notification_channel_name">Download Notification Channel Name</string>
+  <string name="download_notification_channel_description" tools:keep="@string/download_notification_channel_description">Downloading ZIM files…</string>
   <string name="space_available" tools:keep="@string/space_available">Space Available:</string>
   <string name="move_no_space">Insufficient space to move/copy.</string>
   <string name="zim_simple">Simple</string>


### PR DESCRIPTION
Fixes #4375 

* There is a limitation with foreground services — we cannot update a foreground service notification from the background (when the application is not running). Starting with Android 16, foreground services also validate the notification ID to ensure it exists before running; this was not enforced in earlier versions, where it worked fine. When multiple downloads are running in the background and one completes, setting a new notification to the foreground service causes it to stop, which in turn stops all background downloads. Additionally, our foreground service was tied to a specific download ID, so when that download completed, was cancelled, or paused, the service also stopped.
* To fix this, we now show a persistent notification that remains active until all downloads are completed or cancelled. This ensures the foreground service stays active in the background and the network is not suspended while downloads are in progress.