### PR TITLE
Fix accessibility issues when navigating to or refreshing pages

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -30,12 +30,14 @@ import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import org.kiwix.kiwixmobile.core.utils.files.Log
+import java.util.concurrent.atomic.AtomicLong
 
 open class CoreWebViewClient(
   protected val callback: WebViewCallback,
   protected val zimReaderContainer: ZimReaderContainer
 ) : WebViewClient() {
   private var urlWithAnchor: String? = null
+  private val visualStateRequestId = AtomicLong()
 
   @Suppress("ReturnCount")
   override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
@@ -101,7 +103,18 @@ open class CoreWebViewClient(
       return
     }
     jumpToAnchor(view, url)
-    callback.webViewUrlFinishedLoading()
+    view.postVisualStateCallback(
+      visualStateRequestId.incrementAndGet(),
+      object : WebView.VisualStateCallback() {
+        override fun onComplete(requestId: Long) {
+          callback.webViewUrlFinishedLoading(view)
+        }
+      }
+    )
+  }
+
+  override fun onPageCommitVisible(view: WebView, url: String?) {
+    (view as? KiwixWebView)?.refreshVisibleContentForAccessibility()
   }
 
   /*

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -26,6 +26,7 @@ import android.os.Message
 import android.util.AttributeSet
 import android.view.ContextMenu
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.ContextCompat
@@ -111,6 +112,9 @@ open class KiwixWebView constructor(
     }
     setInitialScale(INITIAL_SCALE)
     clearCache(true)
+    isFocusable = true
+    isFocusableInTouchMode = true
+    importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
     webViewClient = coreWebViewClient
     kiwixWebChromeClient =
       KiwixWebChromeClient(callback, videoView, this).apply {
@@ -168,6 +172,19 @@ open class KiwixWebView constructor(
     super.onDetachedFromWindow()
     textZoomJob?.cancel()
     textZoomJob = null
+  }
+
+  fun refreshVisibleContentForAccessibility() {
+    post {
+      requestLayout()
+      invalidate()
+      postInvalidateOnAnimation()
+      sendAccessibilityEventUnchecked(
+        AccessibilityEvent.obtain(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED).apply {
+          contentChangeTypes = AccessibilityEvent.CONTENT_CHANGE_TYPE_SUBTREE
+        }
+      )
+    }
   }
 
   override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/WebViewCallback.kt
@@ -22,7 +22,7 @@ import android.webkit.WebView
 
 interface WebViewCallback {
   fun webViewUrlLoading()
-  fun webViewUrlFinishedLoading()
+  fun webViewUrlFinishedLoading(webView: WebView)
   fun webViewFailedLoading(failingUrl: String)
   fun openExternalUrl(intent: Intent)
   fun showSaveOrOpenUnsupportedFilesDialog(url: String, documentType: String?)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderFragment.kt
@@ -1155,8 +1155,9 @@ abstract class CoreReaderFragment :
     compatCallback = null
   }
 
-  private fun updateTableOfContents() {
-    loadUrlWithCurrentWebview("javascript:($documentParserJs)()")
+  private fun updateTableOfContents(webView: KiwixWebView? = getCurrentWebView()) {
+    val parserScript = documentParserJs ?: return
+    webView?.evaluateJavascript("($parserScript)()", null)
   }
 
   protected fun loadUrlWithCurrentWebview(url: String?) {
@@ -1353,6 +1354,7 @@ abstract class CoreReaderFragment :
     readerScreenState.update {
       copy(selectedWebView = webView)
     }
+    webView.refreshVisibleContentForAccessibility()
   }
 
   protected fun selectTab(position: Int) {
@@ -2339,34 +2341,38 @@ abstract class CoreReaderFragment :
   }
 
   @Suppress("MagicNumber")
-  override fun webViewUrlFinishedLoading() {
+  override fun webViewUrlFinishedLoading(webView: WebView) {
     if (isAdded) {
-      updateTableOfContents()
-      updateBottomToolbarArrowsAlpha()
-      val zimFileReader = zimReaderContainer?.zimFileReader
-      if (hasValidFileAndUrl(getCurrentWebView()?.url, zimFileReader)) {
-        val timeStamp = System.currentTimeMillis()
-        val sdf = SimpleDateFormat(
-          "d MMM yyyy",
-          getCurrentLocale(
-            requireActivity()
+      val loadedWebView = webView as? KiwixWebView
+      loadedWebView?.refreshVisibleContentForAccessibility()
+      if (loadedWebView == getCurrentWebView()) {
+        updateTableOfContents(loadedWebView)
+        updateBottomToolbarArrowsAlpha()
+        val zimFileReader = zimReaderContainer?.zimFileReader
+        if (hasValidFileAndUrl(loadedWebView?.url, zimFileReader)) {
+          val timeStamp = System.currentTimeMillis()
+          val sdf = SimpleDateFormat(
+            "d MMM yyyy",
+            getCurrentLocale(
+              requireActivity()
+            )
           )
-        )
-        @Suppress("UnsafeCallOnNullableType")
-        getCurrentWebView()?.let {
-          val history = HistoryItem(
-            it.url!!,
-            it.title!!,
-            sdf.format(Date(timeStamp)),
-            timeStamp,
-            zimFileReader!!
-          )
-          lifecycleScope.launch {
-            repositoryActions?.saveHistory(history)
+          @Suppress("UnsafeCallOnNullableType")
+          loadedWebView?.let {
+            val history = HistoryItem(
+              it.url!!,
+              it.title!!,
+              sdf.format(Date(timeStamp)),
+              timeStamp,
+              zimFileReader!!
+            )
+            lifecycleScope.launch {
+              repositoryActions?.saveHistory(history)
+            }
           }
         }
+        updateBottomToolbarVisibility()
       }
-      updateBottomToolbarVisibility()
       if (!isWebViewHistoryRestoring) {
         saveTabStates()
       }
@@ -2394,11 +2400,13 @@ abstract class CoreReaderFragment :
 
   override fun webViewProgressChanged(progress: Int, webView: WebView) {
     if (isAdded) {
-      updateUrlFlow()
-      showProgressBarWithProgress(progress)
-      if (progress == HUNDERED) {
-        hideProgressBar()
-        Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView()?.url)
+      if (webView == getCurrentWebView()) {
+        updateUrlFlow()
+        showProgressBarWithProgress(progress)
+        if (progress == HUNDERED) {
+          hideProgressBar()
+          Log.d(TAG_KIWIX, "Loaded URL: " + getCurrentWebView()?.url)
+        }
       }
       (webView.context as AppCompatActivity).invalidateOptionsMenu()
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
@@ -18,9 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.main.reader
 
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -91,6 +88,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -102,7 +100,6 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -157,6 +154,8 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWO_DP
 import org.kiwix.kiwixmobile.core.utils.HUNDERED
 import org.kiwix.kiwixmobile.core.utils.StyleUtils.fromHtml
 import org.kiwix.kiwixmobile.core.utils.ZERO
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Article
 
 const val TAB_SWITCHER_VIEW_TESTING_TAG = "tabSwitcherViewTestingTag"
 const val READER_SCREEN_TESTING_TAG = "readerScreenTestingTag"
@@ -735,16 +734,16 @@ fun TabSwitcherView(
     ) {
       itemsIndexed(webViews, key = { _, item -> item.hashCode() }) { index, webView ->
         val context = LocalContext.current
-        val title = remember(webView) {
-          webView.title?.fromHtml()?.toString()
-            ?: context.getString(R.string.menu_home)
-        }
+        val title = webView.title?.fromHtml()?.toString().orEmpty()
+          .ifBlank { context.getString(R.string.menu_home) }
+        val currentPage = webView.url?.fromHtml()?.toString().orEmpty()
+          .ifBlank { context.getString(R.string.menu_home) }
 
         TabItemView(
           index = index,
           title = title,
+          currentPage = currentPage,
           isSelected = index == selectedIndex,
-          webView = webView,
           onTabClickListener = onTabClickListener,
         )
       }
@@ -818,8 +817,8 @@ private fun BoxScope.CloseAllTabButton(onCloseAllTabs: () -> Unit) {
 fun TabItemView(
   index: Int,
   title: String,
+  currentPage: String,
   isSelected: Boolean,
-  webView: KiwixWebView,
   modifier: Modifier = Modifier,
   onTabClickListener: TabClickListener
 ) {
@@ -835,9 +834,10 @@ fun TabItemView(
     ) {
       TabItemHeader(title, index, onTabClickListener)
       TabItemCard(
-        webView,
         cardWidth,
         cardHeight,
+        title,
+        currentPage,
         onTabClickListener,
         borderColor,
         cardElevation,
@@ -883,9 +883,10 @@ private fun TabItemHeader(
 
 @Composable
 private fun TabItemCard(
-  webView: KiwixWebView,
   cardWidth: Dp,
   cardHeight: Dp,
+  title: String,
+  currentPage: String,
   onTabClickListener: TabClickListener,
   borderColor: Color,
   elevation: Dp,
@@ -898,27 +899,47 @@ private fun TabItemCard(
     modifier = Modifier
       .width(cardWidth)
       .height(cardHeight)
-      .semantics { hideFromAccessibility() }
+      .clickable { onTabClickListener.onSelectTab(index) }
+      .semantics { contentDescription = "$title$index" }
   ) {
-    AndroidView(
-      factory = { context ->
-        FrameLayout(context).apply {
-          (webView.parent as? ViewGroup)?.removeView(webView)
-          addView(webView)
-          val clickableView = View(context).apply {
-            layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-            // Prevent clicking inside the webView when tabs are active.
-            setOnClickListener { onTabClickListener.onSelectTab(index) }
-            contentDescription = "${webView.contentDescription}${webView.hashCode()}"
-          }
-          addView(clickableView)
-        }
-      },
+    Column(
       modifier = Modifier
         .fillMaxSize()
-        .semantics { hideFromAccessibility() }
-    )
+        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f))
+        .padding(TWELVE_DP),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+      PreviewIcon(Icons.Outlined.Article)
+      Spacer(modifier = Modifier.height(TWELVE_DP))
+      Text(
+        text = title,
+        style = MaterialTheme.typography.bodyMedium,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center
+      )
+      Spacer(modifier = Modifier.height(FOUR_DP))
+      Text(
+        text = currentPage,
+        style = MaterialTheme.typography.bodySmall,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center
+      )
+    }
   }
+}
+
+@Composable
+private fun PreviewIcon(icon: ImageVector) {
+  Icon(
+    imageVector = icon,
+    contentDescription = null,
+    modifier = Modifier.size(24.dp),
+    tint = MaterialTheme.colorScheme.primary
+  )
 }
 
 @Composable

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixWebViewWithAppBarScrolling.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixWebViewWithAppBarScrolling.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,35 +70,40 @@ fun KiwixWebViewWithAppBarScrolling(
   val scope = rememberCoroutineScope()
   val settleJob = remember { mutableStateOf<Job?>(null) }
 
-  key(kiwixWebView) {
-    DisposableEffect(Unit) {
-      val listener = createScrollListener(
-        topAppBarScrollBehavior,
-        bottomAppBarScrollBehavior,
-        shouldUpdateAppBars,
-        { accumulatedScroll },
-        { accumulatedScroll = it },
-        scope,
-        settleJob
-      )
-      kiwixWebView.setOnScrollChangeListener(listener)
-      onDispose { kiwixWebView.setOnScrollChangeListener(null) }
-    }
-
-    AndroidView(
-      factory = { context ->
-        FrameLayout(context).apply {
-          (kiwixWebView.parent as? ViewGroup)?.removeView(kiwixWebView)
-          kiwixWebView.layoutParams = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-          )
-          addView(kiwixWebView)
-        }
-      },
-      modifier = Modifier.fillMaxSize()
+  DisposableEffect(kiwixWebView) {
+    val listener = createScrollListener(
+      topAppBarScrollBehavior,
+      bottomAppBarScrollBehavior,
+      shouldUpdateAppBars,
+      { accumulatedScroll },
+      { accumulatedScroll = it },
+      scope,
+      settleJob
     )
+    kiwixWebView.setOnScrollChangeListener(listener)
+    onDispose { kiwixWebView.setOnScrollChangeListener(null) }
   }
+
+  AndroidView(
+    factory = { context ->
+      FrameLayout(context).apply {
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+      }
+    },
+    update = { host ->
+      if (host.getChildAt(0) !== kiwixWebView) {
+        (kiwixWebView.parent as? ViewGroup)?.removeView(kiwixWebView)
+        host.removeAllViews()
+        kiwixWebView.layoutParams = FrameLayout.LayoutParams(
+          FrameLayout.LayoutParams.MATCH_PARENT,
+          FrameLayout.LayoutParams.MATCH_PARENT
+        )
+        host.addView(kiwixWebView)
+        kiwixWebView.refreshVisibleContentForAccessibility()
+      }
+    },
+    modifier = Modifier.fillMaxSize()
+  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClientTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClientTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.kiwix.kiwixmobile.core.main
+
+import android.os.Build
+import android.webkit.WebView
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+class CoreWebViewClientTest {
+  private lateinit var callback: WebViewCallback
+  private lateinit var zimReaderContainer: ZimReaderContainer
+  private lateinit var coreWebViewClient: CoreWebViewClient
+
+  @Before
+  fun setUp() {
+    clearAllMocks()
+    callback = mockk(relaxed = true)
+    zimReaderContainer = mockk(relaxed = true)
+    coreWebViewClient = CoreWebViewClient(callback, zimReaderContainer)
+  }
+
+  @Test
+  fun `onPageFinished dispatches callback for the specific webview after visual state callback`() {
+    val webView = mockk<WebView>(relaxed = true)
+    val visualStateCallback = slot<WebView.VisualStateCallback>()
+    every {
+      webView.postVisualStateCallback(any(), capture(visualStateCallback))
+    } answers {
+      visualStateCallback.captured.onComplete(firstArg())
+      Unit
+    }
+
+    coreWebViewClient.onPageFinished(webView, "zim://content/A/Article")
+
+    verify(exactly = 1) { callback.webViewUrlFinishedLoading(webView) }
+  }
+
+  @Test
+  fun `onPageFinished ignores invalid null article url`() {
+    val webView = mockk<WebView>(relaxed = true)
+
+    coreWebViewClient.onPageFinished(webView, ZimFileReader.CONTENT_PREFIX + "null")
+
+    verify(exactly = 0) { callback.webViewUrlFinishedLoading(any()) }
+    verify(exactly = 0) { webView.postVisualStateCallback(any(), any()) }
+  }
+
+  @Test
+  fun `onPageCommitVisible refreshes accessibility for kiwix webview only`() {
+    val kiwixWebView = mockk<KiwixWebView>(relaxed = true)
+    val plainWebView = mockk<WebView>(relaxed = true)
+
+    coreWebViewClient.onPageCommitVisible(kiwixWebView, "zim://content/A/Article")
+    coreWebViewClient.onPageCommitVisible(plainWebView, "zim://content/A/Article")
+
+    verify(exactly = 1) { kiwixWebView.refreshVisibleContentForAccessibility() }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenComposablesTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenComposablesTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -681,5 +682,53 @@ class ReaderScreenComposablesTest {
       .performClick()
 
     assertTrue("onCloseTab callback should be triggered with index 0", closedIndex == 0)
+  }
+
+  @Test
+  fun readerScreen_tabSwitcher_onSelectTab_triggersCallbackFromPreviewCard() {
+    var selectedIndex = -1
+    val webView = mockk<KiwixWebView>(relaxed = true)
+    every { webView.title } returns "Article title"
+    every { webView.url } returns "zim://content/A/Article"
+
+    val state = createTestState(
+      showTabSwitcher = true
+    ).copy(
+      kiwixWebViewList = listOf(webView),
+      onTabClickListener = object : TabClickListener {
+        override fun onSelectTab(position: Int) {
+          selectedIndex = position
+        }
+
+        override fun onCloseTab(position: Int) { // no-op
+        }
+      }
+    )
+    renderReaderScreen(state)
+    composeTestRule.waitForIdle()
+
+    composeTestRule
+      .onNodeWithContentDescription("Article title0", useUnmergedTree = true)
+      .performClick()
+
+    assertTrue("onSelectTab callback should be triggered with index 0", selectedIndex == 0)
+  }
+
+  @Test
+  fun readerScreen_tabSwitcher_displaysCurrentPagePreviewText() {
+    val webView = mockk<KiwixWebView>(relaxed = true)
+    every { webView.title } returns "Article title"
+    every { webView.url } returns "zim://content/A/Article"
+
+    val state = createTestState(
+      showTabSwitcher = true
+    ).copy(
+      kiwixWebViewList = listOf(webView)
+    )
+    renderReaderScreen(state)
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithText("Article title").assertExists()
+    composeTestRule.onNodeWithText("zim://content/A/Article").assertExists()
   }
 }


### PR DESCRIPTION
## Summary
- delay the page-finished callback until the WebView visual state is committed so accessibility updates happen after rendered content is ready
- refresh visible WebView content for accessibility after page commits, tab selection, and WebView reattachment in Compose
- scope table-of-contents, progress, and history updates to the currently selected WebView to avoid cross-tab side effects
- replace the tab switcher's embedded WebView preview with an accessible Compose preview card showing the article title and current page URL
- add unit and Compose tests covering the visual state callback, accessibility refresh behavior, and tab preview interactions

## Testing
- Added `CoreWebViewClientTest` for page-finished and page-commit accessibility behavior
- Added `ReaderScreenComposablesTest` coverage for tab preview selection and displayed page information

**Screenshots**
- N/A