### PR TITLE
Migrated the saving of HostedBooks to `DataStore` instead of `SharedPreferences`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -131,6 +131,11 @@ class SharedPreferenceToDatastoreMigratorTest {
       )
     }
 
+    val hostedBooksSet = HashSet<String>().apply {
+      add("Alpine Linux Wiki")
+      add("Wikipedia")
+    }
+
     val defaultPrefs = PreferenceManager.getDefaultSharedPreferences(context)
     defaultPrefs.edit()
       .putInt(SharedPreferenceUtil.TEXT_ZOOM, 120)
@@ -154,6 +159,7 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_HISTORY_ALL_BOOKS, false)
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_BOOKMARKS_ALL_BOOKS, true)
       .putBoolean(SharedPreferenceUtil.PREF_SHOW_NOTES_ALL_BOOKS, false)
+      .putStringSet(SharedPreferenceUtil.PREF_HOSTED_BOOKS, hostedBooksSet)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -202,5 +208,6 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_HISTORY_ALL_BOOKS])
     assertEquals(true, prefs[PreferencesKeys.PREF_SHOW_BOOKMARKS_ALL_BOOKS])
     assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_NOTES_ALL_BOOKS])
+    assertEquals(hostedBooksSet, prefs[PreferencesKeys.PREF_HOSTED_BOOKS])
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.core.settings
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -210,7 +209,6 @@ private fun LanguageCategory(settingScreenState: SettingScreenState) {
 
     val prefLanguage by settingScreenState.kiwixDataStore.prefLanguage
       .collectAsState(initial = "en")
-    Log.e("PREF_LANGUAGE", "LanguageCategory: $prefLanguage")
     val selectedCode =
       if (languageCodes.contains(prefLanguage)) {
         prefLanguage

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -145,12 +145,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
         )
       }
 
-  var hostedBooks: Set<String>
-    get() = sharedPreferences.getStringSet(PREF_HOSTED_BOOKS, null)?.toHashSet() ?: HashSet()
-    set(hostedBooks) {
-      sharedPreferences.edit { putStringSet(PREF_HOSTED_BOOKS, hostedBooks) }
-    }
-
   var shouldShowStorageSelectionDialog: Boolean
     get() = sharedPreferences.getBoolean(PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, true)
     set(value) {
@@ -209,7 +203,7 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     const val PREF_SHOW_BOOKMARKS_ALL_BOOKS = "show_bookmarks_current_book"
     const val PREF_SHOW_HISTORY_ALL_BOOKS = "show_history_current_book"
     const val PREF_SHOW_NOTES_ALL_BOOKS = "show_notes_current_book"
-    private const val PREF_HOSTED_BOOKS = "hosted_books"
+    const val PREF_HOSTED_BOOKS = "hosted_books"
     const val PREF_THEME = "pref_dark_mode"
     const val TEXT_ZOOM = "true_text_zoom"
     const val DEFAULT_ZOOM = 100

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -336,4 +336,15 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_SHOW_NOTES_ALL_BOOKS] = showNotesAllBooks
     }
   }
+
+  val hostedBooks: Flow<Set<String>> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_HOSTED_BOOKS] ?: HashSet()
+    }
+
+  suspend fun setHostedBooks(hostedBooks: Set<String>) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_HOSTED_BOOKS] = hostedBooks
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.utils.datastore
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
 
 object PreferencesKeys {
@@ -55,4 +56,5 @@ object PreferencesKeys {
     booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_BOOKMARKS_ALL_BOOKS)
   val PREF_SHOW_NOTES_ALL_BOOKS =
     booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_NOTES_ALL_BOOKS)
+  val PREF_HOSTED_BOOKS = stringSetPreferencesKey(SharedPreferenceUtil.PREF_HOSTED_BOOKS)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -56,6 +56,7 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.PREF_SHOW_HISTORY_ALL_BOOKS,
         SharedPreferenceUtil.PREF_SHOW_BOOKMARKS_ALL_BOOKS,
         SharedPreferenceUtil.PREF_SHOW_NOTES_ALL_BOOKS,
+        SharedPreferenceUtil.PREF_HOSTED_BOOKS,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)


### PR DESCRIPTION
Fixes #4531

Parent PR #4529 

* Refactored the code to use dataStore instead of `SharedPreferences` for saving the hostedBooks.
* Added a migration test case to verify the transfer of data from `SharedPreferences` to `DataStore`.