### PR TITLE
Improved the showing of the HelpScreen description.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
@@ -33,6 +33,7 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
 import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
 import org.hamcrest.Matchers.anyOf
 import org.junit.After
@@ -50,7 +51,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVi
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource
 
-class HelpFragmentTest : BaseActivityTest() {
+class HelpScreenRouteTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -152,7 +153,7 @@ class HelpFragmentTest : BaseActivityTest() {
   private fun setShowCopyMoveToPublicDirectory(showRestriction: Boolean) {
     context.let {
       KiwixDataStore(it).apply {
-        lifeCycleScope.launch {
+        runBlocking {
           setWifiOnly(false)
           setIntroShown()
           setPrefLanguage("en")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -70,6 +71,7 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.EIGHT_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.HELP_SCREEN_ARROW_ICON_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.HELP_SCREEN_ITEM_TITLE_LETTER_SPACING
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.HELP_SCREEN_ITEM_TITLE_TEXT_SIZE
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MATERIAL_MINIMUM_HEIGHT_AND_WIDTH
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIXTEEN_DP
 
 private const val HELP_ITEM_ANIMATION_DURATION = 300
@@ -100,7 +102,7 @@ fun HelpScreenItem(
 }
 
 @Composable
-fun HelpItemHeader(
+private fun HelpItemHeader(
   title: String,
   isOpen: Boolean,
   onToggle: () -> Unit
@@ -145,13 +147,15 @@ fun HelpItemHeader(
 }
 
 @Composable
-fun HelpItemDescription(context: Context, description: String) {
+private fun HelpItemDescription(context: Context, description: String) {
   val textColor = if (isSystemInDarkTheme()) {
     Color.LightGray
   } else {
     MineShaftGray900
   }
   val helpItemDescription = remember { TextView(context) }
+  val density = LocalDensity.current
+  val minHeightPx = with(density) { MATERIAL_MINIMUM_HEIGHT_AND_WIDTH.toPx().toInt() }
   Box(
     contentAlignment = Alignment.CenterStart,
     modifier = Modifier
@@ -160,8 +164,8 @@ fun HelpItemDescription(context: Context, description: String) {
   ) {
     AndroidView(
       factory = { helpItemDescription },
-      modifier = Modifier.padding(bottom = SIXTEEN_DP)
-        .minimumInteractiveComponentSize()
+      modifier = Modifier
+        .padding(bottom = SIXTEEN_DP)
         .testTag(HELP_SCREEN_ITEM_DESCRIPTION_TESTING_TAG)
         .semantics { contentDescription = description }
     ) { textView ->
@@ -169,6 +173,7 @@ fun HelpItemDescription(context: Context, description: String) {
         text = description
         setTextAppearance(R.style.TextAppearance_KiwixTheme_Subtitle2)
         setTextColor(textColor.toArgb())
+        minHeight = minHeightPx
         gravity = Gravity.CENTER or Gravity.START
         LinkifyCompat.addLinks(this, Linkify.WEB_URLS)
         movementMethod = LinkMovementMethod.getInstance()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpScreenItem.kt
@@ -153,7 +153,7 @@ fun HelpItemDescription(context: Context, description: String) {
   }
   val helpItemDescription = remember { TextView(context) }
   Box(
-    contentAlignment = Alignment.Center,
+    contentAlignment = Alignment.CenterStart,
     modifier = Modifier
       .fillMaxWidth()
       .padding(top = SIXTEEN_DP)
@@ -161,6 +161,7 @@ fun HelpItemDescription(context: Context, description: String) {
     AndroidView(
       factory = { helpItemDescription },
       modifier = Modifier.padding(bottom = SIXTEEN_DP)
+        .minimumInteractiveComponentSize()
         .testTag(HELP_SCREEN_ITEM_DESCRIPTION_TESTING_TAG)
         .semantics { contentDescription = description }
     ) { textView ->
@@ -168,8 +169,6 @@ fun HelpItemDescription(context: Context, description: String) {
         text = description
         setTextAppearance(R.style.TextAppearance_KiwixTheme_Subtitle2)
         setTextColor(textColor.toArgb())
-        minHeight =
-          context.resources.getDimensionPixelSize(R.dimen.material_minimum_height_and_width)
         gravity = Gravity.CENTER or Gravity.START
         LinkifyCompat.addLinks(this, Linkify.WEB_URLS)
         movementMethod = LinkMovementMethod.getInstance()


### PR DESCRIPTION
Fixes #4822 

* Now, we are showing the description from the start so that it will look the same on every device in both portrait and landscape mode.
* Removed the XML-based `material_minimum_height_and_width` from the text, and now using the compose-based API to set the minimum height of the textView.


| Potrait mode | Landscape mode |
| ----------------- | ----------------------- |
| <img width="720" height="1650" alt="Screenshot_20260416-112430" src="https://github.com/user-attachments/assets/87c9f97d-2fe2-44e0-b720-c46d10b1c9d9" />  | <img width="1650" height="720" alt="Screenshot_20260416-112419" src="https://github.com/user-attachments/assets/7ba3d2ee-08dc-4c8a-9eb6-d02e8f0f91f7" /> |






