### PR TITLE
Fixed: `TetherSettings` was not found on a device.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -459,13 +459,21 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   }
 
   private fun launchTetheringSettingsScreen() {
-    startActivity(
-      Intent(Intent.ACTION_MAIN, null).apply {
-        addCategory(Intent.CATEGORY_LAUNCHER)
-        component = ComponentName("com.android.settings", "com.android.settings.TetherSettings")
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK
-      }
-    )
+    runCatching {
+      // Try to open the device's dedicated hotspot/tethering screen.
+      // Most AOSP-based devices support this explicit Settings component.
+      startActivity(
+        Intent(Intent.ACTION_MAIN, null).apply {
+          addCategory(Intent.CATEGORY_LAUNCHER)
+          component = ComponentName("com.android.settings", "com.android.settings.TetherSettings")
+          flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+      )
+    }.onFailure {
+      // Some OEMs remove or rename the tethering activity, so the direct intent may fail.
+      // As a fallback, open the Wireless settings screen—this reliably contains the Hotspot option.
+      startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS))
+    }
   }
 
   @Suppress("NestedBlockDepth")


### PR DESCRIPTION
Fixes #4500 

This happened because some devices do not support this explicit intent, as there is no universal direct intent for opening the hotspot screen. A common intent is available for opening the "Wireless settings" screen, so we use that as a fallback. If the device supports the direct intent, the hotspot screen opens directly; otherwise, the Wireless settings screen is opened instead, and the user can turn on the hotspot from there.