### PR TITLE
#4851 Add Update All button to bulk-update outdated locally-installed ZIM books

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryFragment.kt
@@ -61,6 +61,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.BuildConfig
 import org.kiwix.kiwixmobile.R
@@ -90,6 +92,8 @@ import org.kiwix.kiwixmobile.core.ui.components.ONE
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
+import org.kiwix.kiwixmobile.core.downloader.Downloader
+import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -115,6 +119,7 @@ import javax.inject.Inject
 private const val WAS_IN_ACTION_MODE = "WAS_IN_ACTION_MODE"
 const val LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG = "localFileTransferMenuButtonTestingTag"
 const val SELECT_FILE_BUTTON_TESTING_TAG = "selectFileButtonTestingTag"
+const val UPDATE_ALL_BUTTON_TESTING_TAG = "updateAllButtonTestingTag"
 private const val SHOW_SCAN_DIALOG_DELAY = 2000L
 
 @Suppress("LargeClass")
@@ -122,6 +127,8 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
   @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
   @Inject lateinit var kiwixDataStore: KiwixDataStore
+
+  @Inject lateinit var downloader: Downloader
 
   @Inject lateinit var dialogShower: DialogShower
 
@@ -264,22 +271,50 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
     }
   }
 
-  private fun actionMenuItems() = listOf(
-    ActionMenuItem(
-      IconItem.Drawable(org.kiwix.kiwixmobile.core.R.drawable.ic_add_blue_24dp),
-      R.string.select_zim_file,
-      { filePickerButtonClick() },
-      isEnabled = true,
-      testingTag = SELECT_FILE_BUTTON_TESTING_TAG
-    ),
-    ActionMenuItem(
-      IconItem.Drawable(R.drawable.ic_baseline_mobile_screen_share_24px),
-      string.get_content_from_nearby_device,
-      { navigateToLocalFileTransferFragment() },
-      isEnabled = true,
-      testingTag = LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG
+  private fun actionMenuItems(updatableBooks: List<LibkiwixBook> = emptyList()) =
+    listOfNotNull(
+      if (updatableBooks.isNotEmpty()) {
+        ActionMenuItem(
+          IconItem.Drawable(org.kiwix.kiwixmobile.core.R.drawable.ic_file_download_blue_24dp),
+          R.string.update_all_books,
+          { onUpdateAllClick(updatableBooks) },
+          isEnabled = true,
+          testingTag = UPDATE_ALL_BUTTON_TESTING_TAG
+        )
+      } else {
+        null
+      },
+      ActionMenuItem(
+        IconItem.Drawable(org.kiwix.kiwixmobile.core.R.drawable.ic_add_blue_24dp),
+        R.string.select_zim_file,
+        { filePickerButtonClick() },
+        isEnabled = true,
+        testingTag = SELECT_FILE_BUTTON_TESTING_TAG
+      ),
+      ActionMenuItem(
+        IconItem.Drawable(R.drawable.ic_baseline_mobile_screen_share_24px),
+        string.get_content_from_nearby_device,
+        { navigateToLocalFileTransferFragment() },
+        isEnabled = true,
+        testingTag = LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG
+      )
     )
-  )
+
+  private fun onUpdateAllClick(updatableBooks: List<LibkiwixBook>) {
+    dialogShower.show(
+      KiwixDialog.ConfirmUpdateAll,
+      {
+        updatableBooks.forEach { book -> downloader.download(book) }
+        context.toast(
+          resources.getQuantityString(
+            R.plurals.update_all_books_queued,
+            updatableBooks.size,
+            updatableBooks.size
+          )
+        )
+      }
+    )
+  }
 
   private fun onBookItemClick(bookOnDisk: BookOnDisk) {
     lifecycleScope.runSafelyInLifecycleScope {
@@ -337,6 +372,11 @@ class LocalLibraryFragment : BaseFragment(), SelectedZimFileCallback {
       add(sideEffects())
       add(fileSelectActions())
     }
+    zimManageViewModel.updateAvailableBooks
+      .onEach { updatableBooks ->
+        updateLibraryScreenState(actionMenuItems = actionMenuItems(updatableBooks))
+      }
+      .launchIn(viewLifecycleOwner.lifecycleScope)
     zimManageViewModel.deviceListScanningProgress.observe(viewLifecycleOwner) {
       updateLibraryScreenState(
         // hide this progress bar when scanning is complete.

--- a/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/zimManager/ZimManageViewModel.kt
@@ -107,6 +107,7 @@ import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.Req
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestSelect
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestShareMultiSelection
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestValidateZimFiles
+import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RequestUpdateAll
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.RestartActionMode
 import org.kiwix.kiwixmobile.zimManager.ZimManageViewModel.FileSelectActions.UserClickedDownloadBooksButton
 import org.kiwix.kiwixmobile.zimManager.fileselectView.FileSelectListState
@@ -156,6 +157,7 @@ class ZimManageViewModel @Inject constructor(
     object MultiModeFinished : FileSelectActions()
     object RestartActionMode : FileSelectActions()
     object UserClickedDownloadBooksButton : FileSelectActions()
+    object RequestUpdateAll : FileSelectActions()
   }
 
   sealed class OnlineLibraryUiEvent {
@@ -192,6 +194,13 @@ class ZimManageViewModel @Inject constructor(
   val fileSelectListStates: MutableLiveData<FileSelectListState> = MutableLiveData()
   val deviceListScanningProgress = MutableLiveData<Int>()
   val libraryListIsRefreshing = MutableLiveData<Boolean>()
+
+  /**
+   * Holds the list of online [LibkiwixBook] entries that are newer than their locally-installed
+   * counterpart (matched by [LibkiwixBook.bookName]). Non-empty when updates are available.
+   */
+  private val _updateAvailableBooks = MutableStateFlow<List<LibkiwixBook>>(emptyList())
+  val updateAvailableBooks: StateFlow<List<LibkiwixBook>> = _updateAvailableBooks.asStateFlow()
 
   private var onlineLibraryFetchingJob: Job? = null
 
@@ -372,8 +381,42 @@ class ZimManageViewModel @Inject constructor(
       add(observeLanguageChanges())
       add(observeSearch())
       add(observeCategory())
+      add(observeUpdatesAvailable())
     }
   }
+
+  /**
+   * Watches the online library catalog and the local book list for changes, then computes
+   * which locally-installed books have a newer version available online.
+   *
+   * Matching is done by [LibkiwixBook.bookName] (e.g. "wikipedia_en_all_maxi"). A book is
+   * considered outdated when the online entry's [LibkiwixBook.date] (ISO "YYYY-MM" or
+   * "YYYY-MM-DD" string) is lexicographically greater than the local book's date.
+   */
+  private fun observeUpdatesAvailable() =
+    networkLibrary
+      .combine(dataSource.booksOnDiskAsListItems()) { onlineResult, localItems ->
+        val localBooks = localItems.filterIsInstance<BookOnDisk>().map { it.book }
+        val onlineByName = onlineResult.books
+          .filter { !it.bookName.isNullOrBlank() && !it.url.isNullOrBlank() }
+          .associateBy { it.bookName.orEmpty() }
+
+        localBooks.mapNotNull { local ->
+          val name = local.bookName ?: return@mapNotNull null
+          val online = onlineByName[name] ?: return@mapNotNull null
+          val localDate = local.date
+          val onlineDate = online.date
+          if (onlineDate.isNotBlank() && localDate.isNotBlank() && onlineDate > localDate) {
+            online
+          } else {
+            null
+          }
+        }
+      }
+      .catch { it.printStackTrace() }
+      .onEach { updatable -> _updateAvailableBooks.value = updatable }
+      .flowOn(ioDispatcher)
+      .launchIn(viewModelScope)
 
   override fun onCleared() {
     coroutineJobs.forEach {
@@ -476,6 +519,7 @@ class ZimManageViewModel @Inject constructor(
               is RequestSelect -> noSideEffectSelectBook(action.bookOnDisk)
               RestartActionMode -> StartMultiSelection(fileSelectActions)
               UserClickedDownloadBooksButton -> NavigateToDownloads
+              RequestUpdateAll -> None
             }
           )
         }.onFailure {

--- a/app/src/main/res/values-qq/strings.xml
+++ b/app/src/main/res/values-qq/strings.xml
@@ -10,4 +10,9 @@
   <string name="receive_files_title">The titles of an activity used for receiving files.</string>
   <string name="no_app_found_to_open">It is a toast message shown on the library screen when the user is selecting a file from the file chooser but there is no app available to handle the selected file/intent.</string>
   <string name="select_zim_file">* It is a content description of a floating action button on the library screen.\n* This button opens a file chooser for the user to select a zim file to read.</string>
+  <string name="update_all_books">Label for a toolbar action button on the Local Library screen. Tapping it opens a confirmation dialog to download newer versions of all locally-installed books that have an update available online.</string>
+  <plurals name="update_all_books_queued">
+    <item quantity="one">Toast message (singular) shown after the user confirms "Update All" with 1 book. %d is the number (1).</item>
+    <item quantity="other">Toast message (plural) shown after the user confirms "Update All". %d is replaced by the number of book updates queued for download.</item>
+  </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,9 @@
   <string name="other_categories" tools:keep="@string/other_categories">Other categories:</string>
   <string name="all_categories" tools:keep="@string/all_categories">All categories</string>
   <string name="select_category_content_description">Selecting this category will prioritize displaying downloadable books in that language at the top.</string>
+  <string name="update_all_books">Update all books</string>
+  <plurals name="update_all_books_queued">
+    <item quantity="one">%d book update queued for download</item>
+    <item quantity="other">%d book updates queued for download</item>
+  </plurals>
 </resources>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -457,6 +457,13 @@ sealed class KiwixDialog(
     android.R.string.cancel,
     customComposeView = customGetView
   )
+
+  object ConfirmUpdateAll : KiwixDialog(
+    R.string.update_all_books_dialog_title,
+    R.string.update_all_books_dialog_message,
+    R.string.update,
+    R.string.no
+  )
 }
 
 interface HasBodyFormatArgs {

--- a/core/src/main/res/values-qq/strings.xml
+++ b/core/src/main/res/values-qq/strings.xml
@@ -348,4 +348,7 @@
   <string name="resuming_state">This text is shown to inform the user that the current state of download is resuming.</string>
   <string name="downloading_state">This text is shown to inform the user that the current state of download is actively in progress.</string>
   <string name="download_failed_state">This text is shown to inform the user when a download has failed.</string>
+  <string name="update_all_books_dialog_title">Title of a confirmation dialog shown when the user taps "Update All books" on the Local Library screen.</string>
+  <string name="update_all_books_dialog_message">Body of the "Update All books" confirmation dialog. Shown when the user taps the Update All button in the Local Library screen.</string>
+  <string name="update">Label for the confirm/positive button in the "Update All books" dialog. Tapping it queues all outdated books for download.</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -433,4 +433,7 @@
   <string name="shortcut_name_label">Shortcut name</string>
   <string name="open_xiaomi_settings">Open Settings</string>
   <string name="xiaomi_permission_required">This device requires shortcut permission to be granted before adding a shortcut to the home screen. Please grant the permission in settings.</string>
+  <string name="update_all_books_dialog_title">Update books</string>
+  <string name="update_all_books_dialog_message">Some of your books have newer versions available online. Download all updates now?</string>
+  <string name="update">Update</string>
 </resources>


### PR DESCRIPTION
Closes #4851

## Summary

- Adds an **"Update All books"** toolbar button to the Local Library screen that appears automatically when the online catalog has newer versions of locally-installed ZIM books.
- Matches local ↔ online books by `bookName` (e.g. `wikipedia_en_all_maxi`) and compares ISO `date` strings to detect outdated books.
- On tap: shows a confirmation dialog with the update count, then queues each outdated book via the existing `Downloader.download()` mechanism.

## Changes

| File | What changed |
|---|---|
| `ZimManageViewModel.kt` | `updateAvailableBooks: StateFlow` + `observeUpdatesAvailable()` + `RequestUpdateAll` action |
| `LocalLibraryFragment.kt` | Inject `Downloader`; observe `updateAvailableBooks`; show/hide toolbar button; confirmation dialog + download trigger |
| `KiwixDialog.kt` | New `ConfirmUpdateAll(count: Int)` dialog |
| `core/res/values/strings.xml` | Dialog title, message, "Update" button label + `values-qq` translator context |
| `app/res/values/strings.xml` | Menu label, toast string + `values-qq` translator context |

## Test plan

- [ ] Install an older ZIM file where a newer version exists in the online catalog → "Update all books" button appears in Local Library toolbar
- [ ] Tap button → confirmation dialog shows correct book count
- [ ] Confirm → all outdated books queued in Downloads; toast shows count
- [ ] Dismiss → no downloads started
- [ ] All local books up-to-date → button is hidden
- [ ] Offline / catalog not yet loaded → button is hidden