### PR TITLE
Eliminate hardcoded StandardTestDispatchers, UnconfinedTestDispatchers with I.O Rule and Dispatchers.Main with Main Rule

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,11 +124,6 @@ android {
       enableSplit = false
     }
   }
-  sourceSets {
-    getByName("androidTest") {
-      java.srcDirs("$rootDir/core/src/sharedTestFunctions/java")
-    }
-  }
   // By default, Android generates dependency metadata (a file containing information
   // about all the dependencies used in the project) and includes it in both APKs and app bundles.
   // This metadata is particularly useful for the Google Play Store, as it provides actionable

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -62,7 +62,8 @@ abstract class BaseActivityTest {
       arrayOf(POST_NOTIFICATIONS, NEARBY_WIFI_DEVICES)
     }
 
-  @get:Rule
+  @Rule
+  @JvmField
   var permissionRules: GrantPermissionRule = GrantPermissionRule.grant(*permissions())
 
   val context: Context by lazy {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -43,7 +43,8 @@ import org.kiwix.kiwixmobile.core.utils.datastore.SharedPreferenceToDatastoreMig
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
 class SharedPreferenceToDatastoreMigratorTest : BaseActivityTest() {
-  @get:Rule
+  @Rule
+  @JvmField
   val tmpFolder = TemporaryFolder()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -63,7 +63,8 @@ class DeepLinksTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -54,7 +54,8 @@ class DownloadServiceTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -62,7 +62,8 @@ class DownloadTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
@@ -40,7 +40,8 @@ class ErrorActivityTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
@@ -40,7 +40,8 @@ class HelpScreenRouteTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -44,7 +44,8 @@ class InitialDownloadTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
@@ -43,7 +43,8 @@ class LanguageScreenTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -42,7 +42,8 @@ class LocalFileTransferTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -54,11 +54,14 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
 
-  @get:Rule
-  private val dispatcher = MainDispatcherRule()
+  @Rule
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var selectedFile: File
   private lateinit var parentFile: File

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -46,7 +46,6 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
-import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 
 class CopyMoveFileHandlerTest : BaseActivityTest() {
@@ -57,10 +56,6 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
   @Rule(order = COMPOSE_TEST_RULE_ORDER)
   @JvmField
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
-
-  @Rule
-  @JvmField
-  val mainDispatcherRule = MainDispatcherRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var selectedFile: File

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -59,7 +59,8 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private val fileName = "testzim.zim"

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -51,7 +51,8 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var parentFile: File

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -36,7 +36,8 @@ class TopLevelDestinationTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -47,7 +47,8 @@ class LocalLibraryTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
@@ -38,7 +38,8 @@ class OnlineLibraryScreenTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteScreenTest.kt
@@ -48,7 +48,8 @@ class NoteScreenTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
@@ -38,7 +38,8 @@ class OnlineCategoryTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -61,7 +61,8 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createAndroidComposeRule<KiwixMainActivity>()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -45,7 +45,8 @@ class NavigationHistoryTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
@@ -41,7 +41,8 @@ class DonationDialogTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -61,7 +61,6 @@ import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.ui.KiwixDestination
-import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -73,9 +72,6 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
 
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
-
-  @get:Rule
-  private val dispatcher = MainDispatcherRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private val rayCharlesZimFileUrl =
     "https://dev.kiwix.org/kiwix-android/test/wikipedia_en_ray_charles_maxi_2023-12.zim"

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -61,6 +61,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.ui.KiwixDestination
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -73,6 +74,8 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
 
+  @get:Rule
+  private val dispatcher = MainDispatcherRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private val rayCharlesZimFileUrl =
     "https://dev.kiwix.org/kiwix-android/test/wikipedia_en_ray_charles_maxi_2023-12.zim"

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -327,7 +327,9 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       }
     }
     val saveHandler = KiwixWebView.SaveHandler(
-      kiwixWebView.zimReaderContainer
+      kiwixWebView.zimReaderContainer,
+      kiwixWebView.mainDispatcher,
+      kiwixWebView.ioDispatcher
     )
 
     // Must run on main thread because Handler uses MainLooper

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -70,7 +70,8 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private val rayCharlesZimFileUrl =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -52,7 +52,8 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
@@ -59,7 +59,8 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
@@ -40,7 +40,8 @@ class KiwixSettingsScreenTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
@@ -44,7 +44,8 @@ class GetContentShortcutTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   lateinit var kiwixMainActivity: KiwixMainActivity
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -43,7 +43,8 @@ class KiwixSplashActivityTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   @Before

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
@@ -50,7 +50,8 @@ class ZimHostScreenInstrumentTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -41,7 +41,8 @@ class SearchWidgetTest : BaseActivityTest() {
   @JvmField
   val retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/data/remote/OnlineLibraryManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/data/remote/OnlineLibraryManager.kt
@@ -117,10 +117,7 @@ class OnlineLibraryManager @Inject constructor(
    */
   fun getStartOffset(pageIndex: Int, pageSize: Int): Int = pageIndex * pageSize
 
-  private suspend fun extractTotalResults(
-    xml: String,
-    dispatcher: CoroutineDispatcher = ioDispatcher
-  ): Int = withContext(dispatcher) {
+  private suspend fun extractTotalResults(xml: String): Int = withContext(ioDispatcher) {
     val factory = XmlPullParserFactory.newInstance()
     val parser = factory.newPullParser()
     parser.setInput(StringReader(xml))

--- a/app/src/main/java/org/kiwix/kiwixmobile/data/remote/OnlineLibraryManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/data/remote/OnlineLibraryManager.kt
@@ -20,8 +20,8 @@ package org.kiwix.kiwixmobile.data.remote
 
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService.Companion.OPDS_LIBRARY_ENDPOINT
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.utils.ZERO
@@ -32,7 +32,9 @@ import org.xmlpull.v1.XmlPullParserFactory
 import java.io.StringReader
 import javax.inject.Inject
 
-class OnlineLibraryManager @Inject constructor() {
+class OnlineLibraryManager @Inject constructor(
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
   var totalResult = ZERO
   suspend fun parseOPDSStreamAndGetBooks(
     content: String?,
@@ -117,7 +119,7 @@ class OnlineLibraryManager @Inject constructor() {
 
   private suspend fun extractTotalResults(
     xml: String,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    dispatcher: CoroutineDispatcher = ioDispatcher
   ): Int = withContext(dispatcher) {
     val factory = XmlPullParserFactory.newInstance()
     val parser = factory.newPullParser()

--- a/app/src/main/java/org/kiwix/kiwixmobile/di/modules/ServiceModule.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/di/modules/ServiceModule.kt
@@ -25,21 +25,12 @@ import dagger.Module
 import dagger.Provides
 import org.kiwix.kiwixmobile.core.qr.GenerateQR
 import org.kiwix.kiwixmobile.di.ServiceScope
-import org.kiwix.kiwixmobile.webserver.KiwixServer
-import org.kiwix.kiwixmobile.webserver.WebServerHelper
 import org.kiwix.kiwixmobile.webserver.wifi_hotspot.HotspotNotificationManager
 import org.kiwix.kiwixmobile.webserver.wifi_hotspot.HotspotStateReceiver
 import org.kiwix.kiwixmobile.webserver.wifi_hotspot.IpAddressCallbacks
 
 @Module
 class ServiceModule {
-  @Provides
-  @ServiceScope
-  fun providesWebServerHelper(
-    kiwixServerFactory: KiwixServer.Factory,
-    ipAddressCallbacks: IpAddressCallbacks
-  ): WebServerHelper = WebServerHelper(kiwixServerFactory, ipAddressCallbacks)
-
   @Provides
   @ServiceScope
   fun providesIpAddressCallbacks(service: Service): IpAddressCallbacks =

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/PeerGroupHandshake.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/PeerGroupHandshake.kt
@@ -19,7 +19,7 @@ package org.kiwix.kiwixmobile.localFileTransfer
 
 import android.net.wifi.p2p.WifiP2pInfo
 import org.kiwix.kiwixmobile.core.utils.files.Log
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import java.io.InputStream
@@ -42,12 +42,14 @@ import java.net.Socket
  * After obtaining the IP address, the sender also shares metadata regarding the file transfer
  * (no. of files & their names) with the receiver.
  */
-abstract class PeerGroupHandshake(private var groupInfo: WifiP2pInfo) {
+abstract class PeerGroupHandshake(
+  private var groupInfo: WifiP2pInfo,
+  private val ioDispatcher: CoroutineDispatcher
+) {
   private val handshakeMessage = "Request Kiwix File Sharing"
 
-  @Suppress("InjectDispatcher")
   suspend fun handshake(): InetAddress? =
-    withContext(Dispatchers.IO) {
+    withContext(ioDispatcher) {
       Log.d(TAG, "Handshake in progress")
       when {
         groupInfo.groupFormed && groupInfo.isGroupOwner && isActive ->

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverDevice.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverDevice.kt
@@ -17,10 +17,10 @@
  */
 package org.kiwix.kiwixmobile.localFileTransfer
 
-import org.kiwix.kiwixmobile.core.utils.files.Log
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.localFileTransfer.WifiDirectManager.Companion.copyToOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -37,11 +37,14 @@ import java.net.ServerSocket
  * A single Task is used for the entire file transfer (the server socket accepts connections as
  * many times as the no. of files).
  */
-internal class ReceiverDevice(private val wifiDirectManager: WifiDirectManager) {
-  @Suppress("InjectDispatcher")
+internal class ReceiverDevice(
+  private val wifiDirectManager: WifiDirectManager,
+  val ioDispatcher: CoroutineDispatcher,
+  private val mainDispatcher: CoroutineDispatcher
+) {
   suspend fun receive(): Boolean {
     return try {
-      withContext(Dispatchers.IO) {
+      withContext(ioDispatcher) {
         ServerSocket(WifiDirectManager.fileTransferPort).use { serverSocket ->
           Log.d(TAG, "Server: Socket opened at " + WifiDirectManager.fileTransferPort)
           val zimStorageRootPath = wifiDirectManager.zimStorageRootPath()
@@ -92,7 +95,7 @@ internal class ReceiverDevice(private val wifiDirectManager: WifiDirectManager) 
     fileIndex: Int,
     fileStatus: FileItem.FileStatus
   ) {
-    withContext(Dispatchers.Main) {
+    withContext(mainDispatcher) {
       wifiDirectManager.changeStatus(fileIndex, fileStatus)
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverHandShake.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverHandShake.kt
@@ -19,13 +19,17 @@
 package org.kiwix.kiwixmobile.localFileTransfer
 
 import android.net.wifi.p2p.WifiP2pInfo
+import kotlinx.coroutines.CoroutineDispatcher
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.InputStream
 import java.io.ObjectInputStream
 import java.io.OutputStream
 
-class ReceiverHandShake(private val wifiDirectManager: WifiDirectManager, groupInfo: WifiP2pInfo) :
-  PeerGroupHandshake(groupInfo) {
+class ReceiverHandShake(
+  private val wifiDirectManager: WifiDirectManager,
+  groupInfo: WifiP2pInfo,
+  ioDispatcher: CoroutineDispatcher
+) : PeerGroupHandshake(groupInfo, ioDispatcher) {
   companion object {
     private const val TAG = "ReceiverHandshake"
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/SenderDevice.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/SenderDevice.kt
@@ -18,11 +18,13 @@
 package org.kiwix.kiwixmobile.localFileTransfer
 
 import android.content.Context
-import org.kiwix.kiwixmobile.core.utils.files.Log
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.localFileTransfer.WifiDirectManager.Companion.copyToOutputStream
 import java.io.IOException
 import java.net.InetAddress
@@ -46,11 +48,12 @@ private const val TIME_OUT = 15000
 internal class SenderDevice(
   private val context: Context,
   private val wifiDirectManager: WifiDirectManager,
-  private val fileReceiverDeviceAddress: InetAddress
+  private val fileReceiverDeviceAddress: InetAddress,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+  @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) {
-  @Suppress("InjectDispatcher")
   suspend fun send(fileItems: List<FileItem?>) =
-    withContext(Dispatchers.IO) {
+    withContext(ioDispatcher) {
       // Delay trying to connect with receiver, to allow slow receiver devices to setup server
       delay(FOR_SLOW_RECEIVER)
       val hostAddress = fileReceiverDeviceAddress.hostAddress
@@ -94,7 +97,7 @@ internal class SenderDevice(
     fileIndex: Int,
     fileStatus: FileItem.FileStatus
   ) {
-    withContext(Dispatchers.Main) {
+    withContext(mainDispatcher) {
       wifiDirectManager.changeStatus(fileIndex, fileStatus)
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/SenderHandShake.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/SenderHandShake.kt
@@ -19,13 +19,17 @@
 package org.kiwix.kiwixmobile.localFileTransfer
 
 import android.net.wifi.p2p.WifiP2pInfo
+import kotlinx.coroutines.CoroutineDispatcher
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.InputStream
 import java.io.ObjectOutputStream
 import java.io.OutputStream
 
-class SenderHandShake(private val wifiDirectManager: WifiDirectManager, groupInfo: WifiP2pInfo) :
-  PeerGroupHandshake(groupInfo) {
+class SenderHandShake(
+  private val wifiDirectManager: WifiDirectManager,
+  groupInfo: WifiP2pInfo,
+  ioDispatcher: CoroutineDispatcher
+) : PeerGroupHandshake(groupInfo, ioDispatcher) {
   override fun exchangeFileTransferMetadata(inputStream: InputStream, outputStream: OutputStream) {
     try {
       ObjectOutputStream(outputStream).use { objectOutputStream ->

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -38,10 +38,13 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Looper.getMainLooper
 import android.widget.Toast
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -62,7 +65,9 @@ import javax.inject.Inject
 class WifiDirectManager @Inject constructor(
   private val context: Context,
   private val kiwixDataStore: KiwixDataStore,
-  private val manager: WifiP2pManager?
+  private val manager: WifiP2pManager?,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+  @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) : ChannelListener, PeerListListener, ConnectionInfoListener, P2pEventListener {
   var callbacks: Callbacks? = null
 
@@ -274,13 +279,14 @@ class WifiDirectManager @Inject constructor(
         val fileReceiverDeviceAddress =
           if (groupInfo.isGroupOwner) inetAddress else groupInfo.groupOwnerAddress
         context.toast(R.string.preparing_files, Toast.LENGTH_LONG)
-        val senderDevice = SenderDevice(context, this, fileReceiverDeviceAddress)
+        val senderDevice =
+          SenderDevice(context, this, fileReceiverDeviceAddress, ioDispatcher, mainDispatcher)
         val isFileSendSuccessfully = senderDevice.send(filesForTransfer)
         onFileTransferAsyncTaskComplete(isFileSendSuccessfully)
         Log.d(TAG, "SenderDevice completed $isFileSendSuccessfully")
       } else {
         callbacks?.onFilesForTransferAvailable(filesForTransfer)
-        val receiverDevice = ReceiverDevice(this)
+        val receiverDevice = ReceiverDevice(this, ioDispatcher, mainDispatcher)
         val isReceivedFileSuccessFully = receiverDevice.receive()
         onFileTransferAsyncTaskComplete(isReceivedFileSuccessFully)
         Log.d(TAG, "ReceiverDevice completed $isReceivedFileSuccessFully")

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/WifiDirectManager.kt
@@ -246,9 +246,9 @@ class WifiDirectManager @Inject constructor(
     lifecycleCoroutineScope.launch {
       val peerGroupHandshake =
         if (isFileSender) {
-          SenderHandShake(this@WifiDirectManager, groupInfo)
+          SenderHandShake(this@WifiDirectManager, groupInfo, ioDispatcher)
         } else {
-          ReceiverHandShake(this@WifiDirectManager, groupInfo)
+          ReceiverHandShake(this@WifiDirectManager, groupInfo, ioDispatcher)
         }
       val inetAddress = peerGroupHandshake.handshake()
       if (inetAddress != null) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -278,7 +278,7 @@ class KiwixMainActivity : CoreMainActivity() {
    */
   suspend fun getStorageDeviceList(): List<StorageDevice> {
     if (storageDeviceList.isEmpty()) {
-      storageDeviceList.addAll(StorageDeviceUtils.getWritableStorage(this))
+      storageDeviceList.addAll(StorageDeviceUtils.getWritableStorage(this, ioDispatcher))
     }
     return storageDeviceList
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -21,8 +21,6 @@ package org.kiwix.kiwixmobile.main
 import android.app.NotificationManager
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -52,8 +50,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageDeviceUtils
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -69,6 +67,7 @@ import org.kiwix.kiwixmobile.core.R.mipmap
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_NOTIFICATION_ID
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_NOTIFICATION_TITLE
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_TIMEOUT_RESUME_INTENT
@@ -104,6 +103,10 @@ class KiwixMainActivity : CoreMainActivity() {
   override val searchFragmentRoute: String = KiwixDestination.Search.route
 
   @Inject lateinit var libkiwixBookOnDisk: LibkiwixBookOnDisk
+
+  @Inject
+  @MainDispatcher
+  lateinit var mainDispatcher: CoroutineDispatcher
 
   @Inject
   lateinit var kiwixDataStore: KiwixDataStore
@@ -197,14 +200,13 @@ class KiwixMainActivity : CoreMainActivity() {
     }
   }
 
-  @Suppress("InjectDispatcher")
   private fun runMigrations() {
     lifecycleScope.launch {
       migrateInternalToPublicAppDirectory()
       migratedToPerAppLanguage()
     }
     // run the migration on background thread to avoid any UI related issues.
-    CoroutineScope(Dispatchers.IO).launch {
+    CoroutineScope(ioDispatcher).launch {
       (applicationContext as KiwixApp).kiwixComponent
         .provideObjectBoxDataMigrationHandler()
         .migrate()
@@ -322,10 +324,11 @@ class KiwixMainActivity : CoreMainActivity() {
       when (it.scheme) {
         "file",
         "content" -> {
-          Handler(Looper.getMainLooper()).postDelayed({
+          lifecycleScope.launch(mainDispatcher) {
+            delay(OPENING_ZIM_FILE_DELAY)
             openLocalLibraryWithZimFilePath("$it")
             clearIntentDataAndAction()
-          }, OPENING_ZIM_FILE_DELAY)
+          }
         }
 
         "zim" -> {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/CopyMoveProgressBarControllerImpl.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/CopyMoveProgressBarControllerImpl.kt
@@ -34,9 +34,10 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.ProgressBarStyle
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.COPY_MOVE_DIALOG_TITLE_TEXT_SIZE
@@ -50,7 +51,8 @@ import org.kiwix.kiwixmobile.nav.destination.library.COPY_MOVE_DIALOG_TITLE_TEST
 import javax.inject.Inject
 
 class CopyMoveProgressBarControllerImpl @Inject constructor(
-  private val context: Context
+  private val context: Context,
+  @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) : CopyMoveProgressBarController {
   /**
    * Holds the state for the copy/move progress bar.
@@ -117,9 +119,8 @@ class CopyMoveProgressBarControllerImpl @Inject constructor(
     }
   }
 
-  @Suppress("InjectDispatcher")
   override suspend fun updateProgress(progress: Int) {
-    withContext(Dispatchers.Main) {
+    withContext(mainDispatcher) {
       progressBarState.value =
         context.getString(R.string.percentage, progress) to progress
     }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModel.kt
@@ -340,7 +340,12 @@ class LocalLibraryViewModel @Inject constructor(
       is RequestReadWritePermission -> None // We handle this on UI.
       ReadPermissionDialog -> ReadPermissionRequiredDialog(alertDialogShower)
       RequestValidateZimFiles ->
-        ValidateZIMFiles(selectionsFromState(), alertDialogShower, validateZimViewModel)
+        ValidateZIMFiles(
+          selectionsFromState(),
+          alertDialogShower,
+          validateZimViewModel,
+          ioDispatcher
+        )
 
       ManageFilesPermissionDialog ->
         if (kiwixPermissionChecker.isAndroid11OrAbove()) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderFragment.kt
@@ -19,8 +19,6 @@
 package org.kiwix.kiwixmobile.nav.destination.reader
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
@@ -28,6 +26,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavOptions
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.kiwix.kiwixmobile.cachedComponent
@@ -163,11 +162,10 @@ class KiwixReaderFragment : CoreReaderFragment() {
   override fun openHomeScreen() {
     runSafelyInCoreReaderLifecycleScope {
       // Run safely because it is runs after 300 MS.
-      Handler(Looper.getMainLooper()).postDelayed({
-        if (webViewList.isEmpty()) {
-          hideTabSwitcher(false)
-        }
-      }, OPEN_HOME_SCREEN_DELAY)
+      delay(OPEN_HOME_SCREEN_DELAY)
+      if (webViewList.isEmpty()) {
+        hideTabSwitcher(false)
+      }
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/KiwixServer.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/KiwixServer.kt
@@ -19,8 +19,9 @@
 package org.kiwix.kiwixmobile.webserver
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.getDemoFilePathForBrandedApp
@@ -43,11 +44,12 @@ class KiwixServer @Inject constructor(
 ) {
   class Factory @Inject constructor(
     private val context: Context,
-    private val zimReaderContainer: ZimReaderContainer
+    private val zimReaderContainer: ZimReaderContainer,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
   ) {
     @Suppress("NestedBlockDepth", "InjectDispatcher")
     suspend fun createKiwixServer(selectedBooksPath: ArrayList<String>): KiwixServer =
-      withContext(Dispatchers.IO) {
+      withContext(ioDispatcher) {
         val kiwixLibrary = Library()
         selectedBooksPath.forEach { path ->
           try {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
@@ -17,6 +17,7 @@
  */
 package org.kiwix.kiwixmobile.webserver
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -28,6 +29,8 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.timeout
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.utils.DEFAULT_PORT
 import org.kiwix.kiwixmobile.core.utils.ServerUtils
 import org.kiwix.kiwixmobile.core.utils.ServerUtils.INVALID_IP
@@ -50,7 +53,9 @@ const val FINDING_IP_ADDRESS_RETRY_TIME = 1_000L
 
 class WebServerHelper @Inject constructor(
   private val kiwixServerFactory: KiwixServer.Factory,
-  private val ipAddressCallbacks: IpAddressCallbacks
+  private val ipAddressCallbacks: IpAddressCallbacks,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+  @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) {
   private var kiwixServer: KiwixServer? = null
   private var isServerStarted = false
@@ -120,9 +125,8 @@ class WebServerHelper @Inject constructor(
    * - Automatically cancels if [serviceScope] is cancelled (e.g. lifecycle aware).
    */
   @OptIn(FlowPreview::class)
-  @Suppress("InjectDispatcher")
   fun pollForValidIpAddress(serviceScope: CoroutineScope) {
-    serviceScope.launch(Dispatchers.Main) {
+    serviceScope.launch(mainDispatcher) {
       ipPollingFlow()
         .timeout(FINDING_IP_ADDRESS_TIMEOUT.seconds)
         .catch {
@@ -140,7 +144,7 @@ class WebServerHelper @Inject constructor(
    * - If the returned IP is not [INVALID_IP], the flow completes.
    * - The flow runs entirely on [Dispatchers.IO].
    */
-  @Suppress("InjectDispatcher", "TooGenericExceptionCaught")
+  @Suppress("TooGenericExceptionCaught")
   private fun ipPollingFlow(): Flow<String?> = flow {
     while (true) {
       // if ip address is not found wait for 1 second to again getting the ip address.
@@ -156,7 +160,7 @@ class WebServerHelper @Inject constructor(
 
       if (ip != INVALID_IP) break
     }
-  }.flowOn(Dispatchers.IO)
+  }.flowOn(ioDispatcher)
 
   companion object {
     private const val TAG = "WebServerHelper"

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
@@ -24,7 +24,6 @@ import android.os.IBinder
 import android.widget.Toast
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -32,6 +31,7 @@ import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.KiwixApp
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.registerReceiver
 import org.kiwix.kiwixmobile.core.utils.ServerUtils.serverAddress
 import org.kiwix.kiwixmobile.webserver.RESTART_SERVER
@@ -61,7 +61,12 @@ class HotspotService :
   @Inject
   @IoDispatcher
   lateinit var ioDispatcher: CoroutineDispatcher
-  private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+  @Inject
+  @MainDispatcher
+  lateinit var mainDispatcher: CoroutineDispatcher
+
+  private lateinit var serviceScope: CoroutineScope
 
   private var zimHostCallbacks: ZimHostCallbacks? = null
   private val serviceBinder: IBinder = HotspotBinder(this)
@@ -73,6 +78,7 @@ class HotspotService :
       .build()
       .inject(this)
     super.onCreate()
+    serviceScope = CoroutineScope(SupervisorJob() + mainDispatcher)
     hotspotStateReceiver?.let(::registerReceiver)
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFiles.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteZims
@@ -35,7 +36,7 @@ data class DeleteFiles(
   private val dialogShower: DialogShower,
   private val deleteFilesUseCase: DeleteFilesUseCase,
   private val viewModelScope: CoroutineScope,
-  private val ioDispatcher: CoroutineDispatcher
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     dialogShower.show(

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFiles.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFiles.kt
@@ -25,11 +25,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.cachedComponent
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
@@ -43,11 +40,10 @@ import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListIte
 data class ValidateZIMFiles(
   private val booksOnDiskListItems: List<BookOnDisk>,
   private val dialogShower: DialogShower,
-  private val validateZimViewModel: ValidateZimViewModel
+  private val validateZimViewModel: ValidateZimViewModel,
+  private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    (activity as BaseActivity).cachedComponent.inject(this)
-
     val name = booksOnDiskListItems.joinToString(separator = "\n") { it.book.title }
     dialogShower.show(ValidateZimFilesConfirmation(name), {
       startValidatingZimFiles(booksOnDiskListItems, validateZimViewModel, dialogShower)
@@ -57,10 +53,9 @@ data class ValidateZIMFiles(
   private fun startValidatingZimFiles(
     booksOnDiskListItems: List<BookOnDisk>,
     validateZimViewModel: ValidateZimViewModel,
-    dialogShower: DialogShower,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    dialogShower: DialogShower
   ) {
-    CoroutineScope(dispatcher).launch {
+    CoroutineScope(ioDispatcher).launch {
       validateZimViewModel.startValidation(booksOnDiskListItems, false)
     }
     dialogShower.show(

--- a/app/src/test/java/org/kiwix/kiwixmobile/language/LanguageScreenUITest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/language/LanguageScreenUITest.kt
@@ -57,7 +57,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class LanguageScreenUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/LanguageViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/language/viewmodel/LanguageViewModelTest.kt
@@ -53,7 +53,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 @OptIn(ExperimentalCoroutinesApi::class)
 class LanguageViewModelTest {
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private val application: Application = mockk(relaxed = true)
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val kiwixService: KiwixService = mockk()
@@ -69,7 +70,7 @@ class LanguageViewModelTest {
         kiwixDataStore,
         kiwixService,
         connectivityBroadcastReceiver,
-        ioDispatcher.dispatcher
+        mainDispatcherRule.dispatcher
       )
   }
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferScreenTest.kt
@@ -45,7 +45,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class LocalFileTransferScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferViewModelTest.kt
@@ -47,6 +47,7 @@ class LocalFileTransferViewModelTest {
   private lateinit var viewModel: LocalFileTransferViewModel
 
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
 
   @BeforeEach

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -78,7 +78,9 @@ class CopyMoveFileHandlerTest {
   private val copyMoveProgressBarController = mockk<CopyMoveProgressBarController>(relaxed = true)
 
   @RegisterExtension
-  private val dispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+
   private lateinit var fileHandler: CopyMoveFileHandler
 
   private var storageFile: File = File(System.getProperty("java.io.tmpdir"))
@@ -98,7 +100,7 @@ class CopyMoveFileHandlerTest {
       fat32Checker = fat32Checker,
       fileOperationHandler = fileOperationHandler,
       copyMoveProgressBarController = copyMoveProgressBarController,
-      mainDispatcher = dispatcher.dispatcher
+      mainDispatcher = mainDispatcherRule.dispatcher
     )
 
     fileHandler.setStorageFileForUnitTest(storageFile)

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -29,12 +29,9 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
-import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -49,7 +46,6 @@ import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.nav.destination.library.local.ProcessSelectedZimFilesForStandalone
 import org.kiwix.kiwixmobile.nav.destination.library.local.SelectedZimFileCallback
 import java.io.File
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ProcessSelectedZimFilesForStandaloneTest {
@@ -58,18 +54,11 @@ class ProcessSelectedZimFilesForStandaloneTest {
   private val activity: Activity = mockk(relaxed = true)
   private val selectedZimFileCallback: SelectedZimFileCallback = mockk(relaxed = true)
 
-  private lateinit var testDispatcher: TestDispatcher
-  private lateinit var testScope: TestScope
-
   @BeforeEach
   fun setup() {
-    clearAllMocks()
     mockkStatic("org.kiwix.kiwixmobile.core.extensions.ContextExtensionsKt")
     mockkStatic(FileUtils::class)
     mockkStatic("org.kiwix.kiwixmobile.core.extensions.FileExtensionsKt")
-
-    testDispatcher = StandardTestDispatcher()
-    testScope = TestScope(testDispatcher)
 
     processSelectedZimFiles = ProcessSelectedZimFilesForStandalone(
       kiwixDataStore,
@@ -80,7 +69,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @Test
   fun `canHandleUris should return true when not play store build with android 11 or above`() =
-    testScope.runTest {
+    runTest {
       coEvery { kiwixDataStore.isPlayStoreBuildWithAndroid11OrAbove() } returns false
 
       val result = processSelectedZimFiles.canHandleUris()
@@ -90,7 +79,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @Test
   fun `canHandleUris should return false when play store build with android 11 or above`() =
-    testScope.runTest {
+    runTest {
       coEvery { kiwixDataStore.isPlayStoreBuildWithAndroid11OrAbove() } returns true
 
       val result = processSelectedZimFiles.canHandleUris()
@@ -100,7 +89,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @Test
   fun `processSelectedFiles should call navigateToReaderFragment for valid single file`() =
-    testScope.runTest {
+    runTest {
       val uri = createValidUri()
 
       coEvery { selectedZimFileCallback.navigateToReaderFragment(any()) } just Runs
@@ -111,7 +100,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
     }
 
   @Test
-  fun `processSelectedFiles should show toast when file is invalid`() = testScope.runTest {
+  fun `processSelectedFiles should show toast when file is invalid`() = runTest {
     val uri = mockk<Uri>()
     val filePath = "/storage/emulated/0/test.jpg"
 
@@ -127,7 +116,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
   }
 
   @Test
-  fun `processSelectedFiles should show toast when file not found`() = testScope.runTest {
+  fun `processSelectedFiles should show toast when file not found`() = runTest {
     val uri = mockk<Uri>()
 
     coEvery { FileUtils.getLocalFilePathByUri(any(), uri) } returns null
@@ -144,7 +133,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
   }
 
   @Test
-  fun `processSelectedFiles should add multiple valid files to library`() = testScope.runTest {
+  fun `processSelectedFiles should add multiple valid files to library`() = runTest {
     val uri1 = createValidUri("content://test1", "/storage/emulated/0/test1.zim")
     val uri2 = createValidUri("content://test2", "/storage/emulated/0/test2.zim")
 
@@ -163,7 +152,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @Test
   fun `processSelectedFiles should show error dialog for invalid file in multiple selection`() =
-    testScope.runTest {
+    runTest {
       val invalidUri = createValidUri("content://invalid", "/storage/emulated/0/test.jpg")
       val validUri = createValidUri("content://valid", "/storage/emulated/0/test.zim")
 
@@ -185,7 +174,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @Test
   fun `processMultipleFiles should continue with next file after error dialog callback`() =
-    testScope.runTest {
+    runTest {
       val invalidUri = createValidUri("content://invalid", "/storage/emulated/0/test.jpg")
       val validUri = createValidUri("content://valid", "/storage/emulated/0/test.zim")
       val callbackSlot = slot<suspend () -> Unit>()
@@ -216,7 +205,7 @@ class ProcessSelectedZimFilesForStandaloneTest {
 
   @AfterEach
   fun tearDown() {
-    unmockkAll()
+    clearAllMocks()
   }
 
   private fun createValidUri(

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineCategoryDialogScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineCategoryDialogScreenTest.kt
@@ -56,7 +56,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class OnlineCategoryDialogScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeRule = createComposeRule()
 
   private lateinit var viewModel: CategoryViewModel

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/FileOperationHandlerImplTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/FileOperationHandlerImplTest.kt
@@ -52,7 +52,8 @@ class FileOperationHandlerImplTest {
   private val context: Context = mockk()
 
   @RegisterExtension
-  private val dispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   private val contentResolver: ContentResolver = mockk()
   private val selectedFile: DocumentFile = mockk()
@@ -73,7 +74,7 @@ class FileOperationHandlerImplTest {
     every { destinationFile.path } returns "parent/test"
     mockkStatic(DocumentsContract::class)
 
-    fileOperationHandler = FileOperationHandlerImpl(context, dispatcher.dispatcher)
+    fileOperationHandler = FileOperationHandlerImpl(context, mainDispatcherRule.dispatcher)
   }
 
   @AfterEach

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreenTest.kt
@@ -58,7 +58,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class LocalLibraryScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModelTest.kt
@@ -77,7 +77,8 @@ class LocalLibraryViewModelTest {
   private val snackBarHostState: SnackbarHostState = mockk(relaxed = true)
 
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   private val testDispatcher get() = mainDispatcherRule.dispatcher
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/ShowFileCopyMoveErrorDialogTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/ShowFileCopyMoveErrorDialogTest.kt
@@ -47,7 +47,8 @@ class ShowFileCopyMoveErrorDialogTest {
   private lateinit var testScope: TestScope
 
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @Before
   fun setup() {

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/ShowFileSystemScanDialogTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/ShowFileSystemScanDialogTest.kt
@@ -46,7 +46,8 @@ class ShowFileSystemScanDialogTest {
   private val activity: AppCompatActivity = mockk(relaxed = true)
 
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private lateinit var testScope: TestScope
 
   @Before

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/DownloadBookItemUITest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/DownloadBookItemUITest.kt
@@ -57,7 +57,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class DownloadBookItemUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val testIndex = 0

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineBookItemUITest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineBookItemUITest.kt
@@ -63,7 +63,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class OnlineBookItemUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreenTest.kt
@@ -63,7 +63,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class OnlineLibraryScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryItemsTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryItemsTest.kt
@@ -48,6 +48,7 @@ class ObserveOnlineLibraryItemsTest {
   private val fat32Checker: Fat32Checker = mockk()
 
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
 
   private lateinit var observeOnlineLibraryItems: ObserveOnlineLibraryItems

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/repository/OnlineLibraryRepositoryImplTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/repository/OnlineLibraryRepositoryImplTest.kt
@@ -45,6 +45,7 @@ import retrofit2.Response
 @OptIn(ExperimentalCoroutinesApi::class)
 class OnlineLibraryRepositoryImplTest {
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
   private val onlineLibraryManager: OnlineLibraryManager = mockk()
   private val kiwixService: KiwixService = mockk()

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/CategoryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/CategoryViewModelTest.kt
@@ -59,6 +59,7 @@ class CategoryViewModelTest {
   private val connectivityBroadcastReceiver: ConnectivityBroadcastReceiver = mockk()
 
   @RegisterExtension
+  @JvmField
   val mainDispatcher = MainDispatcherRule()
   private val networkStates = MutableStateFlow(NetworkState.CONNECTED)
   private lateinit var categoryViewModel: CategoryViewModel

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -101,6 +101,7 @@ import javax.inject.Provider
 @OptIn(ExperimentalCoroutinesApi::class)
 class OnlineLibraryViewModelTest {
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
   private val downloader: Downloader = mockk(relaxed = true)
   private val downloaderProvider: Provider<Downloader> = mockk(relaxed = true)

--- a/app/src/test/java/org/kiwix/kiwixmobile/storage/StorageSelectDialogScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/storage/StorageSelectDialogScreenTest.kt
@@ -39,7 +39,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class StorageSelectDialogScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeRule = createComposeRule()
   private val storageCalculator = mockk<StorageCalculator>(relaxed = true)
   private val kiwixDataStore = mockk<KiwixDataStore>(relaxed = true)

--- a/app/src/test/java/org/kiwix/kiwixmobile/ui/BookItemUITest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/ui/BookItemUITest.kt
@@ -51,7 +51,8 @@ import java.io.File
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class BookItemUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenTest.kt
@@ -48,7 +48,8 @@ import org.kiwix.kiwixmobile.core.R as CoreR
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class ZimHostScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModelTest.kt
@@ -55,7 +55,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ZimHostViewModelTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val mainDispatcherRule = MainDispatcherRule()
 
   private val context: Application = mockk(relaxed = true)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/Fat32CheckerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/Fat32CheckerTest.kt
@@ -40,7 +40,8 @@ class Fat32CheckerTest {
     protected val fileSystemChecker: FileSystemChecker = mockk()
     protected lateinit var fat32Checker: Fat32Checker
 
-    @get:Rule
+    @Rule
+    @JvmField
     val dispatcherRule = MainDispatcherRule()
 
     protected val pathWithSpace: String = File(System.getProperty("java.io.tmpdir")!!).absolutePath

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/FileWritingFileSystemCheckerTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/FileWritingFileSystemCheckerTest.kt
@@ -38,7 +38,8 @@ import java.io.File
 import java.io.IOException
 
 class FileWritingFileSystemCheckerTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val tempFolder = TemporaryFolder()
 
   private val testFileWriter: (String, Long) -> Unit = mockk()

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFilesTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/DeleteFilesTest.kt
@@ -66,9 +66,10 @@ class DeleteFilesTest {
   private lateinit var deleteFiles: DeleteFiles
 
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
-  private val viewModelScope = CoroutineScope(ioDispatcher.dispatcher)
+  private val viewModelScope = CoroutineScope(mainDispatcherRule.dispatcher)
 
   @BeforeEach
   fun setup() {
@@ -81,7 +82,7 @@ class DeleteFilesTest {
         dialogShower,
         deleteFilesUseCase,
         viewModelScope,
-        ioDispatcher.dispatcher
+        mainDispatcherRule.dispatcher
       )
     every { activity.toast(any<Int>()) } just Runs
   }

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigationTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/OpenFileWithNavigationTest.kt
@@ -44,7 +44,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 
 class OpenFileWithNavigationTest {
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private val scope = TestScope(mainDispatcherRule.dispatcher)
 
   private val zimReaderSource = mockk<ZimReaderSource>()

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFilesTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFilesTest.kt
@@ -44,7 +44,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 @OptIn(ExperimentalCoroutinesApi::class)
 class ValidateZIMFilesTest {
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @Test
   fun `invokeWith should show confirmation dialog with joined titles`() {
@@ -65,7 +66,7 @@ class ValidateZIMFilesTest {
       booksOnDiskListItems = listOf(book1, book2),
       dialogShower = dialogShower,
       validateZimViewModel = validateZimViewModel,
-      ioDispatcher = ioDispatcher.dispatcher
+      ioDispatcher = mainDispatcherRule.dispatcher
     )
 
     effect.invokeWith(activity)
@@ -104,7 +105,7 @@ class ValidateZIMFilesTest {
       booksOnDiskListItems = books,
       dialogShower = dialogShower,
       validateZimViewModel = validateZimViewModel,
-      ioDispatcher = ioDispatcher.dispatcher
+      ioDispatcher = mainDispatcherRule.dispatcher
     )
 
     effect.invokeWith(activity)

--- a/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFilesTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/zimManager/fileselectView/effects/ValidateZIMFilesTest.kt
@@ -38,24 +38,19 @@ import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
-import org.kiwix.kiwixmobile.di.components.KiwixActivityComponent
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.sharedFunctions.MainDispatcherRule
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ValidateZIMFilesTest {
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  private val ioDispatcher = MainDispatcherRule()
 
   @Test
   fun `invokeWith should show confirmation dialog with joined titles`() {
     val activity = mockk<KiwixMainActivity>(relaxed = true)
-    val component = mockk<KiwixActivityComponent>(relaxed = true)
     val dialogShower = mockk<DialogShower>(relaxed = true)
     val validateZimViewModel = mockk<ValidateZimViewModel>(relaxed = true)
-
-    every { activity.cachedComponent } returns component
-    every { component.inject(any<ValidateZIMFiles>()) } just Runs
 
     val book1 = mockBook("Wikipedia")
     val book2 = mockBook("Wiktionary")
@@ -69,7 +64,8 @@ class ValidateZIMFilesTest {
     val effect = ValidateZIMFiles(
       booksOnDiskListItems = listOf(book1, book2),
       dialogShower = dialogShower,
-      validateZimViewModel = validateZimViewModel
+      validateZimViewModel = validateZimViewModel,
+      ioDispatcher = ioDispatcher.dispatcher
     )
 
     effect.invokeWith(activity)
@@ -80,54 +76,51 @@ class ValidateZIMFilesTest {
   }
 
   @Test
-  fun `confirm action should start validation and show validating dialog`() =
-    runTest(mainDispatcherRule.dispatcher) {
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
-      val component = mockk<KiwixActivityComponent>(relaxed = true)
-      val dialogShower = mockk<AlertDialogShower>(relaxed = true)
-      val validateZimViewModel = mockk<ValidateZimViewModel>(relaxed = true)
+  fun `confirm action should start validation and show validating dialog`() = runTest {
+    val activity = mockk<KiwixMainActivity>(relaxed = true)
+    val dialogShower = mockk<AlertDialogShower>(relaxed = true)
+    val validateZimViewModel = mockk<ValidateZimViewModel>(relaxed = true)
 
-      every { activity.cachedComponent } returns component
-      every { component.inject(any<ValidateZIMFiles>()) } just Runs
-      every { validateZimViewModel.items } returns MutableStateFlow(emptyList())
-      every { validateZimViewModel.allZIMValidated } returns MutableStateFlow(false)
+    every { validateZimViewModel.items } returns MutableStateFlow(emptyList())
+    every { validateZimViewModel.allZIMValidated } returns MutableStateFlow(false)
 
-      val confirmationSlot = slot<KiwixDialog>()
-      val confirmCallbackSlot = slot<() -> Unit>()
+    val confirmationSlot = slot<KiwixDialog>()
+    val confirmCallbackSlot = slot<() -> Unit>()
 
-      every {
-        dialogShower.show(
-          capture(confirmationSlot),
-          capture(confirmCallbackSlot)
-        )
-      } just Runs
-
-      every {
-        dialogShower.show(any<KiwixDialog.ValidatingZimFiles>())
-      } just Runs
-
-      val books = listOf(mockBook("Wikipedia"))
-
-      val effect = ValidateZIMFiles(
-        booksOnDiskListItems = books,
-        dialogShower = dialogShower,
-        validateZimViewModel = validateZimViewModel
+    every {
+      dialogShower.show(
+        capture(confirmationSlot),
+        capture(confirmCallbackSlot)
       )
+    } just Runs
 
-      effect.invokeWith(activity)
+    every {
+      dialogShower.show(any<KiwixDialog.ValidatingZimFiles>())
+    } just Runs
 
-      confirmCallbackSlot.captured.invoke()
+    val books = listOf(mockBook("Wikipedia"))
 
-      advanceUntilIdle()
+    val effect = ValidateZIMFiles(
+      booksOnDiskListItems = books,
+      dialogShower = dialogShower,
+      validateZimViewModel = validateZimViewModel,
+      ioDispatcher = ioDispatcher.dispatcher
+    )
 
-      coVerify(exactly = 1) {
-        validateZimViewModel.startValidation(books, false)
-      }
+    effect.invokeWith(activity)
 
-      verify(exactly = 1) {
-        dialogShower.show(any<KiwixDialog.ValidatingZimFiles>())
-      }
+    confirmCallbackSlot.captured.invoke()
+
+    advanceUntilIdle()
+
+    coVerify(exactly = 1) {
+      validateZimViewModel.startValidation(books, false)
     }
+
+    verify(exactly = 1) {
+      dialogShower.show(any<KiwixDialog.ValidatingZimFiles>())
+    }
+  }
 
   private fun mockBook(title: String): BookOnDisk {
     val book = mockk<BookOnDisk>()

--- a/benchmark/src/main/java/org/kiwix/kiwixmobile/benchmark/KiwixAppStartupBenchmark.kt
+++ b/benchmark/src/main/java/org/kiwix/kiwixmobile/benchmark/KiwixAppStartupBenchmark.kt
@@ -12,7 +12,8 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class KiwixAppStartupBenchmark {
-  @get:Rule
+    @Rule
+  @JvmField
   val benchmarkRule = MacrobenchmarkRule()
 
   // Cold start with no compilation: App process is not in memory.

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
@@ -34,6 +34,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -57,7 +58,6 @@ import org.kiwix.kiwixmobile.custom.testutils.TestUtils.getOkkHttpClientForTesti
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.waitUntilTimeout
-import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -72,10 +72,7 @@ class DownloadServiceTestForBrandedApps {
       Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
 
-  @get:Rule
-  val mainDispatcherRule = MainDispatcherRule()
-
-  private val lifeCycleScope = CoroutineScope(mainDispatcherRule.dispatcher + SupervisorJob())
+  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
   @get:Rule
   var permissionRules: GrantPermissionRule =

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
@@ -34,7 +34,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -58,6 +57,7 @@ import org.kiwix.kiwixmobile.custom.testutils.TestUtils.getOkkHttpClientForTesti
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.waitUntilTimeout
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -71,7 +71,11 @@ class DownloadServiceTestForBrandedApps {
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val lifeCycleScope = CoroutineScope(mainDispatcherRule.dispatcher + SupervisorJob())
 
   @get:Rule
   var permissionRules: GrantPermissionRule =

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
@@ -74,7 +74,8 @@ class DownloadServiceTestForBrandedApps {
 
   private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-  @get:Rule
+  @Rule
+  @JvmField
   var permissionRules: GrantPermissionRule =
     GrantPermissionRule.grant(*permissions)
 
@@ -86,7 +87,8 @@ class DownloadServiceTestForBrandedApps {
   @JvmField
   var retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
   private lateinit var brandedMainActivity: BrandedMainActivity
   private lateinit var uiDevice: UiDevice

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
@@ -36,6 +36,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -64,7 +65,6 @@ import org.kiwix.kiwixmobile.custom.testutils.TestUtils.getOkkHttpClientForTesti
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.waitUntilTimeout
-import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -77,9 +77,7 @@ class SearchScreenTestForBrandedApp {
       Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
 
-  @get:Rule
-  val mainDispatcherRule = MainDispatcherRule()
-  private val lifeCycleScope = CoroutineScope(mainDispatcherRule.dispatcher + SupervisorJob())
+  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
   @get:Rule
   var permissionRules: GrantPermissionRule =

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
@@ -79,7 +79,8 @@ class SearchScreenTestForBrandedApp {
 
   private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-  @get:Rule
+  @Rule
+  @JvmField
   var permissionRules: GrantPermissionRule =
     GrantPermissionRule.grant(*permissions)
 
@@ -91,7 +92,8 @@ class SearchScreenTestForBrandedApp {
   @JvmField
   var retryRule = RetryRule()
 
-  @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @Rule(order = COMPOSE_TEST_RULE_ORDER)
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private lateinit var brandedMainActivity: BrandedMainActivity

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
@@ -36,7 +36,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -65,6 +64,7 @@ import org.kiwix.kiwixmobile.custom.testutils.TestUtils.getOkkHttpClientForTesti
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.custom.testutils.TestUtils.waitUntilTimeout
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
@@ -76,7 +76,10 @@ class SearchScreenTestForBrandedApp {
       Manifest.permission.READ_EXTERNAL_STORAGE,
       Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+  private val lifeCycleScope = CoroutineScope(mainDispatcherRule.dispatcher + SupervisorJob())
 
   @get:Rule
   var permissionRules: GrantPermissionRule =

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedFileValidator.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedFileValidator.kt
@@ -40,9 +40,8 @@ class BrandedFileValidator @Inject constructor(
 ) {
   suspend fun validate(
     onFilesFound: suspend (ValidationState) -> Unit,
-    onNoFilesFound: suspend () -> Unit,
-    dispatcher: CoroutineDispatcher = ioDispatcher
-  ) = withContext(dispatcher) {
+    onNoFilesFound: suspend () -> Unit
+  ) = withContext(ioDispatcher) {
     when (val installationState = detectInstallationState()) {
       is HasBothFiles,
       is HasFile -> onFilesFound(installationState)

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedFileValidator.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedFileValidator.kt
@@ -24,8 +24,8 @@ import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.content.res.AssetManager
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasBothFiles
 import org.kiwix.kiwixmobile.custom.main.ValidationState.HasFile
@@ -34,11 +34,14 @@ import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 
-class BrandedFileValidator @Inject constructor(private val context: Context) {
+class BrandedFileValidator @Inject constructor(
+  private val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
   suspend fun validate(
     onFilesFound: suspend (ValidationState) -> Unit,
     onNoFilesFound: suspend () -> Unit,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    dispatcher: CoroutineDispatcher = ioDispatcher
   ) = withContext(dispatcher) {
     when (val installationState = detectInstallationState()) {
       is HasBothFiles,

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
@@ -66,7 +66,6 @@ class BrandedMainActivity : CoreMainActivity() {
   override val cachedComponent by lazy { brandedActivityComponent }
   override val topLevelDestinationsRoute = setOf(CustomDestination.Reader.route)
 
-  @Suppress("InjectDispatcher")
   override fun onCreate(savedInstanceState: Bundle?) {
     brandedActivityComponent.inject(this)
     super.onCreate(savedInstanceState)

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
@@ -35,7 +35,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R.drawable
 import org.kiwix.kiwixmobile.core.R.string
@@ -96,7 +95,7 @@ class BrandedMainActivity : CoreMainActivity() {
       }
     }
     // run the migration on background thread to avoid any UI related issues.
-    CoroutineScope(Dispatchers.IO).launch {
+    CoroutineScope(ioDispatcher).launch {
       (applicationContext as BrandedApp).brandedComponent
         .provideObjectBoxDataMigrationHandler()
         .migrate()

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedReaderFragment.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedReaderFragment.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.ui.graphics.Color
 import androidx.core.net.toUri
 import androidx.navigation.NavOptions
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import org.kiwix.kiwixmobile.core.CoreApp
@@ -239,7 +238,7 @@ class BrandedReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            coreReaderLifeCycleScope?.runSafelyInLifecycleScope(Dispatchers.Main.immediate) {
+            coreReaderLifeCycleScope?.runSafelyInLifecycleScope {
               openZimFile(
                 ZimReaderSource(
                   file = it.file,
@@ -258,7 +257,7 @@ class BrandedReaderFragment : CoreReaderFragment() {
 
           is ValidationState.HasBothFiles -> {
             it.zimFile.delete()
-            coreReaderLifeCycleScope?.runSafelyInLifecycleScope(Dispatchers.Main.immediate) {
+            coreReaderLifeCycleScope?.runSafelyInLifecycleScope {
               openZimFile(ZimReaderSource(it.obbFile), true)
               if (shouldManageExternalLaunch) {
                 // Open the previous loaded pages after ZIM file loads.

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedReaderFragment.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedReaderFragment.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.first
 import org.kiwix.kiwixmobile.core.CoreApp
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
+import kotlinx.coroutines.MainCoroutineDispatcher
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.safelyConsumeObservable
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.getObservableNavigationResult
@@ -238,7 +239,7 @@ class BrandedReaderFragment : CoreReaderFragment() {
       onFilesFound = {
         when (it) {
           is ValidationState.HasFile -> {
-            coreReaderLifeCycleScope?.runSafelyInLifecycleScope {
+            coreReaderLifeCycleScope?.runSafelyInLifecycleScope((mainDispatcher as MainCoroutineDispatcher).immediate) {
               openZimFile(
                 ZimReaderSource(
                   file = it.file,
@@ -257,7 +258,7 @@ class BrandedReaderFragment : CoreReaderFragment() {
 
           is ValidationState.HasBothFiles -> {
             it.zimFile.delete()
-            coreReaderLifeCycleScope?.runSafelyInLifecycleScope {
+            coreReaderLifeCycleScope?.runSafelyInLifecycleScope((mainDispatcher as MainCoroutineDispatcher).immediate) {
               openZimFile(ZimReaderSource(it.obbFile), true)
               if (shouldManageExternalLaunch) {
                 // Open the previous loaded pages after ZIM file loads.

--- a/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/main/BrandedFileValidatorTest.kt
+++ b/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/main/BrandedFileValidatorTest.kt
@@ -44,13 +44,14 @@ class BrandedFileValidatorTest {
   private lateinit var assetManager: AssetManager
 
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @BeforeEach
   fun setUp() {
     context = mockk(relaxed = true)
     assetManager = mockk(relaxed = true)
-    brandedFileValidator = BrandedFileValidator(context, ioDispatcher.dispatcher)
+    brandedFileValidator = BrandedFileValidator(context, mainDispatcherRule.dispatcher)
   }
 
   @Test

--- a/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/main/BrandedFileValidatorTest.kt
+++ b/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/main/BrandedFileValidatorTest.kt
@@ -32,8 +32,10 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.custom.main.BrandedFileValidator
 import org.kiwix.kiwixmobile.custom.main.ValidationState
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 
 class BrandedFileValidatorTest {
@@ -41,11 +43,14 @@ class BrandedFileValidatorTest {
   private lateinit var brandedFileValidator: BrandedFileValidator
   private lateinit var assetManager: AssetManager
 
+  @RegisterExtension
+  private val ioDispatcher = MainDispatcherRule()
+
   @BeforeEach
   fun setUp() {
     context = mockk(relaxed = true)
     assetManager = mockk(relaxed = true)
-    brandedFileValidator = BrandedFileValidator(context)
+    brandedFileValidator = BrandedFileValidator(context, ioDispatcher.dispatcher)
   }
 
   @Test

--- a/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/viewmodel/BrandedDownloadScreenUITest.kt
+++ b/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/viewmodel/BrandedDownloadScreenUITest.kt
@@ -50,7 +50,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class BrandedDownloadScreenUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeRule = createComposeRule()
 
   private fun setScreenContent(

--- a/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/viewmodel/BrandedDownloadViewModelTest.kt
+++ b/branded/src/test/java/org/kiwix/kiwixmobile/custom/download/viewmodel/BrandedDownloadViewModelTest.kt
@@ -61,6 +61,7 @@ internal class BrandedDownloadViewModelTest {
   private val requestNotificationPermission: RequestNotificationPermission = mockk()
 
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
   private lateinit var brandedDownloadViewModel: BrandedDownloadViewModel
   private lateinit var downloadsFlow: MutableSharedFlow<List<DownloadModel>>

--- a/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AppConfigurer.kt
@@ -25,7 +25,6 @@ import com.android.build.gradle.api.ApkVariantOutput
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.exclude
-import org.gradle.kotlin.dsl.project
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -120,6 +119,11 @@ class AppConfigurer {
 
       aaptOptions {
         cruncherEnabled = true
+      }
+      sourceSets {
+        getByName("androidTest") {
+          java.srcDirs("${target.rootDir}/core/src/sharedTestFunctions/java")
+        }
       }
     }
     configureDependencies(target)

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -41,8 +41,11 @@ object StorageDeviceUtils {
   }
 
   @JvmStatic
-  suspend fun getReadableStorage(context: Context): List<StorageDevice> {
-    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context)
+  suspend fun getReadableStorage(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher
+  ): List<StorageDevice> {
+    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context, ioDispatcher)
     val storageDevices =
       ArrayList<StorageDevice>().apply {
         add(environmentDevices(context))

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -23,7 +23,6 @@ import android.content.ContextWrapper
 import android.os.Build
 import android.os.Environment
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
@@ -35,16 +34,17 @@ object StorageDeviceUtils {
   @JvmStatic
   suspend fun getWritableStorage(
     context: Context,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    dispatcher: CoroutineDispatcher
   ) = withContext(dispatcher) {
     validate(externalMediaFilesDirsDevices(context), true)
   }
 
   @JvmStatic
   suspend fun getReadableStorage(
-    context: Context
+    context: Context,
+    ioDispatcher: CoroutineDispatcher
   ): List<StorageDevice> {
-    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context)
+    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context, ioDispatcher)
     val storageDevices =
       ArrayList<StorageDevice>().apply {
         add(environmentDevices(context))

--- a/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
+++ b/core/src/main/java/eu/mhutti1/utils/storage/StorageDeviceUtils.kt
@@ -42,10 +42,9 @@ object StorageDeviceUtils {
 
   @JvmStatic
   suspend fun getReadableStorage(
-    context: Context,
-    ioDispatcher: CoroutineDispatcher
+    context: Context
   ): List<StorageDevice> {
-    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context, ioDispatcher)
+    var kiwixDataStore: KiwixDataStore? = KiwixDataStore(context)
     val storageDevices =
       ArrayList<StorageDevice>().apply {
         add(environmentDevices(context))

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
@@ -45,15 +45,14 @@ class StorageObserver @Inject constructor(
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
   fun getBooksOnFileSystem(
-    scanningProgressListener: ScanningProgressListener,
-    dispatcher: CoroutineDispatcher = ioDispatcher
+    scanningProgressListener: ScanningProgressListener
   ): Flow<List<Book>> = flow {
     val files = scanFiles(scanningProgressListener).first()
     val downloads = downloadRoomDao.downloads().first()
     val result = toFilesThatAreNotDownloading(files, downloads)
       .mapNotNull { convertToLibkiwixBook(it) }
     emit(result)
-  }.flowOn(dispatcher)
+  }.flowOn(ioDispatcher)
 
   private fun scanFiles(scanningProgressListener: ScanningProgressListener): Flow<List<File>> =
     fileSearch.scan(scanningProgressListener)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
@@ -19,13 +19,13 @@
 package org.kiwix.kiwixmobile.core
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadModel
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
@@ -35,16 +35,18 @@ import org.kiwix.libkiwix.Book
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("LongParameterList")
 class StorageObserver @Inject constructor(
   private val downloadRoomDao: DownloadRoomDao,
   private val fileSearch: FileSearch,
   private val zimReaderFactory: ZimFileReader.Factory,
   private val libkiwixBookmarks: LibkiwixBookmarks,
-  private val libkiwixBookFactory: LibkiwixBookFactory
+  private val libkiwixBookFactory: LibkiwixBookFactory,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
   fun getBooksOnFileSystem(
     scanningProgressListener: ScanningProgressListener,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    dispatcher: CoroutineDispatcher = ioDispatcher
   ): Flow<List<Book>> = flow {
     val files = scanFiles(scanningProgressListener).first()
     val downloads = downloadRoomDao.downloads().first()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ThemeConfig.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ThemeConfig.kt
@@ -20,22 +20,24 @@ package org.kiwix.kiwixmobile.core
 import android.content.Context
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
 
 class ThemeConfig @Inject constructor(
   val kiwixDataStore: KiwixDataStore,
-  val context: Context
+  val context: Context,
+  @MainDispatcher private val mainDispatcher: CoroutineDispatcher
 ) {
   val isThemeLoaded: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
   fun init() {
-    CoroutineScope(Dispatchers.Main).launch {
+    CoroutineScope(mainDispatcher).launch {
       kiwixDataStore.appTheme.collect { theme ->
         setMode(theme)
         isThemeLoaded.emit(true)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/DownloadRoomDao.kt
@@ -26,7 +26,7 @@ import androidx.room.Update
 import com.tonyodev.fetch2.Download
 import com.tonyodev.fetch2.Status
 import com.tonyodev.fetch2.Status.COMPLETED
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.dao.entities.DownloadRoomEntity
 import org.kiwix.kiwixmobile.core.dao.entities.PauseReason
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadModel
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadRequest
@@ -47,6 +48,10 @@ import javax.inject.Inject
 abstract class DownloadRoomDao {
   @Inject
   lateinit var libkiwixBookOnDisk: LibkiwixBookOnDisk
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
 
   @Query("SELECT * FROM DownloadRoomEntity")
   abstract fun getAllDownloads(): Flow<List<DownloadRoomEntity>>
@@ -69,7 +74,7 @@ abstract class DownloadRoomDao {
         // In the OPDS stream, the favicon is a URL instead of a Base64 string.
         // So when a download is completed, we extract the illustration directly from the archive.
         val booksOnDisk = completedDownloads.map { download ->
-          val archive = withContext(Dispatchers.IO) {
+          val archive = withContext(ioDispatcher) {
             Archive(download.file)
           }
           Book().apply { update(archive) }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -46,7 +46,9 @@ import org.kiwix.libkiwix.Manager
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
+@Singleton
 class LibkiwixBookOnDisk @Inject constructor(
   @Named(LOCAL_BOOKS_LIBRARY) private val library: Library,
   @Named(LOCAL_BOOKS_MANAGER) private val manager: Manager,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -57,7 +57,9 @@ import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
+@Singleton
 class LibkiwixBookmarks @Inject constructor(
   @Named(BOOKMARK_LIBRARY) private val library: Library,
   @Named(BOOKMARK_MANAGER) private val manager: Manager,
@@ -111,7 +113,7 @@ class LibkiwixBookmarks @Inject constructor(
     if (initialized) return
 
     initMutex.withLock {
-      if (initialized) return
+      if (initialized) return@withLock
       withContext(dispatcher) {
         // Check if bookmark folder exist if not then create the folder first.
         if (!File(bookmarksFolderPath()).isFileExist()) File(bookmarksFolderPath()).mkdir()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DatabaseModule.kt
@@ -20,7 +20,9 @@ package org.kiwix.kiwixmobile.core.di.modules
 import android.content.Context
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.CoroutineDispatcher
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import javax.inject.Singleton
 
@@ -53,8 +55,12 @@ open class DatabaseModule {
 
   @Singleton
   @Provides
-  fun provideDownloadRoomDao(db: KiwixRoomDatabase, libkiwixBookOnDisk: LibkiwixBookOnDisk) =
-    db.downloadRoomDao().also {
-      it.libkiwixBookOnDisk = libkiwixBookOnDisk
-    }
+  fun provideDownloadRoomDao(
+    db: KiwixRoomDatabase,
+    libkiwixBookOnDisk: LibkiwixBookOnDisk,
+    @IoDispatcher ioDispatcher: CoroutineDispatcher
+  ) = db.downloadRoomDao().also {
+    it.libkiwixBookOnDisk = libkiwixBookOnDisk
+    it.ioDispatcher = ioDispatcher
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
@@ -22,84 +22,71 @@ import com.tonyodev.fetch2.Fetch
 import com.tonyodev.fetch2.FetchConfiguration
 import com.tonyodev.fetch2.FetchNotificationManager
 import com.tonyodev.fetch2okhttp.OkHttpDownloader
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
-import org.kiwix.kiwixmobile.core.data.remote.KiwixService
-import org.kiwix.kiwixmobile.core.di.IoDispatcher
-import org.kiwix.kiwixmobile.core.di.OPDSKiwixService
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
 import org.kiwix.kiwixmobile.core.downloader.Downloader
 import org.kiwix.kiwixmobile.core.downloader.DownloaderImpl
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadManagerRequester
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.FetchDownloadNotificationManager
 import org.kiwix.kiwixmobile.core.utils.CONNECT_TIME_OUT
+import org.kiwix.kiwixmobile.core.utils.FIVE
 import org.kiwix.kiwixmobile.core.utils.READ_TIME_OUT
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
-object DownloaderModule {
-  @Provides
+abstract class DownloaderModule {
+  @Binds
   @Singleton
-  fun providesDownloader(
-    downloadRequester: DownloadRequester,
-    downloadRoomDao: DownloadRoomDao,
-    @OPDSKiwixService kiwixService: KiwixService
-  ): Downloader =
-    DownloaderImpl(downloadRequester, downloadRoomDao, kiwixService)
+  abstract fun bindDownloader(impl: DownloaderImpl): Downloader
 
-  @Provides
+  @Binds
   @Singleton
-  fun providesDownloadRequester(
-    fetch: Fetch,
-    kiwixDataStore: KiwixDataStore,
-    context: Context,
-    downloadRoomDao: DownloadRoomDao,
-    @IoDispatcher ioDispatcher: CoroutineDispatcher
-  ): DownloadRequester =
-    DownloadManagerRequester(fetch, kiwixDataStore, context, downloadRoomDao, ioDispatcher)
+  abstract fun bindDownloadRequester(impl: DownloadManagerRequester): DownloadRequester
 
-  @Provides
-  @Singleton
-  fun provideFetch(fetchConfiguration: FetchConfiguration): Fetch =
-    Fetch.getInstance(fetchConfiguration)
+  companion object {
+    @Provides
+    @Singleton
+    fun provideFetch(fetchConfiguration: FetchConfiguration): Fetch =
+      Fetch.getInstance(fetchConfiguration)
 
-  @Provides
-  @Singleton
-  fun provideFetchConfiguration(
-    context: Context,
-    okHttpDownloader: OkHttpDownloader,
-    fetchNotificationManager: FetchNotificationManager
-  ): FetchConfiguration =
-    FetchConfiguration.Builder(context).apply {
-      setDownloadConcurrentLimit(5)
-      enableLogging(BuildConfig.DEBUG)
-      enableRetryOnNetworkGain(true)
-      setHttpDownloader(okHttpDownloader)
-      preAllocateFileOnCreation(false)
-      setNotificationManager(fetchNotificationManager)
-    }.build().also(Fetch.Impl::setDefaultInstanceConfiguration)
+    @Provides
+    @Singleton
+    fun provideFetchConfiguration(
+      context: Context,
+      okHttpDownloader: OkHttpDownloader,
+      fetchNotificationManager: FetchNotificationManager
+    ): FetchConfiguration =
+      FetchConfiguration.Builder(context).apply {
+        setDownloadConcurrentLimit(FIVE)
+        enableLogging(BuildConfig.DEBUG)
+        enableRetryOnNetworkGain(true)
+        setHttpDownloader(okHttpDownloader)
+        preAllocateFileOnCreation(false)
+        setNotificationManager(fetchNotificationManager)
+      }.build().also(Fetch.Impl::setDefaultInstanceConfiguration)
 
-  @Provides
-  @Singleton
-  fun provideOkHttpDownloader() = OkHttpDownloader(
-    OkHttpClient.Builder()
-      .connectTimeout(CONNECT_TIME_OUT, TimeUnit.MINUTES)
-      .readTimeout(READ_TIME_OUT, TimeUnit.MINUTES)
-      .addInterceptor(BasicAuthInterceptor())
-      .followRedirects(true)
-      .followSslRedirects(true)
-      .build()
-  )
+    @Provides
+    @Singleton
+    fun provideOkHttpDownloader() = OkHttpDownloader(
+      OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIME_OUT, TimeUnit.MINUTES)
+        .readTimeout(READ_TIME_OUT, TimeUnit.MINUTES)
+        .addInterceptor(BasicAuthInterceptor())
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .build()
+    )
 
-  @Provides
-  @Singleton
-  fun provideFetchDownloadNotificationManager(context: Context, downloadRoomDao: DownloadRoomDao):
-    FetchNotificationManager = FetchDownloadNotificationManager(context, downloadRoomDao)
+    @Provides
+    @Singleton
+    fun provideFetchDownloadNotificationManager(context: Context, downloadRoomDao: DownloadRoomDao):
+      FetchNotificationManager = FetchDownloadNotificationManager(context, downloadRoomDao)
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/JNIModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/JNIModule.kt
@@ -21,10 +21,6 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import org.kiwix.kiwixmobile.core.LibkiwixBookFactory
-import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
-import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
-import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.JNIKiwix
 import org.kiwix.libkiwix.Library
@@ -51,23 +47,6 @@ class JNIModule {
 
   @Provides
   @Singleton
-  fun providesLibkiwixBookmarks(
-    @Named(BOOKMARK_LIBRARY) library: Library,
-    @Named(BOOKMARK_MANAGER) manager: Manager,
-    kiwixDataStore: KiwixDataStore,
-    libkiwixBookOnDisk: LibkiwixBookOnDisk,
-    zimReaderContainer: ZimReaderContainer
-  ): LibkiwixBookmarks =
-    LibkiwixBookmarks(
-      library,
-      manager,
-      kiwixDataStore,
-      libkiwixBookOnDisk,
-      zimReaderContainer
-    )
-
-  @Provides
-  @Singleton
   @Named(LOCAL_BOOKS_LIBRARY)
   fun provideLocalBooksLibrary(): Library = Library()
 
@@ -77,14 +56,6 @@ class JNIModule {
   fun providesLocalBooksManager(
     @Named(LOCAL_BOOKS_LIBRARY) library: Library
   ): Manager = Manager(library)
-
-  @Provides
-  @Singleton
-  fun providesLibkiwixBooks(
-    @Named(LOCAL_BOOKS_LIBRARY) library: Library,
-    @Named(LOCAL_BOOKS_MANAGER) manager: Manager,
-    kiwixDataStore: KiwixDataStore,
-  ): LibkiwixBookOnDisk = LibkiwixBookOnDisk(library, manager, kiwixDataStore)
 
   /**
    * We are not making this singleton because we need multiple objects of this.

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/DownloaderImpl.kt
@@ -18,11 +18,12 @@
 
 package org.kiwix.kiwixmobile.core.downloader
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.data.remote.KiwixService
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.di.OPDSKiwixService
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import javax.inject.Inject
@@ -30,11 +31,11 @@ import javax.inject.Inject
 class DownloaderImpl @Inject constructor(
   private val downloadRequester: DownloadRequester,
   private val downloadRoomDao: DownloadRoomDao,
-  @OPDSKiwixService private val kiwixService: KiwixService
+  @OPDSKiwixService private val kiwixService: KiwixService,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : Downloader {
-  @Suppress("InjectDispatcher")
   override fun download(book: LibkiwixBook) {
-    CoroutineScope(Dispatchers.IO).launch {
+    CoroutineScope(ioDispatcher).launch {
       runCatching {
         urlProvider(book)?.let {
           downloadRoomDao.addIfDoesNotExist(it, book, downloadRequester)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -43,7 +43,6 @@ import com.tonyodev.fetch2.util.DEFAULT_NOTIFICATION_TIMEOUT_AFTER_RESET
 import com.tonyodev.fetch2core.DownloadBlock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -57,6 +56,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.R.string
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.PauseReason
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.DOWNLOAD_NOTIFICATION_CHANNEL_ID
 import org.kiwix.kiwixmobile.core.utils.ZERO
@@ -74,8 +74,13 @@ const val DOWNLOAD_TIMEOUT_NOTIFICATION_NO_REQUEST_CODE = 2002
 @Suppress("InjectDispatcher")
 class DownloadMonitorService : Service() {
   private val taskFlow = MutableSharedFlow<suspend () -> Unit>(extraBufferCapacity = Int.MAX_VALUE)
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
+
   private var updaterJob: Job? = null
-  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private lateinit var scope: CoroutineScope
   private val notificationManager: NotificationManager by lazy {
     getSystemService(NOTIFICATION_SERVICE) as NotificationManager
   }
@@ -127,6 +132,7 @@ class DownloadMonitorService : Service() {
       .build()
       .inject(this)
     super.onCreate()
+    scope = CoroutineScope(SupervisorJob() + ioDispatcher)
     fetch.addListener(fetchListener, true)
     setupUpdater()
     startForegroundService()
@@ -317,8 +323,8 @@ class DownloadMonitorService : Service() {
    * 3. Resets their `pauseReason` to `NONE` and updates the status to `QUEUED`
    *    so they can continue downloading normally.
    */
-  private fun startPausedDownloadsDueToAndroidServiceLimitation(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-    CoroutineScope(dispatcher).launch {
+  private fun startPausedDownloadsDueToAndroidServiceLimitation() {
+    CoroutineScope(ioDispatcher).launch {
       downloadRoomDao.getDownloadsPausedByService()
         .forEach {
           fetch.resume(it.downloadId.toInt())

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -80,7 +81,7 @@ class DownloadMonitorService : Service() {
   lateinit var ioDispatcher: CoroutineDispatcher
 
   private var updaterJob: Job? = null
-  private lateinit var scope: CoroutineScope
+  private var scope: CoroutineScope? = null
   private val notificationManager: NotificationManager by lazy {
     getSystemService(NOTIFICATION_SERVICE) as NotificationManager
   }
@@ -153,7 +154,7 @@ class DownloadMonitorService : Service() {
   }
 
   private fun setupUpdater() {
-    updaterJob = scope.launch {
+    updaterJob = scope?.launch {
       taskFlow.collect { task ->
         runCatching {
           task.invoke()
@@ -540,6 +541,8 @@ class DownloadMonitorService : Service() {
   @OptIn(ExperimentalCoroutinesApi::class)
   private fun stopForegroundServiceForDownloads() {
     updaterJob?.cancel()
+    scope?.cancel()
+    scope = null
     unregisterNetworkCallback()
     fetch.removeListener(fetchListener)
     stopForeground(STOP_FOREGROUND_REMOVE)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -54,8 +54,8 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.navOptions
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.CoreApp
@@ -63,6 +63,7 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BaseActivity
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.APP_NAME_KEY
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID
@@ -133,6 +134,10 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
   private var drawerToggle: ActionBarDrawerToggle? = null
 
   @Inject lateinit var zimReaderContainer: ZimReaderContainer
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
 
   @Inject
   lateinit var downloadRoomDao: DownloadRoomDao
@@ -233,7 +238,7 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
     }
 
     setMainActivityToCoreApp()
-    lifecycleScope.launch(Dispatchers.IO) {
+    lifecycleScope.launch(ioDispatcher) {
       createApplicationShortcuts()
     }
   }
@@ -314,10 +319,9 @@ abstract class CoreMainActivity : BaseActivity(), WebViewProvider {
    * required app metadata. If no ongoing downloads exist, the service is stopped
    * to avoid unnecessary background work.
    */
-  @Suppress("InjectDispatcher")
   fun startDownloadMonitorServiceIfOngoingDownloads(isAppStart: Boolean = false) {
     if (!isDownloadMonitorServiceRunning) {
-      CoroutineScope(Dispatchers.IO).launch {
+      CoroutineScope(ioDispatcher).launch {
         runCatching {
           if (downloadRoomDao.getOngoingDownloads().isNotEmpty() || !isAppStart) {
             startService(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -29,8 +29,8 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
@@ -41,6 +41,8 @@ import org.kiwix.kiwixmobile.core.BuildConfig
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.coreComponent
 import org.kiwix.kiwixmobile.core.CoreApp.Companion.instance
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.closeFullScreenMode
 import org.kiwix.kiwixmobile.core.extensions.showFullScreenMode
 import org.kiwix.kiwixmobile.core.extensions.toast
@@ -68,6 +70,14 @@ open class KiwixWebView constructor(
 ) : VideoEnabledWebView(context, attrs) {
   @Inject
   lateinit var zimReaderContainer: ZimReaderContainer
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
+
+  @Inject
+  @MainDispatcher
+  lateinit var mainDispatcher: CoroutineDispatcher
 
   private var kiwixWebChromeClient: KiwixWebChromeClient? = null
   private var textZoomJob: Job? = null
@@ -138,7 +148,7 @@ open class KiwixWebView constructor(
       val saveMenu =
         menu.add(0, 1, 0, resources.getString(R.string.save_media))
       saveMenu.setOnMenuItemClickListener {
-        val msg = SaveHandler(zimReaderContainer).obtainMessage()
+        val msg = SaveHandler(zimReaderContainer, mainDispatcher, ioDispatcher).obtainMessage()
         requestFocusNodeHref(msg)
         true
       }
@@ -151,7 +161,7 @@ open class KiwixWebView constructor(
     textZoomJob?.cancel()
     textZoomJob = kiwixDataStore.textZoom
       .onEach { settings.textZoom = it }
-      .launchIn(CoroutineScope(SupervisorJob() + Dispatchers.Main))
+      .launchIn(CoroutineScope(SupervisorJob() + mainDispatcher))
   }
 
   override fun onDetachedFromWindow() {
@@ -187,7 +197,9 @@ open class KiwixWebView constructor(
   }
 
   class SaveHandler(
-    private val zimReaderContainer: ZimReaderContainer
+    private val zimReaderContainer: ZimReaderContainer,
+    private val mainDispatcher: CoroutineDispatcher,
+    private val ioDispatcher: CoroutineDispatcher
   ) : Handler(Looper.getMainLooper()) {
     override fun handleMessage(msg: Message) {
       val url = msg.data.getString("url", null)
@@ -198,7 +210,7 @@ open class KiwixWebView constructor(
       val appContext = ContextCompat.getContextForLanguage(instance)
 
       @Suppress("InjectDispatcher")
-      CoroutineScope(Dispatchers.IO).launch {
+      CoroutineScope(ioDispatcher).launch {
         val result = FileUtils.downloadFileFromUrl(
           context = appContext,
           url = url,
@@ -206,7 +218,7 @@ open class KiwixWebView constructor(
           zimReaderContainer = zimReaderContainer
         )
 
-        withContext(Dispatchers.Main) {
+        withContext(mainDispatcher) {
           when (result) {
             is SaveResult.MediaSaved -> {
               appContext.toast(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -110,6 +110,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.entities.WebViewHistoryEntity
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
@@ -264,6 +265,10 @@ abstract class CoreReaderFragment :
   @Inject
   @MainDispatcher
   lateinit var mainDispatcher: CoroutineDispatcher
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
 
   private val addNoteViewModel by lazy { viewModel<AddNoteViewModel>(viewModelFactory) }
 
@@ -2248,7 +2253,6 @@ abstract class CoreReaderFragment :
    *    openSearch("", isOpenedFromTabView = isInTabSwitcher, false)
    *  }
    */
-  @Suppress("InjectDispatcher")
   private fun saveTabStates(onComplete: () -> Unit = {}) {
     CoroutineScope(mainDispatcher).launch {
       savingTabsMutex.withLock {
@@ -2257,7 +2261,7 @@ abstract class CoreReaderFragment :
           if (view.url == null) return@forEachIndexed
           getWebViewHistoryEntity(view, index)?.let(webViewHistoryEntityList::add)
         }
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
           // clear the previous history saved in database
           repositoryActions?.clearWebViewPageHistory()
           // Store new history in database.

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -32,9 +32,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.CountDownTimer
-import android.os.Handler
 import android.os.IBinder
-import android.os.Looper
 import android.print.PdfPrint
 import android.print.PrintAttributes
 import android.print.PrintAttributes.Margins
@@ -93,6 +91,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -111,6 +110,7 @@ import org.kiwix.kiwixmobile.core.base.BaseFragment
 import org.kiwix.kiwixmobile.core.base.FragmentActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.dao.entities.WebViewHistoryEntity
+import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.hasNotificationPermission
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.observeNavigationResult
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.requestNotificationPermission
@@ -261,6 +261,10 @@ abstract class CoreReaderFragment :
 
   @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
+  @Inject
+  @MainDispatcher
+  lateinit var mainDispatcher: CoroutineDispatcher
+
   private val addNoteViewModel by lazy { viewModel<AddNoteViewModel>(viewModelFactory) }
 
   @JvmField
@@ -357,7 +361,7 @@ abstract class CoreReaderFragment :
   val coreReaderLifeCycleScope: CoroutineScope?
     get() {
       if (readerLifeCycleScope == null) {
-        readerLifeCycleScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        readerLifeCycleScope = CoroutineScope(SupervisorJob() + mainDispatcher)
       }
       return readerLifeCycleScope
     }
@@ -1847,12 +1851,11 @@ abstract class CoreReaderFragment :
   protected open fun openHomeScreen() {
     runSafelyInCoreReaderLifecycleScope {
       // Run safely because it is runs after 300 MS.
-      Handler(Looper.getMainLooper()).postDelayed({
-        if (webViewList.isEmpty()) {
-          createNewTab()
-          hideTabSwitcher()
-        }
-      }, OPEN_HOME_SCREEN_DELAY)
+      delay(OPEN_HOME_SCREEN_DELAY)
+      if (webViewList.isEmpty()) {
+        createNewTab()
+        hideTabSwitcher()
+      }
     }
   }
 
@@ -2062,9 +2065,10 @@ abstract class CoreReaderFragment :
 
   @Suppress("MagicNumber")
   private fun contentsDrawerHint() {
-    Handler(Looper.getMainLooper()).postDelayed({
+    runSafelyInCoreReaderLifecycleScope {
+      delay(500)
       shouldTableOfContentDrawer.update { true }
-    }, 500)
+    }
     alertDialogShower?.show(KiwixDialog.ContentsDrawerHint)
   }
 
@@ -2246,7 +2250,7 @@ abstract class CoreReaderFragment :
    */
   @Suppress("InjectDispatcher")
   private fun saveTabStates(onComplete: () -> Unit = {}) {
-    CoroutineScope(Dispatchers.Main).launch {
+    CoroutineScope(mainDispatcher).launch {
       savingTabsMutex.withLock {
         val webViewHistoryEntityList = arrayListOf<WebViewHistoryEntity>()
         webViewList.forEachIndexed { index, view ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -61,7 +61,13 @@ class BookmarkViewModel @Inject constructor(
     action: Action.UserClickedShowAllToggle,
     state: BookmarkState
   ): BookmarkState {
-    effects.tryEmit(UpdateAllBookmarksPreference(kiwixDataStore, action.isChecked, requireLifeCycleScope()))
+    effects.tryEmit(
+      UpdateAllBookmarksPreference(
+        kiwixDataStore,
+        action.isChecked,
+        requireLifeCycleScope()
+      )
+    )
     return state.copy(showAll = action.isChecked)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -26,14 +26,18 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.ThemeConfig.Theme.Companion.from
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.zim_manager.Category
@@ -55,6 +59,7 @@ val Context.kiwixDataStore by preferencesDataStore(
 @Singleton
 class KiwixDataStore @Inject constructor(
   val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
   val textZoom: Flow<Int> = context.kiwixDataStore.data.map { prefs ->
     prefs[PreferencesKeys.TEXT_ZOOM] ?: DEFAULT_ZOOM
@@ -466,13 +471,15 @@ class KiwixDataStore @Inject constructor(
       path.substringBefore(context.getString(R.string.android_directory_seperator))
     }
 
-  suspend fun defaultStorage(): String =
+  suspend fun defaultStorage(): String = withContext(ioDispatcher) {
     context.getExternalFilesDirs(null)[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
+  }
 
-  private suspend fun defaultPublicStorage(): String =
+  private suspend fun defaultPublicStorage(): String = withContext(ioDispatcher) {
     ContextWrapper(context).externalMediaDirs[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
+  }
 
   val selectedStoragePosition: Flow<Int> =
     context.kiwixDataStore.data.map { pref ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -26,7 +26,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -36,8 +36,9 @@ import org.json.JSONObject
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.ThemeConfig.Theme.Companion.from
-import org.kiwix.kiwixmobile.core.utils.ZERO
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
+import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.zim_manager.Category
 import org.kiwix.kiwixmobile.core.zim_manager.Language
 import java.io.File
@@ -55,7 +56,10 @@ val Context.kiwixDataStore by preferencesDataStore(
 )
 
 @Singleton
-class KiwixDataStore @Inject constructor(val context: Context) {
+class KiwixDataStore @Inject constructor(
+  val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) {
   val textZoom: Flow<Int> = context.kiwixDataStore.data.map { prefs ->
     prefs[PreferencesKeys.TEXT_ZOOM] ?: DEFAULT_ZOOM
   }
@@ -466,14 +470,12 @@ class KiwixDataStore @Inject constructor(val context: Context) {
       path.substringBefore(context.getString(R.string.android_directory_seperator))
     }
 
-  @Suppress("InjectDispatcher")
-  suspend fun defaultStorage(): String = withContext(Dispatchers.IO) {
+  suspend fun defaultStorage(): String = withContext(ioDispatcher) {
     context.getExternalFilesDirs(null)[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
   }
 
-  @Suppress("InjectDispatcher")
-  private suspend fun defaultPublicStorage(): String = withContext(Dispatchers.IO) {
+  private suspend fun defaultPublicStorage(): String = withContext(ioDispatcher) {
     ContextWrapper(context).externalMediaDirs[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -26,17 +26,14 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.ThemeConfig.Theme.Companion.from
-import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.zim_manager.Category
@@ -58,7 +55,6 @@ val Context.kiwixDataStore by preferencesDataStore(
 @Singleton
 class KiwixDataStore @Inject constructor(
   val context: Context,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
   val textZoom: Flow<Int> = context.kiwixDataStore.data.map { prefs ->
     prefs[PreferencesKeys.TEXT_ZOOM] ?: DEFAULT_ZOOM
@@ -470,15 +466,13 @@ class KiwixDataStore @Inject constructor(
       path.substringBefore(context.getString(R.string.android_directory_seperator))
     }
 
-  suspend fun defaultStorage(): String = withContext(ioDispatcher) {
+  suspend fun defaultStorage(): String =
     context.getExternalFilesDirs(null)[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
-  }
 
-  private suspend fun defaultPublicStorage(): String = withContext(ioDispatcher) {
+  private suspend fun defaultPublicStorage(): String =
     ContextWrapper(context).externalMediaDirs[ZERO]?.path
       ?: context.filesDir.path // a workaround for emulators
-  }
 
   val selectedStoragePosition: Flow<Int> =
     context.kiwixDataStore.data.map { pref ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
@@ -29,12 +29,16 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.forEachRow
 import org.kiwix.kiwixmobile.core.extensions.get
 import java.io.File
 import javax.inject.Inject
 
-class FileSearch @Inject constructor(private val context: Context) {
+class FileSearch @Inject constructor(
+  private val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
   private val zimFileExtensions = arrayOf("zim", "zimaa")
 
   fun scan(
@@ -97,7 +101,7 @@ class FileSearch @Inject constructor(private val context: Context) {
   }
 
   private suspend fun directoryRoots() =
-    StorageDeviceUtils.getReadableStorage(context).map(StorageDevice::name)
+    StorageDeviceUtils.getReadableStorage(context, ioDispatcher).map(StorageDevice::name)
 
   private fun scanDirectory(directory: String): List<File> {
     return File(directory).walk()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
@@ -29,15 +29,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.forEachRow
 import org.kiwix.kiwixmobile.core.extensions.get
 import java.io.File
 import javax.inject.Inject
 
 class FileSearch @Inject constructor(
-  private val context: Context,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+  private val context: Context
 ) {
   private val zimFileExtensions = arrayOf("zim", "zimaa")
 
@@ -101,7 +99,7 @@ class FileSearch @Inject constructor(
   }
 
   private suspend fun directoryRoots() =
-    StorageDeviceUtils.getReadableStorage(context, ioDispatcher).map(StorageDevice::name)
+    StorageDeviceUtils.getReadableStorage(context).map(StorageDevice::name)
 
   private fun scanDirectory(directory: String): List<File> {
     return File(directory).walk()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
@@ -24,32 +24,32 @@ import android.provider.MediaStore.MediaColumns
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageDeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.forEachRow
 import org.kiwix.kiwixmobile.core.extensions.get
 import java.io.File
 import javax.inject.Inject
 
 class FileSearch @Inject constructor(
-  private val context: Context
+  private val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
   private val zimFileExtensions = arrayOf("zim", "zimaa")
 
   fun scan(
-    scanningProgressListener: ScanningProgressListener,
-    dispatcher: CoroutineDispatcher = Dispatchers.IO
+    scanningProgressListener: ScanningProgressListener
   ): Flow<List<File>> {
     val fileSystemFlow = flow {
       emit(scanFileSystem(scanningProgressListener))
-    }.flowOn(dispatcher)
+    }.flowOn(ioDispatcher)
 
     val mediaStoreFlow = flow {
       emit(scanMediaStore())
-    }.flowOn(dispatcher)
+    }.flowOn(ioDispatcher)
 
     return combine(fileSystemFlow, mediaStoreFlow) { filesSystemFiles, mediaStoreFiles ->
       filesSystemFiles + mediaStoreFiles
@@ -99,7 +99,7 @@ class FileSearch @Inject constructor(
   }
 
   private suspend fun directoryRoots() =
-    StorageDeviceUtils.getReadableStorage(context).map(StorageDevice::name)
+    StorageDeviceUtils.getReadableStorage(context, ioDispatcher).map(StorageDevice::name)
 
   private fun scanDirectory(directory: String): List<File> {
     return File(directory).walk()

--- a/core/src/sharedTestFunctions/java/org/kiwix/sharedFunctions/MainDispatcherRule.kt
+++ b/core/src/sharedTestFunctions/java/org/kiwix/sharedFunctions/MainDispatcherRule.kt
@@ -35,48 +35,19 @@ class MainDispatcherRule(
   val dispatcher: TestDispatcher = StandardTestDispatcher()
 ) :
   TestWatcher(), BeforeEachCallback, AfterEachCallback {
-  private var isMainOverridden = false
-
   override fun starting(description: Description?) {
-    if (shouldOverrideMain()) {
-      Dispatchers.setMain(dispatcher)
-      isMainOverridden = true
-    }
+    Dispatchers.setMain(dispatcher)
   }
 
   override fun finished(description: Description?) {
-    if (isMainOverridden) {
-      Dispatchers.resetMain()
-      isMainOverridden = false
-    }
+    Dispatchers.resetMain()
   }
 
   override fun beforeEach(context: ExtensionContext?) {
-    if (shouldOverrideMain()) {
-      Dispatchers.setMain(dispatcher)
-      isMainOverridden = true
-    }
+    Dispatchers.setMain(dispatcher)
   }
 
   override fun afterEach(context: ExtensionContext?) {
-    if (isMainOverridden) {
-      Dispatchers.resetMain()
-      isMainOverridden = false
-    }
-  }
-
-  private fun shouldOverrideMain(): Boolean {
-    return try {
-      val runtime = System.getProperty("java.runtime.name")
-      val isAndroidRuntime = runtime?.contains("Android", ignoreCase = true) == true
-      if (isAndroidRuntime) {
-        val fingerprint = android.os.Build.FINGERPRINT
-        fingerprint?.contains("robolectric", ignoreCase = true) == true
-      } else {
-        true
-      }
-    } catch (_: Throwable) {
-      true
-    }
+    Dispatchers.resetMain()
   }
 }

--- a/core/src/sharedTestFunctions/java/org/kiwix/sharedFunctions/MainDispatcherRule.kt
+++ b/core/src/sharedTestFunctions/java/org/kiwix/sharedFunctions/MainDispatcherRule.kt
@@ -35,19 +35,48 @@ class MainDispatcherRule(
   val dispatcher: TestDispatcher = StandardTestDispatcher()
 ) :
   TestWatcher(), BeforeEachCallback, AfterEachCallback {
+  private var isMainOverridden = false
+
   override fun starting(description: Description?) {
-    Dispatchers.setMain(dispatcher)
+    if (shouldOverrideMain()) {
+      Dispatchers.setMain(dispatcher)
+      isMainOverridden = true
+    }
   }
 
   override fun finished(description: Description?) {
-    Dispatchers.resetMain()
+    if (isMainOverridden) {
+      Dispatchers.resetMain()
+      isMainOverridden = false
+    }
   }
 
   override fun beforeEach(context: ExtensionContext?) {
-    Dispatchers.setMain(dispatcher)
+    if (shouldOverrideMain()) {
+      Dispatchers.setMain(dispatcher)
+      isMainOverridden = true
+    }
   }
 
   override fun afterEach(context: ExtensionContext?) {
-    Dispatchers.resetMain()
+    if (isMainOverridden) {
+      Dispatchers.resetMain()
+      isMainOverridden = false
+    }
+  }
+
+  private fun shouldOverrideMain(): Boolean {
+    return try {
+      val runtime = System.getProperty("java.runtime.name")
+      val isAndroidRuntime = runtime?.contains("Android", ignoreCase = true) == true
+      if (isAndroidRuntime) {
+        val fingerprint = android.os.Build.FINGERPRINT
+        fingerprint?.contains("robolectric", ignoreCase = true) == true
+      } else {
+        true
+      }
+    } catch (_: Throwable) {
+      true
+    }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadModel
@@ -45,6 +46,7 @@ import org.kiwix.kiwixmobile.core.utils.files.ScanningProgressListener
 import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.Illustration
 import org.kiwix.libzim.Archive
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.kiwix.sharedFunctions.libkiwixBook
 import java.io.File
 
@@ -67,6 +69,9 @@ class StorageObserverTest {
 
   private lateinit var storageObserver: StorageObserver
 
+  @RegisterExtension
+  private val ioDispatcher = MainDispatcherRule()
+
   @BeforeEach fun init() {
     clearAllMocks()
     coEvery { kiwixDataStore.selectedStorage } returns flowOf("a")
@@ -81,7 +86,8 @@ class StorageObserverTest {
       fileSearch,
       readerFactory,
       libkiwixBookmarks,
-      libkiwixBookFactory
+      libkiwixBookFactory,
+      ioDispatcher.dispatcher
     )
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -70,7 +70,8 @@ class StorageObserverTest {
   private lateinit var storageObserver: StorageObserver
 
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @BeforeEach fun init() {
     clearAllMocks()
@@ -87,7 +88,7 @@ class StorageObserverTest {
       readerFactory,
       libkiwixBookmarks,
       libkiwixBookFactory,
-      ioDispatcher.dispatcher
+      mainDispatcherRule.dispatcher
     )
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/ThemeConfigTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/ThemeConfigTest.kt
@@ -49,7 +49,7 @@ class ThemeConfigTest {
   fun setUp() {
     kiwixDataStore = mockk()
     context = mockk()
-    themeConfig = ThemeConfig(kiwixDataStore, context)
+    themeConfig = ThemeConfig(kiwixDataStore, context, dispatcherRule.dispatcher)
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/ThemeConfigTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/ThemeConfigTest.kt
@@ -42,6 +42,7 @@ class ThemeConfigTest {
   private lateinit var context: Context
 
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
 
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
@@ -57,7 +57,8 @@ class DownloadManagerRequesterTest {
   private lateinit var mainActivity: CoreMainActivity
 
   @RegisterExtension
-  private var dispatcher = MainDispatcherRule()
+  @JvmField
+  var mainDispatcherRule = MainDispatcherRule()
 
   @BeforeEach
   fun setup() {
@@ -80,7 +81,7 @@ class DownloadManagerRequesterTest {
       kiwixDataStore,
       context,
       downloadRoomDao,
-      dispatcher.dispatcher
+      mainDispatcherRule.dispatcher
     )
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
@@ -32,14 +32,12 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.DownloadRoomEntity
@@ -48,6 +46,7 @@ import org.kiwix.kiwixmobile.core.downloader.model.DownloadRequest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.AUTO_RETRY_MAX_ATTEMPTS
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.sharedFunctions.MainDispatcherRule
 
 class DownloadManagerRequesterTest {
   private lateinit var fetch: Fetch
@@ -56,7 +55,9 @@ class DownloadManagerRequesterTest {
   private lateinit var downloadRoomDao: DownloadRoomDao
   private lateinit var requester: DownloadManagerRequester
   private lateinit var mainActivity: CoreMainActivity
-  private lateinit var dispatcher: TestDispatcher
+
+  @RegisterExtension
+  private var dispatcher = MainDispatcherRule()
 
   @BeforeEach
   fun setup() {
@@ -73,20 +74,19 @@ class DownloadManagerRequesterTest {
     every { kiwixDataStore.wifiOnly } returns flowOf(false)
   }
 
-  private fun createRequester(testScheduler: TestCoroutineScheduler) {
-    dispatcher = StandardTestDispatcher(testScheduler)
+  private fun createRequester() {
     requester = DownloadManagerRequester(
       fetch,
       kiwixDataStore,
       context,
       downloadRoomDao,
-      dispatcher
+      dispatcher.dispatcher
     )
   }
 
   @Test
   fun `cancel should call fetch delete`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
 
     requester.cancel(downloadId)
@@ -104,7 +104,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `cancel should remove from Room DB when Fetch returns error`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
     val errorCallbackSlot = slot<Func<Error>>()
     every {
@@ -126,7 +126,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `retryDownload should call fetch retry`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
 
     requester.retryDownload(downloadId)
@@ -145,7 +145,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `retryDownload should re-enqueue when Fetch returns error`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
     val errorCallbackSlot = slot<Func<Error>>()
     every {
@@ -171,7 +171,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `retryDownload should not re-enqueue when stale entity is null`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
     val errorCallbackSlot = slot<Func<Error>>()
     every {
@@ -193,7 +193,7 @@ class DownloadManagerRequesterTest {
 
   @Test
   fun `pauseResumeDownload should call fetch resume when isPause is true`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
 
     requester.pauseResumeDownload(downloadId, isPause = true)
@@ -211,7 +211,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `pauseResumeDownload should re-enqueue when resuming a stale download`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
     val url = "https://example.com/test.zim"
     val errorCallbackSlot = slot<Func<Error>>()
@@ -241,7 +241,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `pauseResumeDownload should call fetch pause when isPause is false`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
 
     requester.pauseResumeDownload(downloadId, isPause = false)
@@ -253,7 +253,7 @@ class DownloadManagerRequesterTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun `pauseResumeDownload should not re-enqueue when stale entity has null url`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadId = 42L
     val errorCallbackSlot = slot<Func<Error>>()
     every {
@@ -277,7 +277,7 @@ class DownloadManagerRequesterTest {
 
   @Test
   fun `enqueue should create fetch request with WiFi only config`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadRequest = mockk<DownloadRequest>(relaxed = true)
 
     every { kiwixDataStore.wifiOnly } returns flowOf(true)
@@ -294,7 +294,7 @@ class DownloadManagerRequesterTest {
 
   @Test
   fun `enqueue should create fetch request with all network config`() = runTest {
-    createRequester(testScheduler)
+    createRequester()
     val downloadRequest = mockk<DownloadRequest>(relaxed = true)
 
     every { kiwixDataStore.wifiOnly } returns flowOf(false)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/help/HelpScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/help/HelpScreenTest.kt
@@ -38,7 +38,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class HelpScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/note/AddNoteDialogScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/note/AddNoteDialogScreenTest.kt
@@ -44,7 +44,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class AddNoteDialogScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeRule = createComposeRule()
 
   private val snackbarHostState = SnackbarHostState()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/note/AddNoteViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/note/AddNoteViewModelTest.kt
@@ -54,7 +54,8 @@ import kotlin.io.path.createTempDirectory
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AddNoteViewModelTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
   private lateinit var activity: Activity
   private lateinit var noteRepository: NoteRepository

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenComposablesTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenComposablesTest.kt
@@ -60,7 +60,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class ReaderScreenComposablesTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/PageScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/PageScreenTest.kt
@@ -74,7 +74,8 @@ import org.threeten.bp.format.DateTimeFormatter
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class PageScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialogTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/NavigationHistoryDialogTest.kt
@@ -51,7 +51,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class NavigationHistoryDialogTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
@@ -30,6 +30,7 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class HistoryViewModelTest {
   @RegisterExtension
+  @JvmField
   val mainDispatcherRule = MainDispatcherRule()
   private val historyRoomDao: HistoryRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -22,21 +22,24 @@ import androidx.appcompat.app.AppCompatActivity
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.historyItem
 import org.kiwix.kiwixmobile.core.page.historyState
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
+import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class DeletePageItemsTest {
+  @get:Rule
+  private val dispatcher = MainDispatcherRule()
   private val pageDao: PageDao = mockk(relaxed = true)
   val activity: AppCompatActivity = mockk()
   private val zimReaderSource: ZimReaderSource = mockk()
   private val item1 = historyItem(zimReaderSource = zimReaderSource)
   private val item2 = historyItem(zimReaderSource = zimReaderSource)
-  private val viewModelScope = CoroutineScope(Dispatchers.Main)
+  private val viewModelScope = CoroutineScope(dispatcher.dispatcher)
 
   @Test
   fun `delete with selected items only deletes the selected items`() =

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -32,14 +32,15 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class DeletePageItemsTest {
-  @get:Rule
-  private val dispatcher = MainDispatcherRule()
+  @Rule
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private val pageDao: PageDao = mockk(relaxed = true)
   val activity: AppCompatActivity = mockk()
   private val zimReaderSource: ZimReaderSource = mockk()
   private val item1 = historyItem(zimReaderSource = zimReaderSource)
   private val item2 = historyItem(zimReaderSource = zimReaderSource)
-  private val viewModelScope = CoroutineScope(dispatcher.dispatcher)
+  private val viewModelScope = CoroutineScope(mainDispatcherRule.dispatcher)
 
   @Test
   fun `delete with selected items only deletes the selected items`() =

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/SearchScreenUITest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/SearchScreenUITest.kt
@@ -49,7 +49,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class SearchScreenUITest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -35,7 +35,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class SearchStateTest {
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -73,7 +73,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class SearchViewModelTest {
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   private val recentSearchRoomDao: RecentSearchRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
@@ -30,7 +30,8 @@ import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class ZimSearchResultGeneratorTest {
   @RegisterExtension
-  private val mainDispatcherRule = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private val zimFileReader: ZimFileReader = mockk()
 
   private val zimSearchResultGenerator: ZimSearchResultGenerator =

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
@@ -69,7 +69,8 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class SettingsScreenTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val composeTestRule = createComposeRule()
 
   private val context get() = RuntimeEnvironment.getApplication()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -136,6 +136,7 @@ private class TestCoreSettingsViewModel(
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CoreSettingsViewModelTest {
   @RegisterExtension
+  @JvmField
   val dispatcherRule = MainDispatcherRule()
   private val context: Application = mockk(relaxed = true)
   private val kiwixDataStore: KiwixDataStore = mockk(relaxed = true)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
@@ -62,7 +62,8 @@ import org.robolectric.shadows.ShadowToast
 )
 class ExternalLinkOpenerTest {
   @RegisterExtension
-  private val dispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private lateinit var kiwixDataStore: KiwixDataStore
   private val alertDialogShower = AlertDialogShower()
   private lateinit var activity: Activity

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
@@ -29,24 +29,22 @@ import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.kiwix.sharedFunctions.TestApplication
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
@@ -63,16 +61,15 @@ import org.robolectric.shadows.ShadowToast
   application = TestApplication::class
 )
 class ExternalLinkOpenerTest {
+  @RegisterExtension
+  private val dispatcher = MainDispatcherRule()
   private lateinit var kiwixDataStore: KiwixDataStore
   private val alertDialogShower = AlertDialogShower()
   private lateinit var activity: Activity
   private lateinit var activityController: ActivityController<Activity>
-  private val testDispatcher = StandardTestDispatcher()
-  private val coroutineScope = CoroutineScope(testDispatcher)
 
   @Before
   fun setUp() {
-    Dispatchers.setMain(testDispatcher)
     kiwixDataStore = mockk()
     activityController = Robolectric.buildActivity(Activity::class.java)
     activity = activityController.setup().get()
@@ -81,11 +78,10 @@ class ExternalLinkOpenerTest {
   @After
   fun tearDown() {
     activityController.pause().stop().destroy()
-    Dispatchers.resetMain()
   }
 
   @Test
-  fun alertDialogShowerOpensLinkIfConfirmButtonIsClicked() = runBlocking {
+  fun alertDialogShowerOpensLinkIfConfirmButtonIsClicked() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
       intent,
@@ -100,7 +96,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {
       setAlertDialogShower(alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -114,7 +110,7 @@ class ExternalLinkOpenerTest {
   }
 
   @Test
-  fun alertDialogShowerOpensLinkIfGeoProtocolAdded() = runBlocking {
+  fun alertDialogShowerOpensLinkIfGeoProtocolAdded() = runTest {
     val uri = Uri.parse("geo:28.61388888888889,77.20833333333334")
     val intent = Intent(Intent.ACTION_VIEW, uri)
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
@@ -130,7 +126,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {
       setAlertDialogShower(alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -142,7 +138,7 @@ class ExternalLinkOpenerTest {
   }
 
   @Test
-  fun alertDialogShowerDoesNoOpenLinkIfNegativeButtonIsClicked() = runBlocking {
+  fun alertDialogShowerDoesNoOpenLinkIfNegativeButtonIsClicked() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
       intent,
@@ -157,7 +153,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {
       setAlertDialogShower(alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -169,7 +165,7 @@ class ExternalLinkOpenerTest {
 
   @Test
   fun alertDialogShowerOpensLinkAndSavesPreferencesIfNeutralButtonIsClicked() =
-    runBlocking {
+    runTest {
       val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
       Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
         intent,
@@ -185,13 +181,13 @@ class ExternalLinkOpenerTest {
       val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {
         setAlertDialogShower(alertDialogShower)
       }
-      externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+      externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
       val dialogData = alertDialogShower.dialogState.value
       assertNotNull(dialogData)
       val (dialog, listeners, _) = dialogData!!
       assert(dialog == KiwixDialog.ExternalLinkPopup)
       listeners[2].invoke()
-      testDispatcher.scheduler.advanceUntilIdle()
+      advanceUntilIdle()
       coVerify {
         kiwixDataStore.setExternalLinkPopup(false)
       }
@@ -200,7 +196,7 @@ class ExternalLinkOpenerTest {
     }
 
   @Test
-  fun intentIsStartedIfExternalLinkPopupPreferenceIsFalse() = runBlocking {
+  fun intentIsStartedIfExternalLinkPopupPreferenceIsFalse() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
       intent,
@@ -215,14 +211,14 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {
       setAlertDialogShower(alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
     val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
     assertNotNull(startedIntent)
     assert(startedIntent.dataString == "https://github.com/")
   }
 
   @Test
-  internal fun toastIfPackageManagerIsNotResolvable() = runBlocking {
+  internal fun toastIfPackageManagerIsNotResolvable() = runTest {
     // In Robolectric, PackageManager is not null, but we can make it return null for resolveActivity
     // or just not add any resolves.
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
@@ -231,7 +227,7 @@ class ExternalLinkOpenerTest {
       setAlertDialogShower(alertDialogShower)
     }
 
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = coroutineScope)
+    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
     val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
     assertNull(startedIntent)
     assert(
@@ -241,7 +237,7 @@ class ExternalLinkOpenerTest {
   }
 
   @Test
-  fun openExternalLinkWithDialog_showsDialogIfIntentIsResolvable() = runBlocking {
+  fun openExternalLinkWithDialog_showsDialogIfIntentIsResolvable() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
       intent,
@@ -266,7 +262,7 @@ class ExternalLinkOpenerTest {
   }
 
   @Test
-  fun openExternalLinkWithDialog_showsToastIfIntentIsNotResolvable() = runBlocking {
+  fun openExternalLinkWithDialog_showsToastIfIntentIsNotResolvable() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     // No resolve info.
     val externalLinkOpener = ExternalLinkOpener(activity, kiwixDataStore).apply {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -29,11 +29,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.zim_manager.Category
 import org.kiwix.kiwixmobile.core.zim_manager.Language
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
@@ -45,6 +47,9 @@ import java.util.Locale
 class KiwixDataStoreTest {
   private lateinit var context: Context
   private lateinit var kiwixDataStore: KiwixDataStore
+
+  @get:Rule
+  private val ioDispatcher = MainDispatcherRule()
 
   @Before
   fun setUp() = runTest {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -48,8 +48,9 @@ class KiwixDataStoreTest {
   private lateinit var context: Context
   private lateinit var kiwixDataStore: KiwixDataStore
 
-  @get:Rule
-  private val ioDispatcher = MainDispatcherRule()
+  @Rule
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @Before
   fun setUp() = runTest {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/UnsupportedMimeTypeHandlerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/UnsupportedMimeTypeHandlerTest.kt
@@ -48,7 +48,8 @@ import java.io.File
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UnsupportedMimeTypeHandlerTest {
-  @get:Rule
+  @Rule
+  @JvmField
   val mainDispatcherRule = MainDispatcherRule()
 
   private val activity: Activity = mockk(relaxed = true)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
 
 class FileSearchTest {
@@ -49,6 +51,9 @@ class FileSearchTest {
   private val storageDevice: StorageDevice = mockk()
   private val scanningProgressListener: ScanningProgressListener = mockk()
 
+  @RegisterExtension
+  private val ioDispatcher = MainDispatcherRule()
+
   @BeforeEach
   fun init() {
     clearAllMocks()
@@ -58,12 +63,12 @@ class FileSearchTest {
     every { Environment.getExternalStorageDirectory() } returns externalStorageDirectory
     every { externalStorageDirectory.absolutePath } returns "/externalStorageDirectory"
     every { context.contentResolver } returns contentResolver
-    coEvery { StorageDeviceUtils.getReadableStorage(context) } returns
+    coEvery { StorageDeviceUtils.getReadableStorage(context, ioDispatcher.dispatcher) } returns
       arrayListOf(
         storageDevice
       )
     every { storageDevice.name } returns "/deviceDir"
-    fileSearch = FileSearch(context)
+    fileSearch = FileSearch(context, ioDispatcher.dispatcher)
   }
 
   @AfterEach

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
@@ -63,12 +63,12 @@ class FileSearchTest {
     every { Environment.getExternalStorageDirectory() } returns externalStorageDirectory
     every { externalStorageDirectory.absolutePath } returns "/externalStorageDirectory"
     every { context.contentResolver } returns contentResolver
-    coEvery { StorageDeviceUtils.getReadableStorage(context, ioDispatcher.dispatcher) } returns
+    coEvery { StorageDeviceUtils.getReadableStorage(context) } returns
       arrayListOf(
         storageDevice
       )
     every { storageDevice.name } returns "/deviceDir"
-    fileSearch = FileSearch(context, ioDispatcher.dispatcher)
+    fileSearch = FileSearch(context)
   }
 
   @AfterEach

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileSearchTest.kt
@@ -52,7 +52,8 @@ class FileSearchTest {
   private val scanningProgressListener: ScanningProgressListener = mockk()
 
   @RegisterExtension
-  private val ioDispatcher = MainDispatcherRule()
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @BeforeEach
   fun init() {
@@ -63,12 +64,12 @@ class FileSearchTest {
     every { Environment.getExternalStorageDirectory() } returns externalStorageDirectory
     every { externalStorageDirectory.absolutePath } returns "/externalStorageDirectory"
     every { context.contentResolver } returns contentResolver
-    coEvery { StorageDeviceUtils.getReadableStorage(context) } returns
+    coEvery { StorageDeviceUtils.getReadableStorage(context, mainDispatcherRule.dispatcher) } returns
       arrayListOf(
         storageDevice
       )
     every { storageDevice.name } returns "/deviceDir"
-    fileSearch = FileSearch(context)
+    fileSearch = FileSearch(context, mainDispatcherRule.dispatcher)
   }
 
   @AfterEach


### PR DESCRIPTION
Fixes: #4946

- [x] Phase 1: Replacing `StandardTestDispatchers`, `UnconfinedTestDispatchers` with I.O Rule.
- [x] Phase 2: Replacing Hardcoded `Dispathers.Main` with newly introduced Main Dispatcher Rule.

Additionally There were many repeatitive Dagger injection which has been cleaned so proper dagger bindings are received.


**We are adopting a unified pattern for both JUnit 4 and JUnit 5 tests to ensure compatibility and consisitency**

- Change old school annotation `@get:Rule` -> `@Rule`

// JUnit 4 JVM, Robolectic, UI tests
`@Rule @JvmField val mainDispatcherRule = MainDispatcherRule()`

// JUnit 5 (JVM)
`@RegisterExtension @JvmField val mainDispatcherRule = MainDispatcherRule()`

Why `@JvmFiled` ?
Explicit Field Visibility with @JvmField:
- By default, Kotlin properties generate a private field and a public getter. JUnit (being a Java framework) often requires direct field access.
- @JvmField eliminates the "private visibility" bug where JUnit 4 would silently ignore rules marked as private for MainDispatcherRule i.e - Different Test Schedular 
- It ensures that the Rule/Extension is fully initialized and "seen" by the framework before the test starts.

