### PR TITLE
Fixed: While fetching the online library, there is an empty screen showing when there are no items available.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -86,6 +86,7 @@ import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.NetworkUtils
 import org.kiwix.kiwixmobile.core.utils.REQUEST_POST_NOTIFICATION_PERMISSION
 import org.kiwix.kiwixmobile.core.utils.REQUEST_STORAGE_PERMISSION
+import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
@@ -302,14 +303,14 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       kiwixDataStore.selectedOnlineContentLanguage.first().takeUnless { it.isBlank() }
     },
     false,
-    1
+    ZERO
   )
 
   private fun observeViewModelData() {
     zimManageViewModel.apply {
       // Observe when library items changes.
       libraryItems
-        .onEach { onLibraryItemsChange(it) }
+        .onEach { onLibraryItemsChange(it.items) }
         .launchIn(viewLifecycleOwner.lifecycleScope)
       // Observe when online library downloading.
       onlineLibraryDownloading

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -56,7 +56,9 @@ import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
@@ -92,6 +94,7 @@ const val ONLINE_LIBRARY_SEARCH_VIEW_CLOSE_BUTTON_TESTING_TAG =
 const val NO_CONTENT_VIEW_TEXT_TESTING_TAG = "noContentViewTextTestingTag"
 const val SHOW_FETCHING_LIBRARY_LAYOUT_TESTING_TAG = "showFetchingLibraryLayoutTestingTag"
 const val ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG = "onlineDividerItemTextTag"
+const val LOAD_MORE_DELAY = 150L
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("ComposableLambdaParameterNaming")
@@ -183,6 +186,7 @@ private fun OnlineLibraryScreenContent(
   }
 }
 
+@OptIn(FlowPreview::class)
 @Composable
 private fun OnlineLibraryList(state: OnlineLibraryScreenState, lazyListState: LazyListState) {
   LazyColumn(
@@ -226,6 +230,7 @@ private fun OnlineLibraryList(state: OnlineLibraryScreenState, lazyListState: La
         val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: ZERO
         Triple(bookItems, totalItems, lastVisibleItemIndex)
       }
+      .debounce(LOAD_MORE_DELAY)
       .distinctUntilChanged()
       .collect { (bookItems, totalItems, lastVisibleItemIndex) ->
         if (bookItems.isNotEmpty() && lastVisibleItemIndex >= totalItems.minus(FIVE)) {

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -87,6 +87,8 @@ import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.Req
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestValidateZimFiles
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RestartActionMode
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.UserClickedDownloadBooksButton
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.OnlineLibraryRequest
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.OnlineLibraryResult
 import org.kiwix.kiwixmobile.zimManager.fileselectView.FileSelectListState
 import org.kiwix.kiwixmobile.zimManager.fileselectView.effects.DeleteFiles
 import org.kiwix.kiwixmobile.zimManager.fileselectView.effects.NavigateToDownloads
@@ -217,7 +219,20 @@ class ZimManageViewModelTest {
         setValidateZimViewModel(validateZimViewModel)
       }
     viewModel.fileSelectListStates.value = FileSelectListState(emptyList())
-    runBlocking { viewModel.networkLibrary.emit(emptyList()) }
+    runBlocking {
+      viewModel.networkLibrary.emit(
+        OnlineLibraryResult(
+          OnlineLibraryRequest(
+            query = null,
+            category = null,
+            lang = null,
+            isLoadMoreItem = false,
+            page = ZERO
+          ),
+          emptyList()
+        )
+      )
+    }
   }
 
   @Nested
@@ -356,9 +371,9 @@ class ZimManageViewModelTest {
         advanceUntilIdle()
 
         val items = awaitItem()
-        val bookItems = items.filterIsInstance<LibraryListItem.BookItem>()
+        val bookItems = items.items.filterIsInstance<LibraryListItem.BookItem>()
         if (bookItems.size >= 2 && bookItems[0].fileSystemState == CanWrite4GbFile) {
-          assertThat(items).isEqualTo(
+          assertThat(items.items).isEqualTo(
             listOf(
               LibraryListItem.DividerItem(Long.MAX_VALUE, "Downloading:"),
               LibraryListItem.LibraryDownloadItem(downloadModel(book = bookDownloading)),
@@ -398,9 +413,9 @@ class ZimManageViewModelTest {
         advanceUntilIdle()
 
         val item = awaitItem()
-        val bookItem = item.filterIsInstance<LibraryListItem.BookItem>().firstOrNull()
+        val bookItem = item.items.filterIsInstance<LibraryListItem.BookItem>().firstOrNull()
         if (bookItem?.fileSystemState == CannotWrite4GbFile) {
-          assertThat(item).isEqualTo(
+          assertThat(item.items).isEqualTo(
             listOf(
               LibraryListItem.DividerItem(Long.MIN_VALUE, "All languages"),
               LibraryListItem.BookItem(bookOver4Gb, CannotWrite4GbFile)
@@ -424,9 +439,9 @@ class ZimManageViewModelTest {
         advanceUntilIdle()
 
         val item = awaitItem()
-        val bookItem = item.filterIsInstance<LibraryListItem.BookItem>().firstOrNull()
+        val bookItem = item.items.filterIsInstance<LibraryListItem.BookItem>().firstOrNull()
         if (bookItem?.fileSystemState == CannotWrite4GbFile) {
-          assertThat(item).isEqualTo(
+          assertThat(item.items).isEqualTo(
             listOf(
               LibraryListItem.DividerItem(Long.MIN_VALUE, "Selected language: English"),
               LibraryListItem.BookItem(bookOver4Gb, CannotWrite4GbFile)
@@ -460,9 +475,9 @@ class ZimManageViewModelTest {
         advanceUntilIdle()
 
         val items = awaitItem()
-        val bookItems = items.filterIsInstance<LibraryListItem.BookItem>()
+        val bookItems = items.items.filterIsInstance<LibraryListItem.BookItem>()
         if (bookItems.size >= 2) {
-          assertThat(items).isEqualTo(
+          assertThat(items.items).isEqualTo(
             listOf(
               LibraryListItem.DividerItem(Long.MAX_VALUE, "Downloading"),
               LibraryListItem.LibraryDownloadItem(downloadModel),


### PR DESCRIPTION
Fixes #4558 

* Fixed an issue where the empty state was not shown when the server returned an empty list more than once. This happened because `StateFlow` ignores identical consecutive emissions, so the UI was not updated on the second empty response.
* Reworked the handling of network results to use `OnlineLibraryResult` and `LibraryListItemWrapper`, ensuring each emission is unique so the UI always refreshes correctly.
* Improved the “load more” logic to prevent the API from being triggered 2–3 times when reaching the end of the list.
* Fixed an issue where the very first “load more” request was loading the same page again because the page index was calculated incorrectly. After the first request, the following pages were loading correctly. So we have improved our request logic to correctly load the online content.
* Refactored the unit test cases according to this change.


| Issue | Fix |
|---------|------|
| <video src="https://github.com/user-attachments/assets/84eff72f-9a09-4c64-90cd-be537d3a3667" />| <video src="https://github.com/user-attachments/assets/58db3971-8cb6-4d8f-9f3a-53521b60503b" />