### PR TITLE
Fixed: Opening bookmarks, notes, and history in the reader screen does not work.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -237,6 +237,26 @@ class NoteFragmentTest : BaseActivityTest() {
     }
   }
 
+  @Test
+  fun testSavedNotePageOpenInReader() {
+    deletePreviouslySavedNotes()
+    loadZimFileInReader("testzim.zim")
+    note {
+      assertHomePageIsLoadedOfTestZimFile()
+      clickOnAndroidArticle(composeTestRule)
+      clickOnNoteMenuItem(composeTestRule)
+      assertNoteDialogDisplayed(composeTestRule)
+      writeDemoNote(composeTestRule)
+      saveNote(composeTestRule)
+      closeAddNoteDialog(composeTestRule)
+      clickOnBackwardButton(composeTestRule)
+      openNoteFragment(kiwixMainActivity as CoreMainActivity, composeTestRule)
+      clickOnSavedNote(composeTestRule)
+      clickOnOpenArticle(composeTestRule)
+      assertAndroidArticleLoadedInReader(composeTestRule)
+    }
+  }
+
   private fun deletePreviouslySavedNotes() {
     // delete the notes if any saved to properly run the test scenario
     note {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
@@ -42,6 +43,7 @@ import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.DELETE_MENU_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_NOTES_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.SAVE_MENU_BUTTON_TESTING_TAG
+import org.kiwix.kiwixmobile.core.main.reader.READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.reader.TAKE_NOTE_MENU_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.DELETE_MENU_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.NO_ITEMS_TEXT_TESTING_TAG
@@ -248,6 +250,62 @@ class NoteRobot : BaseRobot() {
             "//*[contains(text(), 'Android_(operating_system)')]"
           )
         )
+    })
+  }
+
+  fun clickOnAndroidArticle(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onWebView()
+          .withElement(
+            findElement(
+              Locator.XPATH,
+              "//*[contains(text(), 'Android_(operating_system)')]"
+            )
+          )
+          .perform(webClick())
+      }
+    })
+  }
+
+  fun clickOnBackwardButton(composeTestRule: ComposeContentTestRule) {
+    composeTestRule.apply {
+      waitForIdle()
+      waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
+        onNodeWithTag(READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG).isDisplayed()
+      }
+      onNodeWithTag(READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG)
+        .performClick()
+    }
+  }
+
+  fun clickOnOpenArticle(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitUntil(
+          TestUtils.TEST_PAUSE_MS.toLong()
+        ) { onNodeWithTag(ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG).isDisplayed() }
+        onNodeWithTag(ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG)
+          .performClick()
+      }
+    })
+  }
+
+  fun assertAndroidArticleLoadedInReader(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        waitUntilTimeout()
+        onWebView()
+          .withElement(
+            findElement(
+              Locator.XPATH,
+              "//*[contains(text(), 'History')]"
+            )
+          )
+          .perform(webClick())
+      }
     })
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteRobot.kt
@@ -304,7 +304,6 @@ class NoteRobot : BaseRobot() {
               "//*[contains(text(), 'History')]"
             )
           )
-          .perform(webClick())
       }
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -114,6 +114,7 @@ class BookmarksRobot : BaseRobot() {
   fun clickOnSaveBookmarkImage(composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
       waitForIdle()
+      waitUntilTimeout()
       waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
         onNodeWithTag(READER_BOTTOM_BAR_BOOKMARK_BUTTON_TESTING_TAG).isDisplayed()
       }
@@ -194,7 +195,6 @@ class BookmarksRobot : BaseRobot() {
 
   fun assertZimFileLoadedIntoTheReader(composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
-      waitUntilTimeout()
       composeTestRule.apply {
         waitUntilTimeout()
         onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).performClick()
@@ -238,7 +238,6 @@ class BookmarksRobot : BaseRobot() {
               "//*[contains(text(), 'History')]"
             )
           )
-          .perform(webClick())
       }
     })
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/BookmarksRobot.kt
@@ -24,11 +24,18 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTouchInput
+import androidx.test.espresso.web.sugar.Web
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.espresso.web.webdriver.DriverAtoms
+import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
+import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
+import androidx.test.espresso.web.webdriver.Locator
 import applyWithViewHierarchyPrinting
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
@@ -36,13 +43,16 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_BOOKMARK_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.reader.READER_BOTTOM_BAR_BOOKMARK_BUTTON_TESTING_TAG
+import org.kiwix.kiwixmobile.core.main.reader.READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.DELETE_MENU_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.NO_ITEMS_TEXT_TESTING_TAG
+import org.kiwix.kiwixmobile.core.page.PAGE_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.PAGE_LIST_TEST_TAG
 import org.kiwix.kiwixmobile.core.page.SWITCH_TEXT_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_TITLE_TEXT_TESTING_TAG
+import org.kiwix.kiwixmobile.main.BOTTOM_NAV_READER_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST
@@ -180,5 +190,78 @@ class BookmarksRobot : BaseRobot() {
         })
       }
     }
+  }
+
+  fun assertZimFileLoadedIntoTheReader(composeTestRule: ComposeContentTestRule) {
+    composeTestRule.apply {
+      waitUntilTimeout()
+      composeTestRule.apply {
+        waitUntilTimeout()
+        onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).performClick()
+      }
+    }
+    testFlakyView({
+      Web.onWebView()
+        .withElement(
+          DriverAtoms.findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'Android_(operating_system)')]"
+          )
+        )
+    })
+  }
+
+  fun clickOnAndroidArticle(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onWebView()
+          .withElement(
+            findElement(
+              Locator.XPATH,
+              "//*[contains(text(), 'Android_(operating_system)')]"
+            )
+          )
+          .perform(webClick())
+      }
+    })
+  }
+
+  fun assertAndroidArticleLoadedInReader(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onWebView()
+          .withElement(
+            findElement(
+              Locator.XPATH,
+              "//*[contains(text(), 'History')]"
+            )
+          )
+          .perform(webClick())
+      }
+    })
+  }
+
+  fun clickOnBackwardButton(composeTestRule: ComposeContentTestRule) {
+    composeTestRule.apply {
+      waitForIdle()
+      // wait for disappearing the snack-bar after removing the bookmark
+      waitUntilTimeout(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong())
+      waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
+        onNodeWithTag(READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG).isDisplayed()
+      }
+      onNodeWithTag(READER_BOTTOM_BAR_PREVIOUS_SCREEN_BUTTON_TESTING_TAG)
+        .performClick()
+    }
+  }
+
+  fun openBookmarkInReader(composeTestRule: ComposeContentTestRule) {
+    testFlakyView({
+      composeTestRule.apply {
+        waitForIdle()
+        onAllNodesWithTag(PAGE_ITEM_TESTING_TAG)[0].performClick()
+      }
+    })
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -121,19 +121,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
 
   @Test
   fun testBookmarks() {
-    composeTestRule.apply {
-      runOnUiThread {
-        kiwixMainActivity.navigate(KiwixDestination.Library.route)
-        val navOptions = NavOptions.Builder()
-          .setPopUpTo(KiwixDestination.Reader.route, false)
-          .build()
-        kiwixMainActivity.navigate(
-          KiwixDestination.Reader.createRoute(zimFileUri = getZimFile().toUri().toString()),
-          navOptions
-        )
-      }
-      waitComposeToSettleViews() // to load the ZIM file properly.
-    }
+    openZimFileInReader()
     bookmarks {
       // delete any bookmark if already saved to properly perform this test case.
       longClickOnSaveBookmarkImage(composeTestRule)
@@ -187,21 +175,36 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   }
 
   @Test
-  fun testSavedBookmarksShowingOnBookmarkScreen() {
-    val zimFile = getZimFile()
-    composeTestRule.apply {
-      runOnUiThread {
-        kiwixMainActivity.navigate(KiwixDestination.Library.route)
-        val navOptions = NavOptions.Builder()
-          .setPopUpTo(KiwixDestination.Reader.route, false)
-          .build()
-        kiwixMainActivity.navigate(
-          KiwixDestination.Reader.createRoute(zimFileUri = zimFile.toUri().toString()),
-          navOptions
-        )
-      }
-      waitForIdle()
+  fun testBookMarkPageOpenInReader() {
+    openZimFileInReader()
+    bookmarks {
+      openBookmarkScreen(kiwixMainActivity as CoreMainActivity, composeTestRule)
+      clickOnTrashIcon(composeTestRule)
+      assertDeleteBookmarksDialogDisplayed(composeTestRule)
+      clickOnDeleteButton(composeTestRule)
+      assertNoBookMarkTextDisplayed(composeTestRule)
+      pressBack()
+      waitComposeToSettleViews() // to properly load the ZIM file in reader.
+      assertZimFileLoadedIntoTheReader(composeTestRule)
+      clickOnAndroidArticle(composeTestRule)
+      waitComposeToSettleViews()
+      assertAndroidArticleLoadedInReader(composeTestRule)
+      // Save bookmark
+      clickOnSaveBookmarkImage(composeTestRule)
+      // open previous page
+      clickOnBackwardButton(composeTestRule)
+      // open bookmark screen.
+      openBookmarkScreen(kiwixMainActivity as CoreMainActivity, composeTestRule)
+      // tries to open the bookmark page in reader.
+      openBookmarkInReader(composeTestRule)
+      waitComposeToSettleViews()
+      assertAndroidArticleLoadedInReader(composeTestRule)
     }
+  }
+
+  @Test
+  fun testSavedBookmarksShowingOnBookmarkScreen() {
+    openZimFileInReader()
     bookmarks {
       // delete any bookmark if already saved to properly perform this test case.
       longClickOnSaveBookmarkImage(composeTestRule)
@@ -244,6 +247,23 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       // test all the saved bookmarks are showing on the bookmarks screen
       openBookmarkScreen(kiwixMainActivity as CoreMainActivity, composeTestRule)
       testAllBookmarkShowing(bookmarkList, composeTestRule)
+    }
+  }
+
+  private fun openZimFileInReader() {
+    val zimFile = getZimFile()
+    composeTestRule.apply {
+      runOnUiThread {
+        kiwixMainActivity.navigate(KiwixDestination.Library.route)
+        val navOptions = NavOptions.Builder()
+          .setPopUpTo(KiwixDestination.Reader.route, false)
+          .build()
+        kiwixMainActivity.navigate(
+          KiwixDestination.Reader.createRoute(zimFileUri = zimFile.toUri().toString()),
+          navOptions
+        )
+      }
+      waitComposeToSettleViews()
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -189,6 +189,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       clickOnAndroidArticle(composeTestRule)
       waitComposeToSettleViews()
       assertAndroidArticleLoadedInReader(composeTestRule)
+      waitComposeToSettleViews()
       // Save bookmark
       clickOnSaveBookmarkImage(composeTestRule)
       // open previous page

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -46,8 +46,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
-import androidx.navigation.NavOptions
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageDeviceUtils
@@ -76,6 +76,7 @@ import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_SUPPORT_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_ZIM_HOST_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.NEW_TAB_SHORTCUT_ID
 import org.kiwix.kiwixmobile.core.main.ZIM_HOST_DEEP_LINK_SCHEME
+import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.kiwixActivityComponent
@@ -378,6 +379,30 @@ class KiwixMainActivity : CoreMainActivity() {
         isVoice = isVoice
       ),
       NavOptions.Builder().setPopUpTo(searchFragmentRoute, inclusive = true).build()
+    )
+  }
+
+  override fun openPage(
+    pageUrl: String,
+    zimReaderSource: ZimReaderSource?,
+    shouldOpenInNewTab: Boolean
+  ) {
+    var zimFileUri = ""
+    if (zimReaderSource != null) {
+      zimFileUri = zimReaderSource.toDatabase()
+    }
+    val navOptions = NavOptions.Builder()
+      .setLaunchSingleTop(true)
+      .setPopUpTo(readerFragmentRoute, inclusive = true)
+      .build()
+    val readerRoute = KiwixDestination.Reader.createRoute(
+      zimFileUri = zimFileUri,
+      pageUrl = pageUrl,
+      shouldOpenInNewTab = shouldOpenInNewTab
+    )
+    navigate(
+      readerRoute,
+      navOptions
     )
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -384,27 +384,11 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     isVoice: Boolean = false
   )
 
-  fun openPage(
+  abstract fun openPage(
     pageUrl: String,
     zimReaderSource: ZimReaderSource? = null,
     shouldOpenInNewTab: Boolean = false
-  ) {
-    var zimFileUri = ""
-    if (zimReaderSource != null) {
-      zimFileUri = zimReaderSource.toDatabase()
-    }
-    val navOptions = NavOptions.Builder()
-      .setLaunchSingleTop(true)
-      .setPopUpTo(readerFragmentRoute, inclusive = true)
-      .build()
-    val readerRouteWithArguments =
-      "$readerFragmentRoute?$PAGE_URL_KEY=$pageUrl&$ZIM_FILE_URI_KEY=$zimFileUri" +
-        "&$SHOULD_OPEN_IN_NEW_TAB=$shouldOpenInNewTab"
-    navigate(
-      readerRouteWithArguments,
-      navOptions
-    )
-  }
+  )
 
   private fun openBookmarks() {
     handleDrawerOnNavigation()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -279,7 +279,6 @@ abstract class CoreReaderFragment :
       onOpenLibraryButtonClicked = {},
       pageLoadingItem = false to ZERO,
       shouldShowDonationPopup = false,
-      // TODO set in onViewCreated.
       fullScreenItem = false to null,
       showBackToTopButton = false,
       backToTopButtonClick = { backToTop() },
@@ -441,11 +440,11 @@ abstract class CoreReaderFragment :
             }
         }
         LaunchedEffect(Unit) {
+          addFullScreenItemIfNotAttached()
           readerScreenState.update {
             copy(
               readerScreenTitle = context.getString(string.reader),
               darkModeViewPainter = darkModeViewPainter,
-              fullScreenItem = fullScreenItem.first to getVideoView(),
               tocButtonItem = getTocButtonStateAndAction(),
               appName = (requireActivity() as CoreMainActivity).appName,
               donateButtonClick = {
@@ -1172,8 +1171,20 @@ abstract class CoreReaderFragment :
     return null
   }
 
+  /**
+   * Attached the full-screen item for videos in readerState if not already attached.
+   */
+  private fun addFullScreenItemIfNotAttached() {
+    if (readerScreenState.value.fullScreenItem.second == null) {
+      readerScreenState.update {
+        copy(fullScreenItem = fullScreenItem.first to getVideoView())
+      }
+    }
+  }
+
   @Throws(IllegalArgumentException::class)
   protected open fun createWebView(attrs: AttributeSet?): KiwixWebView? {
+    addFullScreenItemIfNotAttached()
     return KiwixWebView(
       requireContext(),
       this,

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -41,6 +41,7 @@ import org.kiwix.kiwixmobile.core.main.DrawerMenuItem
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_ABOUT_APP_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_SUPPORT_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.NEW_TAB_SHORTCUT_ID
+import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.R
@@ -185,6 +186,30 @@ class CustomMainActivity : CoreMainActivity() {
         isVoice = isVoice
       ),
       NavOptions.Builder().setPopUpTo(searchFragmentRoute, inclusive = true).build()
+    )
+  }
+
+  override fun openPage(
+    pageUrl: String,
+    zimReaderSource: ZimReaderSource?,
+    shouldOpenInNewTab: Boolean
+  ) {
+    var zimFileUri = ""
+    if (zimReaderSource != null) {
+      zimFileUri = zimReaderSource.toDatabase()
+    }
+    val navOptions = NavOptions.Builder()
+      .setLaunchSingleTop(true)
+      .setPopUpTo(readerFragmentRoute, inclusive = true)
+      .build()
+    val readerRoute = CustomDestination.Reader.createRoute(
+      zimFileUri = zimFileUri,
+      pageUrl = pageUrl,
+      shouldOpenInNewTab = shouldOpenInNewTab
+    )
+    navigate(
+      readerRoute,
+      navOptions
     )
   }
 


### PR DESCRIPTION
Fixes #4390 

* The issue occurred because the reader screen route was not being created properly, as both modules had different destination classes. We made the openPage method abstract so that each module can provide its own destination with arguments to correctly open pages.
* Improved WebView creation in Compose.
* Added UI test cases for bookmarks and notes to verify that saved items open the exact page in the reader.