### PR TITLE
Upgraded the jacoco library to `0.8.14`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
+      - name: create unit coverage
+        if: ${{ matrix.api-level==30 }}
+        run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
+
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
@@ -105,10 +109,6 @@ jobs:
         with:
           name: ${{ matrix.api-level }}
           path: screencap.png
-
-      - name: create unit coverage
-        if: ${{ matrix.api-level==30 }}
-        run: ./gradlew testDebugUnitTest testCustomexampleDebugUnitTest
 
       - name: Run benchmarks
         if: ${{ matrix.api-level==30 }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation("com.android.tools.build:gradle:8.11.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
   implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.0.0-1.0.24")
-  implementation("org.jacoco:org.jacoco.core:0.8.12")
+  implementation("org.jacoco:org.jacoco.core:0.8.14")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:12.1.2")
   implementation("com.google.apis:google-api-services-androidpublisher:v3-rev20230406-2.0.0") {
     exclude(group = "com.google.guava", module = "guava")

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -179,7 +179,7 @@ class AllProjectConfigurer {
       resolutionStrategy {
         eachDependency {
           if ("org.jacoco" == this.requested.group) {
-            useVersion("0.8.12")
+            useVersion("0.8.14")
           }
         }
       }

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -19,7 +19,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-  toolVersion = "0.8.12"
+  toolVersion = "0.8.14"
 }
 
 tasks.withType(Test).configureEach {
@@ -51,7 +51,8 @@ tasks.register('jacocoInstrumentationTestReport', JacocoReport) {
       javaSrc << "$proj.projectDir/src/main/java"
       kotlinSrc << "$proj.projectDir/src/main/kotlin"
       execution << fileTree(dir: proj.buildDir,
-        includes: ['jacoco/testDebugUnitTest.exec',
+        includes: ['outputs/unit_test_code_coverage/**/*.exec',
+          'jacoco/testDebugUnitTest.exec',
           'outputs/code-coverage/connected/*coverage.ec',
           'outputs/code_coverage/debugAndroidTest/connected/**/*.ec'])
     }

--- a/lintConfig.xml
+++ b/lintConfig.xml
@@ -34,7 +34,7 @@
   <issue id="InvalidPackage">
     <ignore path="**simple-xml-2.7.1.jar" />
     <ignore path="**javapoet-1.8.0.jar" />
-    <ignore path="**/org.jacoco.agent-0.8.12-runtime.jar" />
+    <ignore path="**/org.jacoco.agent-0.8.14-runtime.jar" />
     <ignore regexp="kotlinx.coroutines.debug.AgentPremain" />
   </issue>
   <issue id="IconLocation">


### PR DESCRIPTION
Fixes #4872

* Upgraded JaCoCo to 0.8.14, which provides improved support for Jetpack Compose UI coverage. See https://github.com/jacoco/jacoco/releases
* Fixed an issue where all `unit test coverage` was not included in the final report due to changes in the generated report path.
* Updated the CI workflow to run `unit tests` before `instrumentation` coverage generation. This ensures that when `jacocoInstrumentationTestReport` (which depends on `createDebugCoverageReport`) executes, both `unit test` (.exec) and `instrumentation` (.ec) coverage data are available and correctly merged.
