### PR TITLE
CI: change fail-fast to false in all matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34, 35, 36 ]
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -127,7 +127,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34, 35, 36 ]
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34, 35, 36 ]
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -305,7 +305,7 @@ jobs:
     strategy:
       matrix:
         api-level: [ 25, 30, 33, 34, 35, 36 ]
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
Fixes #4763 
Relates to #4724 

### What this does
Changes `fail-fast` from `true` to `false` in all 4 CI matrix 
job definitions in `ci.yml` (lines 16, 130, 219, 308).

### Why
All 4 jobs run a matrix across API levels [25, 30, 33, 34, 35, 36].
With `fail-fast: true`, a failure on any single API level 
immediately cancels all remaining levels.

This defeats the purpose of the matrix. If API 25 has a flaky 
test, we never find out whether API 34 has a completely different, 
real failure — such as a storage API change breaking downloads 
on newer Android versions.

Changing to `fail-fast: false` lets all 6 levels run to 
completion and report individually, giving full visibility into 
which Android versions are affected.

### Trade-off
A failing CI run will consume more Actions minutes since all 
levels run to completion. This cost is justified because the 
matrix exists specifically to surface API-level differences — 
partial results undermine that goal.

### Verified locally
```bash
grep -n "fail-fast" .github/workflows/ci.yml
16:      fail-fast: true
130:     fail-fast: true
219:     fail-fast: true
308:     fail-fast: true
```

### Related
#4724
