### PR TITLE
Migrated showStorageOption to use DataStore instead of `SharedPreferences`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -161,6 +161,8 @@ class SharedPreferenceToDatastoreMigratorTest {
       .putLong(SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS, 100L)
       .putBoolean(SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN, true)
       .putBoolean(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES, true)
+      .putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
+      .putBoolean(SharedPreferenceUtil.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, false)
       .apply()
 
     val testDataStore = PreferenceDataStoreFactory.create(
@@ -214,5 +216,7 @@ class SharedPreferenceToDatastoreMigratorTest {
     assertEquals(100L, prefs[PreferencesKeys.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS])
     assertEquals(true, prefs[PreferencesKeys.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN])
     assertEquals(true, prefs[PreferencesKeys.PREF_MANAGE_EXTERNAL_FILES])
+    assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_STORAGE_OPTION])
+    assertEquals(false, prefs[PreferencesKeys.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG])
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -91,6 +91,7 @@ class DeepLinksTest : BaseActivityTest() {
         setPrefLanguage("en")
         setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
         setIsScanFileSystemDialogShown(true)
+        setShowStorageSelectionDialogOnCopyMove(false)
       }
     }
     context.let {
@@ -99,7 +100,6 @@ class DeepLinksTest : BaseActivityTest() {
           setIsPlayStoreBuildType(true)
           putPrefIsFirstRun(false)
           prefIsTest = true
-          shouldShowStorageSelectionDialog = false
         }
     }
     val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -99,12 +99,12 @@ class DownloadTest : BaseActivityTest() {
         setPrefLanguage("en")
         setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
         setIsScanFileSystemDialogShown(true)
+        setShowStorageOption(false)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -81,10 +81,10 @@ class InitialDownloadTest : BaseActivityTest() {
         setPrefLanguage("en")
         setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
         setIsScanFileSystemDialogShown(true)
+        setShowStorageOption(true)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(context).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, true)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -75,6 +75,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
 
   private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  private lateinit var kiwixDataStore: KiwixDataStore
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var selectedFile: File
   private lateinit var destinationFile: File
@@ -88,7 +89,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       }
       waitForIdle()
     }
-    val kiwixDataStore = KiwixDataStore(context).apply {
+    kiwixDataStore = KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()
@@ -141,7 +142,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitUntilTimeout() // to properly load the library screen.
       }
       // test with first launch
-      sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+      runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
       showMoveFileToPublicDirectoryDialog(listOf(Uri.fromFile(selectedFile)))
       // should show the permission dialog.
       copyMoveFileHandler {
@@ -207,7 +208,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitUntilTimeout() // to properly load the library screen.
       }
       // test with first launch
-      sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+      runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
       showMoveFileToPublicDirectoryDialog(listOf(Uri.fromFile(selectedFile)))
       // should show the permission dialog.
       copyMoveFileHandler {
@@ -327,6 +328,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     val copyMoveFileHandler = CopyMoveFileHandler(
       kiwixMainActivity,
       sharedPreferenceUtil,
+      kiwixDataStore,
       StorageCalculator(sharedPreferenceUtil),
       Fat32Checker(sharedPreferenceUtil, listOf(FileWritingFileSystemChecker()))
     ).apply {
@@ -377,8 +379,8 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitForIdle()
         waitUntilTimeout() // to properly load the library screen.
       }
+      runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(false) }
       sharedPreferenceUtil.apply {
-        shouldShowStorageSelectionDialog = false
         setIsPlayStoreBuildType(true)
       }
       // test opening images

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -73,6 +73,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
   val composeTestRule = createComposeRule()
 
   private lateinit var sharedPreferenceUtil: SharedPreferenceUtil
+  private lateinit var kiwixDataStore: KiwixDataStore
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var uiDevice: UiDevice
   private val fileName = "testzim.zim"
@@ -87,7 +88,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       }
       waitForIdle()
     }
-    val kiwixDataStore = KiwixDataStore(context).apply {
+    kiwixDataStore = KiwixDataStore(context).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()
@@ -135,7 +136,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       composeTestRule.waitForIdle()
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+        runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
         // open file picker to select a file to test the real scenario.
         composeTestRule.onNodeWithTag(SELECT_FILE_BUTTON_TESTING_TAG).performClick()
         TestUtils.testFlakyView(uiDevice.findObject(By.textContains(fileName))::click, 10)
@@ -168,7 +169,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       composeTestRule.waitForIdle()
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+        runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
         openFileManager()
         TestUtils.testFlakyView(uiDevice.findObject(By.textContains(fileName))::click, 10)
         copyMoveFileHandler {
@@ -207,7 +208,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
   }
 
   private fun testCopyMoveDialogShowing(uri: Uri) {
-    sharedPreferenceUtil.shouldShowStorageSelectionDialog = true
+    runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
     ActivityScenario.launch<KiwixMainActivity>(
       createDeepLinkIntent(uri)
     ).onActivity {}

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryFragmentTest.kt
@@ -79,12 +79,12 @@ class OnlineLibraryFragmentTest : BaseActivityTest() {
         setPrefLanguage("en")
         setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
         setIsScanFileSystemDialogShown(true)
+        setShowStorageOption(false)
       }
     }
     PreferenceManager.getDefaultSharedPreferences(
       InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     ).edit {
-      putBoolean(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION, false)
       putBoolean(SharedPreferenceUtil.IS_PLAY_STORE_BUILD, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_TEST, true)
       putBoolean(SharedPreferenceUtil.PREF_IS_FIRST_RUN, false)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -604,7 +604,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
   private suspend fun storeDeviceInPreferences(
     storageDevice: StorageDevice
   ) {
-    sharedPreferenceUtil.showStorageOption = false
+    kiwixDataStore.setShowStorageOption(false)
     sharedPreferenceUtil.putPrefStorage(
       sharedPreferenceUtil.getPublicDirectoryPath(storageDevice.name)
     )
@@ -725,14 +725,14 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
             }
 
             else ->
-              if (sharedPreferenceUtil.showStorageOption) {
+              if (kiwixDataStore.showStorageOption.first()) {
                 // Show the storage selection dialog for configuration if there is an SD card available.
                 if (getStorageDeviceList().size > 1) {
                   showStorageSelectDialog(getStorageDeviceList())
                 } else {
                   // If only internal storage is available, proceed with the ZIM file download directly.
                   // Displaying a configuration dialog is unnecessary in this case.
-                  sharedPreferenceUtil.showStorageOption = false
+                  kiwixDataStore.setShowStorageOption(false)
                   onBookItemClick(item)
                 }
               } else if (!requireActivity().isManageExternalStoragePermissionGranted(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
@@ -24,10 +24,12 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import com.tonyodev.fetch2.Download
+import com.tonyodev.fetch2.Status
 import com.tonyodev.fetch2.Status.COMPLETED
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
@@ -112,6 +114,14 @@ abstract class DownloadRoomDao {
   abstract fun getDownloadsPausedByService(
     reason: PauseReason = PauseReason.SERVICE
   ): List<DownloadRoomEntity>
+
+  suspend fun getOngoingDownloads(): List<DownloadModel> = allDownloads().first()
+    .filter {
+      it.state == Status.QUEUED ||
+        it.state == Status.DOWNLOADING ||
+        it.state == Status.NONE ||
+        it.state == Status.ADDED
+    }
 
   fun delete(download: Download) {
     deleteDownloadByDownloadId(download.id.toLong())

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CoreSettingsFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/CoreSettingsFragment.kt
@@ -450,7 +450,7 @@ abstract class CoreSettingsFragment : SettingsContract.View, BaseFragment() {
     }
   }
 
-  private fun setShowStorageOption() {
-    sharedPreferenceUtil?.showStorageOption = false
+  private suspend fun setShowStorageOption() {
+    kiwixDataStore?.setShowStorageOption(false)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/SharedPreferenceUtil.kt
@@ -104,21 +104,6 @@ class SharedPreferenceUtil @Inject constructor(val context: Context) {
     sharedPreferences.edit { putBoolean(IS_PLAY_STORE_BUILD, isPlayStoreBuildType) }
   }
 
-  var showStorageOption: Boolean
-    get() = sharedPreferences.getBoolean(PREF_SHOW_STORAGE_OPTION, true)
-    set(prefShowStorageOption) =
-      sharedPreferences.edit {
-        putBoolean(PREF_SHOW_STORAGE_OPTION, prefShowStorageOption)
-      }
-
-  var shouldShowStorageSelectionDialog: Boolean
-    get() = sharedPreferences.getBoolean(PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, true)
-    set(value) {
-      sharedPreferences.edit {
-        putBoolean(PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG, value)
-      }
-    }
-
   fun getPublicDirectoryPath(path: String): String =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       path

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -418,4 +418,26 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       prefs[PreferencesKeys.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH] = showOnRefresh
     }
   }
+
+  val showStorageOption: Flow<Boolean> =
+    context.kiwixDataStore.data.map { pref ->
+      pref[PreferencesKeys.PREF_SHOW_STORAGE_OPTION] ?: true
+    }
+
+  suspend fun setShowStorageOption(showStorageOption: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_STORAGE_OPTION] = showStorageOption
+    }
+  }
+
+  val shouldShowStorageSelectionDialogOnCopyMove: Flow<Boolean> =
+    context.kiwixDataStore.data.map { pref ->
+      pref[PreferencesKeys.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG] ?: true
+    }
+
+  suspend fun setShowStorageSelectionDialogOnCopyMove(showStorageOption: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG] = showStorageOption
+    }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -69,4 +69,8 @@ object PreferencesKeys {
     booleanPreferencesKey(SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES)
   val PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH =
     booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_MANAGE_PERMISSION_DIALOG_ON_REFRESH)
+  val PREF_SHOW_STORAGE_OPTION =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION)
+  val PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG =
+    booleanPreferencesKey(SharedPreferenceUtil.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/SharedPreferenceToDatastoreMigrator.kt
@@ -61,6 +61,8 @@ class SharedPreferenceToDatastoreMigrator(private val context: Context) {
         SharedPreferenceUtil.PREF_LAST_DONATION_POPUP_SHOWN_IN_MILLISECONDS,
         SharedPreferenceUtil.PREF_SCAN_FILE_SYSTEM_DIALOG_SHOWN,
         SharedPreferenceUtil.PREF_MANAGE_EXTERNAL_FILES,
+        SharedPreferenceUtil.PREF_SHOW_STORAGE_OPTION,
+        SharedPreferenceUtil.PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG,
       )
     )
     return listOf(kiwixMobileMigration, kiwixDefaultMigration)


### PR DESCRIPTION
Fixes #4536
Fixes #4538

Parent PR #4542

* Migrated `PREF_SHOW_STORAGE_OPTION` to DataStore (shown when the user downloads a ZIM file for the first time).
* Migrated `PREF_SHOW_COPY_MOVE_STORAGE_SELECTION_DIALOG` to DataStore (shown when the user tries to copy or move a ZIM file for the first time).
* Refactored the unit and UI test cases to work with DataStore.
* Added a migration test case to verify the data transfer from `SharedPreferences` to `DataStore`.