### PR TITLE
Using `java-libkiwix` version `2.4.1`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFiles.kt
@@ -20,6 +20,7 @@ package org.kiwix.kiwixmobile.zimManager.fileselectView.effects
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -29,6 +30,7 @@ import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.ZERO
 import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
@@ -62,6 +64,7 @@ data class ValidateZIMFiles(
     }
     dialogShower.show(
       KiwixDialog.ValidatingZimFiles(
+        customViewBottomPadding = ZERO.dp,
         customGetView = {
           val items by validateZimViewModel.items.collectAsStateWithLifecycle()
           val allValidated by validateZimViewModel.allZIMValidated.collectAsStateWithLifecycle()

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -88,7 +88,7 @@ object Versions {
 
   const val androidx_activity: String = "1.9.3"
 
-  const val libkiwix: String = "2.4.0"
+  const val libkiwix: String = "2.4.1"
 
   const val material: String = "1.12.0"
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -288,13 +288,17 @@ sealed class KiwixDialog(
     dismissButtonText = R.string.cancel
   )
 
-  data class ValidatingZimFiles(private val customGetView: @Composable (() -> Unit)?) : KiwixDialog(
-    null,
-    null,
-    R.string.empty_string,
-    null,
-    customComposeView = customGetView
-  )
+  data class ValidatingZimFiles(
+    private val customViewBottomPadding: Dp,
+    private val customGetView: @Composable (() -> Unit)?
+  ) : KiwixDialog(
+      null,
+      null,
+      R.string.empty_string,
+      null,
+      customComposeView = customGetView,
+      customComposeViewBottomPadding = customViewBottomPadding
+    )
 
   data class OpenCredits(private val customGetView: @Composable (() -> Unit)?) : KiwixDialog(
     null,


### PR DESCRIPTION
Fixes #4511 

* Using `java-libkiwix` version `2.4.1`.
* Removed the extra bottom margin from the buttons in the ZIM integrity checker dialog(Small UI improvement).
<img width="300" height="800" alt="Screenshot_20251201-155029" src="https://github.com/user-attachments/assets/da6642a4-bb91-4793-aa3b-dce91ba9cac6" />
