### PR TITLE
Fixed: The `LeftDrawer` automatically opens when we rotate the screen.

### DIFF
--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -77,6 +77,8 @@ class CustomMainActivity : CoreMainActivity() {
       navController = rememberNavController()
       leftDrawerState = rememberDrawerState(DrawerValue.Closed)
       uiCoroutineScope = rememberCoroutineScope()
+      RestoreDrawerStateOnOrientationChange()
+      PersistDrawerStateOnChange()
       CustomMainActivityScreen(
         navController = navController,
         leftDrawerContent = leftDrawerMenu,
@@ -95,9 +97,6 @@ class CustomMainActivity : CoreMainActivity() {
           .provideObjectBoxDataMigrationHandler()
           .migrate()
       }
-    }
-    if (savedInstanceState != null) {
-      return
     }
   }
 


### PR DESCRIPTION
Fixes #4416

* In Compose, when the screen rotates and the screen width is above `600dp`, the `drawerState` is automatically set to `open`. Because of this, the issue was happening.
* Now we are storing the `drawerState` and updating the `leftDrawerState` based on the previously saved value when the orientation changes.
* Fixed: `LongMethod` lint error.

| Before Fix  | After Fix |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/722364d4-29be-412f-a11d-114afc47abd6" /> | <video src="https://github.com/user-attachments/assets/53bf32c1-2c56-4a41-9d56-88540a4fa197"/>  |