### PR TITLE
Fixed: `testSettingsActivity` test, it is sometimes flaky on CI.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -142,13 +142,9 @@ class KiwixSettingsFragmentTest {
       toggleExternalLinkWarningPref(composeTestRule)
       toggleWifiDownloadsOnlyPref(composeTestRule)
       clickExternalStoragePreference(composeTestRule)
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-        assertExternalStorageSelected(composeTestRule)
-      }
+      assertExternalStorageSelected(composeTestRule)
       clickInternalStoragePreference(composeTestRule)
-      if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-        assertInternalStorageSelected(composeTestRule)
-      }
+      assertInternalStorageSelected(composeTestRule)
       clickClearHistoryPreference(composeTestRule)
       assertHistoryDialogDisplayed(composeTestRule)
       dismissDialog()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.settings
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.filter
@@ -44,6 +45,7 @@ import org.kiwix.kiwixmobile.core.ui.components.TOOLBAR_TITLE_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_TITLE_TEXT_TESTING_TAG
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 
@@ -135,6 +137,8 @@ class SettingsRobot : BaseRobot() {
   private fun clickOnStorageItem(position: Int, composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
       waitForIdle()
+      onAllNodesWithTag(STORAGE_DEVICE_ITEM_TESTING_TAG, true)[position]
+        .performScrollTo()
       onAllNodesWithTag(STORAGE_DEVICE_ITEM_TESTING_TAG, true)[position].performClick()
     }
   }
@@ -151,7 +155,11 @@ class SettingsRobot : BaseRobot() {
     testFlakyView({
       composeTestRule.apply {
         waitForIdle()
-        waitUntilTimeout()
+        waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
+          onAllNodesWithTag(STORAGE_DEVICE_ITEM_TESTING_TAG, true)
+            .fetchSemanticsNodes()[position]
+            .config[SemanticsProperties.Selected]
+        }
         onAllNodesWithTag(STORAGE_DEVICE_ITEM_TESTING_TAG, true)[position]
           .assertIsSelected()
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -76,10 +76,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.FontWeight.Companion.W400
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.convertToLocal
 import org.kiwix.kiwixmobile.core.extensions.snack
@@ -172,7 +169,7 @@ private fun SetUpViewModelAndPermissionLauncher(
   LaunchedEffect(Unit) {
     coreSettingsViewModel.initialize(activity = coreMainActivity)
     coreSettingsViewModel.actions
-      .onEach { action ->
+      .collect { action ->
         handleSettingsAction(
           action = action,
           viewModel = coreSettingsViewModel,
@@ -180,7 +177,6 @@ private fun SetUpViewModelAndPermissionLauncher(
           launchers = launchers
         )
       }
-      .launchIn(coreSettingsViewModel.viewModelScope)
   }
 }
 

--- a/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomSettingsViewModel.kt
+++ b/custom/src/main/java/org/kiwix/kiwixmobile/custom/settings/CustomSettingsViewModel.kt
@@ -52,7 +52,7 @@ class CustomSettingsViewModel @Inject constructor(
   override suspend fun setStorage(coreMainActivity: CoreMainActivity) {
     settingsUiState.update {
       it.copy(
-        shouldShowStorageCategory = true,
+        shouldShowStorageCategory = false,
         isLoadingStorageDetails = false
       )
     }


### PR DESCRIPTION
Fixes #4679 

* Improved the handling of user actions on the UI so that Compose can properly observe them in tests.
* Ensured the Compose UI waits until it has fully settled.
* Improved interaction with the storage device list so items are properly brought into view before clicking.
* Added storage selection tests for all devices (previously not covered on API level 36).