### PR TITLE
Updated the `Diagnostic` email address.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/Constants.kt
@@ -18,7 +18,7 @@
 package org.kiwix.kiwixmobile.core.utils
 
 const val TAG_KIWIX = "kiwix"
-const val CRASH_AND_FEEDBACK_EMAIL_ADDRESS = "android-crash-feedback@kiwix.org"
+const val CRASH_AND_FEEDBACK_EMAIL_ADDRESS = "app-diagnostic@kiwix.org"
 
 // Request stuff
 const val REQUEST_STORAGE_PERMISSION = 1


### PR DESCRIPTION
We have a new email address(app-diagnostic@kiwix.org) for diagnostic reports, so we updated our code to ensure that all new diagnostic reports are sent to this address.