### PR TITLE
Fixed: The search placeholder was cut off in the `Romansh` language.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -145,10 +145,7 @@ class NoteFragmentTest : BaseActivityTest() {
       clickOnSavedNote(composeTestRule)
       clickOnOpenNote(composeTestRule)
       assertNoteSaved(composeTestRule)
-      // to close the note dialog.
-      pressBack()
-      // to close the notes fragment.
-      pressBack()
+      closeAddNoteDialog(composeTestRule)
     }
 
     // goto local library fragment to delete the ZIM file
@@ -185,7 +182,7 @@ class NoteFragmentTest : BaseActivityTest() {
       assertNoteDialogDisplayed(composeTestRule)
       writeDemoNote(composeTestRule)
       saveNote(composeTestRule)
-      pressBack()
+      closeAddNoteDialog(composeTestRule)
       openNoteFragment(kiwixMainActivity as CoreMainActivity, composeTestRule)
       assertToolbarExist(composeTestRule)
       clickOnSavedNote(composeTestRule)
@@ -204,7 +201,7 @@ class NoteFragmentTest : BaseActivityTest() {
         assertNoteDialogDisplayed(composeTestRule)
         writeDemoNote(composeTestRule)
         saveNote(composeTestRule)
-        pressBack()
+        closeAddNoteDialog(composeTestRule)
         openNoteFragment(kiwixMainActivity as CoreMainActivity, composeTestRule)
         assertToolbarExist(composeTestRule)
         clickOnSavedNote(composeTestRule)
@@ -227,7 +224,7 @@ class NoteFragmentTest : BaseActivityTest() {
       assertNoteDialogDisplayed(composeTestRule)
       writeDemoNote(composeTestRule)
       saveNote(composeTestRule)
-      pressBack()
+      closeAddNoteDialog(composeTestRule)
     }
     // Delete that note from "Note" screen.
     deletePreviouslySavedNotes()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -36,6 +36,7 @@ import androidx.test.espresso.web.webdriver.Locator
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.main.ADD_NOTE_DIALOG_CLOSE_IMAGE_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.ADD_NOTE_TEXT_FILED_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.DELETE_MENU_BUTTON_TESTING_TAG
@@ -177,6 +178,15 @@ class NoteRobot : BaseRobot() {
       composeTestRule.waitForIdle()
       composeTestRule.onNodeWithTag(ADD_NOTE_TEXT_FILED_TESTING_TAG)
         .assertTextContains("", ignoreCase = true)
+    })
+  }
+
+  fun closeAddNoteDialog(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onNodeWithTag(ADD_NOTE_DIALOG_CLOSE_IMAGE_BUTTON_TESTING_TAG).performClick()
+      }
     })
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/AddNoteDialog.kt
@@ -74,6 +74,8 @@ import javax.inject.Inject
  * Notes are saved as text files at location: "{External Storage}/Kiwix/Notes/ZimFileName/ArticleUrl.txt"
  */
 
+const val ADD_NOTE_DIALOG_CLOSE_IMAGE_BUTTON_TESTING_TAG = "addNoteDialogCloseImageButtonTestingTag"
+
 class AddNoteDialog : DialogFragment() {
   private lateinit var zimId: String
   private var zimFileName: String? = null
@@ -180,7 +182,8 @@ class AddNoteDialog : DialogFragment() {
             onClick = {
               exitAddNoteDialog()
               closeKeyboard()
-            }
+            },
+            testingTag = ADD_NOTE_DIALOG_CLOSE_IMAGE_BUTTON_TESTING_TAG
           )
         },
         noteText = noteText.value,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixSearchView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixSearchView.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens
 
@@ -75,7 +76,9 @@ fun KiwixSearchView(
       Text(
         text = placeholder,
         color = Color.LightGray,
-        fontSize = ComposeDimens.EIGHTEEN_SP
+        fontSize = ComposeDimens.EIGHTEEN_SP,
+        maxLines = ONE,
+        overflow = Ellipsis
       )
     },
     colors = colors,


### PR DESCRIPTION
Fixes #4385

* Updated the placeholder text to display on a single line and show an ellipsis (...) at the end if the text is too long.
* Fixed: `testUserCanSeeNotesForDeletedFiles` which sometimes fails on CI due to `androidx.test.espresso.base.RootViewPicker$RootViewWithoutFocusException`.


| Before fix  | After fix |
| ------------- | ------------- |
| ![Image](https://github.com/user-attachments/assets/d017da4b-d22c-4e5a-bac2-af226a3660b7)  |  ![SearchPlaceholderFix](https://github.com/user-attachments/assets/199c043e-8c7a-4b69-be10-c690ad1386a4) |