### PR TITLE
Fixed: CI sometimes throw `rootDir must be verified to be directory beforehand` error.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -112,7 +112,16 @@ object FileUtils {
     dispatcher: CoroutineDispatcher = Dispatchers.IO
   ) {
     CoroutineScope(dispatcher).launch {
-      getFileCacheDir(context)?.deleteRecursively()
+      runCatching {
+        val cacheDir = getFileCacheDir(context) ?: return@launch
+        when {
+          !cacheDir.exists() -> Unit
+          cacheDir.isDirectory -> cacheDir.deleteRecursively()
+          else -> cacheDir.delete()
+        }
+      }.onFailure {
+        Log.w("DeleteCache", "Failed to delete cached files", it)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #4927 

## Issues

`deleteRecursively()` internally uses `FileTreeWalk`, which expects the root path to remain a directory while the traversal is being initialized. In rare cases on CI, the cache directory can be deleted or modified between the time it is obtained and the time `deleteRecursively()` begins traversing it(there is a rerun mechanism in test cases). When that happens, `FileTreeWalk` throws:

```
AssertionError: rootDir must be verified to be directory beforehand
```

## Fix

Before invoking `deleteRecursively()`, we verify that the path still exists and is a directory. If the path exists but is no longer a directory, delete it as a regular file instead.