### PR TITLE
Fixed: Tabs not restoring in multiple navigation scenarios.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -272,10 +272,7 @@ class KiwixMainActivity : CoreMainActivity() {
     if (intent?.action == ACTION_GET_CONTENT) {
       navigate(KiwixDestination.Downloads.route) {
         launchSingleTop = true
-        popUpTo(navController.graph.findStartDestination().id) {
-          saveState = true
-        }
-        restoreState = true
+        popUpTo(navController.graph.findStartDestination().id)
       }
     }
   }
@@ -372,6 +369,9 @@ class KiwixMainActivity : CoreMainActivity() {
   }
 
   override fun openSearch(searchString: String, isOpenedFromTabView: Boolean, isVoice: Boolean) {
+    // remove the previous backStack entry with old arguments. Bug Fix #4392
+    removeArgumentsOfReaderScreen()
+    // Freshly open the search fragment.
     navigate(
       KiwixDestination.Search.createRoute(
         searchString = searchString,
@@ -412,6 +412,25 @@ class KiwixMainActivity : CoreMainActivity() {
 
   override fun showBottomAppBar() {
     shouldShowBottomAppBar.update { true }
+  }
+
+  /**
+   * Handles navigation from the left drawer to the Reader screen.
+   *
+   * Clears any existing Reader back stack entry (with its arguments)
+   * and replaces it with a fresh Reader screen using default arguments.
+   * This ensures old arguments are not retained when navigating
+   * via the left drawer.
+   */
+  override fun removeArgumentsOfReaderScreen() {
+    if (navController.currentDestination?.route?.startsWith(readerFragmentRoute) == true) {
+      navigate(
+        readerFragmentRoute,
+        NavOptions.Builder()
+          .setPopUpTo(KiwixDestination.Reader.route, inclusive = true)
+          .build()
+      )
+    }
   }
 
   // Outdated shortcut ids(new_tab, get_content)

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
@@ -198,11 +198,12 @@ fun BottomNavigationBar(
 
               // Pop up to the start destination of the graph to avoid building up a large stack
               popUpTo(navController.graph.findStartDestination().id) {
-                saveState = true
+                // Bug fix #4392
+                saveState = item.route != KiwixDestination.Reader.route
               }
 
               // Restore state when reselecting a previously selected tab
-              restoreState = true
+              restoreState = item.route != KiwixDestination.Reader.route
             }
           }
         },

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigation.kt
@@ -47,7 +47,7 @@ data class OpenFileWithNavigation(private val bookOnDisk: BooksOnDiskListItem.Bo
         )
       } else {
         val navOptions = NavOptions.Builder()
-          .setPopUpTo(KiwixDestination.Library.route, inclusive = false)
+          .setPopUpTo(KiwixDestination.Reader.route, inclusive = true)
           .build()
         activity.navigate(
           KiwixDestination.Reader.createRoute(zimFileUri = zimReaderSource.toDatabase()),

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -315,8 +315,8 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   }
 
   protected fun openHelpFragment() {
-    navigate(helpFragmentRoute)
     handleDrawerOnNavigation()
+    navigate(helpFragmentRoute)
   }
 
   fun navigationDrawerIsOpen(): Boolean = leftDrawerState.isOpen
@@ -403,6 +403,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   protected fun handleDrawerOnNavigation() {
     closeNavigationDrawer()
     disableLeftDrawer()
+    removeArgumentsOfReaderScreen()
   }
 
   private fun setMainActivityToCoreApp() {
@@ -508,4 +509,5 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   abstract fun createApplicationShortcuts()
   abstract fun hideBottomAppBar()
   abstract fun showBottomAppBar()
+  abstract fun removeArgumentsOfReaderScreen()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -1075,6 +1075,7 @@ abstract class CoreReaderFragment :
 
   override fun onDestroyView() {
     super.onDestroyView()
+    libkiwixBook = null
     findInPageTitle = null
     searchItemToOpen = null
     pendingIntent = null

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SearchInPreviousScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SearchInPreviousScreen.kt
@@ -20,25 +20,14 @@ package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
-import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setNavigationResultOnCurrent
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setNavigationResult
 import org.kiwix.kiwixmobile.core.main.FIND_IN_PAGE_SEARCH_STRING
 
 data class SearchInPreviousScreen(private val searchString: String) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    val coreMainActivity = activity as CoreMainActivity
-
-    // Remove current ReaderFragment. Bug Fix #4377
-    coreMainActivity.navController.popBackStack(
-      coreMainActivity.readerFragmentRoute,
-      inclusive = true
-    )
-
-    // Launch fresh ReaderFragment so all the previous arguments will remove.
-    coreMainActivity.navController.navigate(coreMainActivity.readerFragmentRoute)
-
-    // Pass search result to the *new* instance
-    activity.setNavigationResultOnCurrent(searchString, FIND_IN_PAGE_SEARCH_STRING)
+    activity.setNavigationResult(searchString, FIND_IN_PAGE_SEARCH_STRING)
+    activity.popNavigationBackstack()
   }
 
   companion object {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SearchInPreviousScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SearchInPreviousScreenTest.kt
@@ -19,13 +19,12 @@
 package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 
 import android.content.Intent
-import androidx.navigation.NavHostController
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.verifyOrder
+import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setNavigationResultOnCurrent
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.popNavigationBackstack
+import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setNavigationResult
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.FIND_IN_PAGE_SEARCH_STRING
 
@@ -34,20 +33,11 @@ internal class SearchInPreviousScreenTest {
   fun `invoke with returns positive result with string to previous screen`() {
     val searchString = "search"
     mockkConstructor(Intent::class)
-
-    // Mock the activity & navController
-    val mockNavController = mockk<NavHostController>(relaxed = true)
-    val activity = mockk<CoreMainActivity>(relaxed = true) {
-      every { readerFragmentRoute } returns "readerRoute"
-      every { navController } returns mockNavController
-    }
-
+    val activity = mockk<CoreMainActivity>(relaxed = true)
     SearchInPreviousScreen(searchString).invokeWith(activity)
-
-    verifyOrder {
-      mockNavController.popBackStack("readerRoute", true)
-      mockNavController.navigate("readerRoute")
-      activity.setNavigationResultOnCurrent(searchString, FIND_IN_PAGE_SEARCH_STRING)
+    verify {
+      activity.setNavigationResult(searchString, FIND_IN_PAGE_SEARCH_STRING)
+      activity.popNavigationBackstack()
     }
   }
 }

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -179,6 +179,8 @@ class CustomMainActivity : CoreMainActivity() {
   }
 
   override fun openSearch(searchString: String, isOpenedFromTabView: Boolean, isVoice: Boolean) {
+    // remove the previous backStack entry with old arguments.
+    removeArgumentsOfReaderScreen()
     navigate(
       CustomDestination.Search.createRoute(
         searchString = searchString,
@@ -219,6 +221,25 @@ class CustomMainActivity : CoreMainActivity() {
 
   override fun showBottomAppBar() {
     // Do nothing since custom apps does not have the bottomAppBar.
+  }
+
+  /**
+   * Handles navigation from the left drawer to the Reader screen.
+   *
+   * Clears any existing Reader back stack entry (with its arguments)
+   * and replaces it with a fresh Reader screen using default arguments.
+   * This ensures old arguments are not retained when navigating
+   * via the left drawer.
+   */
+  override fun removeArgumentsOfReaderScreen() {
+    if (navController.currentDestination?.route?.startsWith(readerFragmentRoute) == true) {
+      navigate(
+        readerFragmentRoute,
+        NavOptions.Builder()
+          .setPopUpTo(CustomDestination.Reader.route, inclusive = true)
+          .build()
+      )
+    }
   }
 
   // Outdated shortcut id(new_tab)


### PR DESCRIPTION
Fixes #4392 

* Fixed: When opening a new ZIM file from the local library and pressing the back button repeatedly, the previously loaded empty ZIM file reappeared in the reader.
* Fixed: Cached book for bookmarks sometimes returned "null" because it wasn’t properly cleared when navigating to other screens.
* Fixed: Tabs were not restoring when navigating to another screen via the bottomAppBar.
* Refactored the "FIND_IN_PAGE" flow — since we can now directly set the result on the previous back stack entry, relaunching the reader screen is no longer required.
* Fixed: Tabs not restoring when returning from left drawer screens.