### PR TITLE
Fixed: Saving broken/internet files in storage.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/FileExtensions.kt
@@ -21,6 +21,7 @@ package org.kiwix.kiwixmobile.core.extensions
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.utils.ZERO
 import java.io.File
 
 suspend fun File.isFileExist(dispatcher: CoroutineDispatcher = Dispatchers.IO): Boolean =
@@ -37,3 +38,6 @@ suspend fun File.canReadFile(dispatcher: CoroutineDispatcher = Dispatchers.IO): 
 
 suspend fun File.deleteFile(dispatcher: CoroutineDispatcher = Dispatchers.IO): Boolean =
   withContext(dispatcher) { delete() }
+
+suspend fun File.hasContent(dispatcher: CoroutineDispatcher = Dispatchers.IO): Boolean =
+  withContext(dispatcher) { isFileExist() && length() > ZERO }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -46,6 +46,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.downloader.ChunkUtils
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.extensions.deleteFile
+import org.kiwix.kiwixmobile.core.extensions.hasContent
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
@@ -745,7 +746,7 @@ object FileUtils {
             zimReaderContainer.load(it, emptyMap()).data.use { inputStream ->
               fileToSave.outputStream().use(inputStream::copyTo)
             }
-            fileToSave
+            if (fileToSave.hasContent()) fileToSave else null
           }
         } catch (e: IOException) {
           Log.w("kiwix", "Couldn't save file", e)


### PR DESCRIPTION
Fixes #4607 

When an image is on interne,t we are not loading that image, so when the user tries to save it. It saves inside the storage, which is wrong. Now, instead of saving a broken image or file, we show an error message to the user.