### PR TITLE
Fixed: Search results disappear after typing a space.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -312,6 +312,27 @@ class SearchFragmentTest : BaseActivityTest() {
       }
     }
 
+  @Test
+  fun testSearchWithExtraSpaces() {
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      kiwixMainActivity.navigate(KiwixDestination.Library.route)
+    }
+    testZimFile = getTestZimFile()
+    openKiwixReaderFragmentWithFile(testZimFile)
+    search { checkZimFileSearchSuccessful(composeTestRule) }
+    openSearchWithQuery("Android ", testZimFile)
+    search {
+      clickOnSearchItemInSearchList(composeTestRule)
+      checkZimFileSearchSuccessful(composeTestRule)
+    }
+    openSearchWithQuery("   Unit test   ", testZimFile)
+    search {
+      clickOnSearchItemInSearchList(composeTestRule)
+      checkZimFileSearchSuccessful(composeTestRule)
+    }
+  }
+
   private fun removeTemporaryZimFilesToFreeUpDeviceStorage() {
     testZimFile.delete()
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/LanguageFragment.kt
@@ -86,7 +86,7 @@ class LanguageFragment : BaseFragment() {
           onClearClick = { resetSearchState() },
           onAppBarValueChange = {
             searchText = it
-            languageViewModel.actions.tryEmit(Action.Filter(it))
+            languageViewModel.actions.tryEmit(Action.Filter(it.trim()))
           },
           navigationIcon = {
             NavigationIcon(

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -186,7 +186,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     onlineLibraryScreenState.value.update {
       copy(searchText = searchText)
     }
-    zimManageViewModel.requestFiltering.tryEmit(searchText)
+    zimManageViewModel.requestFiltering.tryEmit(searchText.trim())
   }
 
   private val noWifiWithWifiOnlyPreferenceSet

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageFragment.kt
@@ -205,7 +205,7 @@ abstract class PageFragment : OnItemClickListener, BaseFragment(), FragmentActiv
    */
   private fun onTextChanged(searchText: String) {
     pageScreenState.update { copy(searchText = searchText) }
-    pageViewModel.actions.tryEmit(Action.Filter(searchText))
+    pageViewModel.actions.tryEmit(Action.Filter(searchText.trim()))
   }
 
   /**

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -244,7 +244,7 @@ class SearchFragment : BaseFragment() {
   }
 
   private fun searchEntryForSearchTerm(searchText: String) {
-    searchViewModel.searchResults(searchText)
+    searchViewModel.searchResults(searchText.trim())
   }
 
   private fun actionMenuItems() = listOfNotNull(


### PR DESCRIPTION
Fixes #4456 

* This issue occurred because the exact text from the search box was passed, including unnecessary spaces, which caused libkiwix to return no results. The search term is now trimmed before being passed to libkiwix, ensuring extra spaces are removed.
* The same fix has been applied to PageFragment (for bookmarks, notes, and history) as well as the language list and online content search.
* Added UI test case for this so that we can avoid this type of errors in future.

| Before Fix | After Fix |
|---------------|-------------|
| <video src="https://github.com/user-attachments/assets/e79d438b-fed4-48b2-b79b-e2c8ff7bb6a1" /> | <video src="https://github.com/user-attachments/assets/090905bb-5f89-4991-883f-a9e1a5f67abc" />