### PR TITLE
Fixed: When opening the search from widget or from outside the application then search is broken with large ZIM files.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/reader/ReaderRobot.kt
@@ -30,6 +30,7 @@ fun reader(func: ReaderRobot.() -> Unit) = ReaderRobot().applyWithViewHierarchyP
 class ReaderRobot : BaseRobot() {
   fun assertReaderScreenDisplayed(composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
+      waitForIdle()
       waitUntilTimeout()
       onNodeWithTag(READER_SCREEN_TESTING_TAG).assertExists()
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.rememberNavController
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageDeviceUtils
@@ -268,7 +269,13 @@ class KiwixMainActivity : CoreMainActivity() {
 
   private fun handleGetContentIntent(intent: Intent?) {
     if (intent?.action == ACTION_GET_CONTENT) {
-      navigate(KiwixDestination.Downloads.route)
+      navigate(KiwixDestination.Downloads.route) {
+        launchSingleTop = true
+        popUpTo(navController.graph.findStartDestination().id) {
+          saveState = true
+        }
+        restoreState = true
+      }
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import kotlinx.coroutines.CoroutineScope
@@ -189,11 +190,20 @@ fun BottomNavigationBar(
       NavigationBarItem(
         selected = currentDestinationRoute == item.route,
         onClick = {
-          // Do not load again fragment that is already loaded.
-          if (item.route == currentDestinationRoute) return@NavigationBarItem
           uiCoroutineScope.launch {
             leftDrawerState.close()
-            navController.navigate(item.route)
+            navController.navigate(item.route) {
+              // Avoid multiple copies of the same destination
+              launchSingleTop = true
+
+              // Pop up to the start destination of the graph to avoid building up a large stack
+              popUpTo(navController.graph.findStartDestination().id) {
+                saveState = true
+              }
+
+              // Restore state when reselecting a previously selected tab
+              restoreState = true
+            }
           }
         },
         icon = {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -37,6 +37,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.navOptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -360,6 +362,10 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
 
   fun navigate(route: String, navOptions: NavOptions? = null) {
     navController.navigate(route, navOptions)
+  }
+
+  fun navigate(route: String, builder: NavOptionsBuilder.() -> Unit) {
+    navigate(route, navOptions(builder))
   }
 
   private fun openSettings() {


### PR DESCRIPTION
Fixes #4379 

* Fixed: When launching the app fresh (cold start), the search screen could appear before the ZIM file was ready (because ZIM file loading in the reader happens on the IO thread), resulting in no search results. Now, incoming actions are delayed until the ZIM file finishes loading so that the search works correctly.
* Fixed: Multiple fragment instances were created when repeatedly opening different fragments via bottomAppBar buttons, causing the back button to bring them to the foreground one by one instead of the expected behavior.