### PR TITLE
Fix: ZIM files with duplicate titles being selected on the Hotspot screen.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostContract.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostContract.kt
@@ -26,6 +26,6 @@ class ZimHostContract {
   }
 
   interface Presenter : BaseContract.Presenter<View> {
-    suspend fun loadBooks(previouslyHostedBooks: Set<String>)
+    suspend fun loadBooks(previouslyHostedBookIds: Set<String>)
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostFragment.kt
@@ -351,7 +351,7 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
   override fun onResume() {
     super.onResume()
     lifecycleScope.launch {
-      presenter.loadBooks(kiwixDataStore.hostedBooks.first())
+      presenter.loadBooks(kiwixDataStore.hostedBookIds.first())
     }
     if (ServerUtils.isServerStarted) {
       ip = ServerUtils.serverAddress
@@ -365,10 +365,10 @@ class ZimHostFragment : BaseFragment(), ZimHostCallbacks, ZimHostContract.View {
     val hostedBooks = booksList.asSequence()
       .filter(BooksOnDiskListItem::isSelected)
       .filterIsInstance<BookOnDisk>()
-      .map { it.book.title }
+      .map { it.book.id }
       .toSet()
     lifecycleScope.launch {
-      kiwixDataStore.setHostedBooks(hostedBooks)
+      kiwixDataStore.setHostedBookIds(hostedBooks)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -342,12 +342,12 @@ class KiwixDataStore @Inject constructor(val context: Context) {
     }
   }
 
-  val hostedBooks: Flow<Set<String>> =
+  val hostedBookIds: Flow<Set<String>> =
     context.kiwixDataStore.data.map { prefs ->
       prefs[PreferencesKeys.PREF_HOSTED_BOOKS] ?: HashSet()
     }
 
-  suspend fun setHostedBooks(hostedBooks: Set<String>) {
+  suspend fun setHostedBookIds(hostedBooks: Set<String>) {
     context.kiwixDataStore.edit { prefs ->
       prefs[PreferencesKeys.PREF_HOSTED_BOOKS] = hostedBooks
     }


### PR DESCRIPTION
Fixes #4548 

* Previously, selected ZIM files were determined using the book title, which could be shared by multiple ZIM files, causing all of them to appear selected.
* Selection is now based on the unique bookId, ensuring only the correct ZIM file is marked as selected.
* Added a backward-compatibility fallback for users who have not yet been migrated to the new logic, so previously selected books continue to appear selected on first launch.


https://github.com/user-attachments/assets/3048dcba-2921-4016-987a-4be52e5e0723

