### PR TITLE
Added ProGuard rules for `LanguageFeed` and `CategoryFeed`.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -41,7 +41,7 @@
 -keep class org.simpleframework.xml.util.** { *; }
 
 -keepattributes ElementList, Root
-
+-keep @org.simpleframework.xml.Root class * { *; }
 -keepclassmembers class * {
     @org.simpleframework.xml.* *;
 }

--- a/contrib/instrumentation-release.sh
+++ b/contrib/instrumentation-release.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+
+TEST_CLASSES="org.kiwix.kiwixmobile.download.DownloadTest,\
+org.kiwix.kiwixmobile.onlineCategory.OnlineCategoryTest,\
+org.kiwix.kiwixmobile.language.LanguageScreenTest"
+
 # Enable Wi-Fi on the emulator
 adb shell svc wifi enable
 adb logcat -c
@@ -37,7 +42,7 @@ fi
 
 retry=0
 while [ $retry -le 3 ]; do
-  if ./gradlew connectedDebugAndroidTest -PtestingMinimizedBuild -Pandroid.testInstrumentationRunnerArguments.class=org.kiwix.kiwixmobile.download.DownloadTest "-Dorg.gradle.jvmargs=-Xmx16G -XX:+UseParallelGC" -Dfile.encoding=UTF-8; then
+  if ./gradlew connectedDebugAndroidTest -PtestingMinimizedBuild -Pandroid.testInstrumentationRunnerArguments.class="$TEST_CLASSES" "-Dorg.gradle.jvmargs=-Xmx16G -XX:+UseParallelGC" -Dfile.encoding=UTF-8; then
     echo "connectedDebugAndroidTest for release variant succeeded" >&2
     break
   else


### PR DESCRIPTION
Fixes #4937 

* R8/minification was modifying the Simple XML model classes, causing language and category data parsing to fail in the Play Store variant.
* Added common ProGuard rules for current and future Simple XML model classes to ensure they are preserved during minification and to prevent similar issues in the future.
* Added `OnlineCategoryTest`, `LanguageScreenTest` to run in the Play Store variant so that we can ensure this type of issue will not happen in the future.
