### PR TITLE
Add unit tests for ReadAloudService and ReadAloudNotificationManager

### DIFF
--- a/core/detekt_baseline.xml
+++ b/core/detekt_baseline.xml
@@ -75,7 +75,7 @@
     <ID>TopLevelPropertyNaming:Bytes.kt$const val Mb = Kb * 1024</ID>
     <ID>TopLevelPropertyNaming:Bytes.kt$const val Pb = Tb * 1024</ID>
     <ID>TopLevelPropertyNaming:Bytes.kt$const val Tb = Gb * 1024</ID>
-    <ID>PackageNaming:ReadAloudNotificationManger.kt$package org.kiwix.kiwixmobile.core.read_aloud</ID>
+    <ID>PackageNaming:ReadAloudNotificationManager.kt$package org.kiwix.kiwixmobile.core.read_aloud</ID>
     <ID>PackageNaming:ReadAloudService.kt$package org.kiwix.kiwixmobile.core.read_aloud</ID>
     <ID>PackageNaming:ReadAloudCallbacks.kt$package org.kiwix.kiwixmobile.core.read_aloud</ID>
   </CurrentIssues>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/CoreServiceModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/CoreServiceModule.kt
@@ -23,7 +23,7 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import org.kiwix.kiwixmobile.core.di.CoreServiceScope
-import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudNotificationManger
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudNotificationManager
 
 @Module
 class CoreServiceModule {
@@ -32,5 +32,5 @@ class CoreServiceModule {
   fun providesReadAloudNotificationManager(
     notificationManager: NotificationManager,
     context: Context
-  ): ReadAloudNotificationManger = ReadAloudNotificationManger(notificationManager, context)
+  ): ReadAloudNotificationManager = ReadAloudNotificationManager(notificationManager, context)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManager.kt
@@ -31,7 +31,7 @@ import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.IS_TTS_P
 import org.kiwix.kiwixmobile.core.utils.READ_ALOUD_SERVICE_CHANNEL_ID
 import javax.inject.Inject
 
-class ReadAloudNotificationManger @Inject constructor(
+class ReadAloudNotificationManager @Inject constructor(
   private val notificationManager: NotificationManager,
   private val context: Context
 ) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudService.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 
 class ReadAloudService : Service() {
   @set:Inject
-  var readAloudNotificationManager: ReadAloudNotificationManger? = null
+  var readAloudNotificationManager: ReadAloudNotificationManager? = null
   private val serviceBinder: IBinder = ReadAloudBinder(this)
   private var readAloudCallbacks: ReadAloudCallbacks? = null
 
@@ -66,7 +66,7 @@ class ReadAloudService : Service() {
   private fun startForegroundNotificationHelper(isPauseTTS: Boolean) {
     runCatching {
       readAloudNotificationManager?.buildForegroundNotification(isPauseTTS)?.let {
-        startForeground(ReadAloudNotificationManger.READ_ALOUD_NOTIFICATION_ID, it)
+        startForeground(ReadAloudNotificationManager.READ_ALOUD_NOTIFICATION_ID, it)
       }
     }.onFailure { it.printStackTrace() }
   }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManagerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudNotificationManagerTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.read_aloud
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.R
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudNotificationManager.Companion.READ_ALOUD_NOTIFICATION_ID
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_PAUSE_OR_RESUME_TTS
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_STOP_TTS
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.IS_TTS_PAUSE_OR_RESUME
+import org.kiwix.kiwixmobile.core.utils.READ_ALOUD_SERVICE_CHANNEL_ID
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class ReadAloudNotificationManagerTest {
+  private lateinit var context: Context
+  private lateinit var notificationManager: NotificationManager
+  private lateinit var readAloudNotificationManager: ReadAloudNotificationManager
+
+  @Before
+  fun setUp() {
+    clearAllMocks()
+    context = ApplicationProvider.getApplicationContext()
+    notificationManager = mockk(relaxed = true)
+    readAloudNotificationManager = ReadAloudNotificationManager(notificationManager, context)
+  }
+
+  private fun buildNotification(isPaused: Boolean): Notification =
+    readAloudNotificationManager.buildForegroundNotification(isPaused)
+
+  @Test
+  fun `shows pause button when TTS is playing`() {
+    val notification = buildNotification(false)
+
+    val pauseOrResumeAction = notification.actions[1]
+
+    assertThat(notification.actions).hasSize(2)
+    assertThat(pauseOrResumeAction.title)
+      .isEqualTo(context.getString(R.string.tts_pause))
+    assertThat(pauseOrResumeAction.icon)
+      .isEqualTo(R.drawable.ic_baseline_pause)
+  }
+
+  @Test
+  fun `shows resume button when TTS is paused`() {
+    val notification = buildNotification(true)
+
+    val pauseOrResumeAction = notification.actions[1]
+
+    assertThat(notification.actions).hasSize(2)
+    assertThat(pauseOrResumeAction.title)
+      .isEqualTo(context.getString(R.string.tts_resume))
+    assertThat(pauseOrResumeAction.icon)
+      .isEqualTo(R.drawable.ic_baseline_play)
+  }
+
+  @Test
+  fun `includes stop action as first button`() {
+    val notification = buildNotification(false)
+    val actions = notification.actions
+    val stopAction = actions[0]
+
+    assertThat(actions).hasSize(2)
+    assertThat(stopAction.title)
+      .isEqualTo(context.getString(R.string.stop))
+    assertThat(stopAction.icon)
+      .isEqualTo(R.drawable.ic_baseline_stop)
+  }
+
+  @Test
+  fun `has exactly two actions in the notification`() {
+    val notification = buildNotification(false)
+
+    assertThat(notification.actions).hasSize(2)
+  }
+
+  @Test
+  fun `sets correct notification content title and text`() {
+    val notification = buildNotification(false)
+    val extras = notification.extras
+    val contentTitle = extras.getString(Notification.EXTRA_TITLE)
+    val contentText = extras.getString(Notification.EXTRA_TEXT)
+
+    assertThat(contentTitle).isEqualTo(context.getString(R.string.menu_read_aloud))
+    assertThat(contentText).isEqualTo(context.getString(R.string.read_aloud_running))
+    assertThat(notification.contentIntent).isNull()
+  }
+
+  @Test
+  fun `sets small icon on notification`() {
+    val notification = buildNotification(false)
+
+    assertThat(notification.smallIcon.resId)
+      .isEqualTo(R.mipmap.ic_launcher)
+  }
+
+  @Test
+  fun `cancels notification with READ_ALOUD_NOTIFICATION_ID when dismissed`() {
+    readAloudNotificationManager.dismissNotification()
+
+    verify(exactly = 1) {
+      notificationManager.cancel(READ_ALOUD_NOTIFICATION_ID)
+    }
+  }
+
+  @Test
+  fun `creates notification channel on Android O and above`() {
+    val slot = slot<NotificationChannel>()
+    every { notificationManager.createNotificationChannel(capture(slot)) } just Runs
+
+    buildNotification(false)
+
+    verify(exactly = 1) {
+      notificationManager.createNotificationChannel(any())
+    }
+
+    val channel = slot.captured
+    assertThat(channel.id).isEqualTo(READ_ALOUD_SERVICE_CHANNEL_ID)
+    assertThat(channel.importance)
+      .isEqualTo(NotificationManager.IMPORTANCE_DEFAULT)
+    assertThat(channel.name).isEqualTo(context.getString(R.string.read_aloud_service_channel_name))
+    assertThat(channel.description).isEqualTo(context.getString(R.string.read_aloud_channel_description))
+    assertThat(channel.sound).isNull()
+  }
+
+  @Test
+  fun `stop action sends correct intent`() {
+    val notification = buildNotification(false)
+
+    val stopAction = notification.actions[0]
+    val intent = shadowOf(stopAction.actionIntent).savedIntent
+    assertThat(intent.action)
+      .isEqualTo(ACTION_STOP_TTS)
+  }
+
+  @Test
+  fun `pause action sends correct extra when playing`() {
+    val notification = buildNotification(false)
+
+    val action = notification.actions[1]
+    val intent = shadowOf(action.actionIntent).savedIntent
+    assertThat(intent.action)
+      .isEqualTo(ACTION_PAUSE_OR_RESUME_TTS)
+    assertThat(intent.getBooleanExtra(IS_TTS_PAUSE_OR_RESUME, false)).isTrue()
+  }
+
+  @Test
+  fun `resume action sends correct extra when paused`() {
+    val notification = buildNotification(true)
+
+    val action = notification.actions[1]
+    val intent = shadowOf(action.actionIntent).savedIntent
+    assertThat(intent.getBooleanExtra(IS_TTS_PAUSE_OR_RESUME, true)).isFalse()
+  }
+
+  @Test
+  fun `sets valid timestamp on notification`() {
+    val before = System.currentTimeMillis()
+
+    val notification = buildNotification(false)
+
+    val after = System.currentTimeMillis()
+
+    assertThat(notification.`when`).isBetween(before, after)
+  }
+
+  @Test
+  fun `actions are ordered as stop then pause or resume`() {
+    val notification = buildNotification(false)
+
+    val actions = notification.actions
+
+    assertThat(actions[0].title)
+      .isEqualTo(context.getString(R.string.stop))
+    assertThat(actions[1].title)
+      .isEqualTo(context.getString(R.string.tts_pause))
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudServiceTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/read_aloud/ReadAloudServiceTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.read_aloud
+
+import android.app.Notification
+import android.app.Service
+import android.content.Intent
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudNotificationManager.Companion.READ_ALOUD_NOTIFICATION_ID
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_PAUSE_OR_RESUME_TTS
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_STOP_TTS
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.IS_TTS_PAUSE_OR_RESUME
+
+class ReadAloudServiceTest {
+  private val notificationManager: ReadAloudNotificationManager = mockk(relaxed = true)
+  private val readAloudCallbacks: ReadAloudCallbacks = mockk(relaxed = true)
+  private val notification: Notification = mockk(relaxed = true)
+  private lateinit var readAloudService: ReadAloudService
+
+  @BeforeEach
+  fun setUp() {
+    clearAllMocks()
+    readAloudService = spyk(ReadAloudService())
+    readAloudService.readAloudNotificationManager = notificationManager
+    readAloudService.registerCallBack(readAloudCallbacks)
+    every { readAloudService.startForeground(any(), any()) } returns Unit
+    every { readAloudService.stopForeground(any<Int>()) } returns Unit
+    every { readAloudService.stopSelf() } returns Unit
+  }
+
+  private fun createIntent(action: String, isPauseTTS: Boolean = false): Intent {
+    val intent: Intent = mockk(relaxed = true)
+    every { intent.action } returns action
+    every { intent.getBooleanExtra(IS_TTS_PAUSE_OR_RESUME, false) } returns isPauseTTS
+    return intent
+  }
+
+  @Test
+  fun `pause TTS when pause action received with isPause true`() {
+    val pauseIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = true)
+    every {
+      notificationManager.buildForegroundNotification(true)
+    } returns notification
+
+    readAloudService.onStartCommand(pauseIntent, 0, 1)
+    verify { notificationManager.buildForegroundNotification(true) }
+    verify {
+      readAloudService.startForeground(
+        READ_ALOUD_NOTIFICATION_ID,
+        notification
+      )
+    }
+    verify { readAloudCallbacks.onReadAloudPauseOrResume(true) }
+  }
+
+  @Test
+  fun `resume TTS when pause or resume action received with isPause false`() {
+    val resumeIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = false)
+    every {
+      notificationManager.buildForegroundNotification(false)
+    } returns notification
+
+    readAloudService.onStartCommand(resumeIntent, 0, 1)
+
+    verify { notificationManager.buildForegroundNotification(false) }
+    verify {
+      readAloudService.startForeground(
+        READ_ALOUD_NOTIFICATION_ID,
+        notification
+      )
+    }
+    verify { readAloudCallbacks.onReadAloudPauseOrResume(false) }
+  }
+
+  @Test
+  fun `start foreground notification when pause or resume action received`() {
+    val pauseIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = true)
+    every {
+      notificationManager.buildForegroundNotification(true)
+    } returns notification
+
+    readAloudService.onStartCommand(pauseIntent, 0, 1)
+
+    verify(exactly = 1) {
+      readAloudService.startForeground(
+        ReadAloudNotificationManager.READ_ALOUD_NOTIFICATION_ID,
+        notification
+      )
+    }
+  }
+
+  @Test
+  fun `stops TTS and dismisses notification when stop action received`() {
+    val stopIntent = createIntent(ACTION_STOP_TTS)
+
+    readAloudService.onStartCommand(stopIntent, 0, 1)
+
+    verify(exactly = 1) { readAloudCallbacks.onReadAloudStop() }
+    verify(exactly = 1) { readAloudService.stopForeground(Service.STOP_FOREGROUND_REMOVE) }
+    verify(exactly = 1) { readAloudService.stopSelf() }
+    verify(exactly = 1) { notificationManager.dismissNotification() }
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudPauseOrResume(any()) }
+  }
+
+  @Test
+  fun `does not crash when callbacks are null and stop action received`() {
+    readAloudService.registerCallBack(null)
+    val stopIntent = createIntent(ACTION_STOP_TTS)
+
+    readAloudService.onStartCommand(stopIntent, 0, 1)
+
+    verify(exactly = 1) { readAloudService.stopForeground(Service.STOP_FOREGROUND_REMOVE) }
+    verify(exactly = 1) { readAloudService.stopSelf() }
+    verify(exactly = 1) { notificationManager.dismissNotification() }
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudStop() }
+  }
+
+  @Test
+  fun `does not crash when callbacks are null for pause action received`() {
+    readAloudService.registerCallBack(null)
+
+    val intent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = true)
+
+    every {
+      notificationManager.buildForegroundNotification(true)
+    } returns notification
+
+    readAloudService.onStartCommand(intent, 0, 1)
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudPauseOrResume(any()) }
+    verify(exactly = 1) { readAloudService.startForeground(any(), any()) }
+  }
+
+  @Test
+  fun `handles pause action when notification manager is null`() {
+    readAloudService.readAloudNotificationManager = null
+
+    val pauseIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = false)
+    readAloudService.onStartCommand(pauseIntent, 0, 1)
+    verify { readAloudCallbacks.onReadAloudPauseOrResume(false) }
+    verify(exactly = 0) {
+      readAloudService.startForeground(any(), any())
+    }
+  }
+
+  @Test
+  fun `returns START_NOT_STICKY from onStartCommand`() {
+    val stopIntent = createIntent(ACTION_STOP_TTS)
+
+    val result = readAloudService.onStartCommand(stopIntent, 0, 1)
+
+    assertThat(result).isEqualTo(Service.START_NOT_STICKY)
+  }
+
+  @Test
+  fun `returns service binder on bind`() {
+    val binder = readAloudService.onBind(null)
+
+    assertThat(binder).isInstanceOf(ReadAloudService.ReadAloudBinder::class.java)
+
+    val readAloudBinder = binder as ReadAloudService.ReadAloudBinder
+    assertThat(readAloudBinder.service.get()).isNotNull
+  }
+
+  @Test
+  fun `replaces previous callback when registering a new one`() {
+    val newCallback: ReadAloudCallbacks = mockk(relaxed = true)
+    readAloudService.registerCallBack(newCallback)
+    val stopIntent = createIntent(ACTION_STOP_TTS)
+
+    readAloudService.onStartCommand(stopIntent, 0, 1)
+
+    verify(exactly = 1) { newCallback.onReadAloudStop() }
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudStop() }
+  }
+
+  @Test
+  fun `stop service and dismiss notification on timeout`() {
+    readAloudService.onTimeout(1)
+
+    verify(exactly = 1) { readAloudCallbacks.onReadAloudStop() }
+    verify(exactly = 1) { readAloudService.stopForeground(Service.STOP_FOREGROUND_REMOVE) }
+    verify(exactly = 1) { readAloudService.stopSelf() }
+    verify(exactly = 1) { notificationManager.dismissNotification() }
+  }
+
+  @Test
+  fun `does not crash when buildForegroundNotification throws exception`() {
+    val intent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, isPauseTTS = true)
+
+    every {
+      notificationManager.buildForegroundNotification(true)
+    } throws RuntimeException("Test exception")
+
+    readAloudService.onStartCommand(intent, 0, 1)
+    verify(exactly = 0) {
+      readAloudService.startForeground(any(), any())
+    }
+  }
+
+  @Test
+  fun `does nothing when intent action is null`() {
+    val intent: Intent = mockk(relaxed = true)
+    every { intent.action } returns null
+
+    readAloudService.onStartCommand(intent, 0, 1)
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudPauseOrResume(any()) }
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudStop() }
+    verify(exactly = 0) { readAloudService.startForeground(any(), any()) }
+  }
+
+  @Test
+  fun `does nothing for unknown action`() {
+    val intent = createIntent("UNKNOWN_ACTION")
+
+    readAloudService.onStartCommand(intent, 0, 1)
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudPauseOrResume(any()) }
+    verify(exactly = 0) { readAloudCallbacks.onReadAloudStop() }
+    verify(exactly = 0) { readAloudService.startForeground(any(), any()) }
+  }
+
+  @Test
+  fun `handles multiple sequential actions correctly`() {
+    val pauseIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, true)
+    val resumeIntent = createIntent(ACTION_PAUSE_OR_RESUME_TTS, false)
+    val stopIntent = createIntent(ACTION_STOP_TTS)
+
+    every { notificationManager.buildForegroundNotification(any()) } returns notification
+
+    readAloudService.onStartCommand(pauseIntent, 0, 1)
+    readAloudService.onStartCommand(resumeIntent, 0, 2)
+    readAloudService.onStartCommand(stopIntent, 0, 3)
+
+    verify { readAloudCallbacks.onReadAloudPauseOrResume(true) }
+    verify { readAloudCallbacks.onReadAloudPauseOrResume(false) }
+    verify { readAloudCallbacks.onReadAloudStop() }
+  }
+}


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #4709
### Changes
- Added unit tests for ReadAloudNotificationManager and ReadAloudService.
- Verified notification construction logic including pause, resume, and stop actions.
- Tested notification content - title, text, and icon.
- Ensured notification channel creation is triggered on Android O and above.
### Testing
- Used **Robolectric** to build Notification object.
- Used **MockK** to mock `NotificationManager`.

Also corrected the file name ReadAloudNotificationManager file as discussed earlier.