### PR TITLE
Upgraded the ObjectBox dependency to support 16KB page size.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -40,7 +40,7 @@ object Versions {
 
   const val androidx_test_orchestrator: String = "1.5.1"
 
-  const val io_objectbox: String = "4.0.3"
+  const val io_objectbox: String = "4.1.0"
 
   const val io_mockk: String = "1.13.13"
 


### PR DESCRIPTION
Parent Issue #4406 

* ObjectBox added support for 16KB page size in version `4.1.0`(https://github.com/objectbox/objectbox-java/issues/1178), so we upgraded our application to use this version. Our previous version was `4.0.3`, which is just before `4.1.0`.
* For `java-libkiwix`, we have fixed it in https://github.com/kiwix/java-libkiwix/pull/120. So when we use the latest `java-libkiwix`(after release), https://github.com/kiwix/kiwix-android/issues/4406 will be fully fixed.

<img width="1355" height="322" alt="Screenshot from 2025-10-28 18-39-12" src="https://github.com/user-attachments/assets/8df0db69-6f89-4a9d-8c0d-759650d3a2f4" />

