### PR TITLE
Improved the showing of tags for a ZIM file.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/ui/TagsView.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ui/TagsView.kt
@@ -50,7 +50,7 @@ fun TagsView(tags: List<KiwixTag>, modifier: Modifier = Modifier, index: Int) {
       val picture = stringResource(R.string.tag_pic)
       TagChip(text = picture, contentDescription = "$picture$index")
     }
-    if (tags.isYesOrNotDefined<VideoTag>()) {
+    if (tags.isYes<VideoTag>()) {
       val video = stringResource(R.string.tag_vid)
       TagChip(text = video, contentDescription = "$video$index")
     }


### PR DESCRIPTION
Fixes #4643

Now, we are only showing the `vid` tag when there are videos available.