### PR TITLE
Migrated the `prefIsBookmarksMigrated`, `prefIsRecentSearchMigrated`, etc, to use `Datastore` instead of `SharedPreferences`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -125,7 +125,7 @@ class ObjectBoxToRoomMigratorTest {
     objectBoxToRoomMigrator.notesRoomDao = kiwixRoomDatabase.notesRoomDao()
     objectBoxToRoomMigrator.recentSearchRoomDao = kiwixRoomDatabase.recentSearchRoomDao()
     objectBoxToRoomMigrator.boxStore = boxStore
-    objectBoxToRoomMigrator.sharedPreferenceUtil = SharedPreferenceUtil(context)
+    objectBoxToRoomMigrator.kiwixDataStore = KiwixDataStore(context)
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -120,6 +120,12 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putString(SharedPreferenceUtil.PREF_THEME, "2")
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_INTRO, true)
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_SHOWCASE, false)
+      .putBoolean(SharedPreferenceUtil.PREF_BOOKMARKS_MIGRATED, true)
+      .putBoolean(SharedPreferenceUtil.PREF_RECENT_SEARCH_MIGRATED, true)
+      .putBoolean(SharedPreferenceUtil.PREF_NOTES_MIGRATED, true)
+      .putBoolean(SharedPreferenceUtil.PREF_HISTORY_MIGRATED, true)
+      .putBoolean(SharedPreferenceUtil.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, false)
+      .putBoolean(SharedPreferenceUtil.PREF_BOOK_ON_DISK_MIGRATED, true)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -143,6 +149,12 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(false, prefs[PreferencesKeys.PREF_WIFI_ONLY])
     assertEquals(true, prefs[PreferencesKeys.PREF_SHOW_INTRO])
     assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_SHOWCASE])
+    assertEquals(true, prefs[PreferencesKeys.PREF_BOOKMARKS_MIGRATED])
+    assertEquals(true, prefs[PreferencesKeys.PREF_RECENT_SEARCH_MIGRATED])
+    assertEquals(true, prefs[PreferencesKeys.PREF_NOTES_MIGRATED])
+    assertEquals(true, prefs[PreferencesKeys.PREF_HISTORY_MIGRATED])
+    assertEquals(false, prefs[PreferencesKeys.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED])
+    assertEquals(true, prefs[PreferencesKeys.PREF_BOOK_ON_DISK_MIGRATED])
     assertEquals("2", prefs[PreferencesKeys.PREF_THEME])
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -234,14 +234,14 @@ class KiwixMainActivity : CoreMainActivity() {
   }
 
   private suspend fun migrateInternalToPublicAppDirectory() {
-    if (!sharedPreferenceUtil.prefIsAppDirectoryMigrated) {
+    if (!kiwixDataStore.isAppDirectoryMigrated.first()) {
       val storagePath =
         getStorageDeviceList()
           .getOrNull(sharedPreferenceUtil.storagePosition)
           ?.name
       storagePath?.let {
         sharedPreferenceUtil.putPrefStorage(sharedPreferenceUtil.getPublicDirectoryPath(it))
-        sharedPreferenceUtil.putPrefAppDirectoryMigrated(true)
+        kiwixDataStore.setAppDirectoryMigrated(true)
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -78,24 +78,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   val prefDeviceDefaultLanguage: String
     get() = sharedPreferences.getString(PREF_DEVICE_DEFAULT_LANG, "").orEmpty()
 
-  val prefIsBookmarksMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_BOOKMARKS_MIGRATED, false)
-
-  val prefIsRecentSearchMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_RECENT_SEARCH_MIGRATED, false)
-
-  val prefIsNotesMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_NOTES_MIGRATED, false)
-
-  val prefIsHistoryMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_HISTORY_MIGRATED, false)
-
-  val prefIsAppDirectoryMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, false)
-
-  val prefIsBookOnDiskMigrated: Boolean
-    get() = sharedPreferences.getBoolean(PREF_BOOK_ON_DISK_MIGRATED, false)
-
   var prefIsScanFileSystemDialogShown: Boolean
     get() = sharedPreferences.getBoolean(PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, false)
     set(isFileScanFileSystemDialogShown) {
@@ -133,24 +115,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
   fun defaultPublicStorage(): String =
     ContextWrapper(context).externalMediaDirs[0]?.path
       ?: context.filesDir.path // a workaround for emulators
-
-  fun putPrefBookMarkMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_BOOKMARKS_MIGRATED, isMigrated) }
-
-  fun putPrefRecentSearchMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_RECENT_SEARCH_MIGRATED, isMigrated) }
-
-  fun putPrefHistoryMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_HISTORY_MIGRATED, isMigrated) }
-
-  fun putPrefNotesMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_NOTES_MIGRATED, isMigrated) }
-
-  fun putPrefAppDirectoryMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED, isMigrated) }
-
-  fun putPrefBookOnDiskMigrated(isMigrated: Boolean) =
-    sharedPreferences.edit { putBoolean(PREF_BOOK_ON_DISK_MIGRATED, isMigrated) }
 
   fun putPrefLanguage(language: String) =
     sharedPreferences.edit { putString(PREF_LANG, language) }
@@ -207,10 +171,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
         )
       }
     }.onFailure { it.printStackTrace() }.getOrNull()
-
-  fun showIntro(): Boolean = sharedPreferences.getBoolean(PREF_SHOW_INTRO, true)
-
-  fun setIntroShown() = sharedPreferences.edit { putBoolean(PREF_SHOW_INTRO, false) }
 
   var showHistoryAllBooks: Boolean
     get() = sharedPreferences.getBoolean(PREF_SHOW_HISTORY_ALL_BOOKS, true)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -160,4 +160,70 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_SHOW_SHOWCASE] = isShown
     }
   }
+
+  val isBookmarksMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_BOOKMARKS_MIGRATED] ?: false
+    }
+
+  suspend fun setBookMarkMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_BOOKMARKS_MIGRATED] = isMigrated
+    }
+  }
+
+  val isRecentSearchMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_RECENT_SEARCH_MIGRATED] ?: false
+    }
+
+  suspend fun setRecentSearchMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_RECENT_SEARCH_MIGRATED] = isMigrated
+    }
+  }
+
+  val isNotesMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_NOTES_MIGRATED] ?: false
+    }
+
+  suspend fun setNotesMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_NOTES_MIGRATED] = isMigrated
+    }
+  }
+
+  val isHistoryMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_HISTORY_MIGRATED] ?: false
+    }
+
+  suspend fun setHistoryMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_HISTORY_MIGRATED] = isMigrated
+    }
+  }
+
+  val isAppDirectoryMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED] ?: false
+    }
+
+  suspend fun setAppDirectoryMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED] = isMigrated
+    }
+  }
+
+  val isBookOnDiskMigrated: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_BOOK_ON_DISK_MIGRATED] ?: false
+    }
+
+  suspend fun setBookOnDiskMigrated(isMigrated: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_BOOK_ON_DISK_MIGRATED] = isMigrated
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -35,4 +35,13 @@ object PreferencesKeys {
   val PREF_THEME = stringPreferencesKey(SharedPreferenceUtil.PREF_THEME)
   val PREF_SHOW_INTRO = booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_INTRO)
   val PREF_SHOW_SHOWCASE = booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_SHOWCASE)
+  val PREF_BOOKMARKS_MIGRATED = booleanPreferencesKey(SharedPreferenceUtil.PREF_BOOKMARKS_MIGRATED)
+  val PREF_RECENT_SEARCH_MIGRATED =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_RECENT_SEARCH_MIGRATED)
+  val PREF_NOTES_MIGRATED = booleanPreferencesKey(SharedPreferenceUtil.PREF_NOTES_MIGRATED)
+  val PREF_HISTORY_MIGRATED = booleanPreferencesKey(SharedPreferenceUtil.PREF_HISTORY_MIGRATED)
+  val PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED)
+  val PREF_BOOK_ON_DISK_MIGRATED =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_BOOK_ON_DISK_MIGRATED)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -43,6 +43,12 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.Companion.PREF_THEME,
         SharedPreferenceUtil.PREF_SHOW_INTRO,
         SharedPreferenceUtil.PREF_SHOW_SHOWCASE,
+        SharedPreferenceUtil.PREF_BOOKMARKS_MIGRATED,
+        SharedPreferenceUtil.PREF_RECENT_SEARCH_MIGRATED,
+        SharedPreferenceUtil.PREF_NOTES_MIGRATED,
+        SharedPreferenceUtil.PREF_HISTORY_MIGRATED,
+        SharedPreferenceUtil.PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED,
+        SharedPreferenceUtil.PREF_BOOK_ON_DISK_MIGRATED,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)

--- a/objectboxmigration/src/main/java/org/kiwix/kiwixmobile/migration/data/ObjectBoxToLibkiwixMigrator.kt
+++ b/objectboxmigration/src/main/java/org/kiwix/kiwixmobile/migration/data/ObjectBoxToLibkiwixMigrator.kt
@@ -21,13 +21,14 @@ package org.kiwix.kiwixmobile.migration.data
 import io.objectbox.Box
 import io.objectbox.BoxStore
 import io.objectbox.kotlin.boxFor
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.page.bookmark.adapter.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
-import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
 import org.kiwix.kiwixmobile.migration.entities.BookOnDiskEntity
@@ -42,7 +43,7 @@ class ObjectBoxToLibkiwixMigrator {
   lateinit var boxStore: BoxStore
 
   @Inject
-  lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  lateinit var kiwixDataStore: KiwixDataStore
 
   @Inject
   lateinit var libkiwixBookmarks: LibkiwixBookmarks
@@ -52,10 +53,10 @@ class ObjectBoxToLibkiwixMigrator {
   private val migrationMutex = Mutex()
 
   suspend fun migrateObjectBoxDataToLibkiwix() {
-    if (!sharedPreferenceUtil.prefIsBookmarksMigrated) {
+    if (!kiwixDataStore.isBookmarksMigrated.first()) {
       migrateBookMarks(boxStore.boxFor())
     }
-    if (!sharedPreferenceUtil.prefIsBookOnDiskMigrated) {
+    if (!kiwixDataStore.isBookOnDiskMigrated.first()) {
       migrateLocalBooks(boxStore.boxFor())
     }
     // TODO we will migrate here for other entities
@@ -95,7 +96,7 @@ class ObjectBoxToLibkiwixMigrator {
         )
       }
     }
-    sharedPreferenceUtil.putPrefBookOnDiskMigrated(true)
+    kiwixDataStore.setBookOnDiskMigrated(true)
   }
 
   suspend fun migrateBookMarks(box: Box<BookmarkEntity>) {
@@ -160,6 +161,6 @@ class ObjectBoxToLibkiwixMigrator {
         }
       }
     }
-    sharedPreferenceUtil.putPrefBookMarkMigrated(true)
+    kiwixDataStore.setBookMarkMigrated(true)
   }
 }

--- a/objectboxmigration/src/main/java/org/kiwix/kiwixmobile/migration/data/ObjectBoxToRoomMigrator.kt
+++ b/objectboxmigration/src/main/java/org/kiwix/kiwixmobile/migration/data/ObjectBoxToRoomMigrator.kt
@@ -21,13 +21,14 @@ package org.kiwix.kiwixmobile.migration.data
 import io.objectbox.Box
 import io.objectbox.BoxStore
 import io.objectbox.kotlin.boxFor
+import kotlinx.coroutines.flow.first
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.page.history.adapter.HistoryListItem
 import org.kiwix.kiwixmobile.core.page.notes.adapter.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
-import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.migration.entities.HistoryEntity
 import org.kiwix.kiwixmobile.migration.entities.NotesEntity
 import org.kiwix.kiwixmobile.migration.entities.RecentSearchEntity
@@ -42,16 +43,16 @@ class ObjectBoxToRoomMigrator {
 
   @Inject lateinit var boxStore: BoxStore
 
-  @Inject lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  @Inject lateinit var kiwixDataStore: KiwixDataStore
 
   suspend fun migrateObjectBoxDataToRoom() {
-    if (!sharedPreferenceUtil.prefIsRecentSearchMigrated) {
+    if (!kiwixDataStore.isRecentSearchMigrated.first()) {
       migrateRecentSearch(boxStore.boxFor())
     }
-    if (!sharedPreferenceUtil.prefIsHistoryMigrated) {
+    if (!kiwixDataStore.isHistoryMigrated.first()) {
       migrateHistory(boxStore.boxFor())
     }
-    if (!sharedPreferenceUtil.prefIsNotesMigrated) {
+    if (!kiwixDataStore.isNotesMigrated.first()) {
       migrateNotes(boxStore.boxFor())
     }
     // TODO we will migrate here for other entities
@@ -69,7 +70,7 @@ class ObjectBoxToRoomMigrator {
       // removing the single entity from the object box after migration.
       box.remove(recentSearchEntity.id)
     }
-    sharedPreferenceUtil.putPrefRecentSearchMigrated(true)
+    kiwixDataStore.setRecentSearchMigrated(true)
   }
 
   suspend fun migrateHistory(box: Box<HistoryEntity>) {
@@ -99,7 +100,7 @@ class ObjectBoxToRoomMigrator {
       // removing the single entity from the object box after migration.
       box.remove(historyEntity.id)
     }
-    sharedPreferenceUtil.putPrefHistoryMigrated(true)
+    kiwixDataStore.setHistoryMigrated(true)
   }
 
   suspend fun migrateNotes(box: Box<NotesEntity>) {
@@ -125,6 +126,6 @@ class ObjectBoxToRoomMigrator {
       // removing the single entity from the object box after migration.
       box.remove(notesEntity.id)
     }
-    sharedPreferenceUtil.putPrefNotesMigrated(true)
+    kiwixDataStore.setNotesMigrated(true)
   }
 }


### PR DESCRIPTION
Fixes #4521

Parent PR #4520

Continuing from https://github.com/kiwix/kiwix-android/pull/4520


* Migrated the `PREF_BOOKMARKS_MIGRATED` to dataStore.
* Migrated the `PREF_RECENT_SEARCH_MIGRATED` to dataStore.
* Migrated the `PREF_NOTES_MIGRATED` to dataStore.
* Migrated the `PREF_HISTORY_MIGRATED` to dataStore.
* Migrated the `PREF_APP_DIRECTORY_TO_PUBLIC_MIGRATED` to dataStore.
* Migrated the `PREF_BOOK_ON_DISK_MIGRATED` to dataStore.
* Added a migration test case to verify the transfer of data from `SharedPreferences` to `DataStore`.
* Removed unused methods from `SharedPreferenceUtil`.