### PR TITLE
Removed the duplicate code from UI test cases.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -18,35 +18,55 @@
 
 package org.kiwix.kiwixmobile
 
-import android.Manifest.permission
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.Manifest.permission.NEARBY_WIFI_DEVICES
 import android.content.Context
+import android.os.Build
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
+import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
+import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
+import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.Matchers.anyOf
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.di.components.DaggerTestComponent
 import org.kiwix.kiwixmobile.core.di.components.TestComponent
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.TestUtils
 
 @RunWith(AndroidJUnit4::class)
 abstract class BaseActivityTest {
-  val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-  open lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+  protected val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+  protected lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+  protected val kiwixDataStore by lazy {
+    KiwixDataStore(context)
+  }
 
-  private val permissions =
-    arrayOf(
-      permission.READ_EXTERNAL_STORAGE,
-      permission.WRITE_EXTERNAL_STORAGE
-    )
+  open fun permissions(): Array<String> =
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      arrayOf(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE, ACCESS_FINE_LOCATION)
+    } else {
+      arrayOf(POST_NOTIFICATIONS, NEARBY_WIFI_DEVICES)
+    }
 
   @get:Rule
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
+  var permissionRules: GrantPermissionRule = GrantPermissionRule.grant(*permissions())
 
   val context: Context by lazy {
     getInstrumentation().targetContext.applicationContext
@@ -56,5 +76,98 @@ abstract class BaseActivityTest {
     .context(context)
     .build()
 
-  abstract fun waitForIdle()
+  /**
+   * Contains common test setup logic that can be invoked from a subclass
+   * `@Before` method.
+   */
+  open fun waitForIdle() {
+    prepareDevice()
+    setupCommonDataStore()
+  }
+
+  private fun prepareDevice() {
+    UiDevice.getInstance(getInstrumentation()).apply {
+      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
+        TestUtils.closeSystemDialogs(context, this)
+      }
+      waitForIdle()
+    }
+  }
+
+  /**
+   * Initializes the datastore with default values used by most instrumentation
+   * tests. This ensures tests start from a consistent application state and do
+   * not depend on values persisted from previous test runs.
+   */
+  private fun setupCommonDataStore() {
+    kiwixDataStore.apply {
+      runBlocking {
+        setWifiOnly(false)
+        setIntroShown()
+        setPrefLanguage("en")
+        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
+        setShowStorageSelectionDialogOnCopyMove(false)
+        setIsScanFileSystemDialogShown(true)
+        setIsPlayStoreBuild(true)
+        setPrefIsTest(true)
+        setIsFirstRun(false)
+      }
+    }
+  }
+
+  /**
+   * Updates the test [KiwixDataStore] by executing the provided block and waits
+   * for all datastore operations to complete before returning.
+   *
+   * This allows tests to configure only the datastore values they need while
+   * reusing the shared datastore instance.
+   */
+  protected fun updateKiwixDataStore(block: suspend KiwixDataStore.() -> Unit) {
+    runBlocking { kiwixDataStore.block() }
+  }
+
+  /**
+   * Launches [KiwixMainActivity] and sets the application's locale using the
+   * provided language tag. Defaults to English ("en").
+   */
+  protected fun launchMainActivity(
+    languageTag: String = "en",
+    onActivityLaunched: ((KiwixMainActivity) -> Unit)? = null
+  ) {
+    activityScenario =
+      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
+        moveToState(Lifecycle.State.RESUMED)
+        onActivity {
+          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(languageTag))
+          onActivityLaunched?.invoke(it)
+        }
+      }
+  }
+
+  /**
+   * Creates and configures an [AccessibilityValidator] for Compose UI tests.
+   *
+   * Accessibility checks are run from the root view to validate the UI against
+   * accessibility guidelines. Certain framework accessibility checks are
+   * suppressed because they can produce false positives in our test environment:
+   *
+   * - [DuplicateClickableBoundsCheck]
+   * - [SpeakableTextPresentCheck] (Android 14+ only)
+   */
+  protected fun createAccessibilityValidator(): AccessibilityValidator {
+    return AccessibilityValidator()
+      .setRunChecksFromRootView(true)
+      .apply {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+          setSuppressingResultMatcher(
+            anyOf(
+              matchesCheck(DuplicateClickableBoundsCheck::class.java),
+              matchesCheck(SpeakableTextPresentCheck::class.java)
+            )
+          )
+        } else {
+          setSuppressingResultMatcher(anyOf(matchesCheck(DuplicateClickableBoundsCheck::class.java)))
+        }
+      }
+  }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -18,18 +18,12 @@
 
 package org.kiwix.kiwixmobile
 
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import io.objectbox.Box
 import io.objectbox.BoxStore
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -44,9 +38,7 @@ import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.page.bookmark.models.BookmarkItem
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.migration.data.ObjectBoxToLibkiwixMigrator
 import org.kiwix.kiwixmobile.migration.di.component.DaggerMigrationComponent
 import org.kiwix.kiwixmobile.migration.entities.BookOnDiskEntity
@@ -54,13 +46,12 @@ import org.kiwix.kiwixmobile.migration.entities.BookmarkEntity
 import org.kiwix.kiwixmobile.migration.entities.MyObjectBox
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource
 import org.kiwix.libkiwix.Book
 import org.kiwix.libzim.Archive
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 
 class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
@@ -117,32 +108,10 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    launchMainActivity {
+      it.navigate(KiwixDestination.Library.route)
     }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-          it.navigate(KiwixDestination.Library.route)
-        }
-      }
     val migrationComponent = DaggerMigrationComponent.builder()
       .coreComponent(CoreApp.coreComponent)
       .build()
@@ -177,30 +146,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
     runBlocking { clearBookOnDisk() }
 
     // add a file in fileSystem because we need to actual file path for making object of Archive.
-    zimFile = getZimFile("testzim.zim")
-  }
-
-  private fun getZimFile(zimFileName: String): File {
-    val loadFileStream =
-      ObjectBoxToLibkiwixMigratorTest::class.java.classLoader.getResourceAsStream(zimFileName)
-    val zimFile =
-      File(
-        context.getExternalFilesDirs(null)[0],
-        zimFileName
-      )
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
+    zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
   }
 
   @Test
@@ -251,14 +197,14 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
       clearBookOnDisk()
 
       // Test if data successfully migrated to libkiwix and existing data is preserved
-      zimFile = getZimFile("testzim.zim")
-      val secondZimFile = getZimFile("small.zim")
+      zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
+      val secondZimFile = getZimFileFromResourceFolder(context, "small.zim")
       val archive = Archive(secondZimFile.path)
       val book = Book().apply {
         update(archive)
       }
       objectBoxToLibkiwixMigrator.libkiwixBookOnDisk.insert(listOf(book))
-      val thirdZim = getZimFile("characters_encoding.zim")
+      val thirdZim = getZimFileFromResourceFolder(context, "characters_encoding.zim")
       val thirdEntity = BookOnDiskEntity(
         id = 0,
         file = thirdZim,

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -18,23 +18,11 @@
 
 package org.kiwix.kiwixmobile
 
-import android.content.Context
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.room.Room
-import androidx.test.core.app.ActivityScenario
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import io.objectbox.Box
 import io.objectbox.BoxStore
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
@@ -44,58 +32,30 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.migration.data.ObjectBoxToRoomMigrator
 import org.kiwix.kiwixmobile.migration.entities.HistoryEntity
 import org.kiwix.kiwixmobile.migration.entities.MyObjectBox
 import org.kiwix.kiwixmobile.migration.entities.NotesEntity
 import org.kiwix.kiwixmobile.migration.entities.RecentSearchEntity
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 
-@RunWith(AndroidJUnit4::class)
-class ObjectBoxToRoomMigratorTest {
-  private lateinit var context: Context
+class ObjectBoxToRoomMigratorTest : BaseActivityTest() {
   private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
   private lateinit var boxStore: BoxStore
   private lateinit var objectBoxToRoomMigrator: ObjectBoxToRoomMigrator
   private val migrationMaxTime = 35000
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
   @Before
-  fun setup() {
-    context = ApplicationProvider.getApplicationContext()
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        it.navigate(KiwixDestination.Library.route)
-      }
+  override fun waitForIdle() {
+    super.waitForIdle()
+    launchMainActivity {
+      it.navigate(KiwixDestination.Library.route)
     }
     kiwixRoomDatabase =
       Room.inMemoryDatabaseBuilder(context, KiwixRoomDatabase::class.java)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -19,21 +19,9 @@
 package org.kiwix.kiwixmobile
 
 import android.content.Context
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import androidx.lifecycle.Lifecycle
 import androidx.preference.PreferenceManager
-import androidx.test.core.app.ActivityScenario
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.json.JSONArray
 import org.json.JSONObject
@@ -43,7 +31,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE
 import org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_TAB
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
@@ -53,44 +40,17 @@ import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore.Companion.KEY_L
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore.Companion.KEY_OCCURRENCES_OF_LANGUAGE
 import org.kiwix.kiwixmobile.core.utils.datastore.PreferencesKeys
 import org.kiwix.kiwixmobile.core.utils.datastore.SharedPreferenceToDatastoreMigrator
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
-@RunWith(AndroidJUnit4::class)
-class SharedPreferenceToDatastoreMigratorTest {
+class SharedPreferenceToDatastoreMigratorTest : BaseActivityTest() {
   @get:Rule
   val tmpFolder = TemporaryFolder()
-  private lateinit var context: Context
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
   @Before
-  fun setup() {
-    context = ApplicationProvider.getApplicationContext()
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsPlayStoreBuild(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        it.navigate(KiwixDestination.Library.route)
-      }
+  override fun waitForIdle() {
+    super.waitForIdle()
+    launchMainActivity {
+      it.navigate(KiwixDestination.Library.route)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderInstrumentedTest.kt
@@ -18,13 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.reader
 
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -37,63 +30,20 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Companion.CONTENT_PREFIX
 import org.kiwix.kiwixmobile.core.search.viewmodel.MAX_SUGGEST_WORD_COUNT
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
-import org.kiwix.kiwixmobile.reader.EncodedUrlTest
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
-import java.io.FileOutputStream
 
 class ZimFileReaderInstrumentedTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-  }
-
-  private suspend fun copyZimFile(name: String): File {
-    val loadFileStream =
-      EncodedUrlTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = File(context.getExternalFilesDirs(null)[0], name)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      FileOutputStream(zimFile).use { outputStream ->
-        val buffer = ByteArray(1024)
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          outputStream.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
+    super.waitForIdle()
+    launchMainActivity()
   }
 
   private suspend fun createZimFileReader(): ZimFileReader {
-    val zimFile = copyZimFile("testzim.zim")
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     val zimReaderSource = ZimReaderSource(zimFile)
     val archive = zimReaderSource.createArchive()!!
     return ZimFileReader(zimReaderSource, archive, SuggestionSearcher(archive))
@@ -213,7 +163,7 @@ class ZimFileReaderInstrumentedTest : BaseActivityTest() {
       corruptedFile.delete()
 
       // ── Verify Factory.create with valid file ──
-      val validZimFile = copyZimFile("testzim_factory.zim")
+      val validZimFile = getZimFileFromResourceFolder(context, "testzim.zim")
       val validSource = ZimReaderSource(validZimFile)
       val validResult = factory.create(validSource, false)
       assertNotNull(validResult)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -33,14 +33,7 @@ import androidx.core.net.toUri
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -50,7 +43,6 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.ZIM_HOST_NAV_DEEP_LINK
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.OPENING_ZIM_FILE_DELAY
@@ -59,11 +51,10 @@ import org.kiwix.kiwixmobile.page.history.navigationHistory
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class DeepLinksTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -72,39 +63,11 @@ class DeepLinksTest : BaseActivityTest() {
 
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
-  private lateinit var kiwixDataStore: KiwixDataStore
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    kiwixDataStore = KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowStorageSelectionDialogOnCopyMove(false)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -209,21 +172,8 @@ class DeepLinksTest : BaseActivityTest() {
   }
 
   private fun loadZimFileInApplicationAndReturnSchemeTypeUri(schemeType: String): Uri? {
-    val loadFileStream =
-      DeepLinksTest::class.java.classLoader.getResourceAsStream("testzim.zim")
-    val zimFile = runBlocking { File(kiwixDataStore.defaultStorage(), "testzim.zim") }
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
+    val destinationDirectory = runBlocking { File(kiwixDataStore.defaultStorage()) }
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim", destinationDirectory)
     return when (schemeType) {
       "file" -> Uri.fromFile(zimFile)
       "content" ->

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -22,10 +22,8 @@ import android.accessibilityservice.AccessibilityService
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -33,13 +31,6 @@ import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
@@ -49,12 +40,9 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
@@ -73,52 +61,13 @@ class DownloadServiceTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setSelectedOnlineContentCategory("")
+      setSelectedOnlineContentLanguage("")
     }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowStorageOption(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-        setIsFirstRun(false)
-        setSelectedOnlineContentCategory("")
-        setSelectedOnlineContentLanguage("")
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -63,6 +63,7 @@ class DownloadServiceTest : BaseActivityTest() {
   override fun waitForIdle() {
     super.waitForIdle()
     updateKiwixDataStore {
+      setShowStorageOption(false)
       setSelectedOnlineContentCategory("")
       setSelectedOnlineContentLanguage("")
     }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -22,10 +22,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -34,15 +32,8 @@ import androidx.test.espresso.IdlingRegistry
 import androidx.test.filters.LargeTest
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -53,14 +44,11 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
@@ -81,52 +69,14 @@ class DownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setShowStorageOption(false)
+      setSelectedOnlineContentCategory("")
+      setSelectedOnlineContentLanguage("")
     }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowStorageOption(false)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-        setSelectedOnlineContentCategory("")
-        setSelectedOnlineContentLanguage("")
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
@@ -18,37 +18,22 @@
 
 package org.kiwix.kiwixmobile.error
 
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.tryPerformAccessibilityChecks
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class ErrorActivityTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -60,40 +45,9 @@ class ErrorActivityTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -106,7 +60,7 @@ class ErrorActivityTest : BaseActivityTest() {
       waitUntilZimFilesRefreshing(composeTestRule)
       deleteZimIfExists(composeTestRule)
     }
-    loadZimFileInReader("testzim.zim")
+    getZimFileFromResourceFolder(context, "testzim.zim")
     library {
       refreshList(composeTestRule)
       waitUntilZimFilesRefreshing(composeTestRule)
@@ -138,26 +92,5 @@ class ErrorActivityTest : BaseActivityTest() {
       assertZimFileValidationDialogDisplayed(composeTestRule)
     }
     composeTestRule.onRoot().tryPerformAccessibilityChecks()
-  }
-
-  private fun loadZimFileInReader(zimFileName: String) {
-    val loadFileStream =
-      ErrorActivityTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/extensions/BookExtensionsTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/extensions/BookExtensionsTest.kt
@@ -28,10 +28,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.extensions.getFavicon
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.libkiwix.Book
 import org.kiwix.libzim.Archive
-import java.io.File
-import java.io.FileOutputStream
 
 @RunWith(AndroidJUnit4::class)
 @SmallTest
@@ -54,7 +53,10 @@ class BookExtensionsTest {
     )
 
     // Load a real ZIM file and create a Book backed by an Archive
-    val zimFile = getZimFile("testzim.zim")
+    val zimFile = getZimFileFromResourceFolder(
+      InstrumentationRegistry.getInstrumentation().targetContext,
+      "testzim.zim"
+    )
     val archive = Archive(zimFile.path)
     val book = Book().apply { update(archive) }
     val result = book.getFavicon()
@@ -62,30 +64,8 @@ class BookExtensionsTest {
     assertNotNull("getFavicon should not return null for a real ZIM file", result)
     assertTrue(
       "getFavicon should return a non-empty string for a real ZIM file",
-      result!!.isNotEmpty()
+      result?.isNotEmpty() == true
     )
     zimFile.delete()
-  }
-
-  private fun getZimFile(zimFileName: String): File {
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
-    val loadFileStream =
-      BookExtensionsTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDir(null), zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      FileOutputStream(zimFile).use { outputStream ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          outputStream.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
@@ -18,24 +18,12 @@
 package org.kiwix.kiwixmobile.help
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.tryPerformAccessibilityChecks
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.IdlingRegistry
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -43,11 +31,7 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource
 
@@ -61,37 +45,9 @@ class HelpScreenRouteTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -151,16 +107,12 @@ class HelpScreenRouteTest : BaseActivityTest() {
   }
 
   private fun setShowCopyMoveToPublicDirectory(showRestriction: Boolean) {
-    context.let {
-      KiwixDataStore(it).apply {
-        runBlocking {
-          setWifiOnly(false)
-          setIntroShown()
-          setPrefLanguage("en")
-          setIsPlayStoreBuild(showRestriction)
-          setPrefIsTest(true)
-        }
-      }
+    updateKiwixDataStore {
+      setWifiOnly(false)
+      setIntroShown()
+      setPrefLanguage("en")
+      setIsPlayStoreBuild(showRestriction)
+      setPrefIsTest(true)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -19,23 +19,11 @@
 package org.kiwix.kiwixmobile.initial.download
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.filters.LargeTest
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -43,14 +31,11 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.download.downloadRobot
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
 @LargeTest
@@ -65,49 +50,13 @@ class InitialDownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setShowStorageOption(true)
+      setSelectedOnlineContentCategory("")
     }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowStorageOption(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-        setSelectedOnlineContentCategory("")
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/intro/IntroFragmentTest.kt
@@ -17,31 +17,16 @@
  */
 package org.kiwix.kiwixmobile.intro
 
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
 class IntroFragmentTest : BaseActivityTest() {
@@ -66,37 +51,9 @@ class IntroFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown(true)
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    updateKiwixDataStore { setIntroShown(true) }
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
@@ -17,51 +17,28 @@
  */
 package org.kiwix.kiwixmobile.language
 
-import android.Manifest
-import android.app.Instrumentation
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.download.downloadRobot
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.utils.StandardActions
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
-class LanguageScreenTest {
+class LanguageScreenTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -69,65 +46,15 @@ class LanguageScreenTest {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
 
-  private val permissions =
-    arrayOf(
-      Manifest.permission.READ_EXTERNAL_STORAGE,
-      Manifest.permission.WRITE_EXTERNAL_STORAGE
-    )
-
-  @Rule
-  @JvmField
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
-
   lateinit var kiwixMainActivity: KiwixMainActivity
-  private val instrumentation: Instrumentation by lazy(InstrumentationRegistry::getInstrumentation)
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
   @Before
-  fun setUp() {
-    UiDevice.getInstance(instrumentation).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(instrumentation.targetContext.applicationContext, this)
-      }
-      waitForIdle()
+  override fun waitForIdle() {
+    super.waitForIdle()
+    launchMainActivity {
+      kiwixMainActivity = it
     }
-    KiwixDataStore(
-      instrumentation.targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        kiwixMainActivity = it
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-      }
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -18,45 +18,26 @@
 
 package org.kiwix.kiwixmobile.localFileTransfer
 
-import android.Manifest
-import android.app.Instrumentation
-import android.content.Context
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.tryPerformAccessibilityChecks
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
 
-class LocalFileTransferTest {
+class LocalFileTransferTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -64,64 +45,18 @@ class LocalFileTransferTest {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
 
-  private lateinit var context: Context
-  private lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-
-  private val permissions =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      arrayOf(
-        Manifest.permission.NEARBY_WIFI_DEVICES
-      )
-    } else {
-      arrayOf(
-        Manifest.permission.READ_EXTERNAL_STORAGE,
-        Manifest.permission.WRITE_EXTERNAL_STORAGE,
-        Manifest.permission.ACCESS_FINE_LOCATION
-      )
-    }
-
-  @Rule
-  @JvmField
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
-
   lateinit var kiwixMainActivity: KiwixMainActivity
 
-  private val instrumentation: Instrumentation by lazy {
-    InstrumentationRegistry.getInstrumentation()
-  }
-
   @Before
-  fun setup() {
-    context = instrumentation.targetContext.applicationContext
-    UiDevice.getInstance(instrumentation).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+  override fun waitForIdle() {
+    super.waitForIdle()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
   fun localFileTransfer() {
     shouldShowShowCaseFeatureToUser(false)
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
+    launchMainActivity { kiwixMainActivity = it }
     StandardActions.closeDrawer(kiwixMainActivity as CoreMainActivity)
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
@@ -145,15 +80,10 @@ class LocalFileTransferTest {
   @Test
   fun showCaseFeature() {
     shouldShowShowCaseFeatureToUser(true)
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-          it.navigate(KiwixDestination.Library.route)
-        }
-      }
+    launchMainActivity {
+      kiwixMainActivity = it
+      it.navigate(KiwixDestination.Library.route)
+    }
     StandardActions.closeDrawer(kiwixMainActivity as CoreMainActivity)
     library {
       assertGetZimNearbyDeviceDisplayed(composeTestRule)
@@ -180,14 +110,10 @@ class LocalFileTransferTest {
   @Test
   fun testShowCaseFeatureShowOnce() {
     shouldShowShowCaseFeatureToUser(false)
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          it.navigate(KiwixDestination.Library.route)
-        }
-      }
+    launchMainActivity {
+      kiwixMainActivity = it
+      it.navigate(KiwixDestination.Library.route)
+    }
     StandardActions.closeDrawer(kiwixMainActivity as CoreMainActivity)
     library {
       // test show case view show once.
@@ -199,16 +125,14 @@ class LocalFileTransferTest {
   }
 
   private fun shouldShowShowCaseFeatureToUser(shouldShowShowCase: Boolean) {
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setShowCaseViewForFileTransferShown(shouldShowShowCase)
-        setPrefLanguage("en")
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
+    updateKiwixDataStore {
+      setWifiOnly(false)
+      setIntroShown()
+      setShowCaseViewForFileTransferShown(shouldShowShowCase)
+      setPrefLanguage("en")
+      setIsScanFileSystemDialogShown(true)
+      setIsFirstRun(false)
+      setPrefIsTest(true)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -28,15 +28,9 @@ import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -49,7 +43,6 @@ import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.CopyMoveFileHandler
@@ -59,14 +52,13 @@ import org.kiwix.kiwixmobile.nav.destination.library.local.FileOperationHandlerI
 import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.zimManager.Fat32Checker
 import org.kiwix.kiwixmobile.zimManager.FileWritingFileSystemChecker
 import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class CopyMoveFileHandlerTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -78,7 +70,6 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
 
   @get:Rule
   private val dispatcher = MainDispatcherRule()
-  private lateinit var kiwixDataStore: KiwixDataStore
   private lateinit var kiwixMainActivity: KiwixMainActivity
   private lateinit var selectedFile: File
   private lateinit var destinationFile: File
@@ -86,24 +77,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    kiwixDataStore = KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
+    super.waitForIdle()
     composeTestRule.apply {
       runOnUiThread {
         AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
@@ -112,14 +86,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       kiwixMainActivity = activity
       waitForIdle()
     }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -127,7 +94,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     deleteAllFilesInDirectory(parentFile)
     // Test the scenario in playStore build on Android 11 and above.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      selectedFile = getSelectedFile("testzim.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
       composeTestRule.apply {
         waitForIdle()
         runOnUiThread {
@@ -137,7 +104,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitUntilTimeout() // to properly load the library screen.
       }
       // test with first launch
-      runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
+      updateKiwixDataStore { setShowStorageSelectionDialogOnCopyMove(true) }
       showMoveFileToPublicDirectoryDialog(listOf(Uri.fromFile(selectedFile)))
       // should show the permission dialog.
       copyMoveFileHandler {
@@ -168,8 +135,8 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       navigateToLocalLibraryScreen()
       deleteZimFilesIfExistInLocalLibrary()
       val invalidZimFile = getInvalidZimFileUri(".mp4")
-      selectedFile = getSelectedFile("testzim.zim")
-      val secondValidZimFile = getSelectedFile("small.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
+      val secondValidZimFile = getZimFileFromResourceFolder(context, "small.zim")
       showMoveFileToPublicDirectoryDialog(
         mutableListOf(
           invalidZimFile,
@@ -194,7 +161,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     deleteAllFilesInDirectory(parentFile)
     // Test the scenario in playStore build on Android 11 and above.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      selectedFile = getSelectedFile("testzim.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
       composeTestRule.apply {
         waitForIdle()
         runOnUiThread {
@@ -204,7 +171,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitUntilTimeout() // to properly load the library screen.
       }
       // test with first launch
-      runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
+      updateKiwixDataStore { setShowStorageSelectionDialogOnCopyMove(true) }
       showMoveFileToPublicDirectoryDialog(listOf(Uri.fromFile(selectedFile)))
       // should show the permission dialog.
       copyMoveFileHandler {
@@ -219,7 +186,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       // delete the parent directory so that all the previous file will be deleted.
       deleteAllFilesInDirectory(parentFile)
       library { refreshList(composeTestRule) }
-      selectedFile = getSelectedFile("testzim.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
       showMoveFileToPublicDirectoryDialog(listOf(Uri.fromFile(selectedFile)))
       // should show the copyMove dialog.
       copyMoveFileHandler {
@@ -235,8 +202,8 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
       navigateToLocalLibraryScreen()
       deleteZimFilesIfExistInLocalLibrary()
       val invalidZimFile = getInvalidZimFileUri(".mp4")
-      selectedFile = getSelectedFile("testzim.zim")
-      val secondValidZimFile = getSelectedFile("small.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
+      val secondValidZimFile = getZimFileFromResourceFolder(context, "small.zim")
       showMoveFileToPublicDirectoryDialog(
         mutableListOf(
           invalidZimFile,
@@ -305,28 +272,6 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     }
   }
 
-  private fun getSelectedFile(fileName: String): File {
-    val loadFileStream =
-      CopyMoveFileHandlerTest::class.java.classLoader?.getResourceAsStream(fileName)
-    require(loadFileStream != null) {
-      "Unable to load the $fileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDirs(null)[0], fileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
-  }
-
   private fun getInvalidZimFileUri(extension: String): Uri {
     val zimFile = File(context.getExternalFilesDirs(null)[0], "testzim$extension")
     if (zimFile.exists()) zimFile.delete()
@@ -390,7 +335,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
     deleteAllFilesInDirectory(parentFile)
     // Test the scenario in playStore build on Android 11 and above.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      selectedFile = getSelectedFile("testzim.zim")
+      selectedFile = getZimFileFromResourceFolder(context, "testzim.zim")
       composeTestRule.apply {
         runOnUiThread {
           kiwixMainActivity.navigate(KiwixDestination.Library.route)
@@ -398,11 +343,9 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
         waitForIdle()
         waitUntilTimeout() // to properly load the library screen.
       }
-      runBlocking {
-        kiwixDataStore.apply {
-          setShowStorageSelectionDialogOnCopyMove(false)
-          setIsPlayStoreBuild(true)
-        }
+      updateKiwixDataStore {
+        setShowStorageSelectionDialogOnCopyMove(false)
+        setIsPlayStoreBuild(true)
       }
       // test opening images
       showMoveFileToPublicDirectoryDialog(listOf(getInvalidZimFileUri(".jpg")))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -27,26 +27,16 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -55,17 +45,14 @@ import org.junit.jupiter.api.fail
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.local.SELECT_FILE_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileOutputStream
 import java.io.IOException
-import java.io.OutputStream
 
 class OpeningFilesFromStorageTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -74,48 +61,15 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
 
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
-  private lateinit var kiwixDataStore: KiwixDataStore
   private lateinit var kiwixMainActivity: KiwixMainActivity
-  private lateinit var uiDevice: UiDevice
   private val fileName = "testzim.zim"
 
   @Before
   override fun waitForIdle() {
     Intents.init()
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      uiDevice = this
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    kiwixDataStore = KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -128,7 +82,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       composeTestRule.waitForIdle()
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
+        updateKiwixDataStore { setShowStorageSelectionDialogOnCopyMove(true) }
         intending(hasAction(Intent.ACTION_CHOOSER))
           .respondWith(
             Instrumentation.ActivityResult(
@@ -166,7 +120,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
       composeTestRule.waitForIdle()
       val uri = copyFileToDownloadsFolder(context, fileName)
       try {
-        runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
+        updateKiwixDataStore { setShowStorageSelectionDialogOnCopyMove(true) }
         val viewIntent = Intent(Intent.ACTION_VIEW).apply {
           setDataAndType(uri, "application/octet-stream")
           addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -212,7 +166,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
   }
 
   private fun testCopyMoveDialogShowing(uri: Uri) {
-    runBlocking { kiwixDataStore.setShowStorageSelectionDialogOnCopyMove(true) }
+    updateKiwixDataStore { setShowStorageSelectionDialogOnCopyMove(true) }
     ActivityScenario.launch<KiwixMainActivity>(
       createDeepLinkIntent(uri)
     ).onActivity {}
@@ -248,36 +202,10 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
     }
   }
 
-  private fun getSelectedFile(): File {
-    val loadFileStream =
-      CopyMoveFileHandlerTest::class.java.classLoader?.getResourceAsStream(fileName)
-    require(loadFileStream != null) {
-      "Unable to load the $fileName. Please check is it exist in resources folder."
-    }
-    val zimFile =
-      File(
-        context.getExternalFilesDirs(null)[0],
-        fileName
-      )
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
-  }
-
   private fun copyFileToDownloadsFolder(
     context: Context,
     fileName: String,
-    content: ByteArray = getSelectedFile().readBytes()
+    content: ByteArray = getZimFileFromResourceFolder(context, fileName).readBytes()
   ): Uri {
     val contentValues =
       ContentValues().apply {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -25,15 +25,9 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -42,17 +36,15 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -66,25 +58,11 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    val kiwixDataStore = KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowManageExternalFilesPermissionDialog(false)
-        setManageExternalFilesPermissionDialogOnRefresh(false)
-        setIsPlayStoreBuild(false)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setShowManageExternalFilesPermissionDialog(false)
+      setManageExternalFilesPermissionDialogOnRefresh(false)
+      setIsPlayStoreBuild(false)
     }
     composeTestRule.apply {
       kiwixMainActivity = activity
@@ -94,28 +72,21 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
       }
       waitForIdle()
     }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
   fun testZimFileSelectionForStandaloneApp() {
     // Test single ZIM file.
     prepareLocalLibraryForTest()
-    var validZimFile1 = getValidZimFile("testzim.zim")
+    var validZimFile1 = getZimFileFromResourceFolder(context, "testzim.zim")
     triggerProcessSelectedZimFiles(listOf(Uri.fromFile(validZimFile1)))
     copyMoveFileHandler { assertZimFileCopiedAndShowingIntoTheReader(composeTestRule) }
 
     // Test multiple ZIM valid ZIM files.
     prepareLocalLibraryForTest()
-    validZimFile1 = getValidZimFile("testzim.zim")
-    val validZimFile2 = getValidZimFile("small.zim")
+    validZimFile1 = getZimFileFromResourceFolder(context, "testzim.zim")
+    val validZimFile2 = getZimFileFromResourceFolder(context, "small.zim")
     var listOfZimFilesUri = listOf(Uri.fromFile(validZimFile1), Uri.fromFile(validZimFile2))
     triggerProcessSelectedZimFiles(listOfZimFilesUri)
     copyMoveFileHandler {
@@ -129,7 +100,7 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
 
     // Test multiple ZIM files with invalid ZIM file.
     prepareLocalLibraryForTest()
-    validZimFile1 = getValidZimFile("testzim.zim")
+    validZimFile1 = getZimFileFromResourceFolder(context, "testzim.zim")
     val invalidZimUri = getInvalidZimFileUri(".jpg")
     listOfZimFilesUri = listOf(invalidZimUri, Uri.fromFile(validZimFile1))
     triggerProcessSelectedZimFiles(listOfZimFilesUri)
@@ -207,28 +178,6 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
         file.delete()
       }
     }
-  }
-
-  private fun getValidZimFile(zimFileName: String): File {
-    val loadFileStream =
-      CopyMoveFileHandlerTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
   }
 
   private fun getInvalidZimFileUri(extension: String): Uri {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -18,21 +18,9 @@
 package org.kiwix.kiwixmobile.main
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -40,11 +28,8 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.nav.destination.library.onlineLibrary
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 class TopLevelDestinationTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -58,51 +43,13 @@ class TopLevelDestinationTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setExternalLinkPopup(true)
+      setShowCaseViewForFileTransferShown()
     }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setExternalLinkPopup(true)
-        setIntroShown()
-        setShowCaseViewForFileTransferShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity { kiwixMainActivity = it }
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -18,11 +18,6 @@
 
 package org.kiwix.kiwixmobile.mimetype
 
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert
@@ -31,64 +26,21 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.libzim.SuggestionSearcher
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class MimeTypeTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-      }
+    super.waitForIdle()
+    launchMainActivity()
   }
 
   @Test
   fun testMimeType() =
     runBlocking {
-      val zimFileName = "testzim.zim"
-      val loadFileStream = MimeTypeTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-      require(loadFileStream != null) {
-        "Unable to load the $zimFileName. Please check is it exist in resources folder."
-      }
-      val zimFile =
-        File(context.getExternalFilesDirs(null)[0], zimFileName)
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(1024)
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
-        }
-      }
+      val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
       val zimSource = ZimReaderSource(zimFile)
       val archive = zimSource.createArchive()
       val zimFileReader =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -19,23 +19,13 @@
 package org.kiwix.kiwixmobile.nav.destination.library
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -44,18 +34,13 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class LocalLibraryTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -67,47 +52,18 @@ class LocalLibraryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+    super.waitForIdle()
+    updateKiwixDataStore {
+      // set `setShowManageExternalFilesPermissionDialog` false for hiding
+      // manage external storage permission dialog on android 11 and above
+      setShowManageExternalFilesPermissionDialog(false)
+      // Set setManageExternalFilesPermissionDialogOnRefresh to false to hide
+      // the manage external storage permission dialog on Android 11 and above
+      // while refreshing the content in LocalLibraryScreen.
+      setManageExternalFilesPermissionDialogOnRefresh(false)
     }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        // set `setShowManageExternalFilesPermissionDialog` false for hiding
-        // manage external storage permission dialog on android 11 and above
-        setShowManageExternalFilesPermissionDialog(false)
-        // Set setManageExternalFilesPermissionDialogOnRefresh to false to hide
-        // the manage external storage permission dialog on Android 11 and above
-        // while refreshing the content in LocalLibraryScreen.
-        setManageExternalFilesPermissionDialogOnRefresh(false)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   private fun observeLocalLibraryActions() {
@@ -149,7 +105,7 @@ class LocalLibraryTest : BaseActivityTest() {
       deleteZimIfExists(composeTestRule)
     }
     // load a zim file to test, After downloading zim file library list is visible or not
-    loadZimFileInReader("testzim.zim")
+    getZimFileFromResourceFolder(context, "testzim.zim")
     library {
       refreshList(composeTestRule)
       waitUntilZimFilesRefreshing(composeTestRule)
@@ -205,7 +161,7 @@ class LocalLibraryTest : BaseActivityTest() {
         showManagePermissionDialog = false,
         isPlayStoreBuild = false
       )
-      loadZimFileInReader("testzim.zim")
+      getZimFileFromResourceFolder(context, "testzim.zim")
       refreshList(composeTestRule)
       waitUntilZimFilesRefreshing(composeTestRule)
       clickOnReaderFragment(composeTestRule)
@@ -221,43 +177,18 @@ class LocalLibraryTest : BaseActivityTest() {
     }
   }
 
-  private fun loadZimFileInReader(zimFileName: String) {
-    val loadFileStream =
-      LocalLibraryTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-  }
-
   private fun showScanFileSystemDialog(
     scanFileSystemDialogShown: Boolean,
     isTest: Boolean,
     showManagePermissionDialog: Boolean,
     isPlayStoreBuild: Boolean
   ) {
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setIsScanFileSystemDialogShown(scanFileSystemDialogShown)
-        setIsScanFileSystemTest(true)
-        setManageExternalFilesPermissionDialogOnRefresh(showManagePermissionDialog)
-        setIsPlayStoreBuild(isPlayStoreBuild)
-        setPrefIsTest(isTest)
-      }
+    updateKiwixDataStore {
+      setIsScanFileSystemDialogShown(scanFileSystemDialogShown)
+      setIsScanFileSystemTest(true)
+      setManageExternalFilesPermissionDialogOnRefresh(showManagePermissionDialog)
+      setIsPlayStoreBuild(isPlayStoreBuild)
+      setPrefIsTest(isTest)
     }
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
@@ -18,35 +18,19 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library
 
-import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.download.downloadRobot
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
 class OnlineLibraryScreenTest : BaseActivityTest() {
@@ -61,50 +45,10 @@ class OnlineLibraryScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setShowStorageOption(false)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    updateKiwixDataStore { setShowStorageOption(false) }
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteFragmentTest.kt
@@ -19,23 +19,12 @@
 package org.kiwix.kiwixmobile.note
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavOptions
-import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -46,18 +35,13 @@ import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.ZIM_FILE_URI_KEY
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class NoteFragmentTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -71,41 +55,9 @@ class NoteFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity { kiwixMainActivity = it }
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -266,25 +218,7 @@ class NoteFragmentTest : BaseActivityTest() {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
-
-    val loadFileStream =
-      NoteFragmentTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
+    val zimFile = getZimFileFromResourceFolder(context, zimFileName)
     UiThreadStatement.runOnUiThread {
       val navOptions = NavOptions.Builder()
         .setPopUpTo(KiwixDestination.Reader.route, false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
@@ -18,43 +18,22 @@
 
 package org.kiwix.kiwixmobile.onlineCategory
 
-import android.Manifest
-import android.app.Instrumentation
-import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.download.downloadRobot
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
-class OnlineCategoryTest {
+class OnlineCategoryTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -62,62 +41,14 @@ class OnlineCategoryTest {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
 
-  private val permissions =
-    arrayOf(
-      Manifest.permission.READ_EXTERNAL_STORAGE,
-      Manifest.permission.WRITE_EXTERNAL_STORAGE
-    )
-
-  @Rule
-  @JvmField
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
-
   lateinit var kiwixMainActivity: KiwixMainActivity
-  private val instrumentation: Instrumentation by lazy(InstrumentationRegistry::getInstrumentation)
 
   @Before
-  fun setUp() {
-    UiDevice.getInstance(instrumentation).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(instrumentation.targetContext.applicationContext, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(instrumentation.targetContext.applicationContext).apply {
-      runBlocking {
-        setIntroShown(false)
-        setWifiOnly(false)
-        setPrefIsTest(true)
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-      }
-    }
-    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        kiwixMainActivity = it
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-      }
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+  override fun waitForIdle() {
+    super.waitForIdle()
+    updateKiwixDataStore { setIntroShown(false) }
+    launchMainActivity { kiwixMainActivity = it }
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -18,15 +18,8 @@
 
 package org.kiwix.kiwixmobile.page.bookmarks
 
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import io.objectbox.BoxStore
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -37,11 +30,8 @@ import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.migration.di.module.DatabaseModule
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.libkiwix.Library
 import org.kiwix.libkiwix.Manager
 import java.io.File
@@ -101,30 +91,8 @@ class ImportBookmarkTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    val kiwixDataStore = KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
+    super.waitForIdle()
+    launchMainActivity()
     boxStore = DatabaseModule.boxStore
     libkiwixBookOnDisk = LibkiwixBookOnDisk(library, manager, kiwixDataStore)
     libkiwixBookmarks =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -31,15 +31,8 @@ import androidx.core.os.LocaleListCompat
 import androidx.navigation.NavOptions
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -52,20 +45,16 @@ import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.ui.components.NAVIGATION_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS_FOR_SNACKBAR
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.Bookmark
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class LibkiwixBookmarkTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -79,23 +68,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
+    super.waitForIdle()
     kiwixMainActivity = composeTestRule.activity
 
     composeTestRule.apply {
@@ -104,15 +77,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       }
       waitForIdle()
     }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   private fun waitComposeToSettleViews() {
@@ -281,7 +246,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
   }
 
   private fun openZimFileInReader() {
-    val zimFile = getZimFile()
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     composeTestRule.apply {
       runOnUiThread {
         kiwixMainActivity.navigate(KiwixDestination.Library.route)
@@ -295,29 +260,5 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
       }
       waitComposeToSettleViews()
     }
-  }
-
-  private fun getZimFile(): File {
-    val zimFileName = "testzim.zim"
-    val loadFileStream =
-      LibkiwixBookmarkTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile =
-      File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -19,22 +19,11 @@
 package org.kiwix.kiwixmobile.page.history
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavOptions
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -45,17 +34,12 @@ import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.ZIM_FILE_URI_KEY
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class NavigationHistoryTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -69,39 +53,9 @@ class NavigationHistoryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          kiwixMainActivity = it
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity { kiwixMainActivity = it }
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -116,26 +70,7 @@ class NavigationHistoryTest : BaseActivityTest() {
           kiwixMainActivity.navigate(KiwixDestination.Library.route)
         }
       }
-      val zimFileName = "testzim.zim"
-      val loadFileStream =
-        NavigationHistoryTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-      require(loadFileStream != null) {
-        "Unable to load the $zimFileName. Please check is it exist in resources folder."
-      }
-      val zimFile =
-        File(context.getExternalFilesDirs(null)[0], zimFileName)
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(inputStream.available())
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
-        }
-      }
+      val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
       composeTestRule.apply {
         waitForIdle()
         runOnUiThread {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
@@ -18,21 +18,9 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -41,17 +29,12 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.utils.THREE_MONTHS_IN_MILLISECONDS
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class DonationDialogTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -62,49 +45,20 @@ class DonationDialogTest : BaseActivityTest() {
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
-  private lateinit var kiwixDataStore: KiwixDataStore
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    kiwixDataStore = KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
   fun showDonationPopupWhenApplicationIsThreeMonthOldAndHaveAtleastOneZIMFile() {
     loadZIMFileInApplication()
-    runBlocking {
-      kiwixDataStore.setLastDonationPopupShownInMilliSeconds(0L)
-      kiwixDataStore.setLaterClickedMilliSeconds(0L)
+    updateKiwixDataStore {
+      setLastDonationPopupShownInMilliSeconds(0L)
+      setLaterClickedMilliSeconds(0L)
     }
     openReaderFragment()
     donation { assertDonationDialogDisplayed(composeTestRule) }
@@ -112,7 +66,7 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Test
   fun shouldNotShowDonationPopupWhenApplicationIsThreeMonthOldAndDoNotHaveAnyZIMFile() {
-    runBlocking { kiwixDataStore.setLastDonationPopupShownInMilliSeconds(0L) }
+    updateKiwixDataStore { setLastDonationPopupShownInMilliSeconds(0L) }
     activityScenario.onActivity {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
@@ -124,8 +78,8 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Test
   fun shouldNotShowPopupIfTimeSinceLastPopupIsLessThanThreeMonth() {
-    runBlocking {
-      kiwixDataStore.setLastDonationPopupShownInMilliSeconds(
+    updateKiwixDataStore {
+      setLastDonationPopupShownInMilliSeconds(
         System.currentTimeMillis() - (THREE_MONTHS_IN_MILLISECONDS / 2)
       )
     }
@@ -136,8 +90,8 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Test
   fun shouldShowDonationPopupIfTimeSinceLastPopupExceedsThreeMonths() {
-    runBlocking {
-      kiwixDataStore.setLastDonationPopupShownInMilliSeconds(
+    updateKiwixDataStore {
+      setLastDonationPopupShownInMilliSeconds(
         System.currentTimeMillis() - (THREE_MONTHS_IN_MILLISECONDS + 1000)
       )
     }
@@ -148,9 +102,9 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Test
   fun testShouldShowDonationPopupWhenLaterClickedTimeExceedsThreeMonths() {
-    runBlocking {
-      kiwixDataStore.setLastDonationPopupShownInMilliSeconds(0L)
-      kiwixDataStore.setLaterClickedMilliSeconds(System.currentTimeMillis() - (THREE_MONTHS_IN_MILLISECONDS + 1000))
+    updateKiwixDataStore {
+      setLastDonationPopupShownInMilliSeconds(0L)
+      setLaterClickedMilliSeconds(System.currentTimeMillis() - (THREE_MONTHS_IN_MILLISECONDS + 1000))
     }
     loadZIMFileInApplication()
     openReaderFragment()
@@ -159,9 +113,9 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Test
   fun testShouldNotShowPopupIfLaterClickedTimeIsLessThanThreeMonths() {
-    runBlocking {
-      kiwixDataStore.setLastDonationPopupShownInMilliSeconds(0L)
-      kiwixDataStore.setLaterClickedMilliSeconds(System.currentTimeMillis() - 10000L)
+    updateKiwixDataStore {
+      setLastDonationPopupShownInMilliSeconds(0L)
+      setLaterClickedMilliSeconds(System.currentTimeMillis() - 10000L)
     }
     loadZIMFileInApplication()
     openReaderFragment()
@@ -177,26 +131,7 @@ class DonationDialogTest : BaseActivityTest() {
   private fun loadZIMFileInApplication() {
     openLocalLibraryScreen()
     deleteAllZIMFilesFromApplication()
-    val zimFileName = "testzim.zim"
-    val loadFileStream =
-      DonationDialogTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile =
-      File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
+    getZimFileFromResourceFolder(context, "testzim.zim")
     refreshZIMFilesList()
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -18,13 +18,6 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert
@@ -33,66 +26,21 @@ import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.libzim.SuggestionSearcher
-import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
 class EncodedUrlTest : BaseActivityTest() {
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
+    super.waitForIdle()
+    launchMainActivity()
   }
 
   @Test
   fun testEncodedUrls() =
     runBlocking {
-      val zimFileName = "characters_encoding.zim"
-      val loadFileStream =
-        EncodedUrlTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-      require(loadFileStream != null) {
-        "Unable to load the $zimFileName. Please check is it exist in resources folder."
-      }
-      val zimFile =
-        File(context.getExternalFilesDirs(null)[0], zimFileName)
-      if (zimFile.exists()) zimFile.delete()
-      zimFile.createNewFile()
-      loadFileStream.use { inputStream ->
-        val outputStream: OutputStream = FileOutputStream(zimFile)
-        outputStream.use { it ->
-          val buffer = ByteArray(1024)
-          var length: Int
-          while (inputStream.read(buffer).also { length = it } > 0) {
-            it.write(buffer, 0, length)
-          }
-        }
-      }
+      val zimFile = getZimFileFromResourceFolder(context, "characters_encoding.zim")
       val zimReaderSource = ZimReaderSource(zimFile)
       val archive = zimReaderSource.createArchive()
       val zimFileReader =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderFragmentTest.kt
@@ -22,28 +22,17 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Message
 import android.provider.MediaStore
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavOptions
-import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.TouchTargetSizeCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
 import okhttp3.Request
 import okhttp3.ResponseBody
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -57,20 +46,17 @@ import org.kiwix.kiwixmobile.core.main.ZIM_FILE_URI_KEY
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderFragment
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.page.bookmarks.bookmarks
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 import java.io.FileOutputStream
-import java.io.OutputStream
 import java.net.URI
 
 class KiwixReaderFragmentTest : BaseActivityTest() {
@@ -87,45 +73,9 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(TouchTargetSizeCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -135,7 +85,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
     composeTestRule.waitForIdle()
-    val zimFile = getLocalZIMFile()
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     openKiwixReaderFragmentWithFile(zimFile)
     reader {
       checkZimFileLoadedSuccessful(composeTestRule)
@@ -161,7 +111,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
     composeTestRule.waitForIdle()
-    val zimFile = getLocalZIMFile()
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     openKiwixReaderFragmentWithFile(zimFile)
     reader {
       checkZimFileLoadedSuccessful(composeTestRule)
@@ -185,7 +135,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
     composeTestRule.waitForIdle()
-    openKiwixReaderFragmentWithFile(getLocalZIMFile())
+    openKiwixReaderFragmentWithFile(getZimFileFromResourceFolder(context, "testzim.zim"))
     composeTestRule.waitForIdle()
     reader {
       checkZimFileLoadedSuccessful(composeTestRule)
@@ -330,7 +280,7 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
     composeTestRule.waitForIdle()
-    val zimFile = getLocalZIMFile()
+    val zimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     openKiwixReaderFragmentWithFile(zimFile)
     composeTestRule.waitForIdle()
     reader {
@@ -432,30 +382,6 @@ class KiwixReaderFragmentTest : BaseActivityTest() {
         outputStream.flush()
       }
     }
-  }
-
-  private fun getLocalZIMFile(): File {
-    val zimFileName = "testzim.zim"
-    val loadFileStream =
-      KiwixReaderFragmentTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile =
-      File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
   }
 
   private fun openSearchWithQuery(query: String = "", zimFile: File) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -18,23 +18,12 @@
 
 package org.kiwix.kiwixmobile.reader
 
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavOptions
-import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -48,7 +37,6 @@ import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.page.history.navigationHistory
 import org.kiwix.kiwixmobile.testutils.RetryRule
@@ -71,37 +59,9 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderContainerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderContainerTest.kt
@@ -36,6 +36,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Companion.CONTENT_PREFIX
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.libzim.Archive
 import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
@@ -55,12 +56,7 @@ class ZimReaderContainerTest {
 
   @Before
   fun setup() {
-    testZimFile = File(targetContext.cacheDir, zimFileName)
-    this::class.java.classLoader!!.getResourceAsStream(zimFileName)!!.use { input ->
-      testZimFile.outputStream().use { output ->
-        input.copyTo(output)
-      }
-    }
+    testZimFile = getZimFileFromResourceFolder(targetContext, zimFileName, targetContext.cacheDir)
 
     val realFactory = object : ZimFileReader.Factory {
       override suspend fun create(

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderSourceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderSourceTest.kt
@@ -38,6 +38,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)
@@ -51,12 +52,7 @@ class ZimReaderSourceTest {
 
   @Before
   fun setup() {
-    testZimFile = File(targetContext.cacheDir, zimFileName)
-    this::class.java.classLoader!!.getResourceAsStream(zimFileName)!!.use { input ->
-      testZimFile.outputStream().use { output ->
-        input.copyTo(output)
-      }
-    }
+    testZimFile = getZimFileFromResourceFolder(targetContext, zimFileName, targetContext.cacheDir)
   }
 
   @After

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
@@ -18,29 +18,17 @@
 package org.kiwix.kiwixmobile.search
 
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.net.toUri
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavOptions
-import androidx.test.core.app.ActivityScenario
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
 import okhttp3.Request
 import okhttp3.ResponseBody
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -52,18 +40,15 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.Action
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
 import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 import java.io.FileOutputStream
-import java.io.OutputStream
 import java.net.URI
 
 class SearchScreenInstrumentTest : BaseActivityTest() {
@@ -78,53 +63,14 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
   val composeTestRule = createComposeRule()
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
-  private lateinit var uiDevice: UiDevice
   private lateinit var downloadingZimFile: File
   private lateinit var testZimFile: File
 
   @Before
   override fun waitForIdle() {
-    uiDevice =
-      UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-        if (isSystemUINotRespondingDialogVisible(this)) {
-          closeSystemDialogs(context, this)
-        }
-        waitForIdle()
-      }
-    KiwixDataStore(context).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -133,7 +79,7 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
-    testZimFile = getTestZimFile()
+    testZimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     openKiwixReaderFragmentWithFile(testZimFile)
     search { checkZimFileSearchSuccessful(composeTestRule) }
     openSearchWithQuery("Android", testZimFile)
@@ -318,7 +264,7 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(KiwixDestination.Library.route)
     }
-    testZimFile = getTestZimFile()
+    testZimFile = getZimFileFromResourceFolder(context, "testzim.zim")
     openKiwixReaderFragmentWithFile(testZimFile)
     search { checkZimFileSearchSuccessful(composeTestRule) }
     openSearchWithQuery("Android ", testZimFile)
@@ -379,30 +325,6 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
         )
       }
     }
-  }
-
-  private fun getTestZimFile(): File {
-    val zimFileName = "testzim.zim"
-    val loadFileStream =
-      SearchScreenInstrumentTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile =
-      File(context.getExternalFilesDirs(null)[0], zimFileName)
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
-    return zimFile
   }
 
   private fun getDownloadingZimFile(): File {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsFragmentTest.kt
@@ -17,40 +17,23 @@
  */
 package org.kiwix.kiwixmobile.settings
 
-import android.Manifest
-import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.intro.intro
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
 
-class KiwixSettingsFragmentTest {
+class KiwixSettingsFragmentTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -59,64 +42,13 @@ class KiwixSettingsFragmentTest {
   val composeTestRule = createComposeRule()
 
   lateinit var kiwixMainActivity: KiwixMainActivity
-  lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
-
-  private val permissions =
-    arrayOf(
-      Manifest.permission.READ_EXTERNAL_STORAGE,
-      Manifest.permission.WRITE_EXTERNAL_STORAGE
-    )
-
-  @Rule
-  @JvmField
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
 
   @Before
-  fun setup() {
+  override fun waitForIdle() {
+    super.waitForIdle()
     // Go to IntroFragment
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(
-          InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
-          this
-        )
-      }
-      waitForIdle()
-    }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      runBlocking {
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setIsPlayStoreBuild(true)
-        setPrefIsTest(true)
-      }
-    }
-    activityScenario = ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-      }
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
     activityScenario.onActivity {
       kiwixMainActivity = it
       it.navigate(KiwixDestination.Intro.route)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
@@ -18,48 +18,28 @@
 
 package org.kiwix.kiwixmobile.shortcuts
 
-import android.app.Instrumentation
 import android.content.Intent
-import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.help.HelpRobot
 import org.kiwix.kiwixmobile.main.ACTION_GET_CONTENT
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.nav.destination.library.onlineLibrary
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
-class GetContentShortcutTest {
+class GetContentShortcutTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -68,55 +48,15 @@ class GetContentShortcutTest {
   val composeTestRule = createComposeRule()
   lateinit var kiwixMainActivity: KiwixMainActivity
 
-  private val instrumentation: Instrumentation by lazy(InstrumentationRegistry::getInstrumentation)
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-
   @Before
-  fun setUp() {
-    UiDevice.getInstance(instrumentation).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(instrumentation.targetContext.applicationContext, this)
-      }
-      waitForIdle()
+  override fun waitForIdle() {
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setShowCaseViewForFileTransferShown()
+      setExternalLinkPopup(true)
     }
-    KiwixDataStore(
-      InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
-    ).apply {
-      lifeCycleScope.launch {
-        setWifiOnly(false)
-        setIntroShown()
-        setShowCaseViewForFileTransferShown()
-        setExternalLinkPopup(true)
-        setPrefLanguage("en")
-        setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-        setIsScanFileSystemDialogShown(true)
-        setIsFirstRun(false)
-        setPrefIsTest(true)
-      }
-    }
-    ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-      moveToState(Lifecycle.State.RESUMED)
-      onActivity {
-        kiwixMainActivity = it
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-      }
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java),
-          matchesCheck(SpeakableTextPresentCheck::class.java)
-        )
-      )
-    } else {
-      accessibilityValidator.setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity { kiwixMainActivity = it }
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -17,9 +17,6 @@
  */
 package org.kiwix.kiwixmobile.splash
 
-import android.Manifest
-import android.content.Context
-import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
@@ -29,36 +26,23 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.intent.Intents
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.intro.composable.GET_STARTED_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils.closeSystemDialogs
-import org.kiwix.kiwixmobile.testutils.TestUtils.isSystemUINotRespondingDialogVisible
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 
 @LargeTest
-@RunWith(AndroidJUnit4::class)
-class KiwixSplashActivityTest {
+class KiwixSplashActivityTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
@@ -66,37 +50,11 @@ class KiwixSplashActivityTest {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
 
-  @Rule
-  @JvmField
-  val permissionRule: GrantPermissionRule? =
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-      GrantPermissionRule.grant(
-        Manifest.permission.READ_EXTERNAL_STORAGE,
-        Manifest.permission.WRITE_EXTERNAL_STORAGE
-      )
-    } else {
-      null
-    }
-  private lateinit var context: Context
-
   @Before
-  fun setUp() {
+  override fun waitForIdle() {
+    super.waitForIdle()
     Intents.init()
-    context = InstrumentationRegistry.getInstrumentation().targetContext
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (isSystemUINotRespondingDialogVisible(this)) {
-        closeSystemDialogs(context, this)
-      }
-      waitForIdle()
-    }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -150,10 +108,9 @@ class KiwixSplashActivityTest {
   }
 
   private fun shouldShowIntro(value: Boolean) {
-    val dataStore = KiwixDataStore(context)
-    runBlocking {
-      dataStore.setIntroShown(value)
-      dataStore.setPrefIsTest(true)
+    updateKiwixDataStore {
+      setIntroShown(value)
+      setPrefIsTest(true)
     }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/testutils/TestUtils.kt
@@ -249,6 +249,27 @@ object TestUtils {
   }
 
   @JvmStatic
+  fun getZimFileFromResourceFolder(
+    context: Context,
+    zimFileName: String,
+    destinationDirectory: File = context.getExternalFilesDirs(null)[0]
+  ): File {
+    val loadFileStream =
+      requireNotNull(javaClass.classLoader?.getResourceAsStream(zimFileName)) {
+        "Unable to load $zimFileName. Please ensure it exists in the resources folder."
+      }
+    val zimFile = File(destinationDirectory, zimFileName)
+    if (zimFile.exists()) zimFile.delete()
+    zimFile.createNewFile()
+    loadFileStream.use { inputStream ->
+      zimFile.outputStream().use { output ->
+        inputStream.copyTo(output)
+      }
+    }
+    return zimFile
+  }
+
+  @JvmStatic
   @Singleton
   fun getOkkHttpClientForTesting(): OkHttpClient =
     OkHttpClient().newBuilder()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/utils/StandardActions.kt
@@ -20,14 +20,8 @@ package org.kiwix.kiwixmobile.utils
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.matcher.ViewMatchers
-import com.adevinta.android.barista.interaction.BaristaDialogInteractions
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_SETTINGS_ITEM_TESTING_TAG
-import org.kiwix.kiwixmobile.core.utils.files.Log
-import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 
 /**
@@ -47,24 +41,5 @@ object StandardActions {
 
   fun closeDrawer(coreMainActivity: CoreMainActivity) {
     coreMainActivity.closeNavigationDrawer()
-  }
-
-  @JvmStatic
-  fun deleteZimIfExists(zimName: String, adapterId: Int) {
-    try {
-      Espresso.onData(TestUtils.withContent(zimName)).inAdapterView(
-        ViewMatchers.withId(
-          adapterId
-        )
-      ).perform(ViewActions.longClick())
-      BaristaDialogInteractions.clickDialogPositiveButton()
-      Log.i("TEST_DELETE_ZIM", "Successfully deleted ZIM file [$zimName]")
-    } catch (e: RuntimeException) {
-      Log.i(
-        "TEST_DELETE_ZIM",
-        "Failed to delete ZIM file [" + zimName + "]... " +
-          "Probably because it doesn't exist"
-      )
-    }
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
@@ -19,67 +19,43 @@
 package org.kiwix.kiwixmobile.webserver
 
 import android.Manifest
-import android.content.Context
 import android.net.wifi.WifiManager
 import android.os.Build
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.core.os.LocaleListCompat
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
-import org.hamcrest.Matchers.anyOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.ui.components.NAVIGATION_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
 import java.io.File
-import java.io.FileOutputStream
-import java.io.OutputStream
 
-@RunWith(AndroidJUnit4::class)
-class ZimHostScreenInstrumentTest {
+class ZimHostScreenInstrumentTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
   @JvmField
   val retryRule = RetryRule()
 
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
-  private lateinit var kiwixDataStore: KiwixDataStore
-
-  private lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
 
   private lateinit var kiwixMainActivity: KiwixMainActivity
-  private val lifeCycleScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-  private val permissions =
+  override fun permissions(): Array<String> =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       arrayOf(
         Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -96,53 +72,16 @@ class ZimHostScreenInstrumentTest {
       )
     }
 
-  @Rule
-  @JvmField
-  var permissionRules: GrantPermissionRule =
-    GrantPermissionRule.grant(*permissions)
-  private var context: Context? = null
-
   @Before
-  fun waitForIdle() {
-    context = InstrumentationRegistry.getInstrumentation().targetContext
-    UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-      if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-        TestUtils.closeSystemDialogs(context, this)
-      }
-      waitForIdle()
+  override fun waitForIdle() {
+    super.waitForIdle()
+    updateKiwixDataStore {
+      setShowManageExternalFilesPermissionDialog(false)
+      setManageExternalFilesPermissionDialogOnRefresh(false)
+      setHostedBookIds(emptySet())
     }
-    context?.let {
-      kiwixDataStore = KiwixDataStore(it).apply {
-        lifeCycleScope.launch {
-          setWifiOnly(false)
-          setIntroShown()
-          setPrefLanguage("en")
-          setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-          setIsScanFileSystemDialogShown(true)
-          setShowManageExternalFilesPermissionDialog(false)
-          setManageExternalFilesPermissionDialogOnRefresh(false)
-          setIsFirstRun(false)
-          setIsPlayStoreBuild(true)
-          setPrefIsTest(true)
-          setHostedBookIds(emptySet())
-        }
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-        onActivity {
-          AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags("en"))
-        }
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test
@@ -220,7 +159,7 @@ class ZimHostScreenInstrumentTest {
 
   private fun isWifiEnabled(): Boolean {
     val wifiManager =
-      context?.applicationContext?.getSystemService(WifiManager::class.java)
+      context.getSystemService(WifiManager::class.java)
     return wifiManager?.isWifiEnabled == true
   }
 
@@ -252,28 +191,12 @@ class ZimHostScreenInstrumentTest {
   }
 
   private fun loadZimFileInApplication(zimFileName: String) {
-    val loadFileStream =
-      ZimHostScreenInstrumentTest::class.java.classLoader?.getResourceAsStream(zimFileName)
-    require(loadFileStream != null) {
-      "Unable to load the $zimFileName. Please check is it exist in resources folder."
-    }
-    val zimFile = runBlocking { File(kiwixDataStore.defaultStorage(), zimFileName) }
-    if (zimFile.exists()) zimFile.delete()
-    zimFile.createNewFile()
-    loadFileStream.use { inputStream ->
-      val outputStream: OutputStream = FileOutputStream(zimFile)
-      outputStream.use { it ->
-        val buffer = ByteArray(inputStream.available())
-        var length: Int
-        while (inputStream.read(buffer).also { length = it } > 0) {
-          it.write(buffer, 0, length)
-        }
-      }
-    }
+    val destinationFolder = runBlocking { File(kiwixDataStore.defaultStorage()) }
+    getZimFileFromResourceFolder(context, zimFileName, destinationFolder)
   }
 
   @After
   fun finish() {
-    context?.let(TestUtils::deleteTemporaryFilesOfTestCases)
+    context.let(TestUtils::deleteTemporaryFilesOfTestCases)
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -25,15 +25,6 @@ import android.os.Bundle
 import android.widget.RemoteViews
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
-import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResultUtils.matchesCheck
-import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
-import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
-import kotlinx.coroutines.launch
-import org.hamcrest.Matchers.anyOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,11 +32,9 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
-import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.main.KiwixSearchWidget
 import org.kiwix.kiwixmobile.testutils.RetryRule
-import org.kiwix.kiwixmobile.testutils.TestUtils
 
 class SearchWidgetTest : BaseActivityTest() {
   @Rule(order = RETRY_RULE_ORDER)
@@ -55,43 +44,12 @@ class SearchWidgetTest : BaseActivityTest() {
   @get:Rule(order = COMPOSE_TEST_RULE_ORDER)
   val composeTestRule = createComposeRule()
   private lateinit var kiwixMainActivity: KiwixMainActivity
-  private lateinit var uiDevice: UiDevice
 
   @Before
   override fun waitForIdle() {
-    uiDevice =
-      UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).apply {
-        if (TestUtils.isSystemUINotRespondingDialogVisible(this)) {
-          TestUtils.closeSystemDialogs(context, this)
-        }
-        waitForIdle()
-      }
-    context.let {
-      KiwixDataStore(it).apply {
-        lifeCycleScope.launch {
-          setWifiOnly(false)
-          setIntroShown()
-          setPrefLanguage("en")
-          setLastDonationPopupShownInMilliSeconds(System.currentTimeMillis())
-          setIsScanFileSystemDialogShown(true)
-          setIsFirstRun(false)
-          setIsPlayStoreBuild(true)
-          setPrefIsTest(true)
-        }
-      }
-    }
-    activityScenario =
-      ActivityScenario.launch(KiwixMainActivity::class.java).apply {
-        moveToState(Lifecycle.State.RESUMED)
-      }
-    val accessibilityValidator = AccessibilityValidator().setRunChecksFromRootView(true).apply {
-      setSuppressingResultMatcher(
-        anyOf(
-          matchesCheck(DuplicateClickableBoundsCheck::class.java)
-        )
-      )
-    }
-    composeTestRule.enableAccessibilityChecks(accessibilityValidator)
+    super.waitForIdle()
+    launchMainActivity()
+    composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }
 
   @Test


### PR DESCRIPTION
Fixes #4929 

* Improved permissionRule to correctly grant notification permissions on Android 13 and above.
* Moved common test setup into the `waitForIdle()` method, allowing subclasses to easily add additional setup when needed.
* Added documentation comments to helper methods for better readability and maintainability.
* Added `getZimFileFromResourceFolder()` to TestUtils so test classes can reuse it instead of maintaining duplicate implementations.
* Fixed `testZimFileReader`: it was using an invalid ZIM file. After the refactoring, the test started failing with the correct error, which exposed the issue.
* Refactored existing test cases to use the new shared test infrastructure and helper methods.