### PR TITLE
Add unit tests for ProgressResponseBody

### DIFF
--- a/core/src/test/java/org/kiwix/kiwixmobile/core/data/remote/ProgressResponseBodyTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/data/remote/ProgressResponseBodyTest.kt
@@ -226,6 +226,7 @@ class ProgressResponseBodyTest {
 
       val buffer = Buffer()
       while (source.read(buffer, 1) != -1L) {
+        // to nothing
       }
 
       repeat(3) {


### PR DESCRIPTION
Fixes #4771

### What changes were made
- Added unit tests for `ProgressResponseBody.kt`
- Verified `contentType()` returns the expected media type
- Verified `contentLength()` returns the correct length
- Verified `source()` reads the expected content
- Verified `OnlineLibraryProgressListener.onProgress()` is called with the correct progress while reading