### PR TITLE
Improved the file picker to list only ZIM files, reducing the load on the picker.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
@@ -393,7 +393,7 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
   private fun showFileChooser() {
     val intent = Intent().apply {
       action = Intent.ACTION_OPEN_DOCUMENT
-      type = "*/*"
+      type = "application/*"
       addCategory(Intent.CATEGORY_OPENABLE)
       putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
       if (sharedPreferenceUtil.prefIsTest) {


### PR DESCRIPTION
Fixes #4427 

Previously, it displayed all files in storage, which caused hangs on devices with large file sets. We have now restricted the file picker to only show files under the "application/*" MIME type, since ZIM files also fall under this type.