### PR TITLE
Reintroduced "Send diagnostic report" in custom apps.

### DIFF
--- a/buildSrc/src/main/kotlin/custom/CustomApp.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApp.kt
@@ -37,6 +37,7 @@ data class CustomApp(
   val disableReadAloud: Boolean = false,
   val disableTitle: Boolean = false,
   val disableExternalLinks: Boolean = false,
+  val disableHelpMenu: Boolean = false,
   val aboutAppUrl: String = "",
   val supportUrl: String = ""
 ) {
@@ -51,6 +52,7 @@ data class CustomApp(
     parsedJson.getAndCast("disable_read_aloud") ?: false,
     parsedJson.getAndCast("disable_title") ?: false,
     parsedJson.getAndCast("disable_external_links") ?: false,
+    parsedJson.getAndCast("disable_help_menu") ?: false,
     parsedJson.getAndCast("about_app_url") ?: "",
     parsedJson.getAndCast("support_url") ?: ""
   )

--- a/buildSrc/src/main/kotlin/custom/CustomApps.kt
+++ b/buildSrc/src/main/kotlin/custom/CustomApps.kt
@@ -53,6 +53,7 @@ fun ProductFlavors.create(customApps: List<CustomApp>) {
       buildConfigField("Boolean", "DISABLE_READ_ALOUD", "${customApp.disableReadAloud}")
       buildConfigField("Boolean", "DISABLE_TITLE", "${customApp.disableTitle}")
       buildConfigField("Boolean", "DISABLE_EXTERNAL_LINK", "${customApp.disableExternalLinks}")
+      buildConfigField("Boolean", "DISABLE_HELP_MENU", "${customApp.disableHelpMenu}")
       configureStrings(customApp.displayName)
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -1895,7 +1895,7 @@ abstract class CoreReaderFragment :
 
   private fun openSearch(searchString: String?, isOpenedFromTabView: Boolean, isVoice: Boolean) {
     searchString?.let {
-      (requireActivity() as CoreMainActivity).openSearch(
+      (activity as? CoreMainActivity)?.openSearch(
         it,
         isOpenedFromTabView,
         isVoice

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomMainActivity.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.core.main.ACTION_NEW_TAB
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.DrawerMenuItem
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_ABOUT_APP_ITEM_TESTING_TAG
+import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_HELP_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_SUPPORT_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.NEW_TAB_SHORTCUT_ID
 import org.kiwix.kiwixmobile.core.main.PAGE_URL_KEY
@@ -115,18 +116,26 @@ class CustomMainActivity : CoreMainActivity() {
   override val zimHostDrawerMenuItem: DrawerMenuItem? = null
 
   /**
-   * Hide the `HelpFragment` from custom apps.
-   * We have not removed the relevant code for `HelpFragment` from custom apps.
-   * If, in the future, we need to display this for all/some custom apps,
-   * we can either remove the line below or configure it according to the requirements.
-   * For more information, see https://github.com/kiwix/kiwix-android/issues/3584
+   * If custom app is configured to show the "Help menu" in navigation
+   * then show it in navigation.
    */
-  override val helpDrawerMenuItem: DrawerMenuItem? = null
+  override val helpDrawerMenuItem: DrawerMenuItem? =
+    if (BuildConfig.DISABLE_HELP_MENU) {
+      null
+    } else {
+      DrawerMenuItem(
+        title = CoreApp.instance.getString(string.menu_help),
+        iconRes = drawable.ic_help_24px,
+        visible = true,
+        onClick = { openHelpFragment() },
+        testingTag = LEFT_DRAWER_HELP_ITEM_TESTING_TAG
+      )
+    }
 
   override val supportDrawerMenuItem: DrawerMenuItem? =
     /**
      * If custom app is configured to show the "Support app_name" in navigation
-     * then show it navigation. "app_name" will be replaced with custom app name.
+     * then show it in navigation. "app_name" will be replaced with custom app name.
      */
     if (BuildConfig.SUPPORT_URL.isNotEmpty()) {
       DrawerMenuItem(
@@ -152,7 +161,7 @@ class CustomMainActivity : CoreMainActivity() {
 
   /**
    * If custom app is configured to show the "About app_name app" in navigation
-   * then show it navigation. "app_name" will be replaced with custom app name.
+   * then show it in navigation. "app_name" will be replaced with custom app name.
    */
   override val aboutAppDrawerMenuItem: DrawerMenuItem? =
     if (BuildConfig.ABOUT_APP_URL.isNotEmpty()) {


### PR DESCRIPTION
Fixes #4446

* Introduced the `disable_help_menu` key in the `info.json` file for custom apps. When this key is set to `true`, the "Help" menu item will be hidden. If it is not set or set to `false`, the "Help" menu item will be visible in the custom app. See https://github.com/kiwix/kiwix-android-custom/pull/251.
* Refactored the code to adapt to this change.

**Screenshots** 


<img width="1080" height="2400" alt="Image" src="https://github.com/user-attachments/assets/7c5556dc-989c-48ae-b0e8-b939b60e1d25" />
<img width="1080" height="2400" alt="Image" src="https://github.com/user-attachments/assets/e81f2ee2-555d-4032-89a2-576037305a7f" />
