### PR TITLE
Fixed: Only one ZIM file was displayed when multiple ZIM files had the same title and language.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -74,7 +74,7 @@ class Repository @Inject internal constructor(
           } else {
             listOf(bookOnDisk)
           }
-        }.distinctBy { it.book.language to it.book.title }
+        }.distinctBy { it.book.id }
           .sortedBy { it.book.language + it.book.title }
       }
       .map { items ->


### PR DESCRIPTION
Fixes #4357 

* The issue occurred because ZIM files in the local library were being filtered based on their title and language. As a result, if multiple ZIM files shared the same title and language (e.g., English), only one of them was shown on the Local Library screen.
* Since each ZIM file has a unique bookId, we now remove duplicates based on the bookId instead.

As you can see in the video below. I have 3 "Alpine Linux wiki" ZIM files in English language, but there is only a single ZIM file is showing, and after fixing all 3 ZIM files are showing.

| Before Fix | After Fix |
|---------------|-------------|
| <video src="https://github.com/user-attachments/assets/c4f6cf9b-96bb-4d3a-8eef-21755dbbd5d0" /> | <video src="https://github.com/user-attachments/assets/1eea1347-c2f5-4621-96fc-4e6aa9da6d4e" />

