### PR TITLE
Fixed: Diagnostic report not sent when email client was installed.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -191,7 +192,7 @@ open class ErrorActivity : BaseActivity() {
     dismissVerificationDialog()
     // Generate and send send report when all ZIM files are validated.
     val emailIntent = emailIntent()
-    val activities = getSupportedEmailApps(emailIntent, supportedEmailPackages)
+    val activities = getSupportedEmailApps(installedEmailAppsIntent())
     val targetedIntents = createEmailIntents(emailIntent, activities)
     if (activities.isNotEmpty() && targetedIntents.isNotEmpty()) {
       val chooserIntent =
@@ -214,15 +215,8 @@ open class ErrorActivity : BaseActivity() {
   /**
    * Get a list of supported email apps.
    */
-  private fun getSupportedEmailApps(
-    emailIntent: Intent,
-    supportedPackages: List<String>
-  ): List<ResolveInfo> {
-    return packageManager.queryIntentActivitiesCompat(emailIntent, ResolveInfoFlagsCompat.EMPTY)
-      .filter {
-        supportedPackages.any(it.activityInfo.packageName::contains)
-      }
-  }
+  private fun getSupportedEmailApps(emailIntent: Intent): List<ResolveInfo> =
+    packageManager.queryIntentActivitiesCompat(emailIntent, ResolveInfoFlagsCompat.EMPTY)
 
   /**
    * Create a list of intents for supported email apps.
@@ -238,30 +232,14 @@ open class ErrorActivity : BaseActivity() {
     }.toMutableList()
   }
 
-  // List of supported email apps
-  private val supportedEmailPackages =
-    listOf(
-      "com.google.android.gm",
-      "com.zoho.mail",
-      "com.microsoft.office.outlook",
-      "com.yahoo.mobile.client.android.mail",
-      "me.bluemail.mail",
-      "ch.protonmail.android",
-      "com.fsck.k9",
-      "com.maildroid",
-      "org.kman.AquaMail",
-      "com.edison.android.mail",
-      "com.readdle.spark",
-      "com.gmx.mobile.android.mail",
-      "com.fastmail",
-      "ru.mail.mailapp",
-      "ru.yandex.mail",
-      "de.tutao.tutanota"
-    )
-
   private val sendEmailLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
       restartApp()
+    }
+
+  private fun installedEmailAppsIntent(): Intent =
+    Intent(Intent.ACTION_SENDTO).apply {
+      data = "mailto:".toUri()
     }
 
   private suspend fun emailIntent(): Intent {


### PR DESCRIPTION
Fixes #4818

Confirmed by https://github.com/kiwix/kiwix-android/issues/4813#issuecomment-4236458815.

* Removed the hardcoded list of checking the `emailClient`. So that we will not face this type of issue in the future due to new email client launches.
* We have improved our logic to know about the installed email clients on the device. Since `ACTION_SENDTO` with `data = "mailto:"` only handles by the [email apps](https://developer.android.com/guide/components/intents-common#ComposeEmail). So, for getting the email list from the device, we are using this intent for querying(to the Android system, and it returns the list of available apps which can handle this intent) the installed email apps to show when the user shares the diagnostic report. Since this intent does not support the attachments. So for sharing the report, we are still using the `ACTION_SEND` with our custom email list got by the `ACTION_SENDTO` intent. If `ACTION_SENDTO` does not return anything, it means there is no emailClient is installed, so now we don't need any fallback mechanism.

<img width="1010" height="454" alt="image" src="https://github.com/user-attachments/assets/9ab719f2-f1a5-4c22-997a-a07e5cead4e1" />

* By using the above approach. Now, we get rid of both issues:
   * No hardcoded email list.
   * When sharing the report, it only shows the email list(No other apps will be shown).

| Pixel 7a | Android 8 Emulator(Directly opens the email app since in this only a single email app is installed) | Android 13 emaultor(Same as Android 8 emualtor) | 
| ----------- | ---------- | ------------ |
| <img width="1080" height="2400" alt="Screenshot_20260415-110905" src="https://github.com/user-attachments/assets/6f2194f9-4a36-4d3b-b55a-6dfc05305b75" /> | <img width="460" height="641" alt="Screenshot from 2026-04-15 11-12-20" src="https://github.com/user-attachments/assets/0006e4b6-e9a4-4c38-ab85-9805d4ea3069" /> | <img width="483" height="896" alt="Screenshot from 2026-04-15 11-14-30" src="https://github.com/user-attachments/assets/3c87b456-c21f-4e94-a3de-95aeaedbbb2f" /> |





