### PR TITLE
Updated the donation page URL.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -81,7 +81,7 @@ import kotlin.system.exitProcess
 import androidx.core.graphics.createBitmap
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
-const val KIWIX_SUPPORT_URL = "https://www.kiwix.org/support"
+const val KIWIX_SUPPORT_URL = "https://donate.kiwix.org"
 const val PAGE_URL_KEY = "pageUrl"
 const val SHOULD_OPEN_IN_NEW_TAB = "shouldOpenInNewTab"
 const val FIND_IN_PAGE_SEARCH_STRING = "findInPageSearchString"


### PR DESCRIPTION
Fixes #4843 

The old link was not pointing to the correct donation page, so it has now been updated with the proper URL.

Old URL = https://www.kiwix.org/support
New URL = https://donate.kiwix.org
