### PR TITLE
Fixed: Someone has reported a crash for `ZimFileReader.getFavicon`.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -57,7 +57,6 @@ import javax.inject.Inject
 
 private const val TAG = "ZimFileReader"
 
-@Suppress("LongParameterList")
 class ZimFileReader constructor(
   val zimReaderSource: ZimReaderSource,
   val jniKiwixReader: Archive,
@@ -150,15 +149,14 @@ class ZimFileReader constructor(
   val date: String get() = getSafeMetaData("Date", "")
   val description: String get() = getSafeMetaData("Description", "")
   val favicon: String?
-    get() =
-      if (jniKiwixReader.hasIllustration(ILLUSTRATION_SIZE)) {
-        Base64.encodeToString(
-          jniKiwixReader.getIllustrationItem(ILLUSTRATION_SIZE).data.data,
-          Base64.DEFAULT
-        )
-      } else {
-        null
-      }
+    get() = runCatching {
+      Base64.encodeToString(
+        jniKiwixReader.getIllustrationItem(ILLUSTRATION_SIZE).data.data,
+        Base64.DEFAULT
+      )
+    }.onFailure {
+      Log.e(TAG, "Could not get the favicon for $title. Original exception: $it")
+    }.getOrNull()
   val language: String get() = getSafeMetaData("Language", "")
 
   val tags: String


### PR DESCRIPTION
Fixes #4503 

Improved the return of the `illustration` item; previously, we were checking first that it had the `illustration` item or not, and then getting the illustration. It calls twice at the library. Now, we are directly getting the illustration like metadata, and if not found, returning null. It will work similarly to the previous, but an extra JNI call is avoided.