### PR TITLE
Update release/nightly uploads for new destination

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Decrypt files
         env:
           KEYSTORE: ${{ secrets.keystore }}
-          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIXANDROID_FILE_UPLOAD_KEY }}
         run: |
           echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
           KEY_PATH=kiwix_file_upload_ssh_key
@@ -56,4 +56,4 @@ jobs:
         run: |
           mkdir $DATE
           cp $UNIVERSAL_DEBUG_APK $DATE
-          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no $DATE ci@master.download.kiwix.org:/data/download/nightly/
+          scp -P 30322 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no $DATE kiwix-android@master.download.kiwix.org:/data/download/nightly/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Retrieve secrets to files
         env:
           KEYSTORE: ${{ secrets.keystore }}
-          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+          KIWIX_FILE_UPLOAD_SSH_KEY: ${{ secrets.KIWIXANDROID_FILE_UPLOAD_KEY }}
         run: |
           echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
           KEY_PATH=kiwix_file_upload_ssh_key
@@ -57,14 +57,14 @@ jobs:
         run: |
           ./gradlew assembleStandalone
           cp ${UNIVERSAL_RELEASE_APK} ${ARCHIVE_NAME}
-          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no "$ARCHIVE_NAME" ci@master.download.kiwix.org:/data/download/release/kiwix-android/
+          scp -P 30322 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no "$ARCHIVE_NAME" kiwix-android@master.download.kiwix.org:/data/download/release/kiwix-android/
 
 #      This is temporary, once we will publish 3.7.0 then we will uncommented this code.
 #      # This is necessary for F-Droid
 #      - name: Publish "versionInfo" to download.kiwix.org
 #        run: |
 #          ./gradlew generateVersionCodeAndName
-#          scp -P 30022 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no VERSION_INFO ci@master.download.kiwix.org:/data/download/release/kiwix-android/
+#          scp -P 30322 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no VERSION_INFO kiwix-android@master.download.kiwix.org:/data/download/release/kiwix-android/
 
       - name: Upload APKs to Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org`
- Username changes from `ci` to `kiwix-android`
- Port changes from `30022` to `30322`
- Paths remains the same

⚠️ DO NOT MERGE ATM