### PR TITLE
Fixed: Online library sometimes automatically loaded more items without user input.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -215,14 +215,6 @@ private fun OnlineLibraryList(state: OnlineLibraryScreenState, lazyListState: La
     showLoadMoreProgressBar(state.isLoadingMoreItem)
   }
 
-  LaunchedEffect(state.isLoadingMoreItem) {
-    if (state.isLoadingMoreItem) {
-      // Scroll to the last item (i.e., the loading spinner)
-      val lastItemIndex = state.onlineLibraryList?.size ?: 0
-      lazyListState.animateScrollToItem(lastItemIndex)
-    }
-  }
-
   LaunchedEffect(lazyListState) {
     snapshotFlow {
       derivedStateOf {

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -513,6 +513,7 @@ class ZimManageViewModel @Inject constructor(
           }
         }
         .collect { result ->
+          resetDownloadState()
           library.emit(
             if (result.onlineLibraryRequest.isLoadMoreItem) {
               library.value + result.books
@@ -520,7 +521,6 @@ class ZimManageViewModel @Inject constructor(
               result.books
             }
           )
-          resetDownloadState()
         }
     }
   }.flowOn(ioDispatcher)


### PR DESCRIPTION
Fixes #4394 

* Removed the code that auto-scrolled the list to show the progress bar. Now, users will see the progress bar only when they scroll down to load more items(which is ideal).
* Improved `isLoadingMoreItem` handling to avoid duplicate `loadMore` calls after appending items