### PR TITLE
Fixing library Pagination Issues

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -289,7 +289,8 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
         },
         bottomAppBarScrollBehaviour = (requireActivity() as CoreMainActivity).bottomAppBarScrollBehaviour,
         navHostController = (requireActivity() as CoreMainActivity).navController,
-        onUserBackPressed = { onUserBackPressed() }
+        onUserBackPressed = { onUserBackPressed() },
+        zimManageViewModel = zimManageViewModel
       )
       DialogHost(alertDialogShower)
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.kiwix.kiwixmobile.core.R.string
@@ -85,6 +84,8 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.THREE_DP
 import org.kiwix.kiwixmobile.core.utils.FIVE
 import org.kiwix.kiwixmobile.core.utils.ZERO
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.OnlineLibraryUiEvent.ScrollToTop
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem.DividerItem
 
@@ -97,7 +98,7 @@ const val ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG = "onlineDividerItemTextTag"
 const val LOAD_MORE_DELAY = 150L
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Suppress("ComposableLambdaParameterNaming")
+@Suppress("ComposableLambdaParameterNaming", "LongParameterList")
 @Composable
 fun OnlineLibraryScreen(
   state: OnlineLibraryScreenState,
@@ -106,10 +107,19 @@ fun OnlineLibraryScreen(
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
   onUserBackPressed: () -> FragmentActivityExtensions.Super,
   navHostController: NavHostController,
+  zimManageViewModel: ZimManageViewModel,
   navigationIcon: @Composable () -> Unit,
 ) {
   val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-
+  LaunchedEffect(Unit) {
+    zimManageViewModel.onlineLibraryEvent.collect {
+      when (it) {
+        ScrollToTop -> {
+          listState.scrollToItem(ZERO)
+        }
+      }
+    }
+  }
   KiwixTheme {
     Scaffold(
       snackbarHost = { KiwixSnackbarHost(snackbarHostState = state.snackBarHostState) },
@@ -219,26 +229,24 @@ private fun OnlineLibraryList(state: OnlineLibraryScreenState, lazyListState: La
     }
     showLoadMoreProgressBar(state.isLoadingMoreItem)
   }
-  LaunchedEffect(state.onlineLibraryList) {
-    if (!state.isLoadingMoreItem) {
-      lazyListState.scrollToItem(ZERO)
-    }
-  }
   LaunchedEffect(lazyListState, state.onlineLibraryList) {
-    snapshotFlow { lazyListState.layoutInfo }
-      .combine(
-        snapshotFlow { state.onlineLibraryList.orEmpty() }
-      ) { layoutInfo, libraryList ->
-        val bookItems = libraryList.filterIsInstance<LibraryListItem.BookItem>()
-        val totalItems = layoutInfo.totalItemsCount
-        val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: ZERO
-        Triple(bookItems, totalItems, lastVisibleItemIndex)
+    snapshotFlow {
+      val layoutInfo = lazyListState.layoutInfo
+      val visibleIndexes = layoutInfo.visibleItemsInfo.map { it.index }
+      val list = state.onlineLibraryList.orEmpty()
+      val visibleBookIndexes = visibleIndexes.filter { index ->
+        list.getOrNull(index) is LibraryListItem.BookItem
       }
-      .debounce(LOAD_MORE_DELAY)
+      val lastVisibleBookIndex = visibleBookIndexes.maxOrNull() ?: -1
+      val totalBookCount = list.count { it is LibraryListItem.BookItem }
+
+      Pair(lastVisibleBookIndex, totalBookCount)
+    }
       .distinctUntilChanged()
-      .collect { (bookItems, totalItems, lastVisibleItemIndex) ->
-        if (bookItems.isNotEmpty() && lastVisibleItemIndex >= totalItems.minus(FIVE)) {
-          state.onLoadMore(totalItems)
+      .debounce(LOAD_MORE_DELAY)
+      .collect { (lastVisibleBookIndex, totalBookCount) ->
+        if (lastVisibleBookIndex >= totalBookCount.minus(FIVE) && !state.isLoadingMoreItem) {
+          state.onLoadMore(totalBookCount)
         }
       }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -33,7 +33,9 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -128,6 +130,7 @@ const val MAX_PROGRESS = 100
 
 const val THREE = 3
 
+@Suppress("LargeClass")
 class ZimManageViewModel @Inject constructor(
   private val downloadDao: DownloadRoomDao,
   private val libkiwixBookOnDisk: LibkiwixBookOnDisk,
@@ -151,6 +154,10 @@ class ZimManageViewModel @Inject constructor(
     object MultiModeFinished : FileSelectActions()
     object RestartActionMode : FileSelectActions()
     object UserClickedDownloadBooksButton : FileSelectActions()
+  }
+
+  sealed class OnlineLibraryUiEvent {
+    object ScrollToTop : OnlineLibraryUiEvent()
   }
 
   data class OnlineLibraryRequest(
@@ -213,6 +220,8 @@ class ZimManageViewModel @Inject constructor(
   )
   val requestFileSystemCheck = MutableSharedFlow<Unit>(replay = 0)
   val fileSelectActions = MutableSharedFlow<FileSelectActions>()
+  private val _onlineLibraryEvent = MutableSharedFlow<OnlineLibraryUiEvent>()
+  val onlineLibraryEvent: SharedFlow<OnlineLibraryUiEvent> = _onlineLibraryEvent.asSharedFlow()
   private val requestDownloadLibrary = MutableSharedFlow<OnlineLibraryRequest>(
     replay = 0,
     extraBufferCapacity = 1,
@@ -251,6 +260,12 @@ class ZimManageViewModel @Inject constructor(
   fun setAlertDialogShower(alertDialogShower: AlertDialogShower) {
     this.alertDialogShower = alertDialogShower
   }
+
+  // This method will be updated in OnlineLibraryScreen migration
+  fun sendUiEvent(uiEvent: OnlineLibraryUiEvent) =
+    viewModelScope.launch {
+      _onlineLibraryEvent.emit(uiEvent)
+    }
 
   private fun createKiwixServiceWithProgressListener(
     baseUrl: String,
@@ -565,6 +580,9 @@ class ZimManageViewModel @Inject constructor(
             }
           )
           onlineLibraryResult.emit(newResult)
+          if (!result.onlineLibraryRequest.isLoadMoreItem) {
+            sendUiEvent(OnlineLibraryUiEvent.ScrollToTop)
+          }
         }
     }
   }.flowOn(ioDispatcher)


### PR DESCRIPTION
Fixes #4701 - Fixes Pagination not working while downloading.
Fixes #4700 - Fixes Broken Pagination logic. When downloading is in progress then list automatically goes to the top when a download progress update.

Additionally, this caused a regression issue with the wrong fixes #4640, which was pushed


* Introduced event-based scroll handling instead of relying on condition-based list position changes. This separates scroll behavior from list changes and makes the architecture clearer and more maintainable.
* The list now scrolls to the top only when a fresh set of items is fetched from the online source (e.g., after applying search, filters, category, or language changes).
* The current scroll position is preserved during download progress updates and pagination (load more).
* Improved the loadMore functionality.
 