### PR TITLE
fixed: Search: make suggestion items fully clickable

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
@@ -317,13 +317,13 @@ private fun SearchListItem(
       .fillMaxSize()
       .padding(horizontal = EIGHT_DP)
       .padding(top = SEVEN_DP)
-      .combinedClickable(
-        onClick = { onItemClick(searchListItem) },
-        onLongClick = { onItemLongClick?.invoke(searchListItem) }
-      )
       .background(
         shape = RoundedCornerShape(EIGHT_DP),
         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.05f)
+      )
+      .combinedClickable(
+        onClick = { onItemClick(searchListItem) },
+        onLongClick = { onItemLongClick?.invoke(searchListItem) }
       ),
     verticalAlignment = Alignment.CenterVertically
   ) {


### PR DESCRIPTION
Fixes #4564

### What changed
- Fixed incorrect highlight behavior in search suggestions.
- The entire item is now clickable and visually selected instead of only the text.



<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 
![4564](https://github.com/user-attachments/assets/6db8d7e9-cb29-4fc9-8258-d047ec8c0ce9)

