### PR TITLE
Fixed: Hotspot list of books appearing empty(when reopening the ZimHostScreen).

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -22,6 +22,8 @@ import android.Manifest
 import android.content.Context
 import android.os.Build
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.accessibility.AccessibilityChecks
@@ -41,6 +43,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.ui.components.NAVIGATION_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChange
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
@@ -213,6 +216,33 @@ class ZimHostFragmentTest {
       }
     }
     LeakAssertions.assertNoLeaks()
+  }
+
+  @Test
+  fun testZIMFilesShowingOnZimHostScreen() {
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      it.navigate(KiwixDestination.Library.route)
+    }
+    // delete all the ZIM files showing in the LocalLibrary
+    // screen to properly test the scenario.
+    library {
+      refreshList(composeTestRule)
+      waitUntilZimFilesRefreshing(composeTestRule)
+      deleteZimIfExists(composeTestRule)
+    }
+    loadZimFileInApplication("testzim.zim")
+    loadZimFileInApplication("small.zim")
+    zimHost {
+      refreshLibraryList(composeTestRule)
+      assertZimFilesLoaded(composeTestRule)
+      openZimHostFragment(kiwixMainActivity as CoreMainActivity, composeTestRule)
+      assertZimFilesLoaded(composeTestRule)
+      composeTestRule.onNodeWithTag(NAVIGATION_ICON_TESTING_TAG).performClick()
+      composeTestRule.mainClock.advanceTimeByFrame()
+      openZimHostFragment(kiwixMainActivity as CoreMainActivity, composeTestRule)
+      assertZimFilesLoaded(composeTestRule)
+    }
   }
 
   private fun loadZimFileInApplication(zimFileName: String) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -404,7 +404,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   override fun onDestroyView() {
     super.onDestroyView()
     unRegisterHotspotService()
-    presenter.detachView()
+    presenter.detachView(this)
   }
 
   private fun unRegisterHotspotService() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostPresenter.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostPresenter.kt
@@ -30,11 +30,9 @@ import javax.inject.Inject
 @ActivityScope
 class ZimHostPresenter @Inject internal constructor(
   private val dataSource: DataSource
-) : BasePresenter<View>(),
-  Presenter {
-  @Suppress("TooGenericExceptionCaught")
+) : BasePresenter<View>(), Presenter {
   override suspend fun loadBooks(previouslyHostedBooks: Set<String>) {
-    try {
+    runCatching {
       val books = dataSource.getLanguageCategorizedBooks().first()
       books.forEach { item ->
         if (item is BooksOnDiskListItem.BookOnDisk) {
@@ -43,8 +41,8 @@ class ZimHostPresenter @Inject internal constructor(
         }
       }
       view?.addBooks(books)
-    } catch (e: Exception) {
-      Log.e(TAG, "Unable to load books", e)
+    }.onFailure {
+      Log.e(TAG, "Unable to load books", it)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseContract.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseContract.kt
@@ -34,7 +34,9 @@ class BaseContract {
 
     /**
      * Drops the reference to the view when destroyed
+     *
+     * @param view the view instance to be detached
      */
-    fun detachView()
+    fun detachView(view: T)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BasePresenter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BasePresenter.kt
@@ -32,7 +32,11 @@ abstract class BasePresenter<T : View<*>?> : Presenter<T> {
     this.view = view
   }
 
-  override fun detachView() {
-    view = null
+  override fun detachView(view: T) {
+    // Detach the view only if it matches the one currently attached.
+    // Bug Fix #4409
+    if (this.view == view) {
+      this.view = null
+    }
   }
 }


### PR DESCRIPTION
Fixes #4409 

* The issue occurred when reopening the `ZimHostScreen`. The presenter was detaching the view of the previous `ZimHostScreen`, but since the presenter is a singleton, it also cleared the reference to the view attached to the new `ZimHostScreen`. As a result, the `ZimHostPresenter` could not post books because the view reference was null.
* Updated `BasePresenter` so that it only detaches the view if it matches the one currently attached, preventing accidental clearing of the new screen’s view.
* Added `testZIMFilesShowingOnZimHostScreen` UI test case for testing this scenario so that we can avoid this type of error in the future.

| Before Fix  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/e5800f46-53b3-40c5-8049-d4698371a43b"/> |   <video src="https://github.com/user-attachments/assets/d4996555-5ee0-44ea-a503-b4af2c210625"/> |

