### PR TITLE
Add full-text search and search across all books

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -59,6 +59,7 @@ import org.kiwix.kiwixmobile.core.main.reader.helper.TabsManager
 import org.kiwix.kiwixmobile.core.main.reader.helper.intent.ReaderIntentManager
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+import org.kiwix.kiwixmobile.core.search.viewmodel.GlobalSearchResultGenerator
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchResultGenerator
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
@@ -111,6 +112,8 @@ interface CoreComponent {
   fun downloader(): Downloader
   fun notificationManager(): NotificationManager
   fun searchResultGenerator(): SearchResultGenerator
+
+  fun globalSearchResultGenerator(): GlobalSearchResultGenerator
   fun mutex(): Mutex
   fun kiwixPermissionChecker(): KiwixPermissionChecker
   fun inject(application: CoreApp)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/SearchModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/SearchModule.kt
@@ -20,6 +20,8 @@ package org.kiwix.kiwixmobile.core.di.modules
 
 import dagger.Binds
 import dagger.Module
+import org.kiwix.kiwixmobile.core.search.viewmodel.GlobalSearchResultGenerator
+import org.kiwix.kiwixmobile.core.search.viewmodel.GlobalSearchResultGeneratorImpl
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchResultGenerator
 import org.kiwix.kiwixmobile.core.search.viewmodel.ZimSearchResultGenerator
 
@@ -27,4 +29,9 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.ZimSearchResultGenerator
 abstract class SearchModule {
   @Binds
   abstract fun bindsSearchResultGenerator(zimSearchResultGenerator: ZimSearchResultGenerator): SearchResultGenerator
+
+  @Binds
+  abstract fun bindsGlobalSearchResultGenerator(
+    globalSearchResultGenerator: GlobalSearchResultGeneratorImpl
+  ): GlobalSearchResultGenerator
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
@@ -1252,6 +1252,14 @@ abstract class CoreReaderViewModel(
    * resulting URL is then loaded in the current web view.
    */
   private suspend fun openSearchItem(item: SearchItemToOpen) {
+    val targetSourceDatabaseValue = item.zimReaderSourceDatabaseValue
+    if (targetSourceDatabaseValue != null &&
+      targetSourceDatabaseValue != zimReaderContainer.zimReaderSource?.toDatabase()
+    ) {
+      // The result comes from another book (search across all books), so open
+      // that book before loading the page.
+      openBookOfSearchItem(targetSourceDatabaseValue) ?: return
+    }
     if (item.shouldOpenInNewTab) {
       newMainPageTab()
     }
@@ -1260,6 +1268,18 @@ abstract class CoreReaderViewModel(
         loadUrlWithCurrentWebview(zimReaderContainer.urlSuffixToParsableUrl(this))
       }
     }
+  }
+
+  /**
+   * Opens the book a cross-book search result belongs to, returning null when it
+   * cannot be opened (e.g. the file is gone), in which case the result is not opened.
+   */
+  private suspend fun openBookOfSearchItem(sourceDatabaseValue: String): Unit? {
+    val zimReaderSource = ZimReaderSource.fromDatabaseValue(sourceDatabaseValue)
+      ?.takeIf { it.canOpenInLibkiwix() } ?: return null
+    closeZimBook()
+    openZimFile(zimReaderSource)
+    return Unit
   }
 
   private suspend fun newMainPageTab(): KiwixWebView =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -42,6 +42,9 @@ import org.kiwix.libkiwix.SpellingsDB
 import org.kiwix.libzim.Archive
 import org.kiwix.libzim.DirectAccessInfo
 import org.kiwix.libzim.Item
+import org.kiwix.libzim.Query
+import org.kiwix.libzim.Search
+import org.kiwix.libzim.Searcher
 import org.kiwix.libzim.SuggestionSearch
 import org.kiwix.libzim.SuggestionSearcher
 import java.io.ByteArrayInputStream
@@ -120,6 +123,9 @@ class ZimFileReader constructor(
 
   private var spellingsDB: SpellingsDB? = null
 
+  // Lazily created full-text searcher; not every ZIM file has a full-text index.
+  private var fullTextSearcher: Searcher? = null
+
   /**
    * Note that the value returned is NOT unique for each zim file. Versions of the same wiki
    * (complete, nopic, novid, etc) may return the same title.
@@ -188,6 +194,33 @@ class ZimFileReader constructor(
     } catch (exception: Exception) {
       // to handled the exception if there is no FT Xapian index found in the current zim file
       Log.e(TAG, "Unable to search in this file as it does not have FT Xapian index. $exception")
+      null
+    }
+
+  /**
+   * Runs a full-text search over the page content of this ZIM file.
+   *
+   * @return the [Search] for the given query, or null if the ZIM file has no
+   *         full-text Xapian index (or the search failed for any other reason).
+   */
+  fun searchFullText(query: String): Search? =
+    try {
+      getOrCreateFullTextSearcher()?.search(Query(query))
+    } catch (exception: Exception) {
+      Log.e(
+        TAG,
+        "Unable to run the full text search for query = $query." +
+          " Probably this ZIM file does not have a full-text index. $exception"
+      )
+      null
+    }
+
+  @Synchronized
+  private fun getOrCreateFullTextSearcher(): Searcher? =
+    fullTextSearcher ?: try {
+      Searcher(jniKiwixReader).also { fullTextSearcher = it }
+    } catch (exception: Exception) {
+      Log.e(TAG, "Could not create the full text searcher. $exception")
       null
     }
 
@@ -447,6 +480,7 @@ class ZimFileReader constructor(
   fun dispose() {
     jniKiwixReader.dispose()
     searcher.dispose()
+    fullTextSearcher?.dispose()
     spellingsDB?.dispose()
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchListItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchListItem.kt
@@ -27,6 +27,24 @@ sealed class SearchListItem {
 
   data class ZimSearchResultListItem constructor(
     override val value: String,
-    override val url: String?
+    override val url: String?,
+    /**
+     * A short quote of the sentence where the search term was found (full text
+     * search only), with the matched words wrapped in `<b>` tags as returned
+     * by the Xapian index.
+     */
+    val snippet: String? = null,
+    /**
+     * The title of the book this result belongs to. Only set for results of a
+     * search across all books, where it is shown so the user knows which ZIM
+     * file each result came from.
+     */
+    val bookTitle: String? = null,
+    /**
+     * The [org.kiwix.kiwixmobile.core.reader.ZimReaderSource.toDatabase] value
+     * of the book this result belongs to. Only set for cross-book search
+     * results, so the reader can switch to the right book before opening.
+     */
+    val zimReaderSourceDatabaseValue: String? = null
   ) : SearchListItem()
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
@@ -21,9 +21,14 @@ package org.kiwix.kiwixmobile.core.search
 import android.annotation.SuppressLint
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -44,6 +49,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,11 +58,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
@@ -65,11 +75,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
+import androidx.compose.ui.text.withStyle
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.extensions.hideKeyboardOnLazyColumnScroll
+import org.kiwix.kiwixmobile.core.search.viewmodel.SearchMode
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchScreenUiState
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchViewModel
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
@@ -82,12 +97,14 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FIFTEEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FOUR_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.LOAD_MORE_PROGRESS_BAR_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.OPEN_IN_NEW_TAB_ICON_SIZE
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SEARCH_ITEM_SNIPPET_TEXT_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SEARCH_ITEM_TEXT_SIZE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SEVEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIXTEEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.THREE_DP
+import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWO_DP
 import org.kiwix.kiwixmobile.core.utils.ZERO
 
 const val SEARCH_FIELD_TESTING_TAG = "searchFieldTestingTag"
@@ -97,6 +114,10 @@ const val OPEN_ITEM_IN_NEW_TAB_ICON_TESTING_TAG = "openItemInNewTagIconTestingTa
 const val LOADING_ITEMS_BEFORE = 3
 
 const val VOICE_SEARCH_TESTING_TAG = "voiceSearchTestingTag"
+const val SEARCH_IN_TITLE_CHIP_TESTING_TAG = "searchInTitleChipTestingTag"
+const val SEARCH_IN_PAGE_CONTENT_CHIP_TESTING_TAG = "searchInPageContentChipTestingTag"
+const val SEARCH_IN_ALL_BOOKS_CHIP_TESTING_TAG = "searchInAllBooksChipTestingTag"
+const val SEARCH_LIST_TESTING_TAG = "searchListTestingTag"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("ComposableLambdaParameterNaming")
@@ -146,14 +167,104 @@ private fun SearchScreenContent(
   lazyListState: LazyListState
 ) {
   val progressBarTrackColor = MaterialTheme.colorScheme.background
-  Box(
+  Column(
     modifier = Modifier
       .fillMaxSize()
       .padding(
         top = innerPadding.calculateTopPadding(),
         start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),
         end = innerPadding.calculateEndPadding(LocalLayoutDirection.current)
-      ),
+      )
+  ) {
+    SearchModeChips(
+      searchMode = state.searchMode,
+      onSearchModeChanged = { searchViewModel.onSearchModeChanged(it) },
+      searchAllBooks = state.searchAllBooks,
+      onSearchAllBooksChanged = { searchViewModel.onSearchAllBooksChanged(it) }
+    )
+    SearchResults(
+      state,
+      searchViewModel,
+      lazyListState,
+      progressBarTrackColor,
+      // Give the results the remaining height so the list is properly bounded
+      // and can scroll independently of the search-mode chips above it.
+      modifier = Modifier.weight(1f)
+    )
+  }
+}
+
+@Composable
+private fun SearchModeChips(
+  searchMode: SearchMode,
+  onSearchModeChanged: (SearchMode) -> Unit,
+  searchAllBooks: Boolean,
+  onSearchAllBooksChanged: (Boolean) -> Unit
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .horizontalScroll(rememberScrollState())
+      .padding(horizontal = EIGHT_DP),
+    horizontalArrangement = Arrangement.spacedBy(EIGHT_DP)
+  ) {
+    SearchModeChip(
+      selected = searchMode == SearchMode.TITLE,
+      onClick = { onSearchModeChanged(SearchMode.TITLE) },
+      label = stringResource(R.string.search_in_titles),
+      testTag = SEARCH_IN_TITLE_CHIP_TESTING_TAG
+    )
+    SearchModeChip(
+      selected = searchMode == SearchMode.PAGE_CONTENT,
+      onClick = { onSearchModeChanged(SearchMode.PAGE_CONTENT) },
+      label = stringResource(R.string.search_in_page_content),
+      testTag = SEARCH_IN_PAGE_CONTENT_CHIP_TESTING_TAG
+    )
+    SearchModeChip(
+      selected = searchAllBooks,
+      onClick = { onSearchAllBooksChanged(!searchAllBooks) },
+      label = stringResource(R.string.search_in_all_books),
+      testTag = SEARCH_IN_ALL_BOOKS_CHIP_TESTING_TAG
+    )
+  }
+}
+
+@Composable
+private fun SearchModeChip(
+  selected: Boolean,
+  onClick: () -> Unit,
+  label: String,
+  testTag: String
+) {
+  // Highlight the focused chip so dpad users can see where they are.
+  var isFocused by remember { mutableStateOf(false) }
+  FilterChip(
+    selected = selected,
+    onClick = onClick,
+    label = { Text(label) },
+    modifier = Modifier
+      .onFocusChanged { isFocused = it.hasFocus }
+      .then(
+        if (isFocused) {
+          Modifier.border(TWO_DP, MaterialTheme.colorScheme.primary, RoundedCornerShape(EIGHT_DP))
+        } else {
+          Modifier
+        }
+      )
+      .testTag(testTag)
+  )
+}
+
+@Composable
+private fun SearchResults(
+  state: SearchScreenUiState,
+  searchViewModel: SearchViewModel,
+  lazyListState: LazyListState,
+  progressBarTrackColor: Color,
+  modifier: Modifier = Modifier
+) {
+  Box(
+    modifier = modifier.fillMaxSize(),
     contentAlignment = Alignment.Center
   ) {
     when {
@@ -169,6 +280,7 @@ private fun SearchScreenContent(
         LazyColumn(
           modifier = Modifier
             .fillMaxSize()
+            .testTag(SEARCH_LIST_TESTING_TAG)
             // hides keyboard when scrolled
             .hideKeyboardOnLazyColumnScroll(lazyListState),
           state = lazyListState
@@ -325,6 +437,9 @@ private fun SearchListItem(
   onItemClick: (SearchListItem) -> Unit,
   onItemLongClick: ((SearchListItem) -> Unit)? = null
 ) {
+  // Draw a clear border around the focused item so that users navigating with
+  // a dpad (TV remotes, devices without a touch screen) can see where they are.
+  var isFocused by remember { mutableStateOf(false) }
   Row(
     modifier = Modifier
       .fillMaxWidth()
@@ -335,6 +450,13 @@ private fun SearchListItem(
         shape = RoundedCornerShape(EIGHT_DP),
         color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.05f)
       )
+      .then(
+        if (isFocused) {
+          Modifier.border(TWO_DP, MaterialTheme.colorScheme.primary, RoundedCornerShape(EIGHT_DP))
+        } else {
+          Modifier
+        }
+      )
       .clip(RoundedCornerShape(EIGHT_DP)),
     verticalAlignment = Alignment.CenterVertically
   ) {
@@ -342,18 +464,23 @@ private fun SearchListItem(
       modifier = Modifier
         .weight(1f)
         .fillMaxHeight()
+        .onFocusChanged { isFocused = it.hasFocus }
         .combinedClickable(
           onClick = { onItemClick(searchListItem) },
           onLongClick = { onItemLongClick?.invoke(searchListItem) }
         )
         .semantics { testTag = SEARCH_ITEM_TESTING_TAG }
-        .padding(horizontal = EIGHT_DP),
+        .padding(horizontal = EIGHT_DP, vertical = SIX_DP),
       contentAlignment = Alignment.CenterStart
     ) {
-      Text(
-        text = searchListItem.value,
-        fontSize = SEARCH_ITEM_TEXT_SIZE
-      )
+      Column {
+        Text(
+          text = searchListItem.value,
+          fontSize = SEARCH_ITEM_TEXT_SIZE
+        )
+        SearchResultBookLabel(searchListItem)
+        SearchResultSnippet(searchListItem)
+      }
     }
 
     IconButton(
@@ -371,6 +498,63 @@ private fun SearchListItem(
     }
   }
 }
+
+/**
+ * Shows the book a result belongs to (search across all books only), so the
+ * user knows which ZIM file each result came from.
+ */
+@Composable
+private fun SearchResultBookLabel(searchListItem: SearchListItem) {
+  val bookTitle = (searchListItem as? SearchListItem.ZimSearchResultListItem)
+    ?.bookTitle
+    ?.takeIf(String::isNotBlank) ?: return
+  Text(
+    text = bookTitle,
+    fontSize = SEARCH_ITEM_SNIPPET_TEXT_SIZE,
+    color = MaterialTheme.colorScheme.primary,
+    maxLines = 1,
+    overflow = Ellipsis,
+    modifier = Modifier.padding(top = THREE_DP)
+  )
+}
+
+/**
+ * Shows a short quote of the sentence where the search term was found (full
+ * text search results only), with the matched words emphasised.
+ */
+@Composable
+private fun SearchResultSnippet(searchListItem: SearchListItem) {
+  val snippet = (searchListItem as? SearchListItem.ZimSearchResultListItem)
+    ?.snippet
+    ?.takeIf(String::isNotBlank) ?: return
+  Text(
+    text = snippet.parseSnippetBoldMarkup(),
+    fontSize = SEARCH_ITEM_SNIPPET_TEXT_SIZE,
+    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+    maxLines = 2,
+    overflow = Ellipsis,
+    modifier = Modifier.padding(top = THREE_DP)
+  )
+}
+
+/**
+ * Converts a Xapian snippet ("...text with the <b>match</b> emphasised...")
+ * into an [AnnotatedString] with the `<b>` parts rendered in bold.
+ */
+private fun String.parseSnippetBoldMarkup(): AnnotatedString {
+  val snippet = this
+  return buildAnnotatedString {
+    var appendedUpTo = 0
+    BOLD_MARKUP.findAll(snippet).forEach { match ->
+      append(snippet.substring(appendedUpTo, match.range.first))
+      withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(match.groupValues[1]) }
+      appendedUpTo = match.range.last + 1
+    }
+    append(snippet.substring(appendedUpTo))
+  }
+}
+
+private val BOLD_MARKUP = Regex("<b>(.*?)</b>", RegexOption.DOT_MATCHES_ALL)
 
 @Composable
 fun InfiniteListHandler(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/GlobalSearchResultGenerator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/GlobalSearchResultGenerator.kt
@@ -1,0 +1,130 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.search.SearchListItem.ZimSearchResultListItem
+import org.kiwix.kiwixmobile.core.utils.files.Log
+import kotlin.coroutines.coroutineContext
+
+private const val TAG = "GlobalSearchGenerator"
+const val GLOBAL_SEARCH_MAX_RESULTS_PER_BOOK = 10
+const val GLOBAL_SEARCH_MAX_TOTAL_RESULTS = 60
+
+/**
+ * Runs a search across every ZIM file on the device and returns a flat list of
+ * results, each tagged with the book it came from. Each book is opened with a
+ * throw-away [ZimFileReader], searched, and immediately disposed, so no native
+ * archives are kept alive between searches.
+ */
+interface GlobalSearchResultGenerator {
+  suspend fun generateSearchResults(
+    searchTerm: String,
+    searchMode: SearchMode
+  ): List<ZimSearchResultListItem>
+}
+
+class GlobalSearchResultGeneratorImpl @javax.inject.Inject constructor(
+  private val libkiwixBookOnDisk: LibkiwixBookOnDisk,
+  private val zimFileReaderFactory: ZimFileReader.Factory,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) : GlobalSearchResultGenerator {
+  override suspend fun generateSearchResults(
+    searchTerm: String,
+    searchMode: SearchMode
+  ): List<ZimSearchResultListItem> {
+    if (searchTerm.isBlank()) return emptyList()
+    return withContext(ioDispatcher) {
+      val books = runCatching { libkiwixBookOnDisk.getBooks() }
+        .getOrDefault(emptyList())
+        .sortedBy { it.book.title.lowercase() }
+      val results = mutableListOf<ZimSearchResultListItem>()
+      for (bookOnDisk in books) {
+        coroutineContext.ensureActive()
+        if (results.size >= GLOBAL_SEARCH_MAX_TOTAL_RESULTS) break
+        results += searchInBook(bookOnDisk, searchTerm, searchMode)
+      }
+      results.take(GLOBAL_SEARCH_MAX_TOTAL_RESULTS)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private suspend fun searchInBook(
+    bookOnDisk: org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk,
+    searchTerm: String,
+    searchMode: SearchMode
+  ): List<ZimSearchResultListItem> {
+    val reader =
+      runCatching {
+        zimFileReaderFactory.create(bookOnDisk.zimReaderSource, false)
+      }.getOrNull() ?: return emptyList()
+    return try {
+      collectResults(reader, bookOnDisk, searchTerm, searchMode)
+    } catch (exception: Exception) {
+      Log.e(TAG, "Could not search in ${bookOnDisk.book.title}. $exception")
+      emptyList()
+    } finally {
+      runCatching { reader.dispose() }
+    }
+  }
+
+  @Suppress("NestedBlockDepth", "ReturnCount")
+  private fun collectResults(
+    reader: ZimFileReader,
+    bookOnDisk: org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk,
+    searchTerm: String,
+    searchMode: SearchMode
+  ): List<ZimSearchResultListItem> {
+    val bookTitle = bookOnDisk.book.title
+    val sourceDb = bookOnDisk.zimReaderSource.toDatabase()
+    val results = mutableListOf<ZimSearchResultListItem>()
+    if (searchMode == SearchMode.PAGE_CONTENT) {
+      val search = reader.searchFullText(searchTerm)
+      if (search != null) {
+        val iterator = search.getResults(0, GLOBAL_SEARCH_MAX_RESULTS_PER_BOOK)
+        while (iterator.hasNext()) {
+          // Read the snippet from the iterator's current position *before*
+          // next() advances it; otherwise each result shows the next result's
+          // snippet.
+          val snippet = runCatching { iterator.snippet }.getOrNull()
+          val entry = iterator.next()
+          results.add(
+            ZimSearchResultListItem(entry.title, entry.path, snippet, bookTitle, sourceDb)
+          )
+        }
+        return results
+      }
+    }
+    // Title search, or full text fallback for books without a full text index.
+    val suggestionSearch = reader.searchSuggestions(searchTerm) ?: return results
+    val iterator = suggestionSearch.getResults(0, GLOBAL_SEARCH_MAX_RESULTS_PER_BOOK)
+    while (iterator.hasNext()) {
+      val entry = iterator.next()
+      results.add(
+        ZimSearchResultListItem(entry.title, entry.path, null, bookTitle, sourceDb)
+      )
+    }
+    return results
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchMode.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchMode.kt
@@ -1,0 +1,31 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+/**
+ * Defines where a search term should be looked up inside the opened ZIM file.
+ *
+ * [TITLE] searches only in the article titles (the classic suggestion search),
+ * whereas [PAGE_CONTENT] runs a full-text search over the content of the pages
+ * using the Xapian full-text index of the ZIM file.
+ */
+enum class SearchMode {
+  TITLE,
+  PAGE_CONTENT
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchResultGenerator.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchResultGenerator.kt
@@ -22,25 +22,39 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
-import org.kiwix.libzim.SuggestionSearch
 import javax.inject.Inject
 
 interface SearchResultGenerator {
   suspend fun generateSearchResults(
     searchTerm: String,
+    searchMode: SearchMode,
     zimFileReader: ZimFileReader?
-  ): SuggestionSearch?
+  ): ZimSearchResultSet?
 }
 
 class ZimSearchResultGenerator @Inject constructor(
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : SearchResultGenerator {
-  override suspend fun generateSearchResults(searchTerm: String, zimFileReader: ZimFileReader?) =
+  override suspend fun generateSearchResults(
+    searchTerm: String,
+    searchMode: SearchMode,
+    zimFileReader: ZimFileReader?
+  ) =
     if (searchTerm.isBlank() || zimFileReader == null) {
       null
     } else {
       withContext(ioDispatcher) {
-        zimFileReader.searchSuggestions(searchTerm)
+        when (searchMode) {
+          SearchMode.TITLE -> titleSearchResults(searchTerm, zimFileReader)
+          SearchMode.PAGE_CONTENT ->
+            zimFileReader.searchFullText(searchTerm)
+              ?.let { ZimSearchResultSet.PageContent(it) }
+              // Fall back to the title search for ZIM files without a full-text index.
+              ?: titleSearchResults(searchTerm, zimFileReader)
+        }
       }
     }
+
+  private fun titleSearchResults(searchTerm: String, zimFileReader: ZimFileReader) =
+    zimFileReader.searchSuggestions(searchTerm)?.let { ZimSearchResultSet.Title(it) }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchState.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchState.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.kiwix.kiwixmobile.core.search.SearchListItem
 import org.kiwix.kiwixmobile.core.utils.files.Log
-import org.kiwix.libzim.SuggestionSearch
 
 data class SearchState(
   val searchTerm: String,
@@ -33,14 +32,20 @@ data class SearchState(
   val recentResults: List<SearchListItem.RecentSearchListItem>,
   val searchOrigin: SearchOrigin
 ) {
+  @Suppress("ReturnCount")
   suspend fun getVisibleResults(
     startIndex: Int,
     job: Job? = null,
     ioDispatcher: CoroutineDispatcher
   ): List<SearchListItem>? {
     if (searchTerm.isEmpty()) return recentResults
+    // Results of a search across all books are computed up front and are not
+    // paginated; return them on the first page and nothing afterwards.
+    searchResultsWithTerm.globalResults?.let { globalResults ->
+      return if (startIndex == 0) globalResults else null
+    }
     return searchResultsWithTerm.searchMutex?.withLock {
-      searchResultsWithTerm.suggestionSearch?.let {
+      searchResultsWithTerm.zimSearchResultSet?.let {
         yield()
         withContext(ioDispatcher) {
           fetchSearchResults(it, startIndex, job)
@@ -53,7 +58,7 @@ data class SearchState(
 
   @Suppress("MagicNumber")
   private suspend fun fetchSearchResults(
-    suggestionSearch: SuggestionSearch,
+    zimSearchResultSet: ZimSearchResultSet,
     startIndex: Int,
     job: Job?
   ): List<SearchListItem.ZimSearchResultListItem>? {
@@ -65,14 +70,35 @@ data class SearchState(
     runCatching {
       val safeEndIndex = startIndex + 20
       yield()
-      val searchIterator = suggestionSearch.getResults(startIndex, safeEndIndex)
-      while (searchIterator.hasNext()) {
-        // check if the previous job is cancel while retrieving the data for
-        // previous searched item then break the execution of code.
-        if (job?.isActive == false) break
-        yield()
-        val entry = searchIterator.next()
-        results.add(SearchListItem.ZimSearchResultListItem(entry.title, entry.path))
+      when (zimSearchResultSet) {
+        is ZimSearchResultSet.Title -> {
+          val searchIterator =
+            zimSearchResultSet.suggestionSearch.getResults(startIndex, safeEndIndex)
+          while (searchIterator.hasNext()) {
+            // check if the previous job is cancel while retrieving the data for
+            // previous searched item then break the execution of code.
+            if (job?.isActive == false) break
+            yield()
+            val entry = searchIterator.next()
+            results.add(SearchListItem.ZimSearchResultListItem(entry.title, entry.path))
+          }
+        }
+
+        is ZimSearchResultSet.PageContent -> {
+          val searchIterator = zimSearchResultSet.search.getResults(startIndex, safeEndIndex)
+          while (searchIterator.hasNext()) {
+            if (job?.isActive == false) break
+            yield()
+            // A quote of the sentence containing the match; shown under the
+            // page title so the user can see why the page matched. The snippet
+            // must be read from the iterator's *current* position, before
+            // next() advances it, otherwise each result would show the next
+            // result's snippet.
+            val snippet = runCatching { searchIterator.snippet }.getOrNull()
+            val entry = searchIterator.next()
+            results.add(SearchListItem.ZimSearchResultListItem(entry.title, entry.path, snippet))
+          }
+        }
       }
     }.onFailure {
       Log.e(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -65,19 +66,22 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowDeleteSearchDialo
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowToast
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.StartSpeechInput
 import org.kiwix.kiwixmobile.core.utils.ZERO
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.effects.CloseKeyboard
-import org.kiwix.libzim.SuggestionSearch
 import javax.inject.Inject
 
 const val DEBOUNCE_DELAY = 150L
 const val MAX_SUGGEST_WORD_COUNT = 1
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("LongParameterList")
 class SearchViewModel @Inject constructor(
   private val recentSearchRoomDao: RecentSearchRoomDao,
   private val zimReaderContainer: ZimReaderContainer,
   private val searchResultGenerator: SearchResultGenerator,
+  private val globalSearchResultGenerator: GlobalSearchResultGenerator,
+  private val kiwixDataStore: KiwixDataStore,
   private val searchMutex: Mutex = Mutex(),
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
@@ -89,14 +93,29 @@ class SearchViewModel @Inject constructor(
 
   val actions = MutableSharedFlow<Action>(extraBufferCapacity = Int.MAX_VALUE)
   private val filter = MutableStateFlow("")
+  private val searchMode = MutableStateFlow(SearchMode.TITLE)
+  private val searchAllBooks = MutableStateFlow(false)
   private val searchOrigin = MutableStateFlow(FromWebView)
   private lateinit var alertDialogShower: AlertDialogShower
   private val debouncedSearchQuery = MutableStateFlow("")
 
   init {
+    viewModelScope.launch { restoreSearchMode() }
     viewModelScope.launch { reducer() }
     viewModelScope.launch { actionMapper() }
     viewModelScope.launch { debouncedSearchQuery() }
+  }
+
+  /**
+   * Restores the last used search mode (titles/page content) so the search
+   * screen opens the way the user left it, e.g. when opened via the
+   * "search in all pages" reader menu item.
+   */
+  private suspend fun restoreSearchMode() {
+    val storedSearchMode = runCatching {
+      SearchMode.valueOf(kiwixDataStore.searchMode.first())
+    }.getOrDefault(SearchMode.TITLE)
+    onSearchModeChanged(storedSearchMode)
   }
 
   private suspend fun getSuggestedSpelledWords(word: String, maxCount: Int): List<String> =
@@ -189,22 +208,40 @@ class SearchViewModel @Inject constructor(
   }
 
   private fun searchResults() =
-    filter.asStateFlow()
-      .mapLatest {
+    combine(
+      filter.asStateFlow(),
+      searchMode.asStateFlow(),
+      searchAllBooks.asStateFlow()
+    ) { searchTerm, searchMode, searchAllBooks ->
+      Triple(searchTerm, searchMode, searchAllBooks)
+    }.mapLatest { (searchTerm, searchMode, searchAllBooks) ->
+      if (searchAllBooks) {
         SearchResultsWithTerm(
-          it,
-          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader),
+          searchTerm = searchTerm,
+          zimSearchResultSet = null,
+          searchMutex = searchMutex,
+          globalResults = globalSearchResultGenerator.generateSearchResults(searchTerm, searchMode)
+        )
+      } else {
+        SearchResultsWithTerm(
+          searchTerm,
+          searchResultGenerator.generateSearchResults(
+            searchTerm,
+            searchMode,
+            zimReaderContainer.zimFileReader
+          ),
           searchMutex
         )
       }
+    }
 
   @Suppress("CyclomaticComplexMethod")
   private suspend fun actionMapper() {
     actions.collect {
       when (it) {
         ExitedSearch -> _effects.tryEmit(PopFragmentBackstack)
-        is OnItemClick -> saveSearchAndOpenItem(it.searchListItem, false)
-        is OnOpenInNewTabClick -> saveSearchAndOpenItem(it.searchListItem, true)
+        is OnItemClick -> onSearchItemClicked(it.searchListItem, false)
+        is OnOpenInNewTabClick -> onSearchItemClicked(it.searchListItem, true)
         is OnItemLongClick -> showDeleteDialog(it)
         is Filter -> filter.tryEmit(it.term)
         is ConfirmedDelete -> deleteItemAndShowToast(it)
@@ -255,7 +292,7 @@ class SearchViewModel @Inject constructor(
     )
   }
 
-  private fun saveSearchAndOpenItem(searchListItem: SearchListItem, openInNewTab: Boolean) {
+  private fun onSearchItemClicked(searchListItem: SearchListItem, openInNewTab: Boolean) {
     _effects.tryEmit(
       SaveSearchToRecents(
         recentSearchRoomDao,
@@ -320,6 +357,20 @@ class SearchViewModel @Inject constructor(
     updateSearchQuery("")
   }
 
+  fun onSearchModeChanged(mode: SearchMode) {
+    if (searchMode.value == mode) return
+    updateUiState { it.copy(searchMode = mode) }
+    searchMode.value = mode
+    // Remember the chosen mode for the next time the search screen opens.
+    viewModelScope.launch { kiwixDataStore.setSearchMode(mode.name) }
+  }
+
+  fun onSearchAllBooksChanged(allBooks: Boolean) {
+    if (searchAllBooks.value == allBooks) return
+    updateUiState { it.copy(searchAllBooks = allBooks) }
+    searchAllBooks.value = allBooks
+  }
+
   fun onSearchValueChanged(searchText: String) {
     updateSearchQuery(searchText)
   }
@@ -350,8 +401,14 @@ class SearchViewModel @Inject constructor(
 
 data class SearchResultsWithTerm(
   val searchTerm: String,
-  val suggestionSearch: SuggestionSearch?,
-  val searchMutex: Mutex?
+  val zimSearchResultSet: ZimSearchResultSet?,
+  val searchMutex: Mutex?,
+  /**
+   * Pre-computed results for a search across all books (see
+   * [GlobalSearchResultGenerator]). When set, these are shown directly instead
+   * of paginating a single book's [zimSearchResultSet].
+   */
+  val globalResults: List<SearchListItem>? = null
 )
 
 data class SearchScreenUiState(
@@ -360,6 +417,8 @@ data class SearchScreenUiState(
   val isLoading: Boolean = false,
   val isLoadingMore: Boolean = false,
   val spellingCorrectionSuggestions: List<String> = emptyList(),
+  val searchMode: SearchMode = SearchMode.TITLE,
+  val searchAllBooks: Boolean = false,
   val searchOrigin: SearchOrigin = FromWebView,
   val searchState: SearchState = SearchState(
     "",

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultSet.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultSet.kt
@@ -1,0 +1,34 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import org.kiwix.libzim.Search
+import org.kiwix.libzim.SuggestionSearch
+
+/**
+ * The result of a search inside a ZIM file, independent of whether the search
+ * ran over the article titles or over the full page content.
+ */
+sealed class ZimSearchResultSet {
+  /** Results of a title (suggestion) search. See [SearchMode.TITLE]. */
+  data class Title(val suggestionSearch: SuggestionSearch) : ZimSearchResultSet()
+
+  /** Results of a full-text search over the page content. See [SearchMode.PAGE_CONTENT]. */
+  data class PageContent(val search: Search) : ZimSearchResultSet()
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/OpenSearchItem.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/OpenSearchItem.kt
@@ -39,7 +39,8 @@ data class OpenSearchItem(
       SearchItemToOpen(
         searchListItem.value,
         openInNewTab,
-        searchListItem.url?.addContentPrefix
+        searchListItem.url?.addContentPrefix,
+        (searchListItem as? SearchListItem.ZimSearchResultListItem)?.zimReaderSourceDatabaseValue
       ),
       TAG_FILE_SEARCHED
     )
@@ -50,5 +51,11 @@ data class OpenSearchItem(
 data class SearchItemToOpen(
   val pageTitle: String,
   val shouldOpenInNewTab: Boolean,
-  val pageUrl: String?
+  val pageUrl: String?,
+  /**
+   * For a result from a search across all books, the
+   * [org.kiwix.kiwixmobile.core.reader.ZimReaderSource.toDatabase] value of the
+   * book the result belongs to, so the reader can switch to it before opening.
+   */
+  val zimReaderSourceDatabaseValue: String? = null
 ) : Parcelable

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ComposeDimens.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ComposeDimens.kt
@@ -176,6 +176,7 @@ object ComposeDimens {
   // Search screen dimens
   val OPEN_IN_NEW_TAB_ICON_SIZE = 43.dp
   val SEARCH_ITEM_TEXT_SIZE = 16.sp
+  val SEARCH_ITEM_SNIPPET_TEXT_SIZE = 13.sp
   val LOAD_MORE_PROGRESS_BAR_SIZE = 40.dp
 
   // Settings screen dimes

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -126,6 +126,21 @@ class KiwixDataStore @Inject constructor(
     }
   }
 
+  /**
+   * The last used search mode in the search screen, stored as the name of the
+   * [org.kiwix.kiwixmobile.core.search.viewmodel.SearchMode] enum value.
+   */
+  val searchMode: Flow<String> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_SEARCH_MODE].orEmpty()
+    }
+
+  suspend fun setSearchMode(searchMode: String) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SEARCH_MODE] = searchMode
+    }
+  }
+
   val wifiOnly: Flow<Boolean> =
     context.kiwixDataStore.data.map { prefs ->
       prefs[PreferencesKeys.PREF_WIFI_ONLY] ?: true
@@ -660,6 +675,8 @@ class KiwixDataStore @Inject constructor(
   }
 
   companion object {
+    const val PREF_SEARCH_MODE = "pref_search_mode"
+
     // Prefs
     const val PREF_LANG = "pref_language_chooser"
     const val PREF_STORAGE = "pref_select_folder"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -34,6 +34,7 @@ object PreferencesKeys {
     booleanPreferencesKey(KiwixDataStore.PREF_EXTERNAL_LINK_POPUP)
   val PREF_WIFI_ONLY = booleanPreferencesKey(KiwixDataStore.PREF_WIFI_ONLY)
   val PREF_THEME = stringPreferencesKey(KiwixDataStore.PREF_THEME)
+  val PREF_SEARCH_MODE = stringPreferencesKey(KiwixDataStore.PREF_SEARCH_MODE)
   val PREF_SHOW_INTRO = booleanPreferencesKey(KiwixDataStore.PREF_SHOW_INTRO)
   val PREF_SHOW_SHOWCASE = booleanPreferencesKey(KiwixDataStore.PREF_SHOW_SHOWCASE)
   val PREF_BOOKMARKS_MIGRATED = booleanPreferencesKey(KiwixDataStore.PREF_BOOKMARKS_MIGRATED)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -335,6 +335,9 @@
   <string name="percentage">%d%%</string>
   <string name="pref_text_zoom_title">Text Zoom</string>
   <string name="search_open_in_new_tab">Open in new tab</string>
+  <string name="search_in_titles">Titles</string>
+  <string name="search_in_page_content">Page content</string>
+  <string name="search_in_all_books">All books</string>
   <string name="reader">Reader</string>
   <string name="no_open_book">No open book</string>
   <string name="open_library">Open library</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/SearchScreenUITest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/SearchScreenUITest.kt
@@ -22,11 +22,10 @@ import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
 import io.mockk.mockk
 import io.mockk.verify
@@ -284,8 +283,8 @@ class SearchScreenUITest {
         isLoadingMore = false
       )
     )
-    composeTestRule.onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG, true)[8]
-      .performScrollTo()
+    composeTestRule.onNodeWithTag(SEARCH_LIST_TESTING_TAG)
+      .performScrollToIndex(items.size - 1)
 
     composeTestRule.waitForIdle()
 
@@ -306,8 +305,8 @@ class SearchScreenUITest {
         isLoadingMore = true
       )
     )
-    composeTestRule.onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG, true)[8]
-      .performScrollTo()
+    composeTestRule.onNodeWithTag(SEARCH_LIST_TESTING_TAG)
+      .performScrollToIndex(items.size - 1)
 
     composeTestRule.waitForIdle()
 
@@ -327,8 +326,8 @@ class SearchScreenUITest {
     )
 
     repeat(3) {
-      composeTestRule.onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG, true)[8]
-        .performScrollTo()
+      composeTestRule.onNodeWithTag(SEARCH_LIST_TESTING_TAG)
+        .performScrollToIndex(items.size - 1)
     }
 
     composeTestRule.waitForIdle()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/EntryWrapper.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/EntryWrapper.kt
@@ -1,0 +1,26 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import org.kiwix.libzim.Entry
+
+class EntryWrapper : Entry() {
+  override fun getTitle(): String = super.getTitle()
+  override fun getPath(): String = super.getPath()
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/GlobalSearchResultGeneratorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/GlobalSearchResultGeneratorTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
+import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
+import org.kiwix.kiwixmobile.core.search.SearchListItem
+import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
+import org.kiwix.sharedFunctions.MainDispatcherRule
+
+internal class GlobalSearchResultGeneratorTest {
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val libkiwixBookOnDisk: LibkiwixBookOnDisk = mockk()
+  private val zimFileReaderFactory: ZimFileReader.Factory = mockk()
+
+  private val generator =
+    GlobalSearchResultGeneratorImpl(
+      libkiwixBookOnDisk,
+      zimFileReaderFactory,
+      mainDispatcherRule.dispatcher
+    )
+
+  @Test
+  fun `blank search term returns empty list`() = runTest {
+    assertThat(generator.generateSearchResults("", SearchMode.PAGE_CONTENT)).isEmpty()
+  }
+
+  @Test
+  fun `results from each book are tagged with the book title and source`() = runTest {
+    val searchTerm = "kiwix"
+    val bookTitle = "Wikipedia"
+    val sourceDb = "/storage/wikipedia.zim"
+
+    val zimReaderSource: ZimReaderSource = mockk()
+    every { zimReaderSource.toDatabase() } returns sourceDb
+    val libkiwixBook: LibkiwixBook = mockk()
+    every { libkiwixBook.title } returns bookTitle
+    val bookOnDisk: BookOnDisk = mockk()
+    every { bookOnDisk.book } returns libkiwixBook
+    every { bookOnDisk.zimReaderSource } returns zimReaderSource
+    coEvery { libkiwixBookOnDisk.getBooks() } returns listOf(bookOnDisk)
+
+    val reader: ZimFileReader = mockk(relaxed = true)
+    coEvery { zimFileReaderFactory.create(zimReaderSource, false) } returns reader
+
+    val suggestionSearch: SuggestionSearchWrapper = mockk()
+    val iterator: SuggestionIteratorWrapper = mockk()
+    val item: SuggestionItemWrapper = mockk()
+    every { reader.searchFullText(searchTerm) } returns null
+    every { reader.searchSuggestions(searchTerm) } returns suggestionSearch
+    every { suggestionSearch.getResults(0, GLOBAL_SEARCH_MAX_RESULTS_PER_BOOK) } returns iterator
+    every { iterator.hasNext() } returnsMany listOf(true, false)
+    every { iterator.next() } returns item
+    every { item.title } returns "Kiwix"
+    every { item.path } returns "A/Kiwix"
+
+    val results = generator.generateSearchResults(searchTerm, SearchMode.PAGE_CONTENT)
+
+    assertThat(results).isEqualTo(
+      listOf(
+        SearchListItem.ZimSearchResultListItem(
+          value = "Kiwix",
+          url = "A/Kiwix",
+          snippet = null,
+          bookTitle = bookTitle,
+          zimReaderSourceDatabaseValue = sourceDb
+        )
+      )
+    )
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchIteratorWrapper.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchIteratorWrapper.kt
@@ -1,0 +1,31 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import org.kiwix.libzim.SearchIterator
+
+class SearchIteratorWrapper : SearchIterator() {
+  override fun remove() {
+    // Do nothing just to ignore the EmptyFunctionBlock detekt error.
+  }
+
+  override fun hasNext(): Boolean = super.hasNext()
+  override fun next(): EntryWrapper = super.next() as EntryWrapper
+  override fun getSnippet(): String = super.getSnippet()
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchStateTest.kt
@@ -66,11 +66,79 @@ internal class SearchStateTest {
       assertThat(
         SearchState(
           searchTerm,
-          SearchResultsWithTerm("", suggestionSearchWrapper, mockk()),
+          SearchResultsWithTerm("", ZimSearchResultSet.Title(suggestionSearchWrapper), mockk()),
           emptyList(),
           FromWebView
         ).getVisibleResults(0, ioDispatcher = mainDispatcherRule.dispatcher)
       ).isEqualTo(listOf(SearchListItem.ZimSearchResultListItem(searchTerm, "")))
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  internal fun `visibleResults use full text search results when in page content mode`() =
+    runTest {
+      val searchTerm = "notEmpty"
+      val pageUrl = "A/page"
+      val snippet = "a sentence with the <b>notEmpty</b> match"
+      val searchWrapper: SearchWrapper = mockk()
+      val searchIteratorWrapper: SearchIteratorWrapper = mockk()
+      val entry: EntryWrapper = mockk()
+      every { searchIteratorWrapper.hasNext() } returnsMany listOf(true, false)
+      every { searchIteratorWrapper.next() } returns entry
+      every { searchIteratorWrapper.snippet } returns snippet
+      every { entry.title } returns searchTerm
+      every { entry.path } returns pageUrl
+      every { searchWrapper.getResults(0, 20) } returns searchIteratorWrapper
+      assertThat(
+        SearchState(
+          searchTerm,
+          SearchResultsWithTerm("", ZimSearchResultSet.PageContent(searchWrapper), mockk()),
+          emptyList(),
+          FromWebView
+        ).getVisibleResults(0, ioDispatcher = mainDispatcherRule.dispatcher)
+      ).isEqualTo(listOf(SearchListItem.ZimSearchResultListItem(searchTerm, pageUrl, snippet)))
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  internal fun `each page content result keeps its own snippet, not the next one's`() =
+    runTest {
+      // Regression test: the snippet must be read from the iterator's current
+      // position *before* next() advances it. libzim's getSnippet() reflects the
+      // iterator's current position, and next() returns the current entry then
+      // advances. If the snippet is read after next(), every result shows the
+      // *next* result's snippet. This stateful mock reproduces those semantics.
+      val titles = listOf("first", "second")
+      val paths = listOf("A/first", "A/second")
+      val snippets = listOf("first snippet", "second snippet")
+      var position = 0
+      val searchWrapper: SearchWrapper = mockk()
+      val searchIteratorWrapper: SearchIteratorWrapper = mockk()
+      every { searchIteratorWrapper.hasNext() } answers { position < titles.size }
+      // getSnippet() reads the *current* position.
+      every { searchIteratorWrapper.snippet } answers { snippets[position] }
+      // next() returns the current entry, then advances the cursor.
+      every { searchIteratorWrapper.next() } answers {
+        val entry: EntryWrapper = mockk()
+        every { entry.title } returns titles[position]
+        every { entry.path } returns paths[position]
+        position++
+        entry
+      }
+      every { searchWrapper.getResults(0, 20) } returns searchIteratorWrapper
+      assertThat(
+        SearchState(
+          "term",
+          SearchResultsWithTerm("", ZimSearchResultSet.PageContent(searchWrapper), mockk()),
+          emptyList(),
+          FromWebView
+        ).getVisibleResults(0, ioDispatcher = mainDispatcherRule.dispatcher)
+      ).isEqualTo(
+        listOf(
+          SearchListItem.ZimSearchResultListItem(titles[0], paths[0], snippets[0]),
+          SearchListItem.ZimSearchResultListItem(titles[1], paths[1], snippets[1])
+        )
+      )
     }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -82,6 +150,21 @@ internal class SearchStateTest {
         SearchState(
           "",
           SearchResultsWithTerm("", null, mockk()),
+          results,
+          FromWebView
+        ).getVisibleResults(0, ioDispatcher = mainDispatcherRule.dispatcher)
+      ).isEqualTo(results)
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  internal fun `visibleResults use recentResults when zimSearchResultSet is null`() =
+    runTest {
+      val results = listOf(RecentSearchListItem("", ""))
+      assertThat(
+        SearchState(
+          "notEmpty",
+          SearchResultsWithTerm("notEmpty", null, mockk()),
           results,
           FromWebView
         ).getVisibleResults(0, ioDispatcher = mainDispatcherRule.dispatcher)
@@ -130,7 +213,11 @@ internal class SearchStateTest {
       every { suggestionSearchWrapper.getResults(any(), any()) } returns searchIteratorWrapper
 
       val searchResultsWithTerm =
-        SearchResultsWithTerm(searchTerm, suggestionSearchWrapper, mockk())
+        SearchResultsWithTerm(
+          searchTerm,
+          ZimSearchResultSet.Title(suggestionSearchWrapper),
+          mockk()
+        )
       val searchState = SearchState(searchTerm, searchResultsWithTerm, emptyList(), FromWebView)
       var list: List<SearchListItem>? = emptyList()
       var list1: List<SearchListItem>? = emptyList()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -21,12 +21,16 @@ package org.kiwix.kiwixmobile.core.search.viewmodel
 import android.os.Bundle
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
@@ -65,6 +69,7 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchArgumentProcess
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowDeleteSearchDialog
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.ShowToast
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.StartSpeechInput
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.effects.CloseKeyboard
 import org.kiwix.libzim.SuggestionSearch
@@ -79,9 +84,11 @@ internal class SearchViewModelTest {
   private val recentSearchRoomDao: RecentSearchRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val searchResultGenerator: SearchResultGenerator = mockk()
+  private val globalSearchResultGenerator: GlobalSearchResultGenerator = mockk()
   private val zimFileReader: ZimFileReader = mockk()
   private val dialogShower = mockk<AlertDialogShower>(relaxed = true)
   private val searchMutex: Mutex = mockk()
+  private val kiwixDataStore: KiwixDataStore = mockk()
 
   lateinit var viewModel: SearchViewModel
 
@@ -96,15 +103,22 @@ internal class SearchViewModelTest {
       zimFileReader.getSuggestedSpelledWords(any(), any())
     } returns emptyList()
     coEvery {
-      searchResultGenerator.generateSearchResults(any(), zimFileReader)
+      searchResultGenerator.generateSearchResults(any(), any(), zimFileReader)
     } returns null
+    coEvery {
+      globalSearchResultGenerator.generateSearchResults(any(), any())
+    } returns emptyList()
     every { zimReaderContainer.id } returns "id"
     every { recentSearchRoomDao.recentSearches("id") } returns recentsFromDb
+    every { kiwixDataStore.searchMode } returns flowOf("")
+    coEvery { kiwixDataStore.setSearchMode(any()) } just Runs
     viewModel =
       SearchViewModel(
         recentSearchRoomDao,
         zimReaderContainer,
         searchResultGenerator,
+        globalSearchResultGenerator,
+        kiwixDataStore,
         searchMutex,
         mainDispatcherRule.dispatcher
       ).apply {
@@ -163,8 +177,8 @@ internal class SearchViewModelTest {
       timeout: Long
     ) {
       coEvery {
-        searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
-      } returns suggestionSearch
+        searchResultGenerator.generateSearchResults(searchTerm, any(), zimFileReader)
+      } returns ZimSearchResultSet.Title(suggestionSearch)
       viewModel.onSearchValueChanged(searchTerm)
       recentsFromDb.tryEmit(emptyList())
       viewModel.actions.tryEmit(ScreenWasStartedFrom(FromWebView))
@@ -254,6 +268,23 @@ internal class SearchViewModelTest {
       assertThat(viewModel.uiState.value.searchText).isEqualTo(suggestion)
     }
 
+    @Test
+    fun onSearchModeChanged_whenCalled_updatesSearchModeAndRegeneratesResults() = runTest {
+      val searchTerm = "searchTerm"
+      viewModel.onSearchValueChanged(searchTerm)
+      advanceUntilIdle()
+      viewModel.onSearchModeChanged(SearchMode.PAGE_CONTENT)
+      advanceUntilIdle()
+      assertThat(viewModel.uiState.value.searchMode).isEqualTo(SearchMode.PAGE_CONTENT)
+      coVerify {
+        searchResultGenerator.generateSearchResults(
+          searchTerm,
+          SearchMode.PAGE_CONTENT,
+          zimFileReader
+        )
+      }
+    }
+
     private fun emissionOf(
       searchTerm: String,
       suggestionSearch: SuggestionSearch,
@@ -261,8 +292,8 @@ internal class SearchViewModelTest {
       searchOrigin: SearchOrigin
     ) {
       coEvery {
-        searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
-      } returns suggestionSearch
+        searchResultGenerator.generateSearchResults(searchTerm, any(), zimFileReader)
+      } returns ZimSearchResultSet.Title(suggestionSearch)
       viewModel.actions.tryEmit(Filter(searchTerm))
       recentsFromDb.tryEmit(databaseResults)
       viewModel.actions.tryEmit(ScreenWasStartedFrom(searchOrigin))

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchWrapper.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchWrapper.kt
@@ -1,0 +1,28 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.search.viewmodel
+
+import org.kiwix.libzim.Search
+
+class SearchWrapper : Search() {
+  override fun getEstimatedMatches(): Long = super.getEstimatedMatches()
+
+  override fun getResults(start: Int, maxResults: Int): SearchIteratorWrapper =
+    super.getResults(start, maxResults) as SearchIteratorWrapper
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/ZimSearchResultGeneratorTest.kt
@@ -39,8 +39,9 @@ internal class ZimSearchResultGeneratorTest {
 
   @Test
   internal fun `empty search term returns empty list`() = runTest {
-    assertThat(zimSearchResultGenerator.generateSearchResults("", zimFileReader))
-      .isEqualTo(null)
+    assertThat(
+      zimSearchResultGenerator.generateSearchResults("", SearchMode.TITLE, zimFileReader)
+    ).isEqualTo(null)
   }
 
   @Test
@@ -48,9 +49,46 @@ internal class ZimSearchResultGeneratorTest {
     val searchTerm = "a"
     val suggestionSearchWrapper: SuggestionSearchWrapper = mockk()
     every { zimFileReader.searchSuggestions(searchTerm) } returns suggestionSearchWrapper
-    assertThat(zimSearchResultGenerator.generateSearchResults(searchTerm, zimFileReader))
-      .isEqualTo(suggestionSearchWrapper)
+    assertThat(
+      zimSearchResultGenerator.generateSearchResults(searchTerm, SearchMode.TITLE, zimFileReader)
+    ).isEqualTo(ZimSearchResultSet.Title(suggestionSearchWrapper))
     verify {
+      zimFileReader.searchSuggestions(searchTerm)
+    }
+  }
+
+  @Test
+  internal fun `page content mode returns full text search results`() = runTest {
+    val searchTerm = "a"
+    val searchWrapper: SearchWrapper = mockk()
+    every { zimFileReader.searchFullText(searchTerm) } returns searchWrapper
+    assertThat(
+      zimSearchResultGenerator.generateSearchResults(
+        searchTerm,
+        SearchMode.PAGE_CONTENT,
+        zimFileReader
+      )
+    ).isEqualTo(ZimSearchResultSet.PageContent(searchWrapper))
+    verify {
+      zimFileReader.searchFullText(searchTerm)
+    }
+  }
+
+  @Test
+  internal fun `page content mode falls back to title search without full text index`() = runTest {
+    val searchTerm = "a"
+    val suggestionSearchWrapper: SuggestionSearchWrapper = mockk()
+    every { zimFileReader.searchFullText(searchTerm) } returns null
+    every { zimFileReader.searchSuggestions(searchTerm) } returns suggestionSearchWrapper
+    assertThat(
+      zimSearchResultGenerator.generateSearchResults(
+        searchTerm,
+        SearchMode.PAGE_CONTENT,
+        zimFileReader
+      )
+    ).isEqualTo(ZimSearchResultSet.Title(suggestionSearchWrapper))
+    verify {
+      zimFileReader.searchFullText(searchTerm)
       zimFileReader.searchSuggestions(searchTerm)
     }
   }


### PR DESCRIPTION
### Fixes / features

Search currently only matches article **titles**, in the **currently open book**. This PR adds two search options, selected with chips at the top of the search screen:

- **Page content** — full-text search over the page content using the ZIM file's Xapian index. Results show a snippet of the sentence where the term was found, with the match in bold. Books without a full-text index transparently fall back to the title search.
- **All books** — the same search over every book on the device. Each result shows which book it came from, and opening a result switches the reader to that book first.

The selected mode is remembered (data store), so the search screen opens the way the user left it.

### Implementation

- `ZimFileReader.searchFullText()` lazily creates a libzim `Searcher` (and disposes it with the reader).
- `ZimSearchResultSet` models the two kinds of result set (title suggestions / full-text search) so `SearchState` can page through either.
- `GlobalSearchResultGenerator` searches the books of the library one by one on the IO dispatcher; an unreadable book is skipped rather than failing the whole search.
- `SearchItemToOpen` carries the book a result belongs to, which `CoreReaderViewModel` uses to open that book before loading the page.

### Testing

- New `GlobalSearchResultGeneratorTest`; existing search tests updated for the new signatures.
- `:core:testDebugUnitTest`, `:core:ktlintCheck`, `:core:detektDebug` and `:app:assembleDebug` all pass locally.
- Manually tested on a device against a Wikipedia ZIM (title search, full-text search, and cross-book search including opening a result from another book).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3LCEHHPfZmDSH9iF15UqV