### PR TITLE
Fixes #4748 Download takes ~1 minute to resume after network reconnection.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -97,7 +97,7 @@ class DownloadMonitorService : Service() {
 
   private val networkCallback = object : ConnectivityManager.NetworkCallback() {
     override fun onAvailable(network: Network) {
-      retryDownloadsOnNetworkGain()
+      resumeQueuedDownloadsOnNetworkAvailable()
     }
 
     override fun onLost(network: Network) {
@@ -105,12 +105,17 @@ class DownloadMonitorService : Service() {
     }
   }
 
-  private fun retryDownloadsOnNetworkGain() {
-    fetch.getDownloadsWithStatus(
-      listOf(Status.QUEUED)
-    ) { queuedDownloads ->
-      queuedDownloads.forEach { download ->
-        fetch.resume(download.id)
+  /**
+   * Resumes all downloads that are currently in the QUEUED state
+   * when network connectivity becomes available.
+   *
+   * It ensures that any downloads paused due to lack of connectivity
+   * are resumed automatically once the network is restored.
+   */
+  private fun resumeQueuedDownloadsOnNetworkAvailable() {
+    fetch.getDownloadsWithStatus(listOf(Status.QUEUED)) { queuedDownloads ->
+      queuedDownloads.forEach { queuedDownload ->
+        fetch.resume(queuedDownload.id)
       }
     }
   }


### PR DESCRIPTION
Fetch2's internal PriorityIterator jumps from 500ms to a 1-minute backoff after a network error, and its built-in enableRetryOnNetworkGain fails to reliably reset the backoff due to a race condition in the library's NetworkInfoProvider.

Registered a ConnectivityManager.NetworkCallback in DownloadMonitorService to actively call fetch.resume() on queued downloads when network becomes available, bypassing the library's backoff entirely.

Fixes #4748

**Video** 


https://github.com/user-attachments/assets/16c6c410-97a6-443e-87a6-628aa9c1a222

