### PR TITLE
CI: add unit test execution to pull_request.yml workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -155,3 +155,38 @@ jobs:
             name: kiwix-android
             path: |
               **/*.apk
+
+  unit_test_job:
+    name: Unit Tests
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Restore Cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
+
+      - name: Upload Unit Test Reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: unit-test-report
+          path: '**/build/reports/tests/'


### PR DESCRIPTION
Fixes #4760
Relates to #4724

### What this does
Adds a dedicated `unit_test_job` to `pull_request.yml` that runs 
unit tests on every PR.

### Why
`pull_request.yml` runs `ktlint`, `detekt`, `lint`, and `assemble` 
but does not execute unit tests. A PR that breaks existing tests 
will show all green checks and can be merged before the failure 
is detected. Tests only run in `ci.yml` at API level 30, outside 
the PR review window entirely.

Confirmed: `grep -i "test" .github/workflows/pull_request.yml` 
returned no results before this change.

### Changes
- Added `unit_test_job` to `pull_request.yml`
- Runs `testDebugUnitTest` and `testCustomexampleDebugUnitTest`
- Mirrors the exact commands already used in `ci.yml` (line 109)
- No `continue-on-error: true` — a failing test should block 
  the PR, not just warn
- No NDK setup required — unit tests run on the JVM
- Test reports uploaded