### PR TITLE
Updated the CD to better handle the new error response from the Play Publisher library.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,8 +123,9 @@ jobs:
             echo "Gradle build successful."
             exit 0
           fi
-
-          if grep -q "Try another version code." gradle_output.log; then
+          
+          if grep -qi "version code" gradle_output.log &&
+            grep -Eqi "(already been used|try another version code)" gradle_output.log; then
             echo "Upload skipped because very same version."
             exit 0
           fi


### PR DESCRIPTION
Fixes #4909 

## Issue

Our CD takes the last commit date of the main branch and generates the version code based on that. For the last 5 days, there has been nothing merged into the main branch, so it was taking `2026-05-22` as the last merge date and generating the app based on that. With this version code, there is already an app available on the Play Store. So the Play Publisher library was giving an error for the same version code.

<img width="1014" height="549" alt="image" src="https://github.com/user-attachments/assets/a093de34-6a29-48f4-b27a-a1297094330d" />

However, our CD ignores this error. But now the Play Publisher error has changed. So that's why the CD was failing.


## Fix


Improved error handling for cases where the app has already been published with the same version code. The CD now also handles the updated error message returned by the Play Publisher library.
