### PR TITLE
Fix bottom navigation delay

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
@@ -106,9 +106,7 @@ fun KiwixMainActivityScreen(
             BottomNavigationBar(
               navController = navController,
               bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour,
-              navBackStackEntry = navBackStackEntry,
-              leftDrawerState = leftDrawerState,
-              uiCoroutineScope = uiCoroutineScope
+              navBackStackEntry = navBackStackEntry
             )
           }
         },
@@ -162,9 +160,7 @@ private fun OnUserBackPressed(
 fun BottomNavigationBar(
   navController: NavHostController,
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
-  navBackStackEntry: NavBackStackEntry?,
-  leftDrawerState: DrawerState,
-  uiCoroutineScope: CoroutineScope
+  navBackStackEntry: NavBackStackEntry?
 ) {
   val bottomNavItems = listOf(
     BottomNavItem(
@@ -196,21 +192,18 @@ fun BottomNavigationBar(
       NavigationBarItem(
         selected = currentDestinationRoute == item.route,
         onClick = {
-          uiCoroutineScope.launch {
-            leftDrawerState.close()
-            navController.navigate(item.route) {
-              // Avoid multiple copies of the same destination
-              launchSingleTop = true
+          navController.navigate(item.route) {
+            // Avoid multiple copies of the same destination
+            launchSingleTop = true
 
-              // Pop up to the start destination of the graph to avoid building up a large stack
-              popUpTo(navController.graph.findStartDestination().id) {
-                // Bug fix #4392
-                saveState = item.route != KiwixDestination.Reader.route
-              }
-
-              // Restore state when reselecting a previously selected tab
-              restoreState = item.route != KiwixDestination.Reader.route
+            // Pop up to the start destination of the graph to avoid building up a large stack
+            popUpTo(navController.graph.findStartDestination().id) {
+              // Bug fix #4392
+              saveState = item.route != KiwixDestination.Reader.route
             }
+
+            // Restore state when reselecting a previously selected tab
+            restoreState = item.route != KiwixDestination.Reader.route
           }
         },
         icon = {


### PR DESCRIPTION
<!--
- Add the issue number here.

- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- After solving the issue completely change it to "Fixes #{issue_number}.
-->
Fixes #4824

Removed the unnecessary `leftDrawerState.close()` call from the `BottomNavigationBar` and moved the navigation logic outside of the coroutine block. Because the drawer's close() method is a suspend function, it was previously forcing the UI to wait before triggering the tab switch. 

The speed of switching tab is improved now :

<!-- Add here what changes were made in this issue and if possible provide links. -->


<!-- If possible, please add relevant screenshots / GIFs -->

**Screenshots** 

https://github.com/user-attachments/assets/1a86280c-ba30-4a60-b924-bd6ae7ec7b8e

