### PR TITLE
Fixed: In custom apps `isZimFileAlreadyOpenedInReader` could lead to `Input dispatching timeout` error.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -450,6 +450,9 @@ abstract class CoreReaderFragment :
               }
             )
           }
+          // Update the title when Compose is ready to fix the issue
+          // where the user opens pages from history, notes, or bookmarks.
+          updateTitle()
         }
         LaunchedEffect(currentWebViewIndex, readerMenuState?.isInTabSwitcher) {
           readerScreenState.update {
@@ -1599,6 +1602,7 @@ abstract class CoreReaderFragment :
   }
 
   protected fun setUpBookmarks(zimFileReader: ZimFileReader) {
+    if (!isAdded) return
     safelyCancelBookmarkJob()
     val zimFileReaderId = zimFileReader.id
     bookmarkingJob = viewLifecycleOwner.lifecycleScope.launch {

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/main/CustomReaderFragment.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.ui.graphics.Color
 import androidx.core.net.toUri
 import androidx.navigation.NavOptions
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.BaseActivity
@@ -234,7 +235,7 @@ class CustomReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            coreReaderLifeCycleScope?.launch {
+            coreReaderLifeCycleScope?.launch(Dispatchers.Main.immediate) {
               openZimFile(
                 ZimReaderSource(
                   file = it.file,
@@ -262,7 +263,7 @@ class CustomReaderFragment : CoreReaderFragment() {
 
           is ValidationState.HasBothFiles -> {
             it.zimFile.delete()
-            coreReaderLifeCycleScope?.launch {
+            coreReaderLifeCycleScope?.launch(Dispatchers.Main.immediate) {
               openZimFile(ZimReaderSource(it.obbFile), true, shouldManageExternalLaunch)
               if (shouldManageExternalLaunch) {
                 // Open the previous loaded pages after ZIM file loads.
@@ -277,7 +278,7 @@ class CustomReaderFragment : CoreReaderFragment() {
       onNoFilesFound = {
         if (sharedPreferenceUtil?.prefIsTest == false) {
           delay(OPENING_DOWNLOAD_SCREEN_DELAY)
-          coreReaderLifeCycleScope?.launch {
+          coreReaderLifeCycleScope?.launch(Dispatchers.Main.immediate) {
             val navOptions = NavOptions.Builder()
               .setPopUpTo(CustomDestination.Reader.route, true)
               .build()


### PR DESCRIPTION
Fixes #4464 

* This method calls the `archive.check()` function, which takes a long time to validate larger ZIM files. This slows down the entire application because the validation process takes time, and during that period, the user has to wait for the article to load. This is especially time-consuming in scenarios where the user simply goes to the history, notes, bookmarks, or settings screen and then comes back to the reader screen. In the Wikimed app, the validation takes almost 5 seconds, and for larger ZIM files, it takes even longer. We remove this check from our method because the ZIM file is already opened, and keeping it causes performance issues. Retrieving the ZIM file storage and setting it to ZimFileReader takes much less time compared to validating it.
* Instead of this, we have added a condition that checks whether the current reader is null or not(Some other checks are also there that validate the current ZIM file is valid or not). Because if the ZIM file is not valid for some reason, then the archive object would be null in that app lifecycle. So this check plays a similar role, and takes less time.
* Fixed: The Title of the reader screen was not updating when we opening articles from history, notes, or bookmarks in custom apps.
