### PR TITLE
Migrated the IntroScreen to use `DataStore` instead of `SharedPreferences`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -126,10 +126,10 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -83,10 +83,10 @@ class ObjectBoxToRoomMigratorTest {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -70,10 +70,10 @@ class SharedPreferenceToDatastoreMigratorTest {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
@@ -118,6 +118,7 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
       .putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       .putString(SharedPreferenceUtil.PREF_THEME, "2")
+      .putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -139,6 +140,7 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(false, prefs[PreferencesKeys.PREF_NEW_TAB_BACKGROUND])
     assertEquals(true, prefs[PreferencesKeys.PREF_EXTERNAL_LINK_POPUP])
     assertEquals(false, prefs[PreferencesKeys.PREF_WIFI_ONLY])
+    assertEquals(true, prefs[PreferencesKeys.PREF_SHOW_INTRO])
     assertEquals("2", prefs[PreferencesKeys.PREF_THEME])
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -86,12 +86,12 @@ class DeepLinksTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     context.let {
       sharedPreferenceUtil =
         SharedPreferenceUtil(it).apply {
-          setIntroShown()
           setIsPlayStoreBuildType(true)
           putPrefIsFirstRun(false)
           prefIsScanFileSystemDialogShown = true

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -94,12 +94,12 @@ class DownloadTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
@@ -73,11 +73,11 @@ class ErrorActivityTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context)
       .edit {
-        putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
         putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
         putString(SharedPreferenceUtil.PREF_LANG, "en")
         putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpFragmentTest.kt
@@ -153,11 +153,11 @@ class HelpFragmentTest : BaseActivityTest() {
       KiwixDataStore(it).apply {
         lifeCycleScope.launch {
           setWifiOnly(false)
+          setIntroShown()
         }
       }
       sharedPreferenceUtil =
         SharedPreferenceUtil(it).apply {
-          setIntroShown()
           setIsPlayStoreBuildType(showRestriction)
           prefIsTest = true
           putPrefLanguage("en")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -76,10 +76,10 @@ class InitialDownloadTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -28,6 +28,7 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
 import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
+import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
 import org.hamcrest.Matchers.anyOf
 import org.junit.Before
@@ -38,6 +39,7 @@ import org.kiwix.kiwixmobile.core.utils.LanguageUtils.Companion.handleLocaleChan
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
@@ -72,8 +74,13 @@ class IntroFragmentTest : BaseActivityTest() {
       }
       waitForIdle()
     }
+    KiwixDataStore(context).apply {
+      lifeCycleScope.launch {
+        setWifiOnly(false)
+        setIntroShown(true)
+      }
+    }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageFragmentTest.kt
@@ -99,11 +99,11 @@ class LanguageFragmentTest {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(instrumentation.targetContext.applicationContext)
       .edit {
-        putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
         putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
         putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
         putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -212,10 +212,10 @@ class LocalFileTransferTest {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, shouldShowShowCase)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -91,10 +91,10 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -89,10 +89,10 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -75,10 +75,10 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -72,12 +72,12 @@ class TopLevelDestinationTest : BaseActivityTest() {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setExternalLinkPopup(true)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -56,10 +56,10 @@ class MimeTypeTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -75,12 +75,12 @@ class LocalLibraryTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       // set PREF_MANAGE_EXTERNAL_FILES false for hiding
       // manage external storage permission dialog on android 11 and above

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
@@ -74,12 +74,12 @@ class OnlineLibraryFragmentTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -84,10 +84,10 @@ class NoteFragmentTest : BaseActivityTest() {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -112,10 +112,10 @@ class ImportBookmarkTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -90,10 +90,10 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -80,10 +80,10 @@ class NavigationHistoryTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
@@ -76,10 +76,10 @@ class DonationDialogTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -55,10 +55,10 @@ class EncodedUrlTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -86,10 +86,10 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -82,10 +82,10 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchFragmentTest.kt
@@ -93,10 +93,10 @@ class SearchFragmentTest : BaseActivityTest() {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
@@ -86,12 +86,12 @@ class GetContentShortcutTest {
     ).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       instrumentation.targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
       putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -35,6 +35,8 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
 import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
 import org.hamcrest.Matchers.anyOf
 import org.junit.After
@@ -47,6 +49,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.intro.composable.GET_STARTED_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -110,16 +113,10 @@ class KiwixSplashActivityTest {
     }, 10)
 
     // Verify that the value of the "intro shown" boolean inside
-    // the SharedPreferences Database is not changed until
+    // the DataStore Database is not changed until
     // the "Get started" button is pressed
-    val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-    Assert.assertEquals(
-      true,
-      preferences.getBoolean(
-        SharedPreferenceUtil.PREF_SHOW_INTRO,
-        true
-      )
-    )
+    val showIntro = runBlocking { KiwixDataStore(context).showIntro.first() }
+    Assert.assertEquals(true, showIntro)
     LeakAssertions.assertNoLeaks()
   }
 
@@ -148,9 +145,8 @@ class KiwixSplashActivityTest {
         context
       ).edit()
     preferencesEditor.putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true).commit()
-    preferencesEditor.putBoolean(
-      SharedPreferenceUtil.PREF_SHOW_INTRO,
-      value
-    ).commit()
+    runBlocking {
+      KiwixDataStore(context).setIntroShown(value)
+    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostFragmentTest.kt
@@ -111,11 +111,11 @@ class ZimHostFragmentTest {
       KiwixDataStore(it).apply {
         lifeCycleScope.launch {
           setWifiOnly(false)
+          setIntroShown()
         }
       }
       sharedPreferenceUtil =
         SharedPreferenceUtil(it).apply {
-          setIntroShown()
           setIsPlayStoreBuildType(true)
           prefIsTest = true
           putPrefLanguage("en")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -71,10 +71,10 @@ class SearchWidgetTest : BaseActivityTest() {
       KiwixDataStore(it).apply {
         lifeCycleScope.launch {
           setWifiOnly(false)
+          setIntroShown()
         }
       }
       SharedPreferenceUtil(it).apply {
-        setIntroShown()
         setIsPlayStoreBuildType(true)
         prefIsTest = true
         putPrefLanguage("en")

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroContract.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroContract.kt
@@ -23,6 +23,6 @@ interface IntroContract {
   interface View : BaseContract.View<Presenter?>
 
   interface Presenter : BaseContract.Presenter<View?> {
-    fun setIntroShown()
+    suspend fun setIntroShown()
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroFragment.kt
@@ -22,7 +22,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavOptions
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.BaseFragment
@@ -59,11 +61,13 @@ class IntroFragment : BaseFragment(), IntroContract.View, FragmentActivityExtens
   }
 
   private fun navigateToLibrary() {
-    presenter.setIntroShown()
-    val navOptions = NavOptions.Builder()
-      .setPopUpTo(KiwixDestination.Intro.route, inclusive = true)
-      .build()
-    (requireActivity() as CoreMainActivity).navigate(KiwixDestination.Library.route, navOptions)
+    lifecycleScope.launch {
+      presenter.setIntroShown()
+      val navOptions = NavOptions.Builder()
+        .setPopUpTo(KiwixDestination.Intro.route, inclusive = true)
+        .build()
+      (requireActivity() as CoreMainActivity).navigate(KiwixDestination.Library.route, navOptions)
+    }
   }
 
   override fun onDestroyView() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroPresenter.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/intro/IntroPresenter.kt
@@ -18,15 +18,15 @@
 package org.kiwix.kiwixmobile.intro
 
 import org.kiwix.kiwixmobile.core.base.BasePresenter
-import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.intro.IntroContract.Presenter
 import org.kiwix.kiwixmobile.intro.IntroContract.View
 import javax.inject.Inject
 
 class IntroPresenter @Inject internal constructor(
-  private val preferences: SharedPreferenceUtil
+  private val kiwixDataStore: KiwixDataStore
 ) : BasePresenter<View?>(), Presenter {
-  override fun setIntroShown() {
-    preferences.setIntroShown()
+  override suspend fun setIntroShown() {
+    kiwixDataStore.setIntroShown()
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -56,7 +56,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.BuildConfig
 import org.kiwix.kiwixmobile.KiwixApp
 import org.kiwix.kiwixmobile.R
@@ -139,7 +141,7 @@ class KiwixMainActivity : CoreMainActivity() {
       uiCoroutineScope = rememberCoroutineScope()
       bottomAppBarScrollBehaviour = BottomAppBarDefaults.exitAlwaysScrollBehavior()
       val startDestination = remember {
-        if (sharedPreferenceUtil.showIntro() && !isIntroScreenNotVisible()) {
+        if (runBlocking { kiwixDataStore.showIntro.first() } && !isIntroScreenNotVisible()) {
           KiwixDestination.Intro.route
         } else {
           KiwixDestination.Reader.route

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/base/BaseActivity.kt
@@ -25,11 +25,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
 
 open class BaseActivity : AppCompatActivity() {
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+
+  @Inject
+  lateinit var kiwixDataStore: KiwixDataStore
 
   /**
    * Apply the currently selected language to the base context

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -130,4 +130,19 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_THEME] = selectedTheme
     }
   }
+
+  val showIntro: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_INTRO] ?: true
+    }
+
+  /**
+   * Marks the intro as shown. The parameter is mainly used for test cases.
+   * By default, `false` is stored, indicating that the intro has already been shown.
+   */
+  suspend fun setIntroShown(isShown: Boolean = false) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_INTRO] = isShown
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -33,4 +33,5 @@ object PreferencesKeys {
     booleanPreferencesKey(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP)
   val PREF_WIFI_ONLY = booleanPreferencesKey(SharedPreferenceUtil.PREF_WIFI_ONLY)
   val PREF_THEME = stringPreferencesKey(SharedPreferenceUtil.PREF_THEME)
+  val PREF_SHOW_INTRO = booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_INTRO)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -41,6 +41,7 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.Companion.PREF_EXTERNAL_LINK_POPUP,
         SharedPreferenceUtil.Companion.PREF_WIFI_ONLY,
         SharedPreferenceUtil.Companion.PREF_THEME,
+        SharedPreferenceUtil.PREF_SHOW_INTRO,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)

--- a/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
+++ b/custom/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchFragmentTestForCustomApp.kt
@@ -122,10 +122,10 @@ class SearchFragmentTestForCustomApp {
     KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
+        setIntroShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putString(SharedPreferenceUtil.PREF_LANG, "en")
       putLong(


### PR DESCRIPTION
Fixes #4517

Parent PR #4516

Continuing from https://github.com/kiwix/kiwix-android/pull/4516


* Migrated the `IntroScreen` functionality to use DataStore.
* Refactored all related UI test cases to use `DataStore` instead of `SharedPreferences`.
* Added a migration test case to verify the transfer of data from `SharedPreferences` to `DataStore`.
