### PR TITLE
Added rememberSavable only for necessary parts

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,7 +82,7 @@ fun HelpScreenItem(
   data: HelpScreenItemDataClass,
   initiallyOpened: Boolean = false
 ) {
-  var isOpen by remember { mutableStateOf(initiallyOpened) }
+  var isOpen by rememberSaveable { mutableStateOf(initiallyOpened) }
 
   Column(
     modifier = modifier

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -189,7 +190,7 @@ fun ReaderScreen(
   navigationIcon: @Composable () -> Unit
 ) {
   // For managing the scroll event handling of webView.
-  val shouldUpdateTopAppBarAndBottomAppBarOnScrolling = remember { mutableStateOf(true) }
+  val shouldUpdateTopAppBarAndBottomAppBarOnScrolling = rememberSaveable { mutableStateOf(true) }
   val topAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
   val bottomAppBarScrollBehavior = BottomAppBarDefaults.exitAlwaysScrollBehavior()
   LaunchedEffect(bottomAppBarScrollBehavior.state.heightOffset) {
@@ -276,7 +277,7 @@ fun OnBackPressed(
   navHostController: NavHostController
 ) {
   // Tracks whether the fragment's BackHandler should be enabled.
-  var shouldEnableBackPress by remember { mutableStateOf(true) }
+  var shouldEnableBackPress by rememberSaveable { mutableStateOf(true) }
   BackHandler(enabled = shouldEnableBackPress) {
     val result = onUserBackPressed()
     if (result == FragmentActivityExtensions.Super.ShouldCall) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixAppBar.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixAppBar.kt
@@ -44,7 +44,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -133,7 +133,7 @@ private fun AppBarTitle(
 
 @Composable
 private fun ActionMenu(actionMenuItems: List<ActionMenuItem>) {
-  var overflowExpanded by remember { mutableStateOf(false) }
+  var overflowExpanded by rememberSaveable { mutableStateOf(false) }
 
   Row {
     val (mainActions, overflowActions) = actionMenuItems.partition { !it.isInOverflow }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixShowCaseView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixShowCaseView.kt
@@ -39,8 +39,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
@@ -97,7 +99,7 @@ fun KiwixShowCaseView(
   onShowCaseCompleted: () -> Unit
 ) {
   val orderedTargets = targets.values.sortedBy { it.index }
-  var currentIndex by remember { mutableStateOf(ZERO) }
+  var currentIndex by rememberSaveable { mutableIntStateOf(ZERO) }
   val currentTarget = orderedTargets.getOrNull(currentIndex)
 
   currentTarget?.let {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/StorageDeviceItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/StorageDeviceItem.kt
@@ -34,7 +34,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,10 +74,10 @@ fun StorageDeviceItem(
   storageCalculator: StorageCalculator,
   kiwixDataStore: KiwixDataStore,
 ) {
-  var storagePathAndTitle by remember { mutableStateOf("") }
-  var usedSpace by remember { mutableStateOf("") }
-  var freeSpace by remember { mutableStateOf("") }
-  var progress by remember { mutableIntStateOf(0) }
+  var storagePathAndTitle by rememberSaveable { mutableStateOf("") }
+  var usedSpace by rememberSaveable { mutableStateOf("") }
+  var freeSpace by rememberSaveable { mutableStateOf("") }
+  var progress by rememberSaveable { mutableIntStateOf(0) }
   val context = LocalContext.current
   val currentStorageIndex by kiwixDataStore.selectedStoragePosition.collectAsState(ZERO)
   LaunchedEffect(storageDevice) {


### PR DESCRIPTION
Fixes: #4587

### What Changed?
`remember {}` replace with `rememberSavable{}` for certain parts like Searching Text, Tabs Position, Index, As these are the fields which should be robust to configuration changes.

### Why?
important part of app should preserve its data. All fields should not be marked with` rememberSavable{}` as it increase memory usage, but certain part of code needs to be robust to changes