### PR TITLE
Fixed: custom apps disabling the left drawer when configured to disable the `TOC`(the right drawer).

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -87,10 +87,10 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.CoreApp
-import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.StorageObserver
+import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
@@ -562,12 +562,6 @@ abstract class CoreReaderFragment :
    * Handles clicks on the navigation icon.
    * - If the tab switcher is active, triggers the home menu action.
    * - Otherwise, toggles the navigation drawer: opens it if closed, closes it if open.
-   *
-   * Subclasses like CustomReaderFragment can override this method to provide custom behavior,
-   * such as disabling the hamburger icon click when the sidebar is configured to be hidden.
-   *
-   * WARNING: If modifying this method, ensure thorough testing with custom apps
-   * to verify proper functionality.
    */
   open fun navigationIconClick() {
     if (readerMenuState?.isInTabSwitcher == true) {
@@ -575,11 +569,11 @@ abstract class CoreReaderFragment :
       return
     }
 
-    val activity = activity as CoreMainActivity
-    if (activity.navigationDrawerIsOpen()) {
+    val activity = activity as? CoreMainActivity
+    if (activity?.navigationDrawerIsOpen() == true) {
       activity.closeNavigationDrawer()
     } else {
-      activity.openNavigationDrawer()
+      activity?.openNavigationDrawer()
     }
   }
 
@@ -732,13 +726,9 @@ abstract class CoreReaderFragment :
 
   /**
    * Enables the activity's left drawer, allowing it to be opened by clicking the hamburger icon.
-   * Subclasses like CustomReaderFragment can override this method to customize the behavior,
-   * for example, to disable the sidebar when it shouldn't be shown.
-   *
-   * WARNING: If you modify this method, thoroughly test it in custom apps to ensure it works correctly.
    */
   open fun enableLeftDrawer() {
-    (requireActivity() as CoreMainActivity).enableLeftDrawer()
+    (activity as? CoreMainActivity)?.enableLeftDrawer()
   }
 
   private fun goBack() {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -153,28 +153,6 @@ class CustomReaderFragment : CoreReaderFragment() {
     }
   }
 
-  /**
-   * Handles clicks on the navigation icon in custom apps.
-   * - If the tab switcher is active, triggers the home menu action.
-   * - Otherwise, toggles the navigation drawer: closes it if open; opens it only if the sidebar is enabled.
-   *
-   * This override customizes the default behavior by preventing the drawer from opening
-   * when the sidebar is disabled in the app configuration.
-   */
-  override fun navigationIconClick() {
-    if (readerMenuState?.isInTabSwitcher == true) {
-      onHomeMenuClicked()
-      return
-    }
-
-    val activity = activity as CoreMainActivity
-    if (activity.navigationDrawerIsOpen()) {
-      activity.closeNavigationDrawer()
-    } else if (!BuildConfig.DISABLE_SIDEBAR) {
-      activity.openNavigationDrawer()
-    }
-  }
-
   private fun loadPageFromNavigationArguments() {
     val customMainActivity = activity as? CustomMainActivity
     val pageUrl =
@@ -219,19 +197,6 @@ class CustomReaderFragment : CoreReaderFragment() {
     onComplete: () -> Unit
   ) {
     restoreTabs(webViewHistoryItemList, currentTab, onComplete)
-  }
-
-  /**
-   * Enables or disables the sidebar in a custom app based on the configuration.
-   * If the app is configured to disable the sidebar, this method disables it;
-   * otherwise, it enables the sidebar.
-   */
-  override fun enableLeftDrawer() {
-    if (BuildConfig.DISABLE_SIDEBAR) {
-      (requireActivity() as CoreMainActivity).disableLeftDrawer()
-    } else {
-      super.enableLeftDrawer()
-    }
   }
 
   /**


### PR DESCRIPTION
Fixes #4389

Now, when a custom app is configured to disable the TOC(table of contents right sidebar), it only disables the `TOC` sidebar.