### PR TITLE
Fixed: When changing the app's language, a blank screen appeared instead of the settings screen.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -205,9 +205,13 @@ class DownloadTest : BaseActivityTest() {
             clickLanguagePreference(composeTestRule)
             assertLanguagePrefDialogDisplayed(composeTestRule)
             selectDeviceDefaultLanguage(composeTestRule)
+            // Advance the main clock to settle the frame of compose.
+            composeTestRule.mainClock.advanceTimeByFrame()
             clickLanguagePreference(composeTestRule)
             assertLanguagePrefDialogDisplayed(composeTestRule)
             selectAlbanianLanguage(composeTestRule)
+            // Advance the main clock to settle the frame of compose.
+            composeTestRule.mainClock.advanceTimeByFrame()
           }
         }
         clickDownloadOnBottomNav(composeTestRule)
@@ -226,6 +230,8 @@ class DownloadTest : BaseActivityTest() {
             clickLanguagePreference(composeTestRule)
             assertLanguagePrefDialogDisplayed(composeTestRule)
             selectDeviceDefaultLanguage(composeTestRule)
+            // Advance the main clock to settle the frame of compose.
+            composeTestRule.mainClock.advanceTimeByFrame()
             // check if the device default language is selected or not.
             clickLanguagePreference(composeTestRule)
             // close the language dialog.

--- a/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/LanguageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/LanguageViewModelTest.kt
@@ -144,34 +144,36 @@ class LanguageViewModelTest {
   }
 
   @Test
-  fun `observeLanguages uses network when no cache and online`() = runTest {
-    every { application.getString(any()) } returns ""
-    val fetchedLanguages = listOf(language(languageCode = "eng"))
-    LanguageSessionCache.hasFetched = false
-    languages.value = emptyList()
+  fun `observeLanguages uses network when no cache and online`() = flakyTest {
+    runTest {
+      every { application.getString(any()) } returns ""
+      val fetchedLanguages = listOf(language(languageCode = "eng"))
+      LanguageSessionCache.hasFetched = false
+      languages.value = emptyList()
 
-    every { sharedPreferenceUtil.getCachedLanguageList() } returns null
-    coEvery { kiwixService.getLanguages() } returns LanguageFeed().apply {
-      entries = fetchedLanguages.map {
-        LanguageEntry().apply {
-          languageCode = it.languageCode
-          count = 1
-          title = "English"
+      every { sharedPreferenceUtil.getCachedLanguageList() } returns null
+      coEvery { kiwixService.getLanguages() } returns LanguageFeed().apply {
+        entries = fetchedLanguages.map {
+          LanguageEntry().apply {
+            languageCode = it.languageCode
+            count = 1
+            title = "English"
+          }
         }
       }
-    }
-    every { sharedPreferenceUtil.selectedOnlineContentLanguage } returns ""
-    every { sharedPreferenceUtil.saveLanguageList(any()) } just Runs
+      every { sharedPreferenceUtil.selectedOnlineContentLanguage } returns ""
+      every { sharedPreferenceUtil.saveLanguageList(any()) } just Runs
 
-    testFlow(
-      languageViewModel.actions,
-      triggerAction = {},
-      assert = {
-        val result = awaitItem()
-        assertThat(result).isInstanceOf(UpdateLanguages::class.java)
-        verify { sharedPreferenceUtil.saveLanguageList(any()) }
-      }
-    )
+      testFlow(
+        languageViewModel.actions,
+        triggerAction = {},
+        assert = {
+          val result = awaitItem()
+          assertThat(result).isInstanceOf(UpdateLanguages::class.java)
+          verify { sharedPreferenceUtil.saveLanguageList(any()) }
+        }
+      )
+    }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -314,7 +314,6 @@ class ZimManageViewModelTest {
         version = 100L
       )
       viewModel.onlineLibraryRequest.test {
-        skipItems(1)
         viewModel.updateOnlineLibraryFilters(newRequest)
         assertThat(awaitItem()).isEqualTo(newRequest)
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixAppBar.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixAppBar.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
@@ -44,21 +43,16 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.ZERO
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.toPainter
 import org.kiwix.kiwixmobile.core.ui.theme.Black
@@ -233,24 +227,4 @@ private fun OverflowMenuItems(
       )
     }
   }
-}
-
-@Composable
-fun rememberBottomNavigationVisibility(lazyListState: LazyListState?): Boolean {
-  var isToolbarVisible by remember { mutableStateOf(true) }
-  var lastScrollIndex by remember { mutableIntStateOf(ZERO) }
-  val updatedLazyListState = rememberUpdatedState(lazyListState)
-
-  LaunchedEffect(updatedLazyListState) {
-    updatedLazyListState.value?.let { state ->
-      snapshotFlow { state.firstVisibleItemIndex }
-        .collect { newScrollIndex ->
-          if (newScrollIndex != lastScrollIndex) {
-            isToolbarVisible = newScrollIndex < lastScrollIndex
-            lastScrollIndex = newScrollIndex
-          }
-        }
-    }
-  }
-  return isToolbarVisible
 }

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
@@ -215,7 +215,6 @@ internal class CustomDownloadViewModelTest {
         triggerAction = { customDownloadViewModel.actions.tryEmit(action) },
         assert = {
           val items = (1..awaitItemCount).map { awaitItem() }
-          print("items = $items")
           assertThat(items).contains(endState)
         }
       )


### PR DESCRIPTION
Fixes #4387 

* The issue occurred because we reopened the settings screen immediately after removing it from the back stack, causing Compose to not settle the previous frame and display a blank screen.
* Resolved by allowing the popBackStack frame to settle before reopening the settings screen.
* Removed some unused code from the project.
* Improved the `testPauseAndResumeInOtherLanguage` according to this change.
* Fixed: `observeLanguages uses network when no cache and online`, and `updateOnlineLibraryFilters updates onlineLibraryRequest` which sometimes fails on CI.

| Before fix  | After fix |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/1df9be83-683d-4302-8475-df906154c96f" />  |  <video src="https://github.com/user-attachments/assets/d59e417c-0a6f-4bbf-b39c-98a4ce8756dd" /> |