### PR TITLE
Fix #4632: Skip nav and footer text in TTS

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -154,9 +154,8 @@ class KiwixTextToSpeech internal constructor(
       """
       javascript:
       body = document.getElementsByTagName('body')[0].cloneNode(true);
-      toRemove = body.querySelectorAll('sup.reference, #toc, .thumbcaption, title, .navbox, style');
-      Array.prototype.forEach.call(toRemove, function(elem) {    
-        elem.parentElement.removeChild(elem);});
+      toRemove = body.querySelectorAll('sup.reference, #toc, .thumbcaption, title, .navbox, [role="navigation"], script, noscript, style');
+      Array.prototype.forEach.call(toRemove, function(elem) { elem.parentElement.removeChild(elem); });
       tts.speakAloud(body.innerText);
       """.trimIndent()
     )


### PR DESCRIPTION
Fixes #4632

TTS was previously using the full  body text, which caused navigation
menus, headers, and footer links to be read before the actual article
content.

This change prefers main /  article (and  #content where present) and
filters out common navigation elements before passing text to TTS. If none
of those tags are available, it falls back to body as before.

Tested locally on multiple pages – TTS now starts reading directly from the
article instead of menu and footer text.