### PR TITLE
Fixed: `Wikimedar` application crash caused by Input Dispatching Timed Out.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -272,7 +272,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     Request.Builder()
       .url(
         URI.create(
-          "https://download.kiwix.org/zim/wikipedia_fr_climate_change_mini.zim"
+          "https://download.kiwix.org/zim/wikipedia_fr_climate-change_mini.zim"
         ).toURL()
       ).build()
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -2487,17 +2487,16 @@ abstract class CoreReaderFragment :
     )
   }
 
-  @Suppress("TooGenericExceptionCaught")
   protected suspend fun manageExternalLaunchAndRestoringViewState(
     restoreOrigin: RestoreOrigin = FromExternalLaunch,
     dispatchersToGetWebViewHistoryFromDatabase: CoroutineDispatcher = Dispatchers.IO
   ) {
-    val settings = requireActivity().getSharedPreferences(
-      SharedPreferenceUtil.PREF_KIWIX_MOBILE,
-      0
-    )
-    val currentTab = safelyGetCurrentTab(settings)
-    try {
+    runCatching {
+      val settings = requireActivity().getSharedPreferences(
+        SharedPreferenceUtil.PREF_KIWIX_MOBILE,
+        0
+      )
+      val currentTab = safelyGetCurrentTab(settings)
       val webViewHistoryList = withContext(dispatchersToGetWebViewHistoryFromDatabase) {
         // perform database operation on IO thread.
         repositoryActions?.loadWebViewPagesHistory().orEmpty()
@@ -2524,10 +2523,10 @@ abstract class CoreReaderFragment :
         findInPageTitle = null
         handlePendingIntent()
       }
-    } catch (e: Exception) {
+    }.onFailure {
       Log.e(
         TAG_KIWIX,
-        "Could not restore tabs. Original exception = ${e.printStackTrace()}"
+        "Could not restore tabs. Original exception = ${it.printStackTrace()}"
       )
       restoreViewStateOnInvalidWebViewHistory()
       // handle the pending intent if any present.

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomFileValidator.kt
@@ -23,6 +23,9 @@ import android.content.ContextWrapper
 import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.content.res.AssetManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasBothFiles
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasFile
@@ -32,13 +35,18 @@ import java.io.IOException
 import javax.inject.Inject
 
 class CustomFileValidator @Inject constructor(private val context: Context) {
-  fun validate(onFilesFound: (ValidationState) -> Unit, onNoFilesFound: () -> Unit) =
+  suspend fun validate(
+    onFilesFound: suspend (ValidationState) -> Unit,
+    onNoFilesFound: suspend () -> Unit,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO
+  ) = withContext(dispatcher) {
     when (val installationState = detectInstallationState()) {
       is HasBothFiles,
       is HasFile -> onFilesFound(installationState)
 
       HasNothing -> onNoFilesFound()
     }
+  }
 
   private fun detectInstallationState(
     obbFiles: List<File> = obbFiles(),

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/main/CustomFileValidatorTest.kt
@@ -26,6 +26,7 @@ import android.content.res.AssetManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
@@ -48,7 +49,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onFilesFound when both OBB and ZIM files are found`() {
+  fun `validate should call onFilesFound when both OBB and ZIM files are found`() = runTest {
     val obbFile = mockk<File>()
     val zimFile = mockk<File>()
     mockZimFiles(arrayOf(obbFile), "obb")
@@ -65,7 +66,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onFilesFound when only OBB file is found`() {
+  fun `validate should call onFilesFound when only OBB file is found`() = runTest {
     val obbFile = mockk<File>()
     mockZimFiles(arrayOf(obbFile), "obb")
     mockZimFiles(arrayOf(), "zim")
@@ -80,7 +81,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onFilesFound when only ZIM file is found`() {
+  fun `validate should call onFilesFound when only ZIM file is found`() = runTest {
     val zimFile = mockk<File>()
     mockZimFiles(arrayOf(), "obb")
     mockZimFiles(arrayOf(zimFile), "zim")
@@ -95,7 +96,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onNoFilesFound when no OBB or ZIM files are found`() {
+  fun `validate should call onNoFilesFound when no OBB or ZIM files are found`() = runTest {
     mockZimFiles(arrayOf(), extension = "zim")
     mockZimFiles(arrayOf(), extension = "obb")
 
@@ -106,7 +107,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onNoFilesFound when directories are null`() {
+  fun `validate should call onNoFilesFound when directories are null`() = runTest {
     mockZimFiles(null, "zim")
     mockZimFiles(null, "obb")
 
@@ -117,7 +118,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onNoFilesFound when no matching files are found`() {
+  fun `validate should call onNoFilesFound when no matching files are found`() = runTest {
     val textFile = mockk<File>()
     mockZimFiles(arrayOf(textFile), "txt")
 
@@ -128,7 +129,7 @@ class CustomFileValidatorTest {
   }
 
   @Test
-  fun `validate should call onFilesFound for case insensitive file extensions`() {
+  fun `validate should call onFilesFound for case insensitive file extensions`() = runTest {
     val zimFile = mockk<File>()
     mockZimFiles(arrayOf(zimFile), "ZIM")
 


### PR DESCRIPTION
Fixes #4402 

* Moved the file-scanning logic to the IO thread, allowing smooth directory scanning or ZIM file preparation from the asset directory while keeping the main thread free.
* Refactored `CustomFileValidatorTest` to align with this change.