### PR TITLE
Improved search performance on low-memory devices.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -30,16 +30,15 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.ZERO
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.cachedComponent
 import org.kiwix.kiwixmobile.core.extensions.closeKeyboard
 import org.kiwix.kiwixmobile.core.extensions.coreMainActivity
@@ -268,7 +267,6 @@ class SearchFragment : BaseFragment() {
     }
   )
 
-  @Suppress("InjectDispatcher")
   private suspend fun render(state: SearchState) {
     renderingJob?.apply {
       // cancel the children job. Since we are getting the result on IO thread
@@ -285,9 +283,7 @@ class SearchFragment : BaseFragment() {
     // To avoid unnecessary data loading and prevent crashes, we check if the search screen is
     // visible to the user before proceeding. If the screen is not visible,
     // we skip the data loading process.
-    if (!isVisible) {
-      return
-    }
+    if (!isVisible) return
     isDataLoading.value = false
     findInPageMenuItem.value = findInPageMenuItem.value.first to (state.searchOrigin == FromWebView)
     setIsPageSearchEnabled(state.searchTerm)
@@ -295,12 +291,7 @@ class SearchFragment : BaseFragment() {
     renderingJob =
       lifecycleScope.launch {
         try {
-          val searchResult =
-            withContext(Dispatchers.IO) {
-              state.getVisibleResults(0, coroutineContext[Job])
-            }
-
-          searchScreenState.update { copy(isLoading = false) }
+          val searchResult = state.getVisibleResults(ZERO, coroutineContext[Job])
           searchResult?.let {
             searchScreenState.update {
               copy(searchList = it)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -48,7 +48,6 @@ import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ActivityResultReceived
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.ClickedSearchInText
-import org.kiwix.kiwixmobile.core.search.viewmodel.Action.Filter
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnItemLongClick
 import org.kiwix.kiwixmobile.core.search.viewmodel.Action.OnOpenInNewTabClick
@@ -245,7 +244,7 @@ class SearchFragment : BaseFragment() {
   }
 
   private fun searchEntryForSearchTerm(searchText: String) {
-    searchViewModel.actions.trySend(Filter(searchText)).isSuccess
+    searchViewModel.searchResults(searchText)
   }
 
   private fun actionMenuItems() = listOfNotNull(

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -39,7 +39,7 @@ internal class SearchStateTest {
       val suggestionSearchWrapper: SuggestionSearchWrapper = mockk()
       val searchIteratorWrapper: SuggestionIteratorWrapper = mockk()
       val entryWrapper: SuggestionItemWrapper = mockk()
-      val estimatedMatches = 100
+      val estimatedMatches = 20
       every { suggestionSearchWrapper.estimatedMatches } returns estimatedMatches.toLong()
       // Settings list to hasNext() to ensure it returns true only for the first call.
       // Otherwise, if we do not set this, the method will always return true when


### PR DESCRIPTION
Fixes #4399 

* Both the initial search (while typing, was already on IO thread) and loading of additional items have been moved to the IO thread, keeping the UI thread free and ensuring a smoother user experience.
* Optimized result fetching from libkiwix: previously, 100 results were retrieved for every typed character. This was inefficient, as users often continue typing and most of those results went unused.
* Even though ongoing requests were canceled when users typed further, fetching 100 results at a time was still wasteful. Once the native C++ code started processing, it consumed memory(as it do not immediately cancel the ongoing process), regardless of cancellation.
* The default has now been adjusted to fetch 20 results per search instead of 100. This reduces memory usage, improves response time, and remains practical since users cannot view 100 results at once. If additional results are needed, they can simply scroll, and more items will be loaded through the loadMore functionality.
* Added debouncing in search with 150MS.
* Improved the flow triggering for search; it was initiating twice for the same searchTerm.
* Improved the `SearchState combines sources from inputs`, which sometimes fails on CI.
* Added `DebouncedTest` for testing the search functionality.