### PR TITLE
Migrated ShowCaseView functionality to use `DataStore` instead of `SharedPreferences`

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -119,6 +119,7 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putBoolean(SharedPreferenceUtil.PREF_WIFI_ONLY, false)
       .putString(SharedPreferenceUtil.PREF_THEME, "2")
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
+      .putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -141,6 +142,7 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(true, prefs[PreferencesKeys.PREF_EXTERNAL_LINK_POPUP])
     assertEquals(false, prefs[PreferencesKeys.PREF_WIFI_ONLY])
     assertEquals(true, prefs[PreferencesKeys.PREF_SHOW_INTRO])
+    assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_SHOWCASE])
     assertEquals("2", prefs[PreferencesKeys.PREF_THEME])
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -213,11 +213,11 @@ class LocalFileTransferTest {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()
+        setShowCaseViewForFileTransferShown(shouldShowShowCase)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, shouldShowShowCase)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -73,13 +73,13 @@ class TopLevelDestinationTest : BaseActivityTest() {
         setWifiOnly(false)
         setExternalLinkPopup(true)
         setIntroShown()
+        setShowCaseViewForFileTransferShown()
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
@@ -87,14 +87,14 @@ class GetContentShortcutTest {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()
+        setShowCaseViewForFileTransferShown()
+        setExternalLinkPopup(true)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       instrumentation.targetContext.applicationContext
     ).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-      putBoolean(SharedPreferenceUtil.PREF_EXTERNAL_LINK_POPUP, true)
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
       putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)
       putString(SharedPreferenceUtil.PREF_LANG, "en")

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferFragment.kt
@@ -64,6 +64,7 @@ import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem.Vector
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -103,6 +104,9 @@ class LocalFileTransferFragment :
   @Inject
   lateinit var sharedPreferenceUtil: SharedPreferenceUtil
 
+  @Inject
+  lateinit var kiwixDataStore: KiwixDataStore
+
   private val deviceName = mutableStateOf("")
   private val isPeerSearching = mutableStateOf(false)
   private val peerDeviceList = mutableStateOf(emptyList<WifiP2pDevice>())
@@ -136,7 +140,8 @@ class LocalFileTransferFragment :
         transferFileList = transferFileList.value,
         actionMenuItems = actionMenuItem(),
         onDeviceItemClick = { wifiDirectManager.sendToDevice(it) },
-        sharedPreferenceUtil = sharedPreferenceUtil,
+        kiwixDataStore = kiwixDataStore,
+        lifeCycleScope = lifecycleScope,
         navigationIcon = {
           NavigationIcon(
             iconItem = IconItem.Drawable(drawable.ic_close_white_24dp),

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -23,18 +23,14 @@ import android.content.SharedPreferences
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
-import org.kiwix.kiwixmobile.core.ThemeConfig
-import org.kiwix.kiwixmobile.core.ThemeConfig.Theme.Companion.from
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.zim_manager.Language
@@ -54,15 +50,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   private val _prefStorages = MutableStateFlow("")
   val prefStorages
     get() = _prefStorages.asStateFlow().onStart { emit(prefStorage) }
-  private val _textZooms = MutableStateFlow(textZoom)
-  val textZooms get() = _textZooms.asStateFlow()
-  private val appThemes = MutableStateFlow(ThemeConfig.Theme.SYSTEM)
-  private val _prefWifiOnlys = MutableStateFlow(true)
-  val prefWifiOnlys
-    get() = _prefWifiOnlys.onStart { emit(prefWifiOnly) }
-
-  val prefWifiOnly: Boolean
-    get() = sharedPreferences.getBoolean(PREF_WIFI_ONLY, true)
 
   private val _onlineContentLanguage = MutableStateFlow("")
   val onlineContentLanguage = _onlineContentLanguage.asStateFlow()
@@ -81,24 +68,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     set(prefIsScanFileSystemTest) {
       sharedPreferences.edit { putBoolean(PREF_IS_SCAN_FILE_SYSTEM_TEST, prefIsScanFileSystemTest) }
     }
-
-  val prefShowShowCaseToUser: Boolean
-    get() = sharedPreferences.getBoolean(PREF_SHOW_SHOWCASE, true)
-
-  var prefBackToTop: Boolean
-    get() = sharedPreferences.getBoolean(PREF_BACK_TO_TOP, false)
-    set(backToTop) {
-      sharedPreferences.edit { putBoolean(PREF_BACK_TO_TOP, backToTop) }
-    }
-
-  var prefNewTabBackground: Boolean
-    get() = sharedPreferences.getBoolean(PREF_NEW_TAB_BACKGROUND, false)
-    set(newTabInBackground) {
-      sharedPreferences.edit { putBoolean(PREF_NEW_TAB_BACKGROUND, newTabInBackground) }
-    }
-
-  val prefExternalLinkPopup: Boolean
-    get() = sharedPreferences.getBoolean(PREF_EXTERNAL_LINK_POPUP, true)
 
   val isPlayStoreBuild: Boolean
     get() = sharedPreferences.getBoolean(IS_PLAY_STORE_BUILD, false)
@@ -165,10 +134,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     ContextWrapper(context).externalMediaDirs[0]?.path
       ?: context.filesDir.path // a workaround for emulators
 
-  fun showCaseViewForFileTransferShown() {
-    sharedPreferences.edit { putBoolean(PREF_SHOW_SHOWCASE, false) }
-  }
-
   fun putPrefBookMarkMigrated(isMigrated: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_BOOKMARKS_MIGRATED, isMigrated) }
 
@@ -196,11 +161,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   fun putPrefIsFirstRun(isFirstRun: Boolean) =
     sharedPreferences.edit { putBoolean(PREF_IS_FIRST_RUN, isFirstRun) }
 
-  fun putPrefWifiOnly(wifiOnly: Boolean) {
-    sharedPreferences.edit { putBoolean(PREF_WIFI_ONLY, wifiOnly) }
-    _prefWifiOnlys.tryEmit(wifiOnly)
-  }
-
   fun putPrefStorage(storage: String) {
     sharedPreferences.edit { putString(PREF_STORAGE, storage) }
     _prefStorages.tryEmit(storage)
@@ -213,9 +173,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   fun setIsPlayStoreBuildType(isPlayStoreBuildType: Boolean) {
     sharedPreferences.edit { putBoolean(IS_PLAY_STORE_BUILD, isPlayStoreBuildType) }
   }
-
-  fun putPrefExternalLinkPopup(externalLinkPopup: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_EXTERNAL_LINK_POPUP, externalLinkPopup) }
 
   fun saveLanguageList(languages: List<Language>) {
     runCatching {
@@ -282,20 +239,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
         putBoolean(PREF_SHOW_NOTES_ALL_BOOKS, prefShowBookmarksFromCurrentBook)
       }
 
-  val appTheme: ThemeConfig.Theme
-    get() =
-      from(
-        sharedPreferences.getString(PREF_THEME, null)?.toInt()
-          ?: AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-      )
-
-  fun appThemes(): Flow<ThemeConfig.Theme> = appThemes.onStart { emit(appTheme) }
-
-  fun updateAppTheme(selectedTheme: String) {
-    sharedPreferences.edit { putString(PREF_THEME, selectedTheme) }
-    appThemes.tryEmit(appTheme)
-  }
-
   var manageExternalFilesPermissionDialog: Boolean
     get() = sharedPreferences.getBoolean(PREF_MANAGE_EXTERNAL_FILES, true)
     set(prefManageExternalFilesPermissionDialog) =
@@ -319,13 +262,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     get() = sharedPreferences.getStringSet(PREF_HOSTED_BOOKS, null)?.toHashSet() ?: HashSet()
     set(hostedBooks) {
       sharedPreferences.edit { putStringSet(PREF_HOSTED_BOOKS, hostedBooks) }
-    }
-
-  var textZoom: Int
-    get() = sharedPreferences.getInt(TEXT_ZOOM, DEFAULT_ZOOM)
-    set(textZoom) {
-      sharedPreferences.edit { putInt(TEXT_ZOOM, textZoom) }
-      _textZooms.tryEmit(textZoom)
     }
 
   var shouldShowStorageSelectionDialog: Boolean

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -145,4 +145,19 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_SHOW_INTRO] = isShown
     }
   }
+
+  val showShowCaseToUser: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_SHOWCASE] ?: true
+    }
+
+  /**
+   * Marks the showCaseView as shown. The parameter is mainly used for test cases.
+   * By default, `false` is stored, indicating that the showCaseView has already been shown.
+   */
+  suspend fun setShowCaseViewForFileTransferShown(isShown: Boolean = false) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_SHOWCASE] = isShown
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -34,4 +34,5 @@ object PreferencesKeys {
   val PREF_WIFI_ONLY = booleanPreferencesKey(SharedPreferenceUtil.PREF_WIFI_ONLY)
   val PREF_THEME = stringPreferencesKey(SharedPreferenceUtil.PREF_THEME)
   val PREF_SHOW_INTRO = booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_INTRO)
+  val PREF_SHOW_SHOWCASE = booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_SHOWCASE)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -42,6 +42,7 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.Companion.PREF_WIFI_ONLY,
         SharedPreferenceUtil.Companion.PREF_THEME,
         SharedPreferenceUtil.PREF_SHOW_INTRO,
+        SharedPreferenceUtil.PREF_SHOW_SHOWCASE,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)


### PR DESCRIPTION
Fixes #4519

Parent PR #4518 

Continuing from https://github.com/kiwix/kiwix-android/pull/4518

* Migrated the `ShowCaseView` functionality to use `DataStore`.
* Refactored UI test cases to use `DataStore` instead of `SharedPreferences`.
* Added a migration test case to verify the transfer of data from `SharedPreferences` to `DataStore`.
* Removed unused methods from `SharedPreferenceUtil`.