### PR TITLE
Migrated manageExternalFilesPermissionDialog to use DataStore instead of SharedPreferences.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -160,6 +160,7 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putLong(SharedPreferenceUtil.PREF_LATER_CLICKED_MILLIS, 120L)
       .putLong(SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS, 100L)
       .putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
+      .putBoolean(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES, true)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -212,5 +213,6 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(120L, prefs[PreferencesKeys.PREF_LATER_CLICKED_MILLIS])
     assertEquals(100L, prefs[PreferencesKeys.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS])
     assertEquals(true, prefs[PreferencesKeys.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN])
+    assertEquals(true, prefs[PreferencesKeys.PREF_MANAGE_EXTERNAL_FILES])
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -80,19 +80,19 @@ class LocalLibraryTest : BaseActivityTest() {
         setPrefLanguage("en")
         setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
         setIsScanFileSystemDialogShown(true)
+        // set `setShowManageExternalFilesPermissionDialog` false for hiding
+        // manage external storage permission dialog on android 11 and above
+        setShowManageExternalFilesPermissionDialog(false)
+        // Set setManageExternalFilesPermissionDialogOnRefresh to false to hide
+        // the manage external storage permission dialog on Android 11 and above
+        // while refreshing the content in LocalLibraryFragment.
+        setManageExternalFilesPermissionDialogOnRefresh(false)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
-      // set PREF_MANAGE_EXTERNAL_FILES false for hiding
-      // manage external storage permission dialog on android 11 and above
-      putBoolean(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES, false)
-      // Set PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH to false to hide
-      // the manage external storage permission dialog on Android 11 and above
-      // while refreshing the content in LocalLibraryFragment.
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, false)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)
     }
     activityScenario =
@@ -225,16 +225,13 @@ class LocalLibraryTest : BaseActivityTest() {
       lifeCycleScope.launch {
         setIsScanFileSystemDialogShown(scanFileSystemDialogShown)
         setIsScanFileSystemTest(true)
+        setManageExternalFilesPermissionDialogOnRefresh(showManagePermissionDialog)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, isTest)
-      putBoolean(
-        SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH,
-        showManagePermissionDialog
-      )
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, isPlayStoreBuild)
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/storage/StorageSelectDialog.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/storage/StorageSelectDialog.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.lifecycleScope
 import eu.mhutti1.utils.storage.StorageDevice
 import org.kiwix.kiwixmobile.KiwixApp
 import org.kiwix.kiwixmobile.core.R.dimen
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isLandScapeMode
+import org.kiwix.kiwixmobile.core.extensions.runSafelyInLifecycleScope
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.utils.DimenUtils.getWindowWidth
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
@@ -40,7 +42,7 @@ import javax.inject.Inject
 val STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE = 16.sp
 
 class StorageSelectDialog : DialogFragment() {
-  var onSelectAction: ((StorageDevice) -> Unit)? = null
+  var onSelectAction: (suspend (StorageDevice) -> Unit)? = null
   var titleSize: TextUnit? = null
 
   private var composeView: ComposeView? = null
@@ -77,8 +79,10 @@ class StorageSelectDialog : DialogFragment() {
           sharedPreferenceUtil,
           shouldShowCheckboxSelected
         ) {
-          onSelectAction?.invoke(it)
-          dismiss()
+          lifecycleScope.runSafelyInLifecycleScope {
+            onSelectAction?.invoke(it)
+            dismiss()
+          }
         }
       }
     }.also {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -39,10 +39,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.NavOptions
+import kotlinx.coroutines.flow.first
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.REQUEST_POST_NOTIFICATION_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.SharedPreferenceUtil
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.utils.datastore.kiwixDataStore
 
 object ActivityExtensions {
   private val Activity.coreMainActivity: CoreMainActivity get() = this as CoreMainActivity
@@ -176,12 +179,13 @@ object ActivityExtensions {
     packageName != "org.kiwix.kiwixmobile" && packageName != "org.kiwix.kiwixmobile.standalone"
 
   @SuppressLint("NewApi")
-  fun Activity.isManageExternalStoragePermissionGranted(
-    sharedPreferenceUtil: SharedPreferenceUtil?
+  suspend fun Activity.isManageExternalStoragePermissionGranted(
+    sharedPreferenceUtil: SharedPreferenceUtil?,
+    kiwixDataStore: KiwixDataStore?
   ): Boolean =
     if (sharedPreferenceUtil?.isNotPlayStoreBuildWithAndroid11OrAbove() == true &&
       !sharedPreferenceUtil.prefIsTest &&
-      sharedPreferenceUtil.manageExternalFilesPermissionDialogOnRefresh
+      kiwixDataStore?.showManageExternalFilesPermissionDialogOnRefresh?.first() == true
     ) {
       Environment.isExternalStorageManager()
     } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CoroutineScopeExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CoroutineScopeExtensions.kt
@@ -1,0 +1,50 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2025 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.utils.files.Log
+
+/**
+ * Safely runs a suspend function inside a lifecycle-aware CoroutineScope.
+ *
+ * This helper ensures that:
+ * - The coroutine only starts if the Lifecycle's CoroutineScope is valid.
+ * - Execution is skipped if the scope is `null` (lifecycle destroyed or not yet created).
+ * - Execution is skipped if the scope is inactive/cancelled (e.g., view destroyed).
+ * - Exceptions inside the launched coroutine are **not swallowed** and will propagate normally.
+ *
+ * Use this method when you want to launch work in a lifecycle scope without
+ * risking crashes due to calling `launch` after the lifecycle has already ended.
+ *
+ * @param func The suspend function to run within the active CoroutineScope.
+ */
+fun CoroutineScope?.runSafelyInLifecycleScope(func: suspend CoroutineScope.() -> Unit) {
+  // If lifecycleScope is null or already cancelled, skip execution safely.
+  if (this == null || !this.isActive) {
+    Log.w("Lifecycle", "Skipping execution: lifecycle not active")
+    return
+  }
+  // Launch the block normally. Errors inside this coroutine are not swallowed.
+  launch {
+    func(this)
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -100,6 +100,7 @@ import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.consumeObservabl
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
+import org.kiwix.kiwixmobile.core.extensions.runSafelyInLifecycleScope
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.extensions.update
@@ -375,7 +376,7 @@ abstract class CoreReaderFragment :
 
   fun runSafelyInCoreReaderLifecycleScope(func: suspend CoroutineScope.() -> Unit) {
     runCatching {
-      coreReaderLifeCycleScope?.launch { func.invoke(this) }
+      coreReaderLifeCycleScope?.runSafelyInLifecycleScope { func.invoke(this) }
     }.onFailure { it.printStackTrace() }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -22,7 +22,6 @@ import android.content.ContextWrapper
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
-import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -110,25 +109,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     set(prefShowStorageOption) =
       sharedPreferences.edit {
         putBoolean(PREF_SHOW_STORAGE_OPTION, prefShowStorageOption)
-      }
-
-  var manageExternalFilesPermissionDialog: Boolean
-    get() = sharedPreferences.getBoolean(PREF_MANAGE_EXTERNAL_FILES, true)
-    set(prefManageExternalFilesPermissionDialog) =
-      sharedPreferences.edit {
-        putBoolean(PREF_MANAGE_EXTERNAL_FILES, prefManageExternalFilesPermissionDialog)
-      }
-
-  // this is only used for test cases
-  @VisibleForTesting
-  var manageExternalFilesPermissionDialogOnRefresh: Boolean
-    get() = sharedPreferences.getBoolean(PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH, true)
-    set(manageExternalFilesPermissionDialogOnRefresh) =
-      sharedPreferences.edit {
-        putBoolean(
-          PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH,
-          manageExternalFilesPermissionDialogOnRefresh
-        )
       }
 
   var shouldShowStorageSelectionDialog: Boolean

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -395,4 +395,27 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_IS_SCAN_FILE_SYSTEM_TEST] = isScanFileSystemTest
     }
   }
+
+  val showManageExternalFilesPermissionDialog: Flow<Boolean> =
+    context.kiwixDataStore.data.map { pref ->
+      pref[PreferencesKeys.PREF_MANAGE_EXTERNAL_FILES] ?: true
+    }
+
+  suspend fun setShowManageExternalFilesPermissionDialog(isScanFileSystemTest: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_MANAGE_EXTERNAL_FILES] = isScanFileSystemTest
+    }
+  }
+
+  val showManageExternalFilesPermissionDialogOnRefresh: Flow<Boolean> =
+    context.kiwixDataStore.data.map { pref ->
+      pref[PreferencesKeys.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH] ?: true
+    }
+
+  @VisibleForTesting
+  suspend fun setManageExternalFilesPermissionDialogOnRefresh(showOnRefresh: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH] = showOnRefresh
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -65,4 +65,8 @@ object PreferencesKeys {
     booleanPreferencesKey(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN)
   val PREF_IS_SCAN_FILE_SYSTEM_TEST =
     booleanPreferencesKey(SharedPreferenceUtil.PREF_IS_SCAN_FILE_SYSTEM_TEST)
+  val PREF_MANAGE_EXTERNAL_FILES =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES)
+  val PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -60,6 +60,7 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.PREF_LATER_CLICKED_MILLIS,
         SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
         SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN,
+        SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)


### PR DESCRIPTION
Fixes #4537

Parent PR #4541 

* Migrated the `PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH` to dataStore.
* Migrated the `PREF_MANAGE_EXTERNAL_FILES` to dataStore.
* Refactored the codebase and UI test case to use the dataStore values.
* Added `CoroutineScopeExtensions` for safely running the code in lifeCycleScope.
* Added a migration test case to verify the transfer of data from `SharedPreferences` to `DataStore`.