### PR TITLE
Fix #4640: Reset scroll state when searching in Online Library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -219,7 +219,11 @@ private fun OnlineLibraryList(state: OnlineLibraryScreenState, lazyListState: La
     }
     showLoadMoreProgressBar(state.isLoadingMoreItem)
   }
-
+  LaunchedEffect(state.onlineLibraryList) {
+    if (!state.isLoadingMoreItem) {
+      lazyListState.scrollToItem(ZERO)
+    }
+  }
   LaunchedEffect(lazyListState, state.onlineLibraryList) {
     snapshotFlow { lazyListState.layoutInfo }
       .combine(


### PR DESCRIPTION
Fixes #4640

- Reset the list scroll to the top when the online library data changes due to search or filter.
- Avoid resetting the scroll position when loading more items.

See attached screen recording.

https://github.com/user-attachments/assets/305e3644-7349-4346-ad46-1c8932e71cac


