### PR TITLE
Optimize Launched Effect key to book.id

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineBookItem.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineBookItem.kt
@@ -80,7 +80,7 @@ fun OnlineBookItem(
   onBookItemClick: (BookItem) -> Unit
 ) {
   var hasAvailableSpaceInStorage by remember { mutableStateOf(false) }
-  LaunchedEffect(item, availableSpaceCalculator) {
+  LaunchedEffect(item.book, item.fileSystemState, availableSpaceCalculator) {
     hasAvailableSpaceInStorage =
       availableSpaceCalculator.hasAvailableSpaceForBook(item.book)
   }


### PR DESCRIPTION
Fixes #4556 

### What was changed
- Narrowed the LaunchedEffect key to the actual dependency (book identity)

### Why
- Prevents unnecessary effect re-launch when unrelated fields change

**Screenshots**
Not applicable (no UI changes)

