### PR TITLE
Remove home navigation when no book is open in Reader screen

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
@@ -209,15 +209,17 @@ fun ReaderScreen(
           )
         },
         bottomBar = {
-          BottomAppBarOfReaderScreen(
-            state.bookmarkButtonItem,
-            state.previousPageButtonItem,
-            state.onHomeButtonClick,
-            state.nextPageButtonItem,
-            state.tocButtonItem,
-            state.shouldShowBottomAppBar,
-            bottomAppBarScrollBehavior
-          )
+          if (!state.isNoBookOpenInReader) {
+            BottomAppBarOfReaderScreen(
+              state.bookmarkButtonItem,
+              state.previousPageButtonItem,
+              state.onHomeButtonClick,
+              state.nextPageButtonItem,
+              state.tocButtonItem,
+              state.shouldShowBottomAppBar,
+              bottomAppBarScrollBehavior
+            )
+          }
         },
         floatingActionButton = { BackToTopFab(state) },
         modifier = Modifier


### PR DESCRIPTION
Fixes #4718

## Description

This PR removes the bottom navigation from the Reader screen when no book is open.

### Changes made:
- Wrapped `BottomAppBarOfReaderScreen` inside a conditional check:
  `if (!state.isNoBookOpenInReader)`
- Ensured the bottom app bar is shown only when a book is open.

### Testing
- Verified that the bottom navigation is hidden when no book is open.
- Verified that the bottom navigation appears correctly when a book is open.

**Video** 
https://github.com/user-attachments/assets/e90f433d-6a21-4793-9e36-f3258d51284f

