### PR TITLE
Feat: add back to top fab in online library

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
@@ -114,6 +114,7 @@ import javax.inject.Inject
 
 private const val WAS_IN_ACTION_MODE = "WAS_IN_ACTION_MODE"
 const val LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG = "localFileTransferMenuButtonTestingTag"
+const val SELECT_FILE_BUTTON_TESTING_TAG = "selectFileButtonTestingTag"
 private const val SHOW_SCAN_DIALOG_DELAY = 2000L
 
 @Suppress("LargeClass")
@@ -208,7 +209,6 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
         LocalLibraryScreen(
           listState = lazyListState,
           state = libraryScreenState.value,
-          fabButtonClick = { filePickerButtonClick() },
           onClick = { onBookItemClick(it) },
           onLongClick = { onBookItemLongClick(it) },
           onMultiSelect = { offerAction(RequestSelect(it)) },
@@ -265,6 +265,13 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
   }
 
   private fun actionMenuItems() = listOf(
+    ActionMenuItem(
+      IconItem.Drawable(org.kiwix.kiwixmobile.core.R.drawable.ic_add_blue_24dp),
+      R.string.select_zim_file,
+      { filePickerButtonClick() },
+      isEnabled = true,
+      testingTag = SELECT_FILE_BUTTON_TESTING_TAG
+    ),
     ActionMenuItem(
       IconItem.Drawable(R.drawable.ic_baseline_mobile_screen_share_24px),
       string.get_content_from_nearby_device,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
@@ -18,12 +18,15 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.local
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,14 +47,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -65,6 +70,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavHostController
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.R.drawable
 import org.kiwix.kiwixmobile.R.string
 import org.kiwix.kiwixmobile.core.R
@@ -75,14 +81,13 @@ import org.kiwix.kiwixmobile.core.main.reader.OnBackPressed
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixButton
+import org.kiwix.kiwixmobile.core.ui.components.KiwixFloatingActionButton
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSnackbarHost
 import org.kiwix.kiwixmobile.core.ui.components.ProgressBarStyle
 import org.kiwix.kiwixmobile.core.ui.components.SwipeRefreshLayout
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.ui.models.toPainter
-import org.kiwix.kiwixmobile.core.ui.theme.Black
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
-import org.kiwix.kiwixmobile.core.ui.theme.White
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.EIGHT_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FOUR_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
@@ -98,9 +103,9 @@ import kotlin.math.roundToInt
 const val NO_FILE_TEXT_TESTING_TAG = "noFileTextTestingTag"
 const val DOWNLOAD_BUTTON_TESTING_TAG = "downloadButtonTestingTag"
 const val BOOK_LIST_TESTING_TAG = "bookListTestingTag"
-const val SELECT_FILE_BUTTON_TESTING_TAG = "selectFileButtonTestingTag"
 const val SHOW_SWIPE_DOWN_TO_SCAN_FILE_SYSTEM_TEXT_TESTING_TAG =
   "showSwipeDownToScanFileSystemTextTestingTag"
+private const val BACK_TO_TOP_ITEM_THRESHOLD = 5
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("ComposableLambdaParameterNaming", "LongParameterList")
@@ -110,7 +115,6 @@ fun LocalLibraryScreen(
   listState: LazyListState,
   onRefresh: () -> Unit,
   onDownloadButtonClick: () -> Unit,
-  fabButtonClick: () -> Unit,
   onClick: ((BookOnDisk) -> Unit)? = null,
   onLongClick: ((BookOnDisk) -> Unit)? = null,
   onMultiSelect: ((BookOnDisk) -> Unit)? = null,
@@ -131,7 +135,7 @@ fun LocalLibraryScreen(
           topAppBarScrollBehavior = scrollBehavior
         )
       },
-      floatingActionButton = { SelectFileButton(fabButtonClick) },
+      floatingActionButton = { LocalLibraryBackToTopButton(listState) },
       modifier = Modifier
         .systemBarsPadding()
         .nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -219,18 +223,26 @@ private fun BookItemList(
 }
 
 @Composable
-private fun SelectFileButton(fabButtonClick: () -> Unit) {
-  FloatingActionButton(
-    onClick = fabButtonClick,
-    modifier = Modifier
-      .testTag(SELECT_FILE_BUTTON_TESTING_TAG),
-    containerColor = Black,
-    shape = MaterialTheme.shapes.extraLarge
+private fun LocalLibraryBackToTopButton(listState: LazyListState) {
+  val coroutineScope = rememberCoroutineScope()
+  val shouldShowBackToTopButton by remember {
+    derivedStateOf { listState.firstVisibleItemIndex >= BACK_TO_TOP_ITEM_THRESHOLD }
+  }
+
+  AnimatedVisibility(
+    visible = shouldShowBackToTopButton,
+    enter = slideInVertically { it },
+    exit = slideOutVertically { it }
   ) {
-    Icon(
-      painter = painterResource(id = R.drawable.ic_add_blue_24dp),
-      contentDescription = stringResource(id = string.select_zim_file),
-      tint = White
+    KiwixFloatingActionButton(
+      icon = painterResource(id = R.drawable.ic_arrow_upward_24dp),
+      onClick = {
+        coroutineScope.launch {
+          listState.animateScrollToItem(ZERO)
+        }
+      },
+      contentDescription = stringResource(R.string.pref_back_to_top),
+      shouldPulse = true
     )
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBarScrollBehavior
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -135,7 +136,13 @@ fun LocalLibraryScreen(
           topAppBarScrollBehavior = scrollBehavior
         )
       },
-      floatingActionButton = { LocalLibraryBackToTopButton(listState) },
+      floatingActionButton = {
+        LocalLibraryBackToTopButton(
+          listState = listState,
+          scrollBehavior = scrollBehavior,
+          bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
+        )
+      },
       modifier = Modifier
         .systemBarsPadding()
         .nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -145,34 +152,61 @@ fun LocalLibraryScreen(
           } ?: baseModifier
         }
     ) { contentPadding ->
-      SwipeRefreshLayout(
-        isRefreshing = state.swipeRefreshItem.first,
-        isEnabled = state.swipeRefreshItem.second,
-        onRefresh = onRefresh,
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(contentPadding)
-      ) {
-        OnBackPressed(onUserBackPressed, navHostController)
-        if (state.scanningProgressItem.first) {
-          ContentLoadingProgressBar(
-            modifier = Modifier.testTag(CONTENT_LOADING_PROGRESSBAR_TESTING_TAG),
-            progressBarStyle = ProgressBarStyle.HORIZONTAL,
-            progress = state.scanningProgressItem.second
-          )
-        }
-        if (state.noFilesViewItem.third || state.fileSelectListState.bookOnDiskListItems.isEmpty()) {
-          NoFilesView(state.noFilesViewItem, onDownloadButtonClick)
-        } else {
-          BookItemList(
-            state.fileSelectListState,
-            onClick,
-            onLongClick,
-            onMultiSelect,
-            listState
-          )
-        }
-      }
+      LocalLibraryMainContent(
+        state,
+        onRefresh,
+        contentPadding,
+        onUserBackPressed,
+        navHostController,
+        onDownloadButtonClick,
+        onClick,
+        onLongClick,
+        onMultiSelect,
+        listState
+      )
+    }
+  }
+}
+
+@Composable
+private fun LocalLibraryMainContent(
+  state: LocalLibraryScreenState,
+  onRefresh: () -> Unit,
+  contentPadding: PaddingValues,
+  onUserBackPressed: () -> FragmentActivityExtensions.Super,
+  navHostController: NavHostController,
+  onDownloadButtonClick: () -> Unit,
+  onClick: ((BookOnDisk) -> Unit)? = null,
+  onLongClick: ((BookOnDisk) -> Unit)? = null,
+  onMultiSelect: ((BookOnDisk) -> Unit)? = null,
+  listState: LazyListState
+) {
+  SwipeRefreshLayout(
+    isRefreshing = state.swipeRefreshItem.first,
+    isEnabled = state.swipeRefreshItem.second,
+    onRefresh = onRefresh,
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(contentPadding)
+  ) {
+    OnBackPressed(onUserBackPressed, navHostController)
+    if (state.scanningProgressItem.first) {
+      ContentLoadingProgressBar(
+        modifier = Modifier.testTag(CONTENT_LOADING_PROGRESSBAR_TESTING_TAG),
+        progressBarStyle = ProgressBarStyle.HORIZONTAL,
+        progress = state.scanningProgressItem.second
+      )
+    }
+    if (state.noFilesViewItem.third || state.fileSelectListState.bookOnDiskListItems.isEmpty()) {
+      NoFilesView(state.noFilesViewItem, onDownloadButtonClick)
+    } else {
+      BookItemList(
+        state.fileSelectListState,
+        onClick,
+        onLongClick,
+        onMultiSelect,
+        listState
+      )
     }
   }
 }
@@ -222,8 +256,13 @@ private fun BookItemList(
   }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun LocalLibraryBackToTopButton(listState: LazyListState) {
+private fun LocalLibraryBackToTopButton(
+  listState: LazyListState,
+  scrollBehavior: TopAppBarScrollBehavior,
+  bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?
+) {
   val coroutineScope = rememberCoroutineScope()
   val shouldShowBackToTopButton by remember {
     derivedStateOf { listState.firstVisibleItemIndex >= BACK_TO_TOP_ITEM_THRESHOLD }
@@ -238,6 +277,13 @@ private fun LocalLibraryBackToTopButton(listState: LazyListState) {
       icon = painterResource(id = R.drawable.ic_arrow_upward_24dp),
       onClick = {
         coroutineScope.launch {
+          // Manually reset the topAppBar and bottomAppBar scroll offsets
+          // so they become visible when scrolling to top programmatically.
+          // animateScrollToItem alone does not update the nestedScrollConnection.
+          scrollBehavior.state.heightOffset = 0f
+          scrollBehavior.state.contentOffset = 0f
+          bottomAppBarScrollBehaviour?.state?.heightOffset = 0f
+          bottomAppBarScrollBehaviour?.state?.contentOffset = 0f
           listState.animateScrollToItem(ZERO)
         }
       },

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -168,6 +169,7 @@ fun LocalLibraryScreen(
   }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LocalLibraryMainContent(
   state: LocalLibraryScreenState,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -35,8 +35,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -268,7 +266,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     super.onViewCreated(view, savedInstanceState)
     composeView?.setContent {
       val lazyListState = rememberLazyListState()
-      val isBackToTopEnabled by kiwixDataStore.backToTop.collectAsState(false)
       LaunchedEffect(Unit) {
         onlineLibraryScreenState.value.update {
           copy(
@@ -279,7 +276,6 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       }
       OnlineLibraryScreen(
         state = onlineLibraryScreenState.value.value,
-        isBackToTopEnabled = isBackToTopEnabled,
         listState = lazyListState,
         actionMenuItems = actionMenuItems {
           onlineLibraryScreenState.value.update { copy(isSearchActive = true) }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryFragment.kt
@@ -35,6 +35,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -266,6 +268,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
     super.onViewCreated(view, savedInstanceState)
     composeView?.setContent {
       val lazyListState = rememberLazyListState()
+      val isBackToTopEnabled by kiwixDataStore.backToTop.collectAsState(false)
       LaunchedEffect(Unit) {
         onlineLibraryScreenState.value.update {
           copy(
@@ -276,6 +279,7 @@ class OnlineLibraryFragment : BaseFragment(), FragmentActivityExtensions {
       }
       OnlineLibraryScreen(
         state = onlineLibraryScreenState.value.value,
+        isBackToTopEnabled = isBackToTopEnabled,
         listState = lazyListState,
         actionMenuItems = actionMenuItems {
           onlineLibraryScreenState.value.update { copy(isSearchActive = true) }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBarScrollBehavior
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -145,7 +146,11 @@ fun OnlineLibraryScreen(
         )
       },
       floatingActionButton = {
-        OnlineLibraryBackToTopButton(listState)
+        OnlineLibraryBackToTopButton(
+          listState = listState,
+          scrollBehavior = scrollBehavior,
+          bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
+        )
       },
       modifier = Modifier
         .nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -155,27 +160,49 @@ fun OnlineLibraryScreen(
           } ?: baseModifier
         }
     ) { paddingValues ->
-      SwipeRefreshLayout(
-        isRefreshing = state.isRefreshing && !state.scanningProgressItem.first,
-        isEnabled = !state.scanningProgressItem.first,
-        onRefresh = state.onRefresh,
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(
-            top = paddingValues.calculateTopPadding(),
-            start = paddingValues.calculateStartPadding(LocalLayoutDirection.current),
-            end = paddingValues.calculateEndPadding(LocalLayoutDirection.current),
-          )
-      ) {
-        OnBackPressed(onUserBackPressed, navHostController)
-        OnlineLibraryScreenContent(state, listState)
-      }
+      OnlineLibraryMainContent(
+        state,
+        paddingValues,
+        onUserBackPressed,
+        navHostController,
+        listState
+      )
     }
   }
 }
 
 @Composable
-private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
+private fun OnlineLibraryMainContent(
+  state: OnlineLibraryScreenState,
+  paddingValues: PaddingValues,
+  onUserBackPressed: () -> FragmentActivityExtensions.Super,
+  navHostController: NavHostController,
+  listState: LazyListState
+) {
+  SwipeRefreshLayout(
+    isRefreshing = state.isRefreshing && !state.scanningProgressItem.first,
+    isEnabled = !state.scanningProgressItem.first,
+    onRefresh = state.onRefresh,
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(
+        top = paddingValues.calculateTopPadding(),
+        start = paddingValues.calculateStartPadding(LocalLayoutDirection.current),
+        end = paddingValues.calculateEndPadding(LocalLayoutDirection.current),
+      )
+  ) {
+    OnBackPressed(onUserBackPressed, navHostController)
+    OnlineLibraryScreenContent(state, listState)
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OnlineLibraryBackToTopButton(
+  listState: LazyListState,
+  scrollBehavior: TopAppBarScrollBehavior,
+  bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?
+) {
   val coroutineScope = rememberCoroutineScope()
   val shouldShowBackToTopButton by remember {
     derivedStateOf { listState.firstVisibleItemIndex >= BACK_TO_TOP_ITEM_THRESHOLD }
@@ -190,6 +217,13 @@ private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
       icon = painterResource(id = drawable.ic_arrow_upward_24dp),
       onClick = {
         coroutineScope.launch {
+          // Manually reset the topAppBar and bottomAppBar scroll offsets
+          // so they become visible when scrolling to top programmatically.
+          // animateScrollToItem alone does not update the nestedScrollConnection.
+          scrollBehavior.state.heightOffset = 0f
+          scrollBehavior.state.contentOffset = 0f
+          bottomAppBarScrollBehaviour?.state?.heightOffset = 0f
+          bottomAppBarScrollBehaviour?.state?.contentOffset = 0f
           listState.animateScrollToItem(ZERO)
         }
       },

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -19,10 +19,8 @@
 package org.kiwix.kiwixmobile.nav.destination.library.online
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -68,8 +66,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -87,7 +83,6 @@ import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.ui.theme.MineShaftGray700
 import org.kiwix.kiwixmobile.core.ui.theme.White
-import org.kiwix.kiwixmobile.core.utils.ComposeDimens.BACK_TO_TOP_HIDE_DELAY_MS
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_MESSAGE_TEXT_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_PROGRESSBAR_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_PROGRESS_CARD_VIEW_CONTENT_MARGIN
@@ -119,7 +114,6 @@ private const val BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD = 200
 @Composable
 fun OnlineLibraryScreen(
   state: OnlineLibraryScreenState,
-  isBackToTopEnabled: Boolean,
   actionMenuItems: List<ActionMenuItem>,
   listState: LazyListState,
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
@@ -151,9 +145,7 @@ fun OnlineLibraryScreen(
         )
       },
       floatingActionButton = {
-        if (isBackToTopEnabled) {
-          OnlineLibraryBackToTopButton(listState)
-        }
+        OnlineLibraryBackToTopButton(listState)
       },
       modifier = Modifier
         .nestedScroll(scrollBehavior.nestedScrollConnection)
@@ -188,33 +180,21 @@ private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
   var shouldShowBackToTopButton by remember { mutableStateOf(false) }
 
   LaunchedEffect(listState) {
-    var hideBackToTopJob: Job? = null
     snapshotFlow {
       listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
     }
       .distinctUntilChanged()
       .collect { (firstVisibleItemIndex, firstVisibleItemScrollOffset) ->
-        val shouldShowButton =
+        shouldShowBackToTopButton =
           firstVisibleItemIndex > ZERO ||
-            firstVisibleItemScrollOffset > BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD
-
-        hideBackToTopJob?.cancel()
-        if (shouldShowButton) {
-          shouldShowBackToTopButton = true
-          hideBackToTopJob = launch {
-            delay(BACK_TO_TOP_HIDE_DELAY_MS)
-            shouldShowBackToTopButton = false
-          }
-        } else {
-          shouldShowBackToTopButton = false
-        }
+          firstVisibleItemScrollOffset > BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD
       }
   }
 
   AnimatedVisibility(
     visible = shouldShowBackToTopButton,
-    enter = fadeIn() + scaleIn(),
-    exit = fadeOut() + scaleOut()
+    enter = slideInVertically { it },
+    exit = slideOutVertically { it }
   ) {
     KiwixFloatingActionButton(
       icon = painterResource(id = org.kiwix.kiwixmobile.core.R.drawable.ic_arrow_upward_24dp),

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -50,9 +50,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,6 +68,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.extensions.hideKeyboardOnLazyColumnScroll
@@ -107,7 +107,7 @@ const val NO_CONTENT_VIEW_TEXT_TESTING_TAG = "noContentViewTextTestingTag"
 const val SHOW_FETCHING_LIBRARY_LAYOUT_TESTING_TAG = "showFetchingLibraryLayoutTestingTag"
 const val ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG = "onlineDividerItemTextTag"
 const val LOAD_MORE_DELAY = 150L
-private const val BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD = 200
+private const val BACK_TO_TOP_ITEM_THRESHOLD = 5
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("ComposableLambdaParameterNaming", "LongParameterList")
@@ -177,18 +177,8 @@ fun OnlineLibraryScreen(
 @Composable
 private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
   val coroutineScope = rememberCoroutineScope()
-  var shouldShowBackToTopButton by remember { mutableStateOf(false) }
-
-  LaunchedEffect(listState) {
-    snapshotFlow {
-      listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
-    }
-      .distinctUntilChanged()
-      .collect { (firstVisibleItemIndex, firstVisibleItemScrollOffset) ->
-        shouldShowBackToTopButton =
-          firstVisibleItemIndex > ZERO ||
-          firstVisibleItemScrollOffset > BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD
-      }
+  val shouldShowBackToTopButton by remember {
+    derivedStateOf { listState.firstVisibleItemIndex >= BACK_TO_TOP_ITEM_THRESHOLD }
   }
 
   AnimatedVisibility(
@@ -197,7 +187,7 @@ private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
     exit = slideOutVertically { it }
   ) {
     KiwixFloatingActionButton(
-      icon = painterResource(id = org.kiwix.kiwixmobile.core.R.drawable.ic_arrow_upward_24dp),
+      icon = painterResource(id = drawable.ic_arrow_upward_24dp),
       onClick = {
         coroutineScope.launch {
           listState.animateScrollToItem(ZERO)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -171,6 +172,7 @@ fun OnlineLibraryScreen(
   }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun OnlineLibraryMainContent(
   state: OnlineLibraryScreenState,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -18,6 +18,11 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -45,11 +50,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -57,14 +68,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.extensions.hideKeyboardOnLazyColumnScroll
 import org.kiwix.kiwixmobile.core.main.reader.OnBackPressed
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
+import org.kiwix.kiwixmobile.core.ui.components.KiwixFloatingActionButton
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSearchView
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSnackbarHost
 import org.kiwix.kiwixmobile.core.ui.components.SwipeRefreshLayout
@@ -72,6 +87,7 @@ import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.ui.theme.MineShaftGray700
 import org.kiwix.kiwixmobile.core.ui.theme.White
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.BACK_TO_TOP_HIDE_DELAY_MS
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_MESSAGE_TEXT_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_PROGRESSBAR_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_PROGRESS_CARD_VIEW_CONTENT_MARGIN
@@ -96,12 +112,14 @@ const val NO_CONTENT_VIEW_TEXT_TESTING_TAG = "noContentViewTextTestingTag"
 const val SHOW_FETCHING_LIBRARY_LAYOUT_TESTING_TAG = "showFetchingLibraryLayoutTestingTag"
 const val ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG = "onlineDividerItemTextTag"
 const val LOAD_MORE_DELAY = 150L
+private const val BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD = 200
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Suppress("ComposableLambdaParameterNaming", "LongParameterList")
 @Composable
 fun OnlineLibraryScreen(
   state: OnlineLibraryScreenState,
+  isBackToTopEnabled: Boolean,
   actionMenuItems: List<ActionMenuItem>,
   listState: LazyListState,
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
@@ -132,6 +150,11 @@ fun OnlineLibraryScreen(
           searchBar = searchBarIfActive(state)
         )
       },
+      floatingActionButton = {
+        if (isBackToTopEnabled) {
+          OnlineLibraryBackToTopButton(listState)
+        }
+      },
       modifier = Modifier
         .nestedScroll(scrollBehavior.nestedScrollConnection)
         .let { baseModifier ->
@@ -156,6 +179,53 @@ fun OnlineLibraryScreen(
         OnlineLibraryScreenContent(state, listState)
       }
     }
+  }
+}
+
+@Composable
+private fun OnlineLibraryBackToTopButton(listState: LazyListState) {
+  val coroutineScope = rememberCoroutineScope()
+  var shouldShowBackToTopButton by remember { mutableStateOf(false) }
+
+  LaunchedEffect(listState) {
+    var hideBackToTopJob: Job? = null
+    snapshotFlow {
+      listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset
+    }
+      .distinctUntilChanged()
+      .collect { (firstVisibleItemIndex, firstVisibleItemScrollOffset) ->
+        val shouldShowButton =
+          firstVisibleItemIndex > ZERO ||
+            firstVisibleItemScrollOffset > BACK_TO_TOP_SCROLL_OFFSET_THRESHOLD
+
+        hideBackToTopJob?.cancel()
+        if (shouldShowButton) {
+          shouldShowBackToTopButton = true
+          hideBackToTopJob = launch {
+            delay(BACK_TO_TOP_HIDE_DELAY_MS)
+            shouldShowBackToTopButton = false
+          }
+        } else {
+          shouldShowBackToTopButton = false
+        }
+      }
+  }
+
+  AnimatedVisibility(
+    visible = shouldShowBackToTopButton,
+    enter = fadeIn() + scaleIn(),
+    exit = fadeOut() + scaleOut()
+  ) {
+    KiwixFloatingActionButton(
+      icon = painterResource(id = org.kiwix.kiwixmobile.core.R.drawable.ic_arrow_upward_24dp),
+      onClick = {
+        coroutineScope.launch {
+          listState.animateScrollToItem(ZERO)
+        }
+      },
+      contentDescription = stringResource(string.pref_back_to_top),
+      shouldPulse = true
+    )
   }
 }
 

--- a/core/src/main/res/drawable/ic_add_blue_24dp.xml
+++ b/core/src/main/res/drawable/ic_add_blue_24dp.xml
@@ -1,10 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
   android:height="24dp"
-  android:tint="#448AFF"
   android:viewportHeight="24.0"
   android:viewportWidth="24.0"
   android:width="24dp">
   <path
     android:fillColor="#FF000000"
-    android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+    android:pathData="M20,13.5h-7.5V21h-3v-7.5H2v-3h7.5V3h3v7.5H20v3z" />
 </vector>


### PR DESCRIPTION
Fixes  #4742
Adds a "Back to Top" FAB in the Online Library screen.

- Appears when user scrolls down  
- Smoothly scrolls to top on click  
- Local Library: Moved the "Select ZIM file" (+) Floating Action Button (FAB) to the TopAppBar as a menu item.
- Back to Top: Implemented a "Back to Top" FAB in the Local Library that appears upon scrolling (threshold: 5 items),      matching the Online Library implementation.
- Consistency: Replaced the default FloatingActionButton with KiwixFloatingActionButton for unified theme usage.
- Tests: Updated OpeningFilesFromStorageTest to reflect the new TopAppBar menu item location.

https://github.com/user-attachments/assets/fb7fac75-318a-4273-a941-8799d25f2d5c



https://github.com/user-attachments/assets/febe0a58-4587-4873-8678-f8cbb4f1b093

