### PR TITLE
Added support for selecting multiple files via the file picker.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -225,7 +225,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
           .filterIsInstance<LocalLibraryFragment>()
           .firstOrNull()
       localLibraryFragment?.handleSelectedFileUri(
-        uri,
+        arrayListOf(uri),
       )
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -564,7 +564,7 @@ class CopyMoveFileHandler @Inject constructor(
   }
 
   suspend fun getStorageDeviceList() =
-    (activity as KiwixMainActivity).getStorageDeviceList()
+    (activity as? KiwixMainActivity)?.getStorageDeviceList().orEmpty()
 
   fun dispose() {
     storageObservingJob?.cancel()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -49,6 +49,17 @@ sealed class KiwixDialog(
     constructor(zimNameList: String) : this(listOf(zimNameList))
   }
 
+  data class FileCopyMoveError(override val args: List<Any>) :
+    KiwixDialog(
+      null,
+      R.string.file_copy_move_error_dialog_message,
+      R.string.yes,
+      R.string.no
+    ),
+    HasBodyFormatArgs {
+    constructor(errorMessage: String) : this(listOf(errorMessage))
+  }
+
   object LocationPermissionRationale : KiwixDialog(
     null,
     R.string.permission_rationale_location,
@@ -134,15 +145,16 @@ sealed class KiwixDialog(
     private val titleId: Int,
     private val customViewBottomPadding: Dp,
     private val customGetView: @Composable (() -> Unit)?
-  ) : KiwixDialog(
-      title = titleId,
-      message = null,
-      cancelable = false,
-      confirmButtonText = R.string.empty_string,
-      dismissButtonText = null,
-      customComposeView = customGetView,
-      customComposeViewBottomPadding = customViewBottomPadding
-    )
+  ) :
+    KiwixDialog(
+        title = titleId,
+        message = null,
+        cancelable = false,
+        confirmButtonText = R.string.empty_string,
+        dismissButtonText = null,
+        customComposeView = customGetView,
+        customComposeViewBottomPadding = customViewBottomPadding
+      )
 
   data object ShowWarningAboutSplittedZimFile : KiwixDialog(
     R.string.verify_zim_chunk_dialog_title,

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -345,6 +345,8 @@
   <string name="copy_move_files_to_app_directory_description">Due to Google Play policies on Android 11 and above, our app can no longer directly access files stored elsewhere on your device. To let you view your selected files, we need to move or copy them into a special folder within our application directory. This allows us to access and open the files.</string>
   <string name="choose_storage_to_copy_move_zim_file">Choose storage to copy/move ZIM file</string>
   <string name="move_file_error_message">Error in moving the ZIM file: %s.</string>
+  <string name="file_copy_move_error_dialog_message">%s \nDo you want to continue with other ZIM files?</string>
+  <string name="your_selected_files_added_to_library">Your selected ZIM files are added to library.</string>
   <string name="how_to_update_content">How to update content?</string>
   <string name="update_content_description">To update content (a ZIM file) you need to download the full latest version of this very same content. You can do that via the download section.</string>
   <string name="all_files_permission_needed">All Files Permission Needed</string>


### PR DESCRIPTION
Fixes #4181 

* Refactored the code to handle multiple file selections.
* Added a custom error dialog that displays the file name(with proper error message) when an error occurs during copying/moving a ZIM file. If the user chooses to continue, the app resumes processing the remaining ZIM files.
* When a single valid ZIM file is selected, it opens directly in the reader. When multiple files are selected, all valid files are added to the library, and a success message is shown after the last file is processed.
* Added storage validation before copy/move. If the selected location has insufficient space, a Snackbar appears with an option to change storage.
