### PR TITLE
Move storage space check after Copy/Move dialog for Move operation

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/ProcessSelectedZimFilesForPlayStore.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/ProcessSelectedZimFilesForPlayStore.kt
@@ -26,11 +26,13 @@ import androidx.documentfile.provider.DocumentFile
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.mhutti1.utils.storage.Bytes
 import eu.mhutti1.utils.storage.StorageDevice
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.runSafelyInLifecycleScope
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
@@ -39,7 +41,6 @@ import org.kiwix.kiwixmobile.core.ui.components.ONE
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
-import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -55,17 +56,21 @@ import javax.inject.Inject
  * selected ZIM files for the Play Store variant of the app.
  *
  * This class ensures:
- * - Enough storage is available before proceeding.
  * - File validity is checked before copying/moving.
  * - User-friendly error handling (snackbar, dialogs, toasts).
  * - Sequential handling of multiple ZIM files.
+ *
+ * Storage space availability is validated by [CopyMoveFileHandler] right before
+ * a file is actually copied/moved, so it is not checked again here.
  */
+@Suppress("LongParameterList")
 class ProcessSelectedZimFilesForPlayStore @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
   @param:ApplicationContext private val context: Context,
   private val copyMoveFileHandler: CopyMoveFileHandler,
   private val storageCalculator: StorageCalculator,
-  private val storageDeviceProvider: StorageDeviceProvider
+  private val storageDeviceProvider: StorageDeviceProvider,
+  @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : CopyMoveFileHandler.FileCopyMoveCallback {
   private var snackBarHostState: SnackbarHostState? = null
   private var selectedZimFileCallback: SelectedZimFileCallback? = null
@@ -78,7 +83,6 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
    */
   private var multipleFilesProcessAction: MultipleFilesProcessAction? = null
   private val selectedZimFileUriList: MutableList<Uri> = mutableListOf()
-  private var selectedStoragePath: String = ""
 
   /**
    * Initializes the handler with required dependencies and callbacks.
@@ -119,27 +123,10 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
   }
 
   /**
-   * Validates available storage, and processes one or multiple files.
-   * If space is insufficient, shows storage selection dialog.
+   * Processes one or multiple selected files.
    */
   suspend fun processSelectedFiles(uris: List<Uri>, isAfterRetry: Boolean = false) {
     storeSelectedFiles(uris)
-    selectedStoragePath = kiwixDataStore.selectedStorage.first()
-    val totalSelectedFileSize = getTotalSizeOfSelectedZIMFiles(uris)
-    // Exclude files already in the app directory from the space calculation,
-    // since they don't need to be copied/moved.
-    val sizeAlreadyInAppDir = getSizeOfFilesAlreadyInAppDirectory(uris, selectedStoragePath)
-    val additionalSpaceNeeded = totalSelectedFileSize - sizeAlreadyInAppDir
-    if (additionalSpaceNeeded > ZERO) {
-      val availableSpaceInStorage =
-        storageCalculator.availableBytes(File(selectedStoragePath))
-      if (availableSpaceInStorage < additionalSpaceNeeded) {
-        // Not enough storage → show storage selection dialog/snackbar
-        insufficientSpaceInStorage(availableSpaceInStorage)
-        return
-      }
-    }
-
     if (uris.size == 1 && !isAfterRetry) {
       isSingleFileSelected = true
       processSingleFile(uris.first())
@@ -172,7 +159,7 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
       return
     }
 
-    // If the file is already in the app's public directory,
+    // If the file is already in one of the app's public directories,
     // open it directly without copying/moving.
     val existingFile = getExistingFileInAppDirectory(documentFile)
     if (existingFile != null) {
@@ -229,70 +216,38 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
     processSingleFile(uri, true)
   }
 
-  /** Returns total size of all selected ZIM files. */
-  private fun getTotalSizeOfSelectedZIMFiles(urisList: List<Uri>): Long {
-    var totalFilesSize = 0L
-    urisList.forEach { uri ->
-      val documentFile =
-        when (uri.scheme) {
-          "file" -> DocumentFile.fromFile(File("$uri"))
-          else -> {
-            DocumentFile.fromSingleUri(kiwixDataStore.context, uri)
-          }
-        }
-      totalFilesSize = totalFilesSize.plus(documentFile?.length() ?: ZERO.toLong())
-    }
-    return totalFilesSize
-  }
-
   /** Validates whether the given file is a valid ZIM or a split ZIM file. */
   private fun isValidZimFile(fileName: String?): Boolean =
     fileName?.let {
       FileUtils.isValidZimFile(it) || isSplittedZimFile(it)
     } ?: false
 
+  private suspend fun findExistingFileInAppDirectories(fileName: String, fileSize: Long): File? =
+    withContext(ioDispatcher) {
+      storageDeviceProvider.getAppSpecificPublicDirs()
+        .firstNotNullOfOrNull { dir -> findMatchingFile(dir, fileName, fileSize) }
+    }
+
+  private fun findMatchingFile(dir: File, fileName: String, fileSize: Long): File? {
+    val rootFile = File(dir, fileName)
+    if (rootFile.exists() && rootFile.length() == fileSize) {
+      return rootFile
+    }
+    return dir.walkTopDown()
+      .onEnter { !it.name.startsWith(".") }
+      .firstOrNull { it.isFile && it.name == fileName && it.length() == fileSize }
+  }
+
   /**
-   * Checks if a file with the same name and size already exists in the app's
-   * public directory. Returns the existing [File] if found, null otherwise.
-   * This avoids unnecessary copy/move operations for files the user has
-   * already placed in the app directory.
+   * Checks if a file with the same name and size already exists in one of the
+   * app's public app-specific directories. Returns the existing [File] if found,
+   * null otherwise. This avoids unnecessary copy/move operations for files the
+   * user has already placed in one of these directories.
    */
   @VisibleForTesting
   suspend fun getExistingFileInAppDirectory(documentFile: DocumentFile?): File? {
     val fileName = documentFile?.name ?: return null
-    if (selectedStoragePath.isEmpty()) {
-      selectedStoragePath = kiwixDataStore.selectedStorage.first()
-    }
-    val fileInAppDir = File(selectedStoragePath, fileName)
-    return if (fileInAppDir.exists() && fileInAppDir.length() == documentFile.length()) {
-      fileInAppDir
-    } else {
-      null
-    }
-  }
-
-  /**
-   * Returns the total size of files from the given URIs that already exist
-   * in the app's public directory. Used to exclude these files from the
-   * upfront storage space check.
-   */
-  private fun getSizeOfFilesAlreadyInAppDirectory(
-    uris: List<Uri>,
-    selectedStoragePath: String
-  ): Long {
-    var totalSize = 0L
-    uris.forEach { uri ->
-      val documentFile = when (uri.scheme) {
-        "file" -> DocumentFile.fromFile(File("$uri"))
-        else -> DocumentFile.fromSingleUri(context, uri)
-      }
-      val fileName = documentFile?.name ?: return@forEach
-      val fileInAppDir = File(selectedStoragePath, fileName)
-      if (fileInAppDir.exists() && fileInAppDir.length() == documentFile.length()) {
-        totalSize += documentFile.length()
-      }
-    }
-    return totalSize
+    return findExistingFileInAppDirectories(fileName, documentFile.length())
   }
 
   /** Shows a snackbar suggesting the user to change storage. */

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForPlayStoreTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForPlayStoreTest.kt
@@ -36,6 +36,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -87,7 +88,8 @@ class ProcessSelectedZimFilesForPlayStoreTest {
       activity,
       copyMoveFileHandler,
       storageCalculator,
-      storageDeviceProvider
+      storageDeviceProvider,
+      UnconfinedTestDispatcher(testScope.testScheduler)
     )
 
     processSelectedZimFiles.init(
@@ -124,16 +126,10 @@ class ProcessSelectedZimFilesForPlayStoreTest {
   @Test
   fun `insufficient storage and clicking change storage shows storage selection dialog`() =
     testScope.runTest {
+      // The space check itself now lives in CopyMoveFileHandler, which reports back via
+      // the FileCopyMoveCallback. Here we verify this class reacts to that callback by
+      // showing a snackbar that lets the user change storage.
       mockkStatic("org.kiwix.kiwixmobile.core.extensions.SnackbarHostStateExtensionKt")
-      val uri = mockk<Uri>()
-      val documentFile = mockk<DocumentFile>()
-
-      every { uri.scheme } returns "content"
-      every { DocumentFile.fromSingleUri(any(), uri) } returns documentFile
-      every { documentFile.length() } returns 1000L
-      every { documentFile.name } returns "test.file"
-
-      coEvery { storageCalculator.availableBytes(any()) } returns 500L
 
       every { activity.getString(R.string.move_no_space) } returns "Not enough space"
       every { activity.getString(R.string.space_available) } returns "Available"
@@ -149,7 +145,7 @@ class ProcessSelectedZimFilesForPlayStoreTest {
           any()
         )
       } just Runs
-      processSelectedZimFiles.processSelectedFiles(listOf(uri))
+      processSelectedZimFiles.insufficientSpaceInStorage(500L)
       advanceUntilIdle()
       verify(exactly = 0) {
         selectedZimFileCallback.showStorageSelectionDialog(any())
@@ -393,8 +389,8 @@ class ProcessSelectedZimFilesForPlayStoreTest {
       testFile.writeBytes(ByteArray(100))
 
       try {
-        // Point selectedStorage to the temp directory
-        every { kiwixDataStore.selectedStorage } returns flowOf(appDir.absolutePath)
+        // Point the app-specific directories lookup to the temp directory
+        coEvery { storageDeviceProvider.getAppSpecificPublicDirs() } returns listOf(appDir)
 
         val uri = createValidUri(fileSize = 100L)
 
@@ -423,15 +419,17 @@ class ProcessSelectedZimFilesForPlayStoreTest {
   fun `processSelectedFiles should skip space check when file already in app directory`() =
     testScope.runTest {
       // Create a real temp directory with a file of size 1000 bytes
-      val appDir = File(System.getProperty("java.io.tmpdir"), "kiwix_test_space_${System.nanoTime()}")
+      val appDir =
+        File(System.getProperty("java.io.tmpdir"), "kiwix_test_space_${System.nanoTime()}")
       appDir.mkdirs()
       val testFile = File(appDir, "test.zim")
       testFile.writeBytes(ByteArray(1000))
 
       try {
-        every { kiwixDataStore.selectedStorage } returns flowOf(appDir.absolutePath)
-        // File size = 1000, available space = 500 (insufficient for copy)
-        // But since file is already in app dir, space check should be skipped
+        coEvery { storageDeviceProvider.getAppSpecificPublicDirs() } returns listOf(appDir)
+        // File size = 1000, available space = 500 (insufficient for a copy/move).
+        // Since the file is already in an app-specific directory, it should open
+        // directly without ever going through the copy/move (and space check) flow.
         val uri = createValidUri(fileSize = 1000L, availableSpace = 500L)
 
         processSelectedZimFiles.processSelectedFiles(listOf(uri))
@@ -460,13 +458,14 @@ class ProcessSelectedZimFilesForPlayStoreTest {
   @Test
   fun `getExistingFileInAppDirectory returns null when sizes differ`() =
     testScope.runTest {
-      val appDir = File(System.getProperty("java.io.tmpdir"), "kiwix_test_diff_${System.nanoTime()}")
+      val appDir =
+        File(System.getProperty("java.io.tmpdir"), "kiwix_test_diff_${System.nanoTime()}")
       appDir.mkdirs()
       val testFile = File(appDir, "test.zim")
       testFile.writeBytes(ByteArray(100))
 
       try {
-        every { kiwixDataStore.selectedStorage } returns flowOf(appDir.absolutePath)
+        coEvery { storageDeviceProvider.getAppSpecificPublicDirs() } returns listOf(appDir)
 
         val documentFile = mockk<DocumentFile>()
         every { documentFile.name } returns "test.zim"
@@ -491,13 +490,14 @@ class ProcessSelectedZimFilesForPlayStoreTest {
   @Test
   fun `getExistingFileInAppDirectory returns file when file exists with matching size`() =
     testScope.runTest {
-      val appDir = File(System.getProperty("java.io.tmpdir"), "kiwix_test_match_${System.nanoTime()}")
+      val appDir =
+        File(System.getProperty("java.io.tmpdir"), "kiwix_test_match_${System.nanoTime()}")
       appDir.mkdirs()
       val testFile = File(appDir, "test.zim")
       testFile.writeBytes(ByteArray(100))
 
       try {
-        every { kiwixDataStore.selectedStorage } returns flowOf(appDir.absolutePath)
+        coEvery { storageDeviceProvider.getAppSpecificPublicDirs() } returns listOf(appDir)
 
         val documentFile = mockk<DocumentFile>()
         every { documentFile.name } returns "test.zim"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
@@ -43,6 +43,7 @@ class StorageDeviceProvider @Inject constructor(
   private val mutex = Mutex()
   private var writableStorage: List<StorageDevice>? = null
   private var staticAppSpecificDirsCache: List<File>? = null
+  private var staticAppSpecificPublicDirsCache: List<File>? = null
 
   /**
    * Returns the writable storage devices, caching the result for the lifetime of the app process.
@@ -86,5 +87,20 @@ class StorageDeviceProvider @Inject constructor(
         dirs.add(File(selectedStoragePath))
       }
       dirs.distinctBy { it.absolutePath }
+    }
+
+  /**
+   * Returns only the *public* app-specific directories — the external "media"
+   * directory (Android/media/<package>) on every storage volume (internal
+   * and any SD card).
+   */
+  suspend fun getAppSpecificPublicDirs(): List<File> =
+    mutex.withLock {
+      val staticDirs = staticAppSpecificPublicDirsCache ?: withContext(ioDispatcher) {
+        val dirs = mutableListOf<File>()
+        ContextWrapper(context).externalMediaDirs?.filterNotNull()?.let { dirs.addAll(it) }
+        dirs
+      }.also { staticAppSpecificPublicDirsCache = it }
+      staticDirs.distinctBy { it.absolutePath }
     }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProviderTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProviderTest.kt
@@ -164,4 +164,67 @@ class StorageDeviceProviderTest {
         File(selectedStoragePath).absolutePath
       )
     }
+
+  @Test
+  fun `getAppSpecificPublicDirs returns the external media directory`() = runTest {
+    val dirs = storageDeviceProvider.getAppSpecificPublicDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactly(externalMediaDir.absolutePath)
+  }
+
+  @Test
+  fun `getAppSpecificPublicDirs returns a media directory per storage volume`() = runTest {
+    val sdCardMediaDir =
+      File("/storage/1234-5678/Android/media/org.kiwix.kiwixmobile")
+    every {
+      anyConstructed<ContextWrapper>().externalMediaDirs
+    } returns arrayOf(externalMediaDir, sdCardMediaDir)
+
+    val dirs = storageDeviceProvider.getAppSpecificPublicDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactlyInAnyOrder(
+      externalMediaDir.absolutePath,
+      sdCardMediaDir.absolutePath
+    )
+  }
+
+  @Test
+  fun `getAppSpecificPublicDirs dedupes directories that resolve to the same path`() = runTest {
+    every {
+      anyConstructed<ContextWrapper>().externalMediaDirs
+    } returns arrayOf(externalMediaDir, externalMediaDir)
+
+    val dirs = storageDeviceProvider.getAppSpecificPublicDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactly(externalMediaDir.absolutePath)
+  }
+
+  @Test
+  fun `getAppSpecificPublicDirs excludes internal storage and the private external files dir`() =
+    runTest {
+      val dirs = storageDeviceProvider.getAppSpecificPublicDirs()
+
+      assertThat(dirs.map { it.absolutePath }).doesNotContain(
+        externalFilesDir.absolutePath,
+        filesDir.absolutePath,
+        cacheDir.absolutePath
+      )
+    }
+
+  @Test
+  fun `getAppSpecificPublicDirs does not include the selected storage path`() = runTest {
+    val dirs = storageDeviceProvider.getAppSpecificPublicDirs()
+
+    assertThat(dirs.map { it.absolutePath }).doesNotContain(
+      File(selectedStoragePath).absolutePath
+    )
+  }
+
+  @Test
+  fun `getAppSpecificPublicDirs caches the static dirs across multiple calls`() = runTest {
+    storageDeviceProvider.getAppSpecificPublicDirs()
+    storageDeviceProvider.getAppSpecificPublicDirs()
+
+    verify(exactly = 1) { anyConstructed<ContextWrapper>().externalMediaDirs }
+  }
 }


### PR DESCRIPTION
Fix: #4965 

* The app now shows the copy/move dialog first. If there is insufficient storage available for any file, it then shows the `StorageSelectionDialog`.
* Improved the scenario where the selected file is already inside the app-specific directory. Instead of copying or moving it, the app now opens the file directly in the reader.
* Refactored the test cases to align with these changes.



