### PR TITLE
Fixed: Map interaction was difficult and caused jitter.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -54,9 +54,9 @@ import javax.inject.Inject
 
 private const val INITIAL_SCALE = 100
 
-@SuppressLint("ViewConstructor")
+@SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
 @Suppress("LongParameterList")
-open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
+open class KiwixWebView constructor(
   context: Context,
   private val callback: WebViewCallback,
   attrs: AttributeSet,
@@ -125,18 +125,6 @@ open class KiwixWebView @SuppressLint("SetJavaScriptEnabled") constructor(
     return super.performLongClick()
   }
 
-  /**
-   * We override performClick() because we attach an OnTouchListener
-   * to this WebView in KiwixWebViewWithAppBarScrolling.
-   *
-   * When a View uses setOnTouchListener(), Android expects performClick()
-   * to be overridden for proper accessibility support.
-   *
-   * We simply call super.performClick(), but keeping this override
-   * prevents accessibility issues and avoids Lint warnings.
-   */
-  @Suppress("RedundantOverride")
-  override fun performClick(): Boolean = super.performClick()
   override fun onCreateContextMenu(menu: ContextMenu) {
     super.onCreateContextMenu(menu)
     val result = hitTestResult

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixWebViewWithAppBarScrolling.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixWebViewWithAppBarScrolling.kt
@@ -18,8 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.ui.components
 
-import android.annotation.SuppressLint
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -75,7 +73,7 @@ fun KiwixWebViewWithAppBarScrolling(
 
   key(kiwixWebView) {
     DisposableEffect(Unit) {
-      val listener = createTouchListener(
+      val listener = createScrollListener(
         topAppBarScrollBehavior,
         bottomAppBarScrollBehavior,
         shouldUpdateAppBars,
@@ -84,9 +82,8 @@ fun KiwixWebViewWithAppBarScrolling(
         scope,
         settleJob
       )
-
-      kiwixWebView.setOnTouchListener(listener)
-      onDispose { kiwixWebView.setOnTouchListener(null) }
+      kiwixWebView.setOnScrollChangeListener(listener)
+      onDispose { kiwixWebView.setOnScrollChangeListener(null) }
     }
 
     AndroidView(
@@ -105,9 +102,8 @@ fun KiwixWebViewWithAppBarScrolling(
   }
 }
 
-@SuppressLint("ClickableViewAccessibility")
 @OptIn(ExperimentalMaterial3Api::class)
-private fun createTouchListener(
+private fun createScrollListener(
   topAppBarScrollBehavior: TopAppBarScrollBehavior,
   bottomAppBarScrollBehavior: BottomAppBarScrollBehavior,
   shouldUpdateScroll: MutableState<Boolean>,
@@ -115,50 +111,35 @@ private fun createTouchListener(
   updateAccumulatedScroll: (Float) -> Unit,
   scope: CoroutineScope,
   settleJob: MutableState<Job?>
-): View.OnTouchListener {
-  var lastY = 0f
+): View.OnScrollChangeListener {
+  return View.OnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
+    val deltaY = (scrollY - oldScrollY).toFloat()
+    if (deltaY == 0f || !shouldUpdateScroll.value) return@OnScrollChangeListener
 
-  return View.OnTouchListener { _, event ->
-    if (!shouldUpdateScroll.value) return@OnTouchListener false
-
-    when (event.actionMasked) {
-      MotionEvent.ACTION_DOWN -> {
-        lastY = event.y
-        settleJob.value?.cancel()
-      }
-
-      MotionEvent.ACTION_MOVE -> {
-        val deltaY = event.y - lastY
-        lastY = event.y
-        val accumulated = accumulatedScroll() + deltaY
-
-        if (abs(accumulated) < MIN_SCROLL_DELTA) {
-          updateAccumulatedScroll(accumulated)
-          return@OnTouchListener false
-        }
-
-        val scroll = accumulated * SCROLL_CONSUME_FACTOR
-        updateAccumulatedScroll(0f)
-
-        consumeScroll(
-          scroll,
-          topAppBarScrollBehavior,
-          bottomAppBarScrollBehavior
-        )
-      }
-
-      MotionEvent.ACTION_UP,
-      MotionEvent.ACTION_CANCEL -> {
-        settleJob.value?.cancel()
-        settleJob.value = scope.launch {
-          delay(DEFAULT_SETTLE_DELAY)
-          settleTopAppBarWithoutVelocity(topAppBarScrollBehavior)
-          settleBottomAppBarWithoutVelocity(bottomAppBarScrollBehavior)
-        }
-      }
+    val accumulated = accumulatedScroll() - deltaY
+    if (abs(accumulated) < MIN_SCROLL_DELTA) {
+      updateAccumulatedScroll(accumulated)
+      return@OnScrollChangeListener
     }
+    val scroll = accumulated * SCROLL_CONSUME_FACTOR
+    updateAccumulatedScroll(0f)
+    consumeScroll(scroll, topAppBarScrollBehavior, bottomAppBarScrollBehavior)
+    triggerSettle(scope, settleJob, topAppBarScrollBehavior, bottomAppBarScrollBehavior)
+  }
+}
 
-    false
+@OptIn(ExperimentalMaterial3Api::class)
+private fun triggerSettle(
+  scope: CoroutineScope,
+  settleJob: MutableState<Job?>,
+  topAppBarScrollBehavior: TopAppBarScrollBehavior,
+  bottomAppBarScrollBehavior: BottomAppBarScrollBehavior
+) {
+  settleJob.value?.cancel()
+  settleJob.value = scope.launch {
+    delay(DEFAULT_SETTLE_DELAY)
+    settleTopAppBarWithoutVelocity(topAppBarScrollBehavior)
+    settleBottomAppBarWithoutVelocity(bottomAppBarScrollBehavior)
   }
 }
 


### PR DESCRIPTION
Fixes #4792 

* When the `TopAppBar` and `BottomAppBar` were visible, interacting with maps caused a noticeable jitter. This happened because we were intercepting touch events. Once the app bars were hidden, map interactions became smooth.
* To fix this, we removed the touch listener from the WebView and switched to using a scroll listener instead. This allows the WebView to have full control over touch handling while still providing scroll position updates when applicable.
* For content like maps (and similar ZIM files), touch events are handled internally (e.g., via JavaScript). In such cases, the WebView does not emit scroll updates, so the app bars will not hide during these interactions.
* This behavior is expected and aligns with how modern browsers handle embedded interactive content (e.g., maps in Chrome or Firefox).
* Attempting to control or intercept touch events at the WebView level can lead to gesture conflicts and issues like the jitter observed here, so it is better to let the WebView manage touch interactions natively.

This issue was introduced in https://github.com/kiwix/kiwix-android/pull/4714, due to https://github.com/kiwix/kiwix-android/issues/4677.

| Before Fix | After Fix |
|---------------|-------------|
| <video src ="https://github.com/user-attachments/assets/25ddb09e-587a-4f2e-a1ed-7bf1bcdacb71" /> | <video src ="https://github.com/user-attachments/assets/f58b65a5-9176-4787-9458-a46d18711b5d" /> | 
