### PR TITLE
Improved our `Nightly` CD to correctly decrypt the `KIWIX_FILE_UPLOAD_SSH_KEY`.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,11 +32,12 @@ jobs:
         env:
           KEYSTORE: ${{ secrets.keystore }}
           KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
-          KIWIX_FILE_UPLOAD_SSH_KEY_PATH: kiwix_file_upload_ssh_key
         run: |
           echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
-          echo "$KIWIX_FILE_UPLOAD_SSH_KEY" | base64 -d > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
-          chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+          KEY_PATH=kiwix_file_upload_ssh_key
+          echo "$KIWIX_FILE_UPLOAD_SSH_KEY" > $KEY_PATH
+          chmod 600 $KEY_PATH
+          echo "KIWIX_FILE_UPLOAD_SSH_KEY_PATH=$KEY_PATH" >> $GITHUB_ENV
 
       - name: build debug
         env:
@@ -55,4 +56,4 @@ jobs:
         run: |
           mkdir $DATE
           cp $UNIVERSAL_DEBUG_APK $DATE
-          scp -P 30022 -vrp -i $KIWIX_FILE_UPLOAD_SSH_KEY_PATH -o StrictHostKeyChecking=no $DATE ci@master.download.kiwix.org:/data/download/nightly/
+          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no $DATE ci@master.download.kiwix.org:/data/download/nightly/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,12 @@ jobs:
         env:
           KEYSTORE: ${{ secrets.keystore }}
           KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
-          KIWIX_FILE_UPLOAD_SSH_KEY_PATH: kiwix_file_upload_ssh_key
         run: |
           echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
-          echo "$KIWIX_FILE_UPLOAD_SSH_KEY" | base64 -d > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
-          chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+          KEY_PATH=kiwix_file_upload_ssh_key
+          echo "$KIWIX_FILE_UPLOAD_SSH_KEY" > $KEY_PATH
+          chmod 600 $KEY_PATH
+          echo "KIWIX_FILE_UPLOAD_SSH_KEY_PATH=$KEY_PATH" >> $GITHUB_ENV
 
       - name: Publish APK to download.kiwix.org
         env:
@@ -56,14 +57,14 @@ jobs:
         run: |
           ./gradlew assembleStandalone
           cp ${UNIVERSAL_RELEASE_APK} ${ARCHIVE_NAME}
-          scp -P 30022 -vrp -i $KIWIX_FILE_UPLOAD_SSH_KEY_PATH -o StrictHostKeyChecking=no "$ARCHIVE_NAME" ci@master.download.kiwix.org:/data/download/release/kiwix-android/
+          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no "$ARCHIVE_NAME" ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
 #      This is temporary, once we will publish 3.7.0 then we will uncommented this code.
 #      # This is necessary for F-Droid
 #      - name: Publish "versionInfo" to download.kiwix.org
 #        run: |
 #          ./gradlew generateVersionCodeAndName
-#          scp -P 30022 -vrp -i $KIWIX_FILE_UPLOAD_SSH_KEY_PATH -o StrictHostKeyChecking=no VERSION_INFO ci@master.download.kiwix.org:/data/download/release/kiwix-android/
+#          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no VERSION_INFO ci@master.download.kiwix.org:/data/download/release/kiwix-android/
 
       - name: Upload APKs to Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Fixes #4592 

* The `KIWIX_FILE_UPLOAD_SSH_KEY` is plain text, so we don't need to decode it.
* Made the `KIWIX_FILE_UPLOAD_SSH_KEY_PATH` GitHub env variable so that we can use it in other steps.