### PR TITLE
Imporve Coverage while eliminating a block of fragile boilerplate from the codebase addressing comment.

### DIFF
--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.core.utils.files.FileSearch
 import org.kiwix.kiwixmobile.core.utils.files.ScanningProgressListener
 import org.kiwix.kiwixmobile.core.utils.files.testFlow
 import org.kiwix.libkiwix.Book
+import org.kiwix.libkiwix.Illustration
 import org.kiwix.libzim.Archive
 import org.kiwix.sharedFunctions.libkiwixBook
 import java.io.File
@@ -141,8 +142,39 @@ class StorageObserverTest {
   }
 }
 
-class BookTestWrapper(private val id: String) : Book(0L) {
+class BookTestWrapper(
+  private val id: String,
+  private val bookTitle: String = "",
+  private val bookDescription: String = "",
+  private val bookLanguage: String = "",
+  private val bookCreator: String = "",
+  private val bookPublisher: String = "",
+  private val bookDate: String = "",
+  private val bookUrl: String = "",
+  private val bookArticleCount: String = "",
+  private val bookMediaCount: String = "",
+  private val bookSize: String = "",
+  private val bookPath: String = "",
+  private val bookName: String = "",
+  private val bookTags: String = ""
+) : Book(0L) {
   override fun getId(): String = id
+  override fun getTitle(): String = bookTitle
+  override fun getDescription(): String = bookDescription
+  override fun getLanguage(): String = bookLanguage
+  override fun getCreator(): String = bookCreator
+  override fun getPublisher(): String = bookPublisher
+  override fun getDate(): String = bookDate
+  override fun getUrl(): String = bookUrl
+  override fun getArticleCount(): Long = bookArticleCount.toLong()
+  override fun getMediaCount(): Long = bookMediaCount.toLong()
+  override fun getSize(): Long = bookSize.toLong()
+  override fun getPath(): String = bookPath
+  override fun getName(): String = bookName
+  override fun getTags(): String = bookTags
+
+  // Returning null due to not construing the `Illustration` since it is libkiwix internal class.
+  override fun getIllustration(size: Int): Illustration? = null
   override fun equals(other: Any?): Boolean = other is BookTestWrapper && getId() == other.getId()
   override fun hashCode(): Int = getId().hashCode()
   override fun update(archive: Archive?) {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/entity/LibKiwixBookTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/entity/LibKiwixBookTest.kt
@@ -1,18 +1,18 @@
 /*
  * Kiwix Android
  * Copyright (c) 2026 Kiwix <android.kiwix.org>
- * This program is free software: you can redistribute it and/or modify
+ * program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
@@ -24,23 +24,132 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.BookTestWrapper
 import java.io.File
 
 class LibKiwixBookTest {
+  private val bookId = "id"
+  private val bookTitle = "title"
+  private val bookDescription = "description"
+  private val bookLanguage = "eng"
+  private val bookCreator = "creator"
+  private val bookPublisher = "publisher"
+  private val bookDate = "2022-10-30"
+  private val bookUrl = "https://kiwix.org/download/alpine-linux.url.meta4"
+  private val bookArticleCount = "10"
+  private val bookMediaCount = "20"
+  private val bookSize = "1024"
+  private val name = "Alpine Linux Wiki"
+  private val bookPath = "/storage/test.zim"
+  private val bookFavIcon = "favIcon"
+  private val bookFile = File("")
+  private val bookTags = ""
+  private val bookSearchMatches = 10
+
   @AfterEach
   fun tearDown() {
     unmockkAll()
   }
 
   @Nested
-  inner class PropertyFallbacks {
+  inner class PropertyBehavior {
     @Test
-    fun libkiwixBook_whenNativeBookIsNull_returnsEmptyStrings() = runTest {
-      val libkiwixBook = LibkiwixBook(nativeBook = null)
-
+    fun libkiwixBookWhenNativeBookIsNullReturnsDefaultValues() = runTest {
+      val libkiwixBook = LibkiwixBook()
       assertThat(libkiwixBook.id).isEmpty()
       assertThat(libkiwixBook.title).isEmpty()
+      assertThat(libkiwixBook.description).isNull()
+      assertThat(libkiwixBook.language).isEmpty()
+      assertThat(libkiwixBook.creator).isEmpty()
+      assertThat(libkiwixBook.publisher).isEmpty()
+      assertThat(libkiwixBook.date).isEmpty()
+      assertThat(libkiwixBook.url).isNull()
+      assertThat(libkiwixBook.articleCount).isNull()
+      assertThat(libkiwixBook.mediaCount).isNull()
+      assertThat(libkiwixBook.size).isEmpty()
+      assertThat(libkiwixBook.bookName).isNull()
+      assertThat(libkiwixBook.favicon).isEmpty()
+      assertThat(libkiwixBook.tags).isNull()
       assertThat(libkiwixBook.path).isNull()
+      assertThat(libkiwixBook.file).isNull()
+    }
+
+    @Test
+    fun libkiwixBookWhenNativeBookIsNullAndSetValues() = runTest {
+      val libkiwixBook = LibkiwixBook().apply {
+        id = bookId
+        title = bookTitle
+        description = bookDescription
+        language = bookLanguage
+        creator = bookCreator
+        publisher = bookPublisher
+        date = bookDate
+        url = bookUrl
+        articleCount = bookArticleCount
+        mediaCount = bookMediaCount
+        size = bookSize
+        file = bookFile
+        path = bookPath
+        bookName = name
+        favicon = bookFavIcon
+        tags = bookTags
+        searchMatches = bookSearchMatches
+      }
+      assertLibkiwixBookValues(libkiwixBook)
+    }
+
+    @Test
+    fun libkiwixBookWhenNativeBookAvailable() = runTest {
+      val nativeBook = BookTestWrapper(
+        bookId,
+        bookTitle,
+        bookDescription,
+        bookLanguage,
+        bookCreator,
+        bookPublisher,
+        bookDate,
+        bookUrl,
+        bookArticleCount,
+        bookMediaCount,
+        bookSize,
+        bookPath,
+        name,
+        bookTags
+      )
+      val libkiwixBook = LibkiwixBook(nativeBook).apply {
+        searchMatches = bookSearchMatches
+        file = bookFile
+      }
+      assertLibkiwixBookValues(libkiwixBook, true)
+    }
+
+    private fun assertLibkiwixBookValues(
+      libkiwixBook: LibkiwixBook,
+      isNativeBook: Boolean = false
+    ) {
+      assertThat(libkiwixBook.id).isEqualTo(bookId)
+      assertThat(libkiwixBook.title).isEqualTo(bookTitle)
+      assertThat(libkiwixBook.description).isEqualTo(bookDescription)
+      assertThat(libkiwixBook.language).isEqualTo(bookLanguage)
+      assertThat(libkiwixBook.creator).isEqualTo(bookCreator)
+      assertThat(libkiwixBook.publisher).isEqualTo(bookPublisher)
+      assertThat(libkiwixBook.date).isEqualTo(bookDate)
+      assertThat(libkiwixBook.url).isEqualTo(bookUrl)
+      assertThat(libkiwixBook.articleCount).isEqualTo(bookArticleCount)
+      assertThat(libkiwixBook.mediaCount).isEqualTo(bookMediaCount)
+      assertThat(libkiwixBook.size).isEqualTo(bookSize)
+      assertThat(libkiwixBook.bookName).isEqualTo(name)
+      if (isNativeBook) {
+        // Since we are not mocking the native Illustration.
+        // Default value is empty string.
+        assertThat(libkiwixBook.favicon).isEqualTo("")
+      } else {
+        assertThat(libkiwixBook.favicon).isEqualTo(bookFavIcon)
+      }
+      assertThat(libkiwixBook.tags).isEqualTo(bookTags)
+      assertThat(libkiwixBook.path).isEqualTo(bookPath)
+      assertThat(libkiwixBook.file).isEqualTo(bookFile)
+      assertThat(libkiwixBook.searchMatches).isEqualTo(bookSearchMatches)
     }
   }
 
@@ -48,11 +157,11 @@ class LibKiwixBookTest {
   inner class IdentityAndEquality {
     @Test
     fun libkiwix_whenIDsMatchesRegardlessOfOtherFields_returnsTrue() = runTest {
-      val book1 = LibkiwixBook(nativeBook = null).apply {
+      val book1 = LibkiwixBook().apply {
         id = "kiwix"
         title = "Book 1"
       }
-      val book2 = LibkiwixBook(nativeBook = null).apply {
+      val book2 = LibkiwixBook().apply {
         id = "kiwix"
         title = "Book 2"
       }
@@ -67,17 +176,44 @@ class LibKiwixBookTest {
       val book2 = LibkiwixBook().apply { id = "B" }
       assertThat(book1).isNotEqualTo(book2)
     }
+
+    @Test
+    fun libkiwix_whenComparedWithDifferentType_returnsFalse() = runTest {
+      val book = LibkiwixBook().apply { id = "A" }
+
+      val result = book.equals("not a book")
+
+      assertThat(result).isFalse()
+    }
+
+    @Test
+    fun libkiwix_whenComparedWithNull_returnsFalse() = runTest {
+      val book = LibkiwixBook().apply { id = "A" }
+
+      val result = book.equals(null)
+
+      assertThat(result).isFalse()
+    }
   }
 
   @Nested
   inner class SourceCreation {
     @Test
     fun zimReaderSource_whenCreatesSourceWithCorrectFilePath_returnsTrue() = runTest {
-      val libkiwixBook = LibkiwixBook().apply { path = "/storage/test.zim" }
+      val libkiwixBook = LibkiwixBook().apply { path = bookPath }
+      val source = libkiwixBook.zimReaderSource
+      assertThat(source.file).isEqualTo(File(bookPath))
+    }
+
+    @Test
+    fun zimReaderSource_whenPathIsNull_returnsEmptyFile() = runTest {
+      val libkiwixBook = LibkiwixBook().apply {
+        path = null
+      }
 
       val source = libkiwixBook.zimReaderSource
 
-      assertThat(source.file).isEqualTo(File("/storage/test.zim"))
+      assertThat(source.file).isEqualTo(File(""))
     }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/entity/LibKiwixBookTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/entity/LibKiwixBookTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.entity
+
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class LibKiwixBookTest {
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Nested
+  inner class PropertyFallbacks {
+    @Test
+    fun libkiwixBook_whenNativeBookIsNull_returnsEmptyStrings() = runTest {
+      val libkiwixBook = LibkiwixBook(nativeBook = null)
+
+      assertThat(libkiwixBook.id).isEmpty()
+      assertThat(libkiwixBook.title).isEmpty()
+      assertThat(libkiwixBook.path).isNull()
+    }
+  }
+
+  @Nested
+  inner class IdentityAndEquality {
+    @Test
+    fun libkiwix_whenIDsMatchesRegardlessOfOtherFields_returnsTrue() = runTest {
+      val book1 = LibkiwixBook(nativeBook = null).apply {
+        id = "kiwix"
+        title = "Book 1"
+      }
+      val book2 = LibkiwixBook(nativeBook = null).apply {
+        id = "kiwix"
+        title = "Book 2"
+      }
+
+      assertThat(book1).isEqualTo(book2)
+      assertThat(book1.hashCode()).isEqualTo(book2.hashCode())
+    }
+
+    @Test
+    fun libkiwix_whenIDsDoesNotMatches_returnsFalse() = runTest {
+      val book1 = LibkiwixBook().apply { id = "A" }
+      val book2 = LibkiwixBook().apply { id = "B" }
+      assertThat(book1).isNotEqualTo(book2)
+    }
+  }
+
+  @Nested
+  inner class SourceCreation {
+    @Test
+    fun zimReaderSource_whenCreatesSourceWithCorrectFilePath_returnsTrue() = runTest {
+      val libkiwixBook = LibkiwixBook().apply { path = "/storage/test.zim" }
+
+      val source = libkiwixBook.zimReaderSource
+
+      assertThat(source.file).isEqualTo(File("/storage/test.zim"))
+    }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/entity/MetaLinkNetworkEntityTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/entity/MetaLinkNetworkEntityTest.kt
@@ -17,111 +17,183 @@
 */
 package org.kiwix.kiwixmobile.core.entity
 
-import org.assertj.core.api.AbstractAssert
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.simpleframework.xml.core.Persister
 
 class MetaLinkNetworkEntityTest {
-  @Test
-  @Throws(Exception::class)
-  fun testDeserialize() {
-    val serializer = Persister()
-    val result = serializer.read(
-      MetaLinkNetworkEntity::class.java,
-      MetaLinkNetworkEntityTest::class.java.classLoader!!.getResourceAsStream(
-        "wikipedia_af_all_nopic_2016-05.zim.meta4"
-      )
-    )
-    result?.urls?.let {
-      MetaLinkNetworkEntityUrlAssert(it).hasItems(
-        listOf(
-          DummyUrl(
-            "us",
-            1,
-            "http://ftpmirror.your.org/pub/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
-          ),
-          @Suppress("ktlint")
-          DummyUrl(
-            "gb",
-            2,
-            "http://www.mirrorservice.org/sites/download.kiwix.org/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
-          ),
-          DummyUrl(
-            "us",
-            3,
-            "http://download.wikimedia.org/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
-          ),
-          DummyUrl(
-            "de",
-            4,
-            "http://mirror.netcologne.de/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
-          ),
-          DummyUrl(
-            "fr",
-            5,
-            "http://mirror3.kiwix.org/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
-          )
-        )
-      )
-    }
-    // Basic file attributes
-    assertThat(result.file?.name).isEqualTo("wikipedia_af_all_nopic_2016-05.zim")
-    assertThat(result.file?.size).isEqualTo(63973123L)
-    // File hashes
-    assertThat(result.file?.getHash("md5")).isEqualTo("6f06866b61c4a921b57f28cfd4307220")
-    assertThat(
-      result.file?.getHash("sha-1")
-    ).isEqualTo("8aac4c7f89e3cdd45b245695e19ecde5aac59593")
-    assertThat(
-      result.file?.getHash("sha-256")
-    ).isEqualTo("83126775538cf588a85edb10db04d6e012321a2025278a08a084b258849b3a5c")
-
-    // Pieces
-    assertThat(result.file?.pieces?.hashType).isEqualTo("sha-1")
-    assertThat(result.file?.pieces?.length).isEqualTo(1048576)
-
-    // Check only the first and the last elements of the piece hashes
-    assertThat(result.file?.pieceHashes?.size).isEqualTo(62)
-    assertThat(
-      result.file?.pieceHashes?.get(0) ?: ""
-    ).isEqualTo("f36815d904d4fd563aaef4ee6ef2600fb1fd70b2")
-    assertThat(
-      result.file?.pieceHashes?.get(61) ?: ""
-    ).isEqualTo("8055e515aa6e78f2810bbb0e0cd07330838b8920")
-  }
-
   data class DummyUrl(val location: String, val priority: Int, val value: String)
 
-  /**
-   * Implemented as a matcher only to avoid putting extra code into {@code MetaLinkNetworkEntity}.
-   * However in case {@code equals} and {@code hashCode} methods are added to
-   * {@code MetaLinkNetworkEntity.Url} class itself, this Matcher should be deleted.
-   */
-  class MetaLinkNetworkEntityUrlAssert(
-    actual: List<MetaLinkNetworkEntity.Url>
-  ) : AbstractAssert<MetaLinkNetworkEntityUrlAssert, List<MetaLinkNetworkEntity.Url>>(
-      actual,
-      MetaLinkNetworkEntityUrlAssert::class.java
-    ) {
-    private fun <S, T> intersectionWith(
-      first: List<S>,
-      second: List<T>,
-      function: (S, T) -> Boolean
-    ): Boolean {
-      val filtered = first.filter { a -> second.any { b -> function(a, b) } }
-      return filtered.isNotEmpty()
+  // ======== Helper ========
+  private fun makeUrl(value: String, location: String = "us", priority: Int = 1) =
+    MetaLinkNetworkEntity.Url().apply {
+      this.value = value
+      this.location = location
+      this.priority = priority
     }
 
-    fun hasItems(items: List<DummyUrl>): Boolean {
-      return intersectionWith(actual, items) { a, b ->
-        a.location == b.location && a.priority == b.priority && a.value == b.value
+  private fun entityWithUrls(urlsList: List<MetaLinkNetworkEntity.Url>) =
+    MetaLinkNetworkEntity().apply {
+      file = MetaLinkNetworkEntity.FileElement().apply {
+        urls = urlsList
       }
+    }
+
+  @Nested
+  inner class ParseXmlFiles {
+    private lateinit var result: MetaLinkNetworkEntity
+
+    @BeforeEach
+    fun setup() {
+      val serializer = Persister()
+      val stream =
+        MetaLinkNetworkEntityTest::class.java.classLoader!!.getResourceAsStream("wikipedia_af_all_nopic_2016-05.zim.meta4")
+      result = serializer.read(MetaLinkNetworkEntity::class.java, stream)
+    }
+
+    @Test
+    fun urls_whenParsedCorrectly_returnsExpectedList() = runTest {
+      val actualUrls = result.urls?.map {
+        DummyUrl(it.location.orEmpty(), it.priority, it.value.orEmpty())
+      }
+
+      val expectedUrls = listOf(
+        DummyUrl(
+          "us",
+          1,
+          "http://ftpmirror.your.org/pub/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
+        ),
+        DummyUrl(
+          "gb",
+          2,
+          "http://www.mirrorservice.org/sites/download.kiwix.org/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
+        ),
+        DummyUrl(
+          "us",
+          3,
+          "http://download.wikimedia.org/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
+        ),
+        DummyUrl(
+          "de",
+          4,
+          "http://mirror.netcologne.de/kiwix/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
+        ),
+        DummyUrl(
+          "fr",
+          5,
+          "http://mirror3.kiwix.org/zim/wikipedia/wikipedia_af_all_nopic_2016-05.zim"
+        )
+      )
+
+      // List should have all the parameters regardless of the order
+      assertThat(actualUrls).containsExactlyInAnyOrderElementsOf(expectedUrls)
+    }
+
+    @Test
+    fun file_whenParsedCorrectly_returnsExpectedProperties() = runTest {
+      val file = result.file
+      assertThat(file?.name).isEqualTo("wikipedia_af_all_nopic_2016-05.zim")
+      assertThat(file?.size).isEqualTo(63973123L)
+    }
+
+    @Test
+    fun getHash_whenParsedCorrectly_returnsExpectedHash() = runTest {
+      val file = result.file
+      assertThat(file?.getHash("md5")).isEqualTo("6f06866b61c4a921b57f28cfd4307220")
+      assertThat(file?.getHash("sha-1")).isEqualTo("8aac4c7f89e3cdd45b245695e19ecde5aac59593")
+      assertThat(file?.getHash("sha-256")).isEqualTo("83126775538cf588a85edb10db04d6e012321a2025278a08a084b258849b3a5c")
+    }
+
+    @Test
+    fun piece_whenParsedCorrectly_returnsExpectedPieces() = runTest {
+      val file = result.file
+      assertThat(file?.pieces?.hashType).isEqualTo("sha-1")
+      assertThat(file?.pieces?.length).isEqualTo(1048576)
+      assertThat(file?.pieceHashes?.size).isEqualTo(62)
+      assertThat(file?.pieceHashes?.get(0)).isEqualTo("f36815d904d4fd563aaef4ee6ef2600fb1fd70b2")
+      assertThat(file?.pieceHashes?.get(61)).isEqualTo("8055e515aa6e78f2810bbb0e0cd07330838b8920")
     }
   }
 
-  companion object {
-    fun assertThat(actual: List<MetaLinkNetworkEntity.Url>): MetaLinkNetworkEntityUrlAssert =
-      MetaLinkNetworkEntityUrlAssert(actual)
+  @Nested
+  inner class RelevantUrlProperty {
+    @Test
+    fun relevantUrl_whenFileIsNull_returnsEmptyUrl() {
+      val result = MetaLinkNetworkEntity()
+
+      assertThat(result.relevantUrl.location).isNull()
+      assertThat(result.relevantUrl.priority).isEqualTo(0)
+      assertThat(result.relevantUrl.value).isNull()
+    }
+
+    @Test
+    fun relevantUrl_whenUrlsIsEmpty_throwsIndexOutOfBoundsException() = runTest {
+      val entity = entityWithUrls(emptyList())
+
+      assertThatThrownBy { entity.relevantUrl }.isInstanceOf(IndexOutOfBoundsException::class.java)
+    }
+
+    @Test
+    fun relevantUrl_whenUrlsHasEntries_returnsFirstUrl() = runTest {
+      val entity = entityWithUrls(
+        listOf(
+          makeUrl("http://kiwix1.example.org/file.zim", priority = 1),
+          makeUrl("http://kiwix2.example.org/file.zim", priority = 2)
+        )
+      )
+
+      assertThat(entity.relevantUrl.value).isEqualTo("http://kiwix1.example.org/file.zim")
+    }
+
+    @Nested
+    inner class FileAttributes {
+      @Test
+      fun urls_whenFileIsNull_returnsNull() = runTest {
+        assertThat(MetaLinkNetworkEntity().urls).isNull()
+      }
+
+      @Test
+      fun urls_whenFileHasUrls_delegatesToFileUrls() = runTest {
+        val entity = entityWithUrls(listOf(makeUrl("http://kiwix.org/file.zim")))
+        assertThat(entity.urls).hasSize(1)
+        assertThat(entity.urls?.first()?.value).isEqualTo("http://kiwix.org/file.zim")
+      }
+
+      @Test
+      fun getHash_whenTypeDoesNotExist_returnsNull() = runTest {
+        val file =
+          MetaLinkNetworkEntity.FileElement().apply { hashes = mapOf("sha-256" to "kiwix2208") }
+        assertThat(file.getHash("md5")).isNull()
+      }
+
+      @Test
+      fun getHash_whenHashesMapIsNull_returnsNull() = runTest {
+        val file = MetaLinkNetworkEntity.FileElement().apply { hashes = null }
+        assertThat(file.getHash("sha-256")).isNull()
+      }
+
+      @Test
+      fun pieceHashes_whenPiecesIsNull_returnsNull() = runTest {
+        val file = MetaLinkNetworkEntity.FileElement().apply { pieces = null }
+        assertThat(file.pieceHashes).isNull()
+      }
+
+      @Test
+      fun pieceHashes_whenPiecesHasHashes_delegatesToPieces() = runTest {
+        val pieceHashesList = listOf("aabbcc", "ddeeff")
+        val file = MetaLinkNetworkEntity.FileElement().apply {
+          pieces = MetaLinkNetworkEntity.Pieces().apply {
+            hashType = "sha-256"
+            length = 220805
+            pieceHashes = pieceHashesList
+          }
+        }
+        assertThat(file.pieceHashes).containsExactly(pieceHashesList[0], pieceHashesList[1])
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #4788

Improved Coverage for `LibKiwixBookMark ` and `MetaLinkNetworkEntity` , resolved a very old TODO comment: that simplified `MetaLinkNetworkEntityTest` by reducing boilerplate legacy code.