### PR TITLE
Fixed: Room was giving error when downgrading the application.

### DIFF
--- a/app/src/test/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/KiwixRoomDatabaseTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.data.RoomDowngradeBackupHelper
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
@@ -50,19 +51,31 @@ class KiwixRoomDatabaseTest {
   private lateinit var db: KiwixRoomDatabase
   private lateinit var historyRoomDao: HistoryRoomDao
   private lateinit var notesRoomDao: NotesRoomDao
+  private lateinit var context: Context
+  private lateinit var databaseFile: File
 
   @Before
   fun setUpDatabase() {
-    val context = ApplicationProvider.getApplicationContext<Context>()
-    db =
-      Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java)
-        .allowMainThreadQueries()
-        .build()
+    context = ApplicationProvider.getApplicationContext()
+    databaseFile = context.getDatabasePath(RoomDowngradeBackupHelper.DB_NAME)
+
+    cleanupDatabase()
+    db = Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
   }
 
   @After
   fun teardown() {
     db.close()
+    KiwixRoomDatabase.destroyInstance()
+    cleanupDatabase()
+  }
+
+  private fun cleanupDatabase() {
+    if (databaseFile.exists()) {
+      databaseFile.deleteRecursively()
+    }
   }
 
   @Test
@@ -188,6 +201,58 @@ class KiwixRoomDatabaseTest {
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 0)
     }
+
+  @Test
+  fun `database callback restores snapshot into newly created database`() = runBlocking {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+
+    context.deleteDatabase(RoomDowngradeBackupHelper.DB_NAME)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.DatabaseSnapshot(
+        notes = listOf(
+          RoomDowngradeBackupHelper.RowSnapshot(
+            values = mapOf(
+              "zimId" to "zim-id",
+              "zimUrl" to "https://kiwix.app/page",
+              "noteTitle" to "Restored Note",
+              "noteFilePath" to "/notes/restored.txt",
+              "favicon" to null,
+              "zimReaderSource" to null
+            )
+          )
+        ),
+        history = emptyList(),
+        recentSearches = emptyList()
+      )
+
+    val callBack =
+      KiwixRoomDatabase.createRestoreCallback(snapshot)
+
+    val db =
+      Room.databaseBuilder(
+        context,
+        KiwixRoomDatabase::class.java,
+        RoomDowngradeBackupHelper.DB_NAME
+      )
+        .addCallback(callBack)
+        .allowMainThreadQueries()
+        .build()
+
+    val notes =
+      db.notesRoomDao().notes().first() as List<NoteListItem>
+
+    assertEquals(1, notes.size)
+
+    with(notes.first()) {
+      assertEquals("zim-id", zimId)
+      assertEquals("https://kiwix.app/page", zimUrl)
+      assertEquals("Restored Note", title)
+      assertEquals("/notes/restored.txt", noteFilePath)
+    }
+
+    db.close()
+  }
 
   companion object {
     fun getHistoryItem(

--- a/app/src/test/java/org/kiwix/kiwixmobile/RoomDowngradeBackupHelperTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/RoomDowngradeBackupHelperTest.kt
@@ -1,0 +1,620 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.os.Build
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.data.RoomDowngradeBackupHelper
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
+class RoomDowngradeBackupHelperTest {
+  private lateinit var context: Context
+  private lateinit var databaseFile: File
+
+  @Before
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+
+    databaseFile = context.getDatabasePath(RoomDowngradeBackupHelper.DB_NAME)
+    cleanupDatabase()
+
+    KiwixRoomDatabase.destroyInstance()
+  }
+
+  @After
+  fun teardown() {
+    KiwixRoomDatabase.destroyInstance()
+    cleanupDatabase()
+  }
+
+  private fun cleanupDatabase() {
+    if (databaseFile.exists()) {
+      databaseFile.deleteRecursively()
+    }
+  }
+
+  private fun createDatabase(): KiwixRoomDatabase {
+    return Room.databaseBuilder(
+      context,
+      KiwixRoomDatabase::class.java,
+      RoomDowngradeBackupHelper.DB_NAME
+    )
+      .allowMainThreadQueries()
+      .build()
+  }
+
+  private fun createDatabaseWithVersion(version: Int) {
+    SQLiteDatabase.openOrCreateDatabase(
+      databaseFile,
+      null
+    ).apply {
+      this.version = version
+      close()
+    }
+  }
+
+  @Test
+  fun `isDowngrade returns true when existing version is higher`() {
+    createDatabaseWithVersion(version = 15)
+
+    val result = RoomDowngradeBackupHelper.isDowngrade(context, targetVersion = 10)
+    assertTrue(result)
+  }
+
+  @Test
+  fun `isDowngrade returns false when existing version is lower`() {
+    createDatabaseWithVersion(version = 5)
+
+    val result = RoomDowngradeBackupHelper.isDowngrade(context, targetVersion = 10)
+    assertFalse(result)
+  }
+
+  @Test
+  fun `isDowngrade returns false when database does not exist`() {
+    val result = RoomDowngradeBackupHelper.isDowngrade(context, targetVersion = 10)
+    assertFalse(result)
+  }
+
+  @Test
+  fun `createSnapshot backs up all supported tables`() = runBlocking {
+    val db = createDatabase()
+
+    db.notesRoomDao().saveNote(
+      KiwixRoomDatabaseTest.getNoteListItem(
+        title = "Note",
+        zimUrl = "https://kiwix.app/note"
+      )
+    )
+
+    db.historyRoomDao().saveHistory(
+      KiwixRoomDatabaseTest.getHistoryItem(
+        title = "History"
+      )
+    )
+
+    db.recentSearchRoomDao().saveSearch(
+      title = "kiwix",
+      zimId = "zim-id",
+      url = ""
+    )
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    assertEquals(1, snapshot.notes.size)
+    assertEquals(1, snapshot.history.size)
+    assertEquals(1, snapshot.recentSearches.size)
+
+    db.close()
+  }
+
+  @Test
+  fun `createSnapshot stores correct note values`() = runBlocking {
+    val db = createDatabase()
+
+    val note =
+      KiwixRoomDatabaseTest.getNoteListItem(
+        title = "Kiwix Note",
+        zimId = "zim-123",
+        zimUrl = "https://kiwix.app/note",
+        noteFilePath = "/storage/notes/file.txt"
+      )
+
+    db.notesRoomDao().saveNote(note)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    val row = snapshot.notes.first().values
+
+    assertEquals(note.title, row["noteTitle"])
+    assertEquals(note.zimId, row["zimId"])
+    assertEquals(note.zimUrl, row["zimUrl"])
+    assertEquals(note.noteFilePath, row["noteFilePath"])
+
+    db.close()
+  }
+
+  @Test
+  fun `createSnapshot preserves null values`() = runBlocking {
+    val db = createDatabase()
+
+    val note =
+      KiwixRoomDatabaseTest.getNoteListItem(
+        zimUrl = "https://kiwix.app/note"
+      )
+
+    db.notesRoomDao().saveNote(note)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    val row = snapshot.notes.first().values
+
+    assertNull(row["favicon"])
+
+    db.close()
+  }
+
+  @Test
+  fun `createSnapshot safely handles missing tables`() {
+    createDatabaseWithVersion(version = 10)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    assertTrue(snapshot.notes.isEmpty())
+    assertTrue(snapshot.history.isEmpty())
+    assertTrue(snapshot.recentSearches.isEmpty())
+  }
+
+  @Test
+  fun `restoreSnapshot restores complete note data`() = runBlocking {
+    val originalDb = createDatabase()
+
+    val originalNote =
+      KiwixRoomDatabaseTest.getNoteListItem(
+        title = "Alpine Wiki",
+        zimId = "zim-123",
+        zimUrl = "https://kiwix.app/note",
+        noteFilePath = "/storage/notes/alpine.txt"
+      )
+
+    originalDb.notesRoomDao().saveNote(originalNote)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    originalDb.close()
+
+    cleanupDatabase()
+
+    val restoredDb = createDatabase()
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      restoredDb.openHelper.writableDatabase,
+      snapshot
+    )
+
+    val restoredNotes =
+      restoredDb.notesRoomDao().notes().first()
+
+    assertEquals(1, restoredNotes.size)
+
+    val restored = restoredNotes.first()
+
+    with(restored) {
+      assertEquals(originalNote.title, title)
+      assertEquals(originalNote.zimId, zimId)
+      assertEquals(originalNote.zimUrl, url)
+      assertEquals(originalNote.zimReaderSource, zimReaderSource)
+      assertEquals(originalNote.favicon, favicon)
+    }
+
+    restoredDb.close()
+  }
+
+  @Test
+  fun `restoreSnapshot restores multiple rows`() = runBlocking {
+    val db = createDatabase()
+
+    val snapshot =
+      RoomDowngradeBackupHelper.DatabaseSnapshot(
+        notes = listOf(
+          RoomDowngradeBackupHelper.RowSnapshot(
+            mapOf(
+              "zimId" to "1",
+              "zimUrl" to "url1",
+              "noteTitle" to "title1",
+              "noteFilePath" to "path1"
+            )
+          ),
+          RoomDowngradeBackupHelper.RowSnapshot(
+            mapOf(
+              "zimId" to "2",
+              "zimUrl" to "url2",
+              "noteTitle" to "title2",
+              "noteFilePath" to "path2"
+            )
+          )
+        ),
+        history = emptyList(),
+        recentSearches = emptyList()
+      )
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      db.openHelper.writableDatabase,
+      snapshot
+    )
+
+    val notes =
+      db.notesRoomDao().notes().first()
+
+    assertEquals(2, notes.size)
+
+    db.close()
+  }
+
+  @Test
+  fun `restoreSnapshot does nothing for empty snapshot`() = runBlocking {
+    val db = createDatabase()
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      db.openHelper.writableDatabase,
+      RoomDowngradeBackupHelper.DatabaseSnapshot(
+        notes = emptyList(),
+        history = emptyList(),
+        recentSearches = emptyList()
+      )
+    )
+
+    val notes =
+      db.notesRoomDao().notes().first()
+
+    assertTrue(notes.isEmpty())
+
+    db.close()
+  }
+
+  @Test
+  fun `restoreSnapshot ignores unsupported columns from newer schema`() =
+    runBlocking {
+      val db = createDatabase()
+
+      val snapshot =
+        RoomDowngradeBackupHelper.DatabaseSnapshot(
+          notes = listOf(
+            RoomDowngradeBackupHelper.RowSnapshot(
+              values = mapOf(
+                // Valid columns
+                "zimId" to "zim-123",
+                "zimUrl" to "https://kiwix.app/note",
+                "noteTitle" to "Kiwix Note",
+                "noteFilePath" to "/storage/notes/kiwix.txt",
+                // Future schema columns
+                "futureColumn" to "ignored",
+                "anotherField" to 12345
+              )
+            )
+          ),
+          history = emptyList(),
+          recentSearches = emptyList()
+        )
+
+      RoomDowngradeBackupHelper.restoreSnapshot(
+        db.openHelper.writableDatabase,
+        snapshot
+      )
+
+      val notes =
+        db.notesRoomDao().notes().first()
+
+      assertEquals(1, notes.size)
+
+      val restored = notes.first()
+
+      assertEquals("zim-123", restored.zimId)
+      assertEquals("Kiwix Note", restored.title)
+
+      db.close()
+    }
+
+  @Test
+  fun `restoreSnapshot skips rows with only unsupported columns`() =
+    runBlocking {
+      val db = createDatabase()
+
+      val snapshot =
+        RoomDowngradeBackupHelper.DatabaseSnapshot(
+          notes = listOf(
+            RoomDowngradeBackupHelper.RowSnapshot(
+              mapOf(
+                "futureOnlyColumn" to "value"
+              )
+            )
+          ),
+          history = emptyList(),
+          recentSearches = emptyList()
+        )
+
+      RoomDowngradeBackupHelper.restoreSnapshot(
+        db.openHelper.writableDatabase,
+        snapshot
+      )
+
+      val notes =
+        db.notesRoomDao().notes().first()
+
+      assertTrue(notes.isEmpty())
+
+      db.close()
+    }
+
+  @Test
+  fun `restoreSnapshot ignores id column and generates new primary key`() =
+    runBlocking {
+      val db = createDatabase()
+
+      val snapshot =
+        RoomDowngradeBackupHelper.DatabaseSnapshot(
+          notes = listOf(
+            RoomDowngradeBackupHelper.RowSnapshot(
+              mapOf(
+                "id" to 999L,
+                "zimId" to "zim-id",
+                "zimUrl" to "url",
+                "noteTitle" to "title",
+                "noteFilePath" to "path"
+              )
+            )
+          ),
+          history = emptyList(),
+          recentSearches = emptyList()
+        )
+
+      RoomDowngradeBackupHelper.restoreSnapshot(
+        db.openHelper.writableDatabase,
+        snapshot
+      )
+
+      val restored =
+        db.notesRoomDao().notes().first().first()
+
+      assertNotEquals(999L, restored.id)
+
+      db.close()
+    }
+
+  @Test
+  fun `restoreSnapshot restores blob values correctly`() {
+    val db = createDatabase()
+
+    val blob = byteArrayOf(1, 2, 3, 4)
+
+    val sqliteDb: SupportSQLiteDatabase =
+      db.openHelper.writableDatabase
+
+    sqliteDb.execSQL(
+      """
+      INSERT INTO WebViewHistoryEntity(
+        zimId,
+        webViewIndex,
+        webViewCurrentPosition,
+        webViewBackForwardListBundle
+      ) VALUES (?, ?, ?, ?)
+      """.trimIndent(),
+      arrayOf(
+        "zim-id",
+        1,
+        2,
+        blob
+      )
+    )
+
+    val cursor =
+      sqliteDb.query(
+        "SELECT webViewBackForwardListBundle FROM WebViewHistoryEntity"
+      )
+
+    cursor.moveToFirst()
+
+    val restoredBlob =
+      cursor.getBlob(0)
+
+    assertArrayEquals(blob, restoredBlob)
+
+    cursor.close()
+    db.close()
+  }
+
+  @Test
+  fun `restoreSnapshot restores complete history data`() = runBlocking {
+    val originalDb = createDatabase()
+
+    val originalHistory =
+      KiwixRoomDatabaseTest.getHistoryItem(
+        title = "Main Page",
+        historyUrl = "https://kiwix.app/A/MainPage",
+        zimId = "zim-history-id"
+      )
+
+    originalDb.historyRoomDao().saveHistory(originalHistory)
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    originalDb.close()
+
+    cleanupDatabase()
+
+    val restoredDb = createDatabase()
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      restoredDb.openHelper.writableDatabase,
+      snapshot
+    )
+
+    val restoredHistory =
+      restoredDb.historyRoomDao()
+        .historyRoomEntity()
+        .first()
+
+    assertEquals(1, restoredHistory.size)
+
+    val restored = restoredHistory.first()
+
+    with(restored) {
+      assertEquals(originalHistory.title, historyTitle)
+      assertEquals(originalHistory.zimId, zimId)
+      assertEquals(originalHistory.historyUrl, historyUrl)
+      assertEquals(originalHistory.zimName, zimName)
+      assertEquals(originalHistory.favicon, favicon)
+      assertEquals(originalHistory.dateString, dateString)
+      assertEquals(originalHistory.timeStamp, timeStamp)
+      assertEquals(
+        originalHistory.zimReaderSource,
+        zimReaderSource
+      )
+    }
+
+    restoredDb.close()
+  }
+
+  @Test
+  fun `restoreSnapshot restores recent searches`() = runBlocking {
+    val originalDb = createDatabase()
+
+    originalDb.recentSearchRoomDao().saveSearch(
+      title = "kiwix",
+      zimId = "zim-search-id",
+      url = "https://kiwix.app/search"
+    )
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    originalDb.close()
+
+    cleanupDatabase()
+
+    val restoredDb = createDatabase()
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      restoredDb.openHelper.writableDatabase,
+      snapshot
+    )
+
+    val restoredSearches =
+      restoredDb.recentSearchRoomDao()
+        .search("zim-search-id")
+        .first()
+
+    assertEquals(1, restoredSearches.size)
+
+    val restored = restoredSearches.first()
+
+    assertEquals("kiwix", restored.searchTerm)
+    assertEquals("zim-search-id", restored.zimId)
+    assertEquals(
+      "https://kiwix.app/search",
+      restored.url
+    )
+
+    restoredDb.close()
+  }
+
+  @Test
+  fun `restoreSnapshot restores all tables together`() = runBlocking {
+    val originalDb = createDatabase()
+
+    originalDb.notesRoomDao().saveNote(
+      KiwixRoomDatabaseTest.getNoteListItem(
+        zimUrl = "note-url"
+      )
+    )
+
+    originalDb.historyRoomDao().saveHistory(
+      KiwixRoomDatabaseTest.getHistoryItem()
+    )
+
+    originalDb.recentSearchRoomDao().saveSearch(
+      title = "search",
+      zimId = "zim-id",
+      url = "url"
+    )
+
+    val snapshot =
+      RoomDowngradeBackupHelper.createSnapshot(context)
+
+    originalDb.close()
+
+    cleanupDatabase()
+
+    val restoredDb = createDatabase()
+
+    RoomDowngradeBackupHelper.restoreSnapshot(
+      restoredDb.openHelper.writableDatabase,
+      snapshot
+    )
+
+    assertEquals(
+      1,
+      restoredDb.notesRoomDao().notes().first().size
+    )
+
+    assertEquals(
+      1,
+      restoredDb.historyRoomDao()
+        .historyRoomEntity()
+        .first()
+        .size
+    )
+
+    assertEquals(
+      1,
+      restoredDb.recentSearchRoomDao()
+        .search("zim-id")
+        .first()
+        .size
+    )
+
+    restoredDb.close()
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.data
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -104,7 +105,8 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
       }
     }
 
-    private fun createRestoreCallback(
+    @VisibleForTesting
+    fun createRestoreCallback(
       backup: RoomDowngradeBackupHelper.DatabaseSnapshot?
     ): RoomDatabase.Callback = object : RoomDatabase.Callback() {
       override fun onCreate(db: SupportSQLiteDatabase) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabase.kt
@@ -41,6 +41,9 @@ import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 import org.kiwix.kiwixmobile.core.dao.entities.StatusConverter
 import org.kiwix.kiwixmobile.core.dao.entities.WebViewHistoryEntity
 import org.kiwix.kiwixmobile.core.dao.entities.ZimSourceRoomConverter
+import org.kiwix.kiwixmobile.core.data.RoomDowngradeBackupHelper.CURRENT_ROOM_DB_VERSION
+import org.kiwix.kiwixmobile.core.data.RoomDowngradeBackupHelper.DB_NAME
+import org.kiwix.kiwixmobile.core.utils.files.Log
 
 @Suppress("UnnecessaryAbstractClass")
 @Database(
@@ -51,7 +54,7 @@ import org.kiwix.kiwixmobile.core.dao.entities.ZimSourceRoomConverter
     DownloadRoomEntity::class,
     WebViewHistoryEntity::class
   ],
-  version = 10,
+  version = CURRENT_ROOM_DB_VERSION,
   exportSchema = false
 )
 @TypeConverters(
@@ -73,8 +76,15 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
     private var db: KiwixRoomDatabase? = null
     fun getInstance(context: Context): KiwixRoomDatabase {
       return db ?: synchronized(KiwixRoomDatabase::class) {
+        val backup =
+          if (RoomDowngradeBackupHelper.isDowngrade(context, CURRENT_ROOM_DB_VERSION)) {
+            Log.w("RoomDowngrade", "Downgrade detected. Backing up user data.")
+            RoomDowngradeBackupHelper.createSnapshot(context)
+          } else {
+            null
+          }
         return@getInstance db
-          ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, "KiwixRoom.db")
+          ?: Room.databaseBuilder(context, KiwixRoomDatabase::class.java, DB_NAME)
             // We have already database name called kiwix.db in order to avoid complexity we named
             // as kiwixRoom.db
             .addMigrations(
@@ -88,7 +98,20 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
               MIGRATION_8_9,
               MIGRATION_9_10
             )
+            .fallbackToDestructiveMigrationOnDowngrade()
+            .addCallback(createRestoreCallback(backup))
             .build().also { db = it }
+      }
+    }
+
+    private fun createRestoreCallback(
+      backup: RoomDowngradeBackupHelper.DatabaseSnapshot?
+    ): RoomDatabase.Callback = object : RoomDatabase.Callback() {
+      override fun onCreate(db: SupportSQLiteDatabase) {
+        super.onCreate(db)
+        backup?.let {
+          RoomDowngradeBackupHelper.restoreSnapshot(db, it)
+        }
       }
     }
 
@@ -298,8 +321,8 @@ abstract class KiwixRoomDatabase : RoomDatabase() {
     @Suppress("MagicNumber")
     val MIGRATION_7_8 =
       object : Migration(7, 8) {
-        override fun migrate(database: SupportSQLiteDatabase) {
-          database.execSQL(
+        override fun migrate(db: SupportSQLiteDatabase) {
+          db.execSQL(
             """
             CREATE TABLE IF NOT EXISTS `WebViewHistoryEntity` (
                 `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/RoomDowngradeBackupHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/RoomDowngradeBackupHelper.kt
@@ -25,6 +25,10 @@ import android.util.Log
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 object RoomDowngradeBackupHelper {
+  private const val NOTES_TABLE = "NotesRoomEntity"
+  private const val HISTORY_TABLE = "HistoryRoomEntity"
+  private const val RECENT_SEARCH_TABLE = "RecentSearchRoomEntity"
+
   data class RowSnapshot(val values: Map<String, Any?>)
 
   data class DatabaseSnapshot(
@@ -55,9 +59,9 @@ object RoomDowngradeBackupHelper {
     )
 
     val snapshot = DatabaseSnapshot(
-      notes = backupTable(sqliteDb, "NotesRoomEntity"),
-      history = backupTable(sqliteDb, "HistoryRoomEntity"),
-      recentSearches = backupTable(sqliteDb, "RecentSearchRoomEntity")
+      notes = backupTable(sqliteDb, NOTES_TABLE),
+      history = backupTable(sqliteDb, HISTORY_TABLE),
+      recentSearches = backupTable(sqliteDb, RECENT_SEARCH_TABLE)
     )
 
     sqliteDb.close()
@@ -68,9 +72,9 @@ object RoomDowngradeBackupHelper {
     db: SupportSQLiteDatabase,
     snapshot: DatabaseSnapshot
   ) {
-    restoreTableRows(db, "NotesRoomEntity", snapshot.notes)
-    restoreTableRows(db, "HistoryRoomEntity", snapshot.history)
-    restoreTableRows(db, "RecentSearchRoomEntity", snapshot.recentSearches)
+    restoreTableRows(db, NOTES_TABLE, snapshot.notes)
+    restoreTableRows(db, HISTORY_TABLE, snapshot.history)
+    restoreTableRows(db, RECENT_SEARCH_TABLE, snapshot.recentSearches)
   }
 
   private fun getExistingDbVersion(context: Context): Int? {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/RoomDowngradeBackupHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/RoomDowngradeBackupHelper.kt
@@ -1,0 +1,222 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.data
+
+import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.util.Log
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object RoomDowngradeBackupHelper {
+  data class RowSnapshot(val values: Map<String, Any?>)
+
+  data class DatabaseSnapshot(
+    val notes: List<RowSnapshot>,
+    val history: List<RowSnapshot>,
+    val recentSearches: List<RowSnapshot>
+  )
+
+  const val DB_NAME = "KiwixRoom.db"
+  const val CURRENT_ROOM_DB_VERSION = 10
+  private const val ROOM_DOWNGRADE_HELPER = "RoomDowngradeHelper"
+
+  fun isDowngrade(context: Context, targetVersion: Int): Boolean {
+    val existingVersion = getExistingDbVersion(context) ?: return false
+    return existingVersion > targetVersion
+  }
+
+  fun createSnapshot(context: Context): DatabaseSnapshot {
+    val dbFile = context.getDatabasePath(DB_NAME)
+    if (!dbFile.exists()) {
+      return DatabaseSnapshot(emptyList(), emptyList(), emptyList())
+    }
+
+    val sqliteDb = SQLiteDatabase.openDatabase(
+      dbFile.path,
+      null,
+      SQLiteDatabase.OPEN_READONLY
+    )
+
+    val snapshot = DatabaseSnapshot(
+      notes = backupTable(sqliteDb, "NotesRoomEntity"),
+      history = backupTable(sqliteDb, "HistoryRoomEntity"),
+      recentSearches = backupTable(sqliteDb, "RecentSearchRoomEntity")
+    )
+
+    sqliteDb.close()
+    return snapshot
+  }
+
+  fun restoreSnapshot(
+    db: SupportSQLiteDatabase,
+    snapshot: DatabaseSnapshot
+  ) {
+    restoreTableRows(db, "NotesRoomEntity", snapshot.notes)
+    restoreTableRows(db, "HistoryRoomEntity", snapshot.history)
+    restoreTableRows(db, "RecentSearchRoomEntity", snapshot.recentSearches)
+  }
+
+  private fun getExistingDbVersion(context: Context): Int? {
+    val dbFile = context.getDatabasePath(DB_NAME)
+    if (!dbFile.exists()) return null
+
+    val db = SQLiteDatabase.openDatabase(
+      dbFile.path,
+      null,
+      SQLiteDatabase.OPEN_READONLY
+    )
+
+    val version = db.version
+    db.close()
+    return version
+  }
+
+  private fun backupTable(
+    db: SQLiteDatabase,
+    tableName: String
+  ): List<RowSnapshot> {
+    return try {
+      db.rawQuery("SELECT * FROM $tableName", null).use { cursor ->
+        readAllRows(cursor)
+      }
+    } catch (ignore: Exception) {
+      Log.e(ROOM_DOWNGRADE_HELPER, "Can not make backup of database. original exception = $ignore")
+      emptyList()
+    }
+  }
+
+  private fun readAllRows(cursor: Cursor): List<RowSnapshot> {
+    val rows = mutableListOf<RowSnapshot>()
+
+    val columnNames = cursor.columnNames
+    val columnIndexMap = mapColumnIndices(cursor, columnNames)
+
+    while (cursor.moveToNext()) {
+      rows.add(RowSnapshot(readRow(cursor, columnIndexMap)))
+    }
+
+    return rows
+  }
+
+  private fun mapColumnIndices(
+    cursor: Cursor,
+    columnNames: Array<String>
+  ): Map<String, Int> {
+    val indexMap = HashMap<String, Int>(columnNames.size)
+
+    for (column in columnNames) {
+      val index = cursor.getColumnIndex(column)
+      if (index != -1) {
+        indexMap[column] = index
+      }
+    }
+
+    return indexMap
+  }
+
+  private fun readRow(
+    cursor: Cursor,
+    columnIndexMap: Map<String, Int>
+  ): Map<String, Any?> {
+    val row = HashMap<String, Any?>(columnIndexMap.size)
+
+    for ((column, index) in columnIndexMap) {
+      row[column] = readCursorValue(cursor, index)
+    }
+
+    return row
+  }
+
+  private fun readCursorValue(cursor: Cursor, index: Int): Any? {
+    return when (cursor.getType(index)) {
+      Cursor.FIELD_TYPE_INTEGER -> cursor.getLong(index)
+      Cursor.FIELD_TYPE_FLOAT -> cursor.getDouble(index)
+      Cursor.FIELD_TYPE_STRING -> cursor.getString(index)
+      Cursor.FIELD_TYPE_BLOB -> cursor.getBlob(index)
+      Cursor.FIELD_TYPE_NULL -> null
+      else -> null
+    }
+  }
+
+  private fun getExistingColumns(
+    db: SupportSQLiteDatabase,
+    tableName: String
+  ): Set<String> {
+    val columns = mutableSetOf<String>()
+
+    try {
+      db.query("PRAGMA table_info($tableName)").use { cursor ->
+        while (cursor.moveToNext()) {
+          columns.add(cursor.getString(cursor.getColumnIndexOrThrow("name")))
+        }
+      }
+    } catch (ignore: Exception) {
+      Log.e(ROOM_DOWNGRADE_HELPER, "Can not get existing column. original exception = $ignore")
+    }
+
+    return columns
+  }
+
+  private fun restoreTableRows(
+    db: SupportSQLiteDatabase,
+    tableName: String,
+    rows: List<RowSnapshot>
+  ) {
+    if (rows.isEmpty()) return
+
+    val existingColumns = getExistingColumns(db, tableName)
+    if (existingColumns.isEmpty()) return
+
+    val insertableColumns = existingColumns - "id"
+
+    db.beginTransaction()
+    try {
+      var cachedSql: String? = null
+      var cachedColumnOrder: List<String>? = null
+
+      for (row in rows) {
+        val filteredRow = row.values.filterKeys { it in insertableColumns }
+        if (filteredRow.isEmpty()) continue
+
+        val columnOrder = filteredRow.keys.sorted()
+
+        if (cachedSql == null || cachedColumnOrder != columnOrder) {
+          val columnList = columnOrder.joinToString(", ")
+          val placeholders = columnOrder.joinToString(", ") { "?" }
+
+          cachedSql =
+            "INSERT OR REPLACE INTO $tableName ($columnList) VALUES ($placeholders)"
+
+          cachedColumnOrder = columnOrder
+        }
+
+        val args = Array(columnOrder.size) { i ->
+          filteredRow[columnOrder[i]]
+        }
+
+        db.execSQL(cachedSql, args)
+      }
+
+      db.setTransactionSuccessful()
+    } finally {
+      db.endTransaction()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4875 

* Introduced the `RoomDowngradeBackupHelper` to properly backup the existing data and restore it when the migration runs.
* Added comprehensive RoomDowngradeBackupHelperTest coverage to verify database snapshot backup and restore behavior during Room downgrade scenarios.
* Verified snapshot creation for notes, history, and recent searches.
* Verified restore logic correctly restores backed-up data into a newly created database.
* Added downgrade restore callback test to ensure user data is preserved after destructive downgrade recreation.
* Added schema compatibility tests to verify that unsupported columns from newer schemas are safely ignored during restore.
* Added edge case coverage for empty snapshots and missing databases.