### PR TITLE
Fixed: PlayStore reported a crash for `android.app.BackgroundServiceStartNotAllowedException`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -218,6 +219,14 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
           )
         }
         DialogHost(dialogShower as AlertDialogShower)
+        DisposableEffect(Unit) {
+          onDispose {
+            // Dispose UI resources when this Compose view is removed. Compose disposes
+            // its content before Fragment.onDestroyView(), so callback and listener cleanup
+            // should happen here.
+            destroyViews()
+          }
+        }
       }
     }
   }
@@ -611,6 +620,10 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
 
   override fun onDestroyView() {
     super.onDestroyView()
+    destroyViews()
+  }
+
+  private fun destroyViews() {
     actionMode = null
     coroutineJobs.forEach {
       it.cancel()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchFragment.kt
@@ -137,6 +137,14 @@ class SearchFragment : BaseFragment() {
           isDataLoading.value
         )
         DialogHost(dialogShower as AlertDialogShower)
+        DisposableEffect(Unit) {
+          onDispose {
+            // Dispose UI resources when this Compose view is removed. Compose disposes
+            // its content before Fragment.onDestroyView(), so callback and listener cleanup
+            // should happen here.
+            destroyViews()
+          }
+        }
       }
     }
     searchViewModel.setAlertDialogShower(dialogShower as AlertDialogShower)
@@ -217,6 +225,10 @@ class SearchFragment : BaseFragment() {
 
   override fun onDestroyView() {
     super.onDestroyView()
+    destroyViews()
+  }
+
+  private fun destroyViews() {
     renderingJob?.cancel()
     renderingJob = null
     activity?.intent?.action = null


### PR DESCRIPTION
Fixes #4492 

* The crash occurred because the fragment was not visible on the window when attempting to stop the read-aloud service. We improved the service-stopping logic to ensure it is handled correctly when the Compose view is disposed.
* Applied similar improvements to other fragments with the same pattern, ensuring all listeners, callbacks, and services are properly cleaned up at the appropriate lifecycle moment.