### PR TITLE
Improved the startup behavior of `DownloadMonitorService`.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -124,12 +124,15 @@ class DownloadMonitorService : Service() {
    * until there are no active downloads, at which point the service is stopped.
    */
   private fun showDownloadServiceForegroundNotification() {
+    // Start the foreground service immediately before going to background.
+    downloadNotificationChannel()
+    startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
     fetch.getDownloadsWithStatus(
       listOf(Status.NONE, Status.ADDED, Status.QUEUED, Status.DOWNLOADING, Status.PAUSED)
     ) { activeDownloads ->
       if (activeDownloads.isNotEmpty()) {
-        downloadNotificationChannel()
-        startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
+        // Update the notification.
+        notificationManager.notify(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
       } else {
         // Stop the foreground service if no active downloads.
         stopForegroundServiceForDownloads()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -256,9 +256,14 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     super.onStart()
     externalLinkOpener.setAlertDialogShower(alertDialogShower)
     rateDialogHandler.setAlertDialogShower(alertDialogShower)
+    rateDialogHandler.checkForRateDialog(getIconResId())
+  }
+
+  override fun onResume() {
+    super.onResume()
+    // Resume in-app download monitoring now that the app is visible again.
     downloadMonitor.startMonitoringDownload()
     stopDownloadServiceIfRunning()
-    rateDialogHandler.checkForRateDialog(getIconResId())
   }
 
   /**
@@ -276,10 +281,12 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     }
   }
 
-  override fun onStop() {
+  override fun onPause() {
+    // Start the DownloadService as the app is about to enter the background,
+    // so downloads can continue even if the app is no longer in the foreground.
     startMonitoringDownloads()
     downloadMonitor.stopListeningDownloads()
-    super.onStop()
+    super.onPause()
   }
 
   /**


### PR DESCRIPTION
Fixes #4495

* Moved the start of `DownloadMonitorService` from the `onStop` lifecycle event to `onPause`, so the service begins slightly earlier—right before the app goes into the background.
* Updated `DownloadMonitorService` to start the foreground service immediately, before performing any work or checking the download status. Previously, while the service was checking download status, the app could transition to the background, causing the service to fail to start. Now, the service starts first and performs all checks afterward, ensuring it always launches successfully. If no downloads are active, the service stops itself afterward.