### PR TITLE
Fix flaky tests by removing launch/job wrapper from testFlow

### DIFF
--- a/app/src/test/java/org/kiwix/kiwixmobile/category/viewmodel/CategoryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/category/viewmodel/CategoryViewModelTest.kt
@@ -58,7 +58,6 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.State
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.State.Content
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.State.Loading
 import org.kiwix.kiwixmobile.zimManager.awaitItemOfType
-import org.kiwix.kiwixmobile.zimManager.testFlow
 import org.kiwix.sharedFunctions.InstantExecutorExtension
 import org.kiwix.sharedFunctions.category
 
@@ -138,14 +137,19 @@ class CategoryViewModelTest {
     }
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun `an empty categories emission does not send update action`() = runTest {
-    createViewModel()
-    testFlow(
-      categoryViewModel.actions,
-      triggerAction = { categories.emit(listOf()) },
-      assert = { expectNoEvents() }
-    )
+  fun `an empty categories emission does not send update action`() = flakyTest {
+    runTest {
+      createViewModel()
+      advanceUntilIdle()
+      categoryViewModel.actions.test {
+        categories.emit(listOf())
+        expectNoEvents()
+        cancelAndIgnoreRemainingEvents()
+        ensureAllEventsConsumed()
+      }
+    }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModelTest.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
+
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -695,15 +695,12 @@ suspend fun <T> TestScope.testFlow(
   assert: suspend TurbineTestContext<T>.() -> Unit,
   timeout: Duration? = null
 ) {
-  val job = launch {
-    flow.test(timeout = timeout) {
-      triggerAction()
-      assert()
-      cancelAndIgnoreRemainingEvents()
-      ensureAllEventsConsumed()
-    }
+  flow.test(timeout = timeout) {
+    triggerAction()
+    assert()
+    cancelAndIgnoreRemainingEvents()
+    ensureAllEventsConsumed()
   }
-  job.join()
 }
 
 suspend inline fun <reified T> ReceiveTurbine<*>.awaitItemOfType(): T {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -74,7 +74,6 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowDeleteSearchDialo
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowToast
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.StartSpeechInput
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
-import org.kiwix.kiwixmobile.core.utils.files.testFlow
 import org.kiwix.libzim.SuggestionSearch
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -390,4 +389,24 @@ internal class SearchViewModelTest {
     recentsFromDb.trySend(databaseResults).isSuccess
     viewModel.actions.trySend(ScreenWasStartedFrom(searchOrigin)).isSuccess
   }
+}
+
+/**
+ * Local testFlow that uses launch/job.join() because SearchViewModel
+ * uses debounce which requires concurrent coroutine execution.
+ */
+private suspend fun <T> TestScope.testFlow(
+  flow: kotlinx.coroutines.flow.Flow<T>,
+  triggerAction: suspend () -> Unit,
+  assert: suspend app.cash.turbine.TurbineTestContext<T>.() -> Unit
+) {
+  val job = launch {
+    flow.test {
+      triggerAction()
+      assert()
+      cancelAndIgnoreRemainingEvents()
+      ensureAllEventsConsumed()
+    }
+  }
+  job.join()
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
@@ -33,7 +33,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -179,13 +178,10 @@ suspend fun <T> TestScope.testFlow(
   triggerAction: suspend () -> Unit,
   assert: suspend TurbineTestContext<T>.() -> Unit
 ) {
-  val job = launch {
-    flow.test {
-      triggerAction()
-      assert()
-      cancelAndIgnoreRemainingEvents()
-      ensureAllEventsConsumed()
-    }
+  flow.test {
+    triggerAction()
+    assert()
+    cancelAndIgnoreRemainingEvents()
+    ensureAllEventsConsumed()
   }
-  job.join()
 }

--- a/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
+++ b/custom/src/test/java/org/kiwix/kiwixmobile/custom/download/CustomDownloadViewModelTest.kt
@@ -26,7 +26,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -253,15 +252,12 @@ suspend fun <T> TestScope.testFlow(
   triggerAction: suspend () -> Unit,
   assert: suspend TurbineTestContext<T>.() -> Unit
 ) {
-  val job = launch {
-    flow.test(timeout = TURBINE_TIMEOUT) {
-      triggerAction()
-      assert()
-      cancelAndIgnoreRemainingEvents()
-      ensureAllEventsConsumed()
-    }
+  flow.test(timeout = TURBINE_TIMEOUT) {
+    triggerAction()
+    assert()
+    cancelAndIgnoreRemainingEvents()
+    ensureAllEventsConsumed()
   }
-  job.join()
 }
 
 val TURBINE_TIMEOUT = 5000.toDuration(DurationUnit.MILLISECONDS)


### PR DESCRIPTION
fix #4779 

fix: improve test reliability by refactoring testFlow

- Removed manual coroutine (launch/job) usage for synchronous flow testing  
- Standardized Turbine usage across tests  
- Added concurrent testFlow for SearchViewModelTest (handles debounce)  
- Used advanceUntilIdle() where needed to stabilize tests  

### Files Updated
- ZimManageViewModelTest  
- FileSearchTest  
- CustomDownloadViewModelTest  
- CategoryViewModelTest  
- SearchViewModelTest  