### PR TITLE
Fixed: `Read Aloud` is not resuming in `Android 16` when the app is in the background.

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
   <!-- Device with versions >= Pie need this permission -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
   <queries>
     <intent>
@@ -93,7 +94,8 @@
       android:name=".error.DiagnosticReportActivity"
       android:exported="false" />
 
-    <service android:name=".read_aloud.ReadAloudService" />
+    <service android:name=".read_aloud.ReadAloudService"
+      android:foregroundServiceType="mediaPlayback" />
     <service
       android:name=".downloader.downloadManager.DownloadMonitorService"
       android:foregroundServiceType="dataSync" />

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -352,12 +352,12 @@ abstract class CoreReaderFragment :
            *  1) User has previously checked on "Don't ask me again", and/or
            *  2) Permission has been disabled on device
            */
-          requireActivity().toast(
+          context?.toast(
             string.ext_storage_permission_rationale_add_note,
             Toast.LENGTH_LONG
           )
         } else {
-          requireActivity().toast(
+          context?.toast(
             string.ext_storage_write_permission_denied_add_note,
             Toast.LENGTH_LONG
           )
@@ -2649,7 +2649,7 @@ abstract class CoreReaderFragment :
   }
 
   private fun createReadAloudIntent(action: String, isPauseTTS: Boolean): Intent =
-    Intent(requireActivity(), ReadAloudService::class.java).apply {
+    Intent(context, ReadAloudService::class.java).apply {
       setAction(action)
       putExtra(
         ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
@@ -2658,7 +2658,7 @@ abstract class CoreReaderFragment :
     }
 
   private fun setActionAndStartTTSService(action: String, isPauseTTS: Boolean = false) {
-    requireActivity().startService(
+    context?.startService(
       createReadAloudIntent(action, isPauseTTS)
     ).also {
       isReadAloudServiceRunning = action == ACTION_PAUSE_OR_RESUME_TTS

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManger.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManger.kt
@@ -89,10 +89,6 @@ class ReadAloudNotificationManger @Inject constructor(
       .build()
   }
 
-  fun notifyNotification(notification: Notification) {
-    notificationManager.notify(READ_ALOUD_NOTIFICATION_ID, notification)
-  }
-
   private fun getPauseOrResumeTitle(isPauseTTS: Boolean) = if (isPauseTTS) {
     context.getString(R.string.tts_resume)
   } else {


### PR DESCRIPTION
Fixes #4553 

* Converted `ReadAloudService` into a foreground service so that `Read Aloud` can resume while the app is in the background. We are using the `mediaPlayback` foreground service type for this service, which requires providing a justification to the Play Store. With this change, resuming `Read Aloud` in the background now works correctly.
* Since the service is now a foreground service, we have handled the `onTimeout` callback that is triggered when the background execution limit is about to be reached. In this case, we properly stop the service before the timeout occurs. Although it is unlikely that any page contains content that Read Aloud would read continuously for 6 hours, we have still handled this edge case—for example, when a user pauses Read Aloud and forgets to resume it, so stopping the service safely before the timeout.