### PR TITLE
Fixed: Online library was not retrieving after clicking “Allow downloading via mobile network” in the confirmation dialog.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -132,10 +132,12 @@ class BookmarksRobot : BaseRobot() {
 
   fun assertBookmarkSaved(composeTestRule: ComposeContentTestRule) {
     pauseForBetterTestPerformance()
-    composeTestRule.apply {
-      waitForIdle()
-      onNodeWithText("Test Zim").assertExists()
-    }
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onNodeWithText("Test Zim").assertExists()
+      }
+    })
   }
 
   fun assertBookmarkRemoved(composeTestRule: ComposeTestRule) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -155,7 +155,9 @@ class ZimManageViewModel @Inject constructor(
     val category: String? = null,
     val lang: String? = null,
     val isLoadMoreItem: Boolean,
-    val page: Int
+    val page: Int,
+    // Bug Fix #4381
+    val version: Long = System.nanoTime()
   )
 
   data class OnlineLibraryResult(
@@ -371,7 +373,20 @@ class ZimManageViewModel @Inject constructor(
         category = newRequest.category ?: current.category,
         lang = newRequest.lang ?: current.lang,
         page = newRequest.page,
-        isLoadMoreItem = newRequest.isLoadMoreItem
+        isLoadMoreItem = newRequest.isLoadMoreItem,
+        version = if (isUnitTestCase) {
+          // In unit tests, we want predictable and testable values,
+          // so use the provided version instead of a dynamic timestamp.
+          newRequest.version
+        } else {
+          // Bug Fix #4381:
+          // Force StateFlow to emit even if all other fields are unchanged.
+          // Without this, identical requests may not trigger observers,
+          // causing the UI not to refresh.
+          // Using System.nanoTime() ensures a unique value each time,
+          // guaranteeing that collectors receive an update.
+          System.nanoTime()
+        }
       )
     }
   }

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -302,18 +302,22 @@ class ZimManageViewModelTest {
   }
 
   @Test
-  fun `updateOnlineLibraryFilters updates onlineLibraryRequest`() = runTest {
-    val newRequest = ZimManageViewModel.OnlineLibraryRequest(
-      query = "test",
-      category = "cat",
-      lang = "en",
-      page = 2,
-      isLoadMoreItem = true
-    )
-    viewModel.onlineLibraryRequest.test {
-      skipItems(1)
-      viewModel.updateOnlineLibraryFilters(newRequest)
-      assertThat(awaitItem()).isEqualTo(newRequest)
+  fun `updateOnlineLibraryFilters updates onlineLibraryRequest`() = flakyTest {
+    runTest {
+      viewModel.setIsUnitTestCase()
+      val newRequest = ZimManageViewModel.OnlineLibraryRequest(
+        query = "test",
+        category = "cat",
+        lang = "en",
+        page = 2,
+        isLoadMoreItem = true,
+        version = 100L
+      )
+      viewModel.onlineLibraryRequest.test {
+        skipItems(1)
+        viewModel.updateOnlineLibraryFilters(newRequest)
+        assertThat(awaitItem()).isEqualTo(newRequest)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4381 

* Cause: The request object emitted after user confirmation was identical to the previous one, so the flow collector skipped it, and the fetch was never triggered.
* Solution: Added a `System.nanoTime()` field to the request to ensure a unique emission while still preserving existing values.
* Refactored the `updateOnlineLibraryFilters updates onlineLibraryRequest` according to this new change.
* Improved the `testBookmarkRemainsSavedOrNot`, which sometimes fails on Android 15 and 16.

| Before fix  | After fix |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/51320366-58c8-49d7-b327-a508e9bdb724" />  |  <video src="https://github.com/user-attachments/assets/26ca83d1-fcdf-408f-8768-180f2c09eda5" /> |