### PR TITLE
Make the WebView darken ZIM articles in night mode

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -28,6 +28,8 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.content.ContextCompat
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -96,6 +98,7 @@ open class KiwixWebView constructor(
       @Suppress("DEPRECATION")
       allowUniversalAccessFromFileURLs = true
     }
+    enableDarkeningOfContent()
     setInitialScale(INITIAL_SCALE)
     clearCache(true)
     webViewClient = coreWebViewClient
@@ -110,6 +113,22 @@ open class KiwixWebView constructor(
         )
       }
     webChromeClient = kiwixWebChromeClient
+  }
+
+  /**
+   * Lets the WebView darken the ZIM article itself when the app theme is dark.
+   *
+   * Without this the renderer is never told it is in dark mode: the app chrome
+   * follows [androidx.appcompat.app.AppCompatDelegate], but the document keeps
+   * rendering the ZIM's own (usually black-on-white) CSS. With darkening allowed
+   * the WebView reports `prefers-color-scheme: dark` to ZIMs that style
+   * themselves, and algorithmically darkens the ones that do not. It follows
+   * `android:isLightTheme`, which KiwixTheme declares in values/ and values-night/.
+   */
+  private fun enableDarkeningOfContent() {
+    if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+      WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, true)
+    }
   }
 
   override fun performLongClick(): Boolean {

--- a/core/src/main/res/values-night/themes.xml
+++ b/core/src/main/res/values-night/themes.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <!--Top level DayNight theme to be used in AndroidManifest.xml-->
   <style name="KiwixTheme" parent="Base.KiwixTheme">
+    <!--Tells WebView that the content it renders must be dark too; this is what
+        makes the ZIM article itself (not just the app chrome) follow night mode.
+        See enableDarkeningOfContent in KiwixWebView.-->
+    <item name="android:isLightTheme" tools:ignore="NewApi">false</item>
+
     <!-- Dark theme customisations here-->
     <item name="colorPrimary">@color/denim_blue200</item>
 

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -4,6 +4,12 @@
   <!--Top level theme to be used in AndroidManifest.xml-->
   <style name="KiwixTheme" parent="Base.KiwixTheme">
 
+    <!--WebView reads this attribute to decide whether the content it renders is
+        light or dark (see enableDarkeningOfContent in KiwixWebView). It must be
+        declared explicitly: without it the ZIM article stays light while the app
+        chrome follows the theme.-->
+    <item name="android:isLightTheme" tools:ignore="NewApi">true</item>
+
     <!--colorPrimary colors map to components and elements, such as app bars and buttons. -->
     <item name="colorPrimary">@color/denim_blue800</item>
 


### PR DESCRIPTION
### Problem

In night mode only the app chrome goes dark. The article itself keeps rendering the ZIM's own (usually black-on-white) CSS, so the reader is a bright white page inside a dark app.

### Cause

6c0ac69 removed the colour-inversion pipeline (`DarkModeViewPainter` + the injected `INVERT_IMAGES_VIDEO` CSS) in favour of letting ZIMs react to `prefers-color-scheme`. But nothing ever tells the renderer that it is in dark mode.

Since targetSdk 33 the WebView only reports a dark colour scheme to content when the app explicitly allows *algorithmic darkening*, and that in turn keys off the theme's `android:isLightTheme`. Neither was set anywhere in the project, so `prefers-color-scheme` stays `light` and the document renders as authored.

### Fix

- Declare `android:isLightTheme` on `KiwixTheme` — `true` in `values/`, `false` in `values-night/`.
- Allow algorithmic darkening on the reader's WebView (`WebSettingsCompat.setAlgorithmicDarkeningAllowed`).

ZIMs that style themselves now receive a real `prefers-color-scheme: dark`, and the ones that don't are darkened by the renderer — which is what 6c0ac69 intended. Light mode is unchanged.

`androidx.webkit` is already a dependency. The call is guarded by `WebViewFeature.isFeatureSupported(ALGORITHMIC_DARKENING)`, so WebViews without the feature keep their current behaviour.

### Verification

Built and run on a physical device (Samsung Galaxy A16, Android 15) with the Hebrew Wikipedia ZIM and a small test ZIM:

- dark theme → article renders light-on-dark
- light theme → article renders exactly as before

`ktlint`, `detekt` and `app:lintDebug` pass.