### PR TITLE
Using java-libkiwix `2.4.2`.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -80,7 +80,7 @@ object Versions {
 
   const val androidx_activity: String = "1.9.3"
 
-  const val libkiwix: String = "2.4.1"
+  const val libkiwix: String = "2.4.2"
 
   const val material: String = "1.12.0"
 


### PR DESCRIPTION
We have recently released the java-libkiwix 2.4.2. So we are using the new binaries here.