### PR TITLE
Fixed: Bookmark button deletes the previous bookmark instead of saving a new one for the same page section (in D3.js Docs).

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -19,6 +19,7 @@
 package org.kiwix.kiwixmobile.core.dao
 
 import android.os.Build
+import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -168,16 +169,10 @@ class LibkiwixBookmarks @Inject constructor(
     ensureInitialized()
     if (!isBookMarkExist(libkiwixBookmarkItem)) {
       addBookToLibraryIfNotExist(libkiwixBookmarkItem.libKiwixBook)
-      val sectionTitle = libkiwixBookmarkItem.url.substringAfter("#", "")
-      val bookMarkTitle = if (sectionTitle.isNotEmpty()) {
-        "${libkiwixBookmarkItem.title}#$sectionTitle"
-      } else {
-        libkiwixBookmarkItem.title
-      }
       val bookmark =
         Bookmark().apply {
           bookId = libkiwixBookmarkItem.zimId
-          title = bookMarkTitle
+          title = getBookmarkTitle(libkiwixBookmarkItem)
           url = libkiwixBookmarkItem.url
           bookTitle =
             when {
@@ -198,6 +193,37 @@ class LibkiwixBookmarks @Inject constructor(
       }
     }
   }
+
+  /**
+   * Builds a display title for a bookmark.
+   *
+   * When the bookmark URL points to a sub-section (i.e., contains a fragment after '#'),
+   * the fragment is appended to the base title in parentheses.
+   * For example: "Gro polygon (angle)".
+   *
+   * If no fragment is present, the base title is returned as-is.
+   */
+  private fun getBookmarkTitle(libkiwixBookmarkItem: LibkiwixBookmarkItem): String {
+    val subSectionFragment = getSubSectionFragment(libkiwixBookmarkItem.url)
+    return if (!subSectionFragment.isNullOrEmpty()) {
+      "${libkiwixBookmarkItem.title} ($subSectionFragment)"
+    } else {
+      libkiwixBookmarkItem.title
+    }
+  }
+
+  /**
+   * Returns the fragment (the part after '#') from the given URL, if present.
+   *
+   * A non-null, non-empty fragment indicates that the URL points to a sub-section
+   * (anchor) within the page.
+   *
+   * @return the decoded fragment, or null if none exists
+   *
+   * @see android.net.Uri.fragment
+   */
+  private fun getSubSectionFragment(url: String): String? =
+    url.toUri().fragment
 
   suspend fun addBookToLibrary(file: File? = null, archive: Archive? = null) {
     ensureInitialized()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -45,8 +45,8 @@ import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.utils.files.FileUtils.EXPORT_BOOK_MARK_PATH
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.Bookmark
 import org.kiwix.libkiwix.Library
@@ -168,10 +168,16 @@ class LibkiwixBookmarks @Inject constructor(
     ensureInitialized()
     if (!isBookMarkExist(libkiwixBookmarkItem)) {
       addBookToLibraryIfNotExist(libkiwixBookmarkItem.libKiwixBook)
+      val sectionTitle = libkiwixBookmarkItem.url.substringAfter("#", "")
+      val bookMarkTitle = if (sectionTitle.isNotEmpty()) {
+        "${libkiwixBookmarkItem.title}#$sectionTitle"
+      } else {
+        libkiwixBookmarkItem.title
+      }
       val bookmark =
         Bookmark().apply {
           bookId = libkiwixBookmarkItem.zimId
-          title = libkiwixBookmarkItem.title
+          title = bookMarkTitle
           url = libkiwixBookmarkItem.url
           bookTitle =
             when {


### PR DESCRIPTION
Fixes #4728 

* In D3.js Docs, multiple subsections exist under the same page, so the WebView title remains the same across sections, while the URLs differ, for example:
  - https://kiwix.app/d3-request#request_abort
  - https://kiwix.app/d3-request#request
* To address this, the bookmark title now includes the section fragment from the URL. This ensures each bookmark is uniquely identified.
* As a result, bookmarks for different sections are now saved correctly and displayed distinctly in the bookmarks list.


https://github.com/user-attachments/assets/554d502d-37ec-4c20-8466-f0467eedfc87


