### PR TITLE
Fix tab switcher badge truncation and style like Chrome

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderMenuState.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderMenuState.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.core.main.reader
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -44,12 +43,11 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.page.SEARCH_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.EXTRA_SMALL_ROUND_SHAPE_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MATERIAL_MINIMUM_HEIGHT_AND_WIDTH
-import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
-import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TAB_SWITCHER_ICON_CORNER_RADIUS
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TAB_SWITCHER_TEXT_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWELVE_DP
-import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWENTY_DP
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWENTY_FOUR_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWO_DP
 
 const val READ_ALOUD_MENU_ITEM_TESTING_TAG = "readAloudMenuItemTestingTag"
@@ -226,16 +224,15 @@ class ReaderMenuState(
       contentAlignment = Alignment.Center
     ) {
       Box(
-        modifier = modifier
-          .clip(RoundedCornerShape(TAB_SWITCHER_ICON_CORNER_RADIUS))
+        modifier = Modifier
+          .clip(RoundedCornerShape(EXTRA_SMALL_ROUND_SHAPE_SIZE))
           .background(MaterialTheme.colorScheme.onPrimary)
           .border(
             TWO_DP,
             MaterialTheme.colorScheme.onBackground,
-            RoundedCornerShape(TAB_SWITCHER_ICON_CORNER_RADIUS)
+            RoundedCornerShape(EXTRA_SMALL_ROUND_SHAPE_SIZE)
           )
-          .padding(horizontal = SIX_DP, vertical = TWO_DP)
-          .defaultMinSize(minWidth = TWENTY_DP, minHeight = TWENTY_DP),
+          .size(TWENTY_FOUR_DP),
         contentAlignment = Alignment.Center
       ) {
         Text(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ComposeDimens.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ComposeDimens.kt
@@ -44,6 +44,7 @@ object ComposeDimens {
   val SIXTY_DP = 60.dp
   val THIRTY_TWO_DP = 30.dp
   val TWENTY_DP = 20.dp
+  val TWENTY_FOUR_DP = 24.dp
   val SEVENTEEN_DP = 17.dp
   val SIXTEEN_DP = 16.dp
   val FIFTEEN_DP = 15.dp


### PR DESCRIPTION
fix #4968 
<img width="250" height="500" alt="Screenshot 2026-07-09 at 16 37 27" src="https://github.com/user-attachments/assets/cb1af51b-e6bf-4b6f-87cb-62c61cad8646" />
