### PR TITLE
Initial setup for migrating from `SharedPreferences` to `DataStore`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -28,6 +28,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavOptions
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R.string
@@ -53,8 +55,6 @@ import org.kiwix.kiwixmobile.core.main.reader.SEARCH_ITEM_TITLE_KEY
 import org.kiwix.kiwixmobile.core.page.history.adapter.WebViewHistoryItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource.Companion.fromDatabaseValue
-import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
-import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.core.utils.files.Log
@@ -252,9 +252,10 @@ class KiwixReaderFragment : CoreReaderFragment() {
     when (restoreOrigin) {
       FromExternalLaunch -> {
         if (!isAdded) return
-        val settings =
-          activity?.getSharedPreferences(SharedPreferenceUtil.PREF_KIWIX_MOBILE, 0)
-        val zimReaderSource = fromDatabaseValue(settings?.getString(TAG_CURRENT_FILE, null))
+        val zimReaderSource =
+          kiwixDataStore?.currentZimFile?.map { value ->
+            fromDatabaseValue(value)
+          }?.first()
         if (zimReaderSource?.canOpenInLibkiwix() == true) {
           if (zimReaderContainer?.zimReaderSource == null) {
             openZimFile(zimReaderSource, isFromManageExternalLaunch = true)

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -370,4 +370,6 @@ object Libs {
   const val COIL3_OKHTTP_COMPOSE = "io.coil-kt.coil3:coil-network-okhttp:${Versions.COIL_COMPOSE}"
   const val COMPOSE_NAVIGATION =
     "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
+
+  const val DATASTORE = "androidx.datastore:datastore-preferences:${Versions.DATASTORE}"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -121,6 +121,8 @@ object Versions {
   const val COIL_COMPOSE = "3.2.0"
 
   const val COMPOSE_NAVIGATION = "2.7.7"
+
+  const val DATASTORE = "1.2.0"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -250,6 +250,9 @@ class AllProjectConfigurer {
       implementation(Libs.COIL3_OKHTTP_COMPOSE)
       implementation(Libs.COMPOSE_NAVIGATION)
 
+      // Jetpack Datastore
+      implementation(Libs.DATASTORE)
+
       // Compose UI test implementation
       androidTestImplementation(Libs.COMPOSE_UI_TEST_JUNIT)
       androidTestImplementation(Libs.COMPOSE_UI_TEST_JUNIT_ACCESSIBILITY)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -52,6 +52,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchResultGenerator
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Singleton
 
 @Singleton
@@ -77,6 +78,7 @@ interface CoreComponent {
   fun activityComponentBuilder(): CoreActivityComponent.Builder
   fun zimReaderContainer(): ZimReaderContainer
   fun sharedPrefUtil(): SharedPreferenceUtil
+  fun kiwixDataStore(): KiwixDataStore
   fun zimFileReaderFactory(): ZimFileReader.Factory
   fun libkiwixBookFactory(): LibkiwixBookFactory
   fun storageObserver(): StorageObserver

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -253,18 +253,23 @@ class DownloadMonitorService : Service() {
    * until there are no active downloads, at which point the service is stopped.
    */
   private fun showDownloadServiceForegroundNotification() {
-    // Start the foreground service immediately before going to background.
-    downloadNotificationChannel()
-    startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
-    fetch.getDownloadsWithStatus(
-      listOf(Status.NONE, Status.ADDED, Status.QUEUED, Status.DOWNLOADING, Status.PAUSED)
-    ) { activeDownloads ->
-      if (activeDownloads.isNotEmpty()) {
-        // Update the notification.
-        notificationManager.notify(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
-      } else {
-        // Stop the foreground service if no active downloads.
-        stopForegroundServiceForDownloads()
+    runCatching {
+      // Start the foreground service immediately before going to background.
+      downloadNotificationChannel()
+      startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
+      fetch.getDownloadsWithStatus(
+        listOf(Status.NONE, Status.ADDED, Status.QUEUED, Status.DOWNLOADING, Status.PAUSED)
+      ) { activeDownloads ->
+        if (activeDownloads.isNotEmpty()) {
+          // Update the notification.
+          notificationManager.notify(
+            DOWNLOAD_SERVICE_NOTIFICATION_ID,
+            buildForegroundNotification()
+          )
+        } else {
+          // Stop the foreground service if no active downloads.
+          stopForegroundServiceForDownloads()
+        }
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -45,6 +45,7 @@ import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.getCurrentLocale
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.videowebview.VideoEnabledWebChromeClient.ToggledFullscreenCallback
@@ -61,7 +62,8 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
   attrs: AttributeSet,
   videoView: ViewGroup?,
   private val coreWebViewClient: CoreWebViewClient,
-  val sharedPreferenceUtil: SharedPreferenceUtil
+  val sharedPreferenceUtil: SharedPreferenceUtil,
+  val kiwixDataStore: KiwixDataStore
 ) : VideoEnabledWebView(context, attrs) {
   @Inject
   lateinit var zimReaderContainer: ZimReaderContainer
@@ -144,7 +146,7 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
     super.onAttachedToWindow()
     // cancel any previous running job.
     textZoomJob?.cancel()
-    textZoomJob = sharedPreferenceUtil.textZooms
+    textZoomJob = kiwixDataStore.textZoom
       .onEach { settings.textZoom = it }
       .launchIn(CoroutineScope(SupervisorJob() + Dispatchers.Main))
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsPresenter.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsPresenter.kt
@@ -24,13 +24,14 @@ import org.kiwix.kiwixmobile.core.settings.SettingsContract.View
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import javax.inject.Inject
 
-internal class SettingsPresenter @Inject constructor(private val dataSource: DataSource) :
-  BasePresenter<View?>(), Presenter {
-    override suspend fun clearHistory() {
-      runCatching {
-        dataSource.clearHistory()
-      }.onFailure {
-        Log.e("SettingsPresenter", it.message, it)
-      }
+internal class SettingsPresenter @Inject constructor(
+  private val dataSource: DataSource
+) : BasePresenter<View?>(), Presenter {
+  override suspend fun clearHistory() {
+    runCatching {
+      dataSource.clearHistory()
+    }.onFailure {
+      Log.e("SettingsPresenter", it.message, it)
     }
   }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/SettingsViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/SettingsViewModel.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore.Companion.DEFAULT_ZOOM
 import javax.inject.Inject
 
 const val ZOOM_OFFSET = 2
@@ -39,7 +41,8 @@ const val ZOOM_SCALE = 25
 
 class SettingsViewModel @Inject constructor(
   private val context: Application,
-  val sharedPreferenceUtil: SharedPreferenceUtil
+  val sharedPreferenceUtil: SharedPreferenceUtil,
+  val kiwixDataStore: KiwixDataStore
 ) : ViewModel() {
   private val _actions = MutableSharedFlow<Action>()
   val actions: SharedFlow<Action> = _actions
@@ -64,11 +67,11 @@ class SettingsViewModel @Inject constructor(
 
   var externalLinkPopup = mutableStateOf(sharedPreferenceUtil.prefExternalLinkPopup)
 
-  val textZoom: StateFlow<Int> = sharedPreferenceUtil.textZooms
+  val textZoom: StateFlow<Int> = kiwixDataStore.textZoom
     .stateIn(
       scope = viewModelScope,
-      started = SharingStarted.Companion.Eagerly,
-      initialValue = sharedPreferenceUtil.textZoom
+      started = SharingStarted.Eagerly,
+      initialValue = DEFAULT_ZOOM
     )
 
   var newTabInBackground = mutableStateOf(sharedPreferenceUtil.prefNewTabBackground)
@@ -103,7 +106,9 @@ class SettingsViewModel @Inject constructor(
   }
 
   fun setTextZoom(position: Int) {
-    sharedPreferenceUtil.textZoom = (position + ZOOM_OFFSET) * ZOOM_SCALE
+    viewModelScope.launch {
+      kiwixDataStore.setTextZoom((position + ZOOM_OFFSET) * ZOOM_SCALE)
+    }
   }
 
   fun setNewTabInBackground(enabled: Boolean) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -400,7 +400,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     private const val PREF_SHOW_NOTES_ALL_BOOKS = "show_notes_current_book"
     private const val PREF_HOSTED_BOOKS = "hosted_books"
     const val PREF_THEME = "pref_dark_mode"
-    private const val TEXT_ZOOM = "true_text_zoom"
+    const val TEXT_ZOOM = "true_text_zoom"
     private const val DEFAULT_ZOOM = 100
     const val PREF_MANAGE_EXTERNAL_FILES = "pref_manage_external_files"
     const val PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH = "pref_show_manage_external_files"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -1,0 +1,78 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils.datastore
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val KIWIX_DATASTORE_NAME = "kiwix_datastore_preferences"
+
+val Context.kiwixDataStore by preferencesDataStore(
+  name = KIWIX_DATASTORE_NAME,
+  produceMigrations = { context ->
+    SharedPreferenceToDatastoreMigrator(context).createMigration()
+  }
+)
+
+@Singleton
+class KiwixDataStore @Inject constructor(val context: Context) {
+  val textZoom: Flow<Int> = context.kiwixDataStore.data.map { prefs ->
+    prefs[PreferencesKeys.TEXT_ZOOM] ?: DEFAULT_ZOOM
+  }
+
+  suspend fun setTextZoom(value: Int) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.TEXT_ZOOM] = value
+    }
+  }
+
+  val currentZimFile: Flow<String?> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.TAG_CURRENT_FILE]
+    }
+
+  suspend fun setCurrentZimFile(currentZimFilePath: String) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.TAG_CURRENT_FILE] = currentZimFilePath
+    }
+  }
+
+  val currentTab: Flow<Int?> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.TAG_CURRENT_TAB]
+    }
+
+  suspend fun setCurrentTab(currentTab: Int) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.TAG_CURRENT_TAB] = currentTab
+    }
+    Log.e("CURRENT_TAB", "setCurrentTab: $currentTab")
+  }
+
+  companion object {
+    const val DEFAULT_ZOOM = 100
+    const val TEXT_ZOOM_KEY = "text_zoom_key"
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -1,0 +1,29 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils.datastore
+
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore.Companion.TEXT_ZOOM_KEY
+
+object PreferencesKeys {
+  val TEXT_ZOOM = intPreferencesKey(TEXT_ZOOM_KEY)
+  val TAG_CURRENT_FILE = stringPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE)
+  val TAG_CURRENT_TAB = intPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_TAB)
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -1,0 +1,52 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils.datastore
+
+import android.content.Context
+import androidx.datastore.migrations.SharedPreferencesMigration
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+
+class SharedPreferenceToDatastoreMigrator(private val context: Context) {
+  fun createMigration(): List<SharedPreferencesMigration<Preferences>> {
+    val kiwixMobileMigration =
+      SharedPreferencesMigration(
+        context = context,
+        sharedPreferencesName = SharedPreferenceUtil.PREF_KIWIX_MOBILE
+      )
+    // SharedPreferencesMigration(
+    //   produceSharedPreferences = { PreferenceManager.getDefaultSharedPreferences(context) },
+    //   keysToMigrate = setOf(
+    //     SharedPreferenceUtil.Companion.TEXT_ZOOM,
+    //   ),
+    //   migrate = { prefs ->
+    //     // currentPreferences.toMutablePreferences().apply {
+    //     //   if (!contains(PreferencesKeys.TEXT_ZOOM)) {
+    //     //     put(
+    //     //       PreferencesKeys.TEXT_ZOOM,
+    //     //       prefs.getInt(SharedPreferenceUtil.Companion.TEXT_ZOOM, DEFAULT_ZOOM)
+    //     //     )
+    //     //   }
+    //     // }
+    //   }
+    // )
+    return listOf(kiwixMobileMigration)
+  }
+}


### PR DESCRIPTION
Parent Issue #2688 

* Created the `KiwixDataStore` and `SharedPreferenceToDatastoreMigrator` classes to handle the migration of existing `SharedPreferences` data to `DataStore`.
* Migrated the currently opened ZIM file and the currently opened tab to `DataStore`.
* Migrated the `TextZoom` value to `DataStore` (the zoom level configured by the user for reading ZIM files).
* Added `DataStore` dependency in our project.