### PR TITLE
Removed the `Activity` reference from `CoreApp`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onFirst
@@ -64,14 +65,18 @@ class DownloadRobot : BaseRobot() {
   private val searchZIMFileTitle = "D3 js docs"
   fun clickLibraryOnBottomNav(composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
-      waitUntilTimeout()
+      waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
+        onNodeWithTag(BOTTOM_NAV_LIBRARY_ITEM_TESTING_TAG).isDisplayed()
+      }
       onNodeWithTag(BOTTOM_NAV_LIBRARY_ITEM_TESTING_TAG).performClick()
     }
   }
 
   fun clickDownloadOnBottomNav(composeTestRule: ComposeContentTestRule) {
     composeTestRule.apply {
-      waitUntilTimeout()
+      waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST.toLong()) {
+        onNodeWithTag(BOTTOM_NAV_DOWNLOADS_ITEM_TESTING_TAG).isDisplayed()
+      }
       onNodeWithTag(BOTTOM_NAV_DOWNLOADS_ITEM_TESTING_TAG).performClick()
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -22,7 +22,6 @@ import android.app.NotificationManager
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.view.ActionMode
 import androidx.compose.material3.BottomAppBarDefaults
@@ -107,7 +106,6 @@ class KiwixMainActivity : CoreMainActivity() {
   @Inject
   @MainDispatcher
   lateinit var mainDispatcher: MainCoroutineDispatcher
-  override val mainActivity: AppCompatActivity by lazy { this }
   override val appName: String by lazy { getString(R.string.app_name) }
 
   override val bookmarksScreenRoute: String = KiwixDestination.Bookmarks.route
@@ -234,7 +232,7 @@ class KiwixMainActivity : CoreMainActivity() {
   }
 
   private fun safelyHandleDeepLink(intent: Intent) {
-    if (intent.data != null && intent.extras != null) {
+    intent.data?.let {
       navController.handleDeepLink(intent)
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotNotificationManager.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotNotificationManager.kt
@@ -27,7 +27,6 @@ import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.net.toUri
-import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.main.ZIM_HOST_NAV_DEEP_LINK
 import org.kiwix.kiwixmobile.core.qr.GenerateQR
@@ -56,14 +55,18 @@ class HotspotNotificationManager @Inject constructor(
 
   @SuppressLint("UnspecifiedImmutableFlag")
   fun buildForegroundNotification(uri: String? = null): Notification {
-    val coreMainActivity = (context as CoreApp).getMainActivity()
+    val launchIntent = requireNotNull(
+      context.packageManager.getLaunchIntentForPackage(context.packageName)
+    ) {
+      "No launcher activity found for package ${context.packageName}"
+    }.apply {
+      action = Intent.ACTION_VIEW
+      data = ZIM_HOST_NAV_DEEP_LINK.toUri()
+    }
     val contentIntent = PendingIntent.getActivity(
       context,
       0,
-      Intent(context, coreMainActivity.mainActivity::class.java).apply {
-        action = Intent.ACTION_VIEW
-        data = ZIM_HOST_NAV_DEEP_LINK.toUri()
-      },
+      launchIntent,
       PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
     )
     hotspotNotificationChannel()

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
@@ -21,7 +21,6 @@ package org.kiwix.kiwixmobile.custom.main
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.rememberDrawerState
@@ -47,13 +46,12 @@ import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_HELP_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.LEFT_DRAWER_SUPPORT_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.main.NEW_TAB_SHORTCUT_ID
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
-import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.BrandedApp
+import org.kiwix.kiwixmobile.custom.BuildConfig
 import org.kiwix.kiwixmobile.custom.R
 import org.kiwix.kiwixmobile.custom.brandedActivityComponent
 
 class BrandedMainActivity : CoreMainActivity() {
-  override val mainActivity: AppCompatActivity by lazy { this }
   override val appName: String by lazy { getString(R.string.app_name) }
 
   override val searchScreenRoute: String = CustomDestination.Search.route

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/CoreApp.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/CoreApp.kt
@@ -26,7 +26,6 @@ import androidx.multidex.MultiDex
 import com.jakewharton.threetenabp.AndroidThreeTen
 import org.kiwix.kiwixmobile.core.di.components.CoreComponent
 import org.kiwix.kiwixmobile.core.di.components.DaggerCoreComponent
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.files.FileLogger
 import javax.inject.Inject
 
@@ -52,8 +51,6 @@ abstract class CoreApp : Application() {
 
   @Inject
   lateinit var fileLogger: FileLogger
-
-  private lateinit var coreMainActivity: CoreMainActivity
 
   override fun attachBaseContext(base: Context) {
     super.attachBaseContext(base)
@@ -113,10 +110,4 @@ abstract class CoreApp : Application() {
       )
     }
   }
-
-  fun setMainActivity(coreMainActivity: CoreMainActivity) {
-    this.coreMainActivity = coreMainActivity
-  }
-
-  fun getMainActivity() = coreMainActivity
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -52,6 +52,7 @@ import org.kiwix.kiwixmobile.core.di.modules.NetworkModule
 import org.kiwix.kiwixmobile.core.di.modules.ReaderModule
 import org.kiwix.kiwixmobile.core.di.modules.SearchModule
 import org.kiwix.kiwixmobile.core.downloader.Downloader
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorServiceManager
 import org.kiwix.kiwixmobile.core.error.ErrorActivity
 import org.kiwix.kiwixmobile.core.main.KiwixWebView
 import org.kiwix.kiwixmobile.core.main.reader.helper.TabsManager
@@ -128,4 +129,5 @@ interface CoreComponent {
   fun provideTabsManager(): TabsManager
   fun provideReaderIntentManager(): ReaderIntentManager
   fun provideStorageDeviceProvider(): StorageDeviceProvider
+  fun provideDownloadMonitorServiceManager(): DownloadMonitorServiceManager
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadManagerRequester.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadManagerRequester.kt
@@ -18,7 +18,6 @@
 
 package org.kiwix.kiwixmobile.core.downloader.downloadManager
 
-import android.content.Context
 import com.tonyodev.fetch2.Fetch
 import com.tonyodev.fetch2.NetworkType.ALL
 import com.tonyodev.fetch2.NetworkType.WIFI_ONLY
@@ -27,7 +26,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
@@ -39,8 +37,8 @@ import javax.inject.Inject
 class DownloadManagerRequester @Inject constructor(
   private val fetch: Fetch,
   private val kiwixDataStore: KiwixDataStore,
-  private val context: Context,
   private val downloadRoomDao: DownloadRoomDao,
+  private val downloadMonitorServiceManager: DownloadMonitorServiceManager,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : DownloadRequester {
   override suspend fun enqueue(downloadRequest: DownloadRequest): Long {
@@ -100,7 +98,7 @@ class DownloadManagerRequester @Inject constructor(
   }
 
   override fun startDownloadMonitorService() {
-    (context as CoreApp).getMainActivity().startDownloadMonitorServiceIfOngoingDownloads()
+    downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads()
   }
 }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -66,7 +66,6 @@ import javax.inject.Inject
 
 const val THIRTY_TREE = 33
 const val DOWNLOAD_SERVICE_NOTIFICATION_ID = 1
-const val APP_NAME_KEY = "appNameKey"
 const val DOWNLOAD_TIMEOUT_RESUME_INTENT = "downloadTimeoutResumeIntent"
 const val BACKGROUND_DOWNLOAD_LIMIT_REACH_ACTION = "backgroundDownloadLimitReachAction"
 const val DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID = 2
@@ -102,8 +101,6 @@ class DownloadMonitorService : Service() {
 
   @Inject
   lateinit var kiwixDataStore: KiwixDataStore
-
-  private var appName: String? = "kiwix"
 
   private val networkCallback = object : ConnectivityManager.NetworkCallback() {
     override fun onAvailable(network: Network) {
@@ -170,9 +167,6 @@ class DownloadMonitorService : Service() {
   override fun onBind(intent: Intent?): IBinder? = null
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    if (intent?.hasExtra(APP_NAME_KEY) == true) {
-      appName = intent.getStringExtra(APP_NAME_KEY)
-    }
     if (intent?.action == STOP_DOWNLOAD_SERVICE) {
       stopForegroundServiceForDownloads()
     }
@@ -252,7 +246,7 @@ class DownloadMonitorService : Service() {
     }
   }
 
-  private fun buildTimeoutNotification(): Notification {
+  private suspend fun buildTimeoutNotification(): Notification {
     val yesIntent = Intents.internal(CoreMainActivity::class.java).apply {
       addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
       // on clicking on yes button it will open the "Download" screen.
@@ -280,7 +274,7 @@ class DownloadMonitorService : Service() {
     return NotificationCompat.Builder(this, DOWNLOAD_NOTIFICATION_CHANNEL_ID)
       .setPriority(NotificationManager.IMPORTANCE_DEFAULT)
       .setSmallIcon(android.R.drawable.stat_sys_warning)
-      .setContentTitle(appName)
+      .setContentTitle(kiwixDataStore.appName.first())
       .setContentText(getString(R.string.download_timeout_resume_message))
       .setAutoCancel(true)
       .setOngoing(false)
@@ -300,15 +294,17 @@ class DownloadMonitorService : Service() {
 
   private fun startForegroundService() {
     runCatching {
-      downloadNotificationChannel()
-      startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
-      startPausedDownloadsDueToAndroidServiceLimitation()
+      CoroutineScope(ioDispatcher).launch {
+        downloadNotificationChannel()
+        startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
+        startPausedDownloadsDueToAndroidServiceLimitation()
+      }
     }.onFailure { it.printStackTrace() }
   }
 
-  private fun buildForegroundNotification(): Notification =
+  private suspend fun buildForegroundNotification(): Notification =
     NotificationCompat.Builder(this, DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-      .setContentTitle(appName)
+      .setContentTitle(kiwixDataStore.appName.first())
       .setContentText(getString(string.download_notification_channel_description))
       .setSmallIcon(R.mipmap.ic_launcher)
       .setWhen(System.currentTimeMillis())
@@ -328,19 +324,17 @@ class DownloadMonitorService : Service() {
    * 3. Resets their `pauseReason` to `NONE` and updates the status to `QUEUED`
    *    so they can continue downloading normally.
    */
-  private fun startPausedDownloadsDueToAndroidServiceLimitation() {
-    CoroutineScope(ioDispatcher).launch {
-      downloadRoomDao.getDownloadsPausedByService()
-        .forEach {
-          fetch.resume(it.downloadId.toInt())
-          // Reset the PauseReason.
-          downloadRoomDao.getEntityForDownloadId(it.downloadId)?.let { downloadRoomEntity ->
-            downloadRoomDao.updateDownloadItem(
-              downloadRoomEntity.copy(pauseReason = PauseReason.NONE, status = Status.QUEUED)
-            )
-          }
+  private suspend fun startPausedDownloadsDueToAndroidServiceLimitation() {
+    downloadRoomDao.getDownloadsPausedByService()
+      .forEach {
+        fetch.resume(it.downloadId.toInt())
+        // Reset the PauseReason.
+        downloadRoomDao.getEntityForDownloadId(it.downloadId)?.let { downloadRoomEntity ->
+          downloadRoomDao.updateDownloadItem(
+            downloadRoomEntity.copy(pauseReason = PauseReason.NONE, status = Status.QUEUED)
+          )
         }
-    }
+      }
   }
 
   private val fetchListener = object : FetchListener {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorServiceManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorServiceManager.kt
@@ -1,0 +1,81 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.downloader.downloadManager
+
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService.Companion.STOP_DOWNLOAD_SERVICE
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService.Companion.isDownloadMonitorServiceRunning
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DownloadMonitorServiceManager @Inject constructor(
+  private val context: Context,
+  private val downloadRoomDao: DownloadRoomDao,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+  /**
+   * Starts the [DownloadMonitorService] if there are any ongoing downloads.
+   *
+   * This method checks whether the download monitoring service is already running.
+   * If not, it queries the database for ongoing downloads on a background thread.
+   * When at least one active download is found, the service is started with the
+   * required app metadata. If no ongoing downloads exist, the service is stopped
+   * to avoid unnecessary background work.
+   */
+  fun startDownloadMonitorServiceIfOngoingDownloads(isAppStart: Boolean = false) {
+    if (!isDownloadMonitorServiceRunning) {
+      CoroutineScope(ioDispatcher).launch {
+        runCatching {
+          if (downloadRoomDao.getOngoingDownloads().isNotEmpty() || !isAppStart) {
+            context.startService(
+              Intent(
+                context,
+                DownloadMonitorService::class.java
+              )
+            )
+          } else {
+            stopDownloadServiceIfRunning()
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Stops the DownloadService if it is currently running,
+   * as the application is now in the foreground and can handle downloads directly.
+   */
+  private fun stopDownloadServiceIfRunning() {
+    if (isDownloadMonitorServiceRunning) {
+      context.startService(
+        Intent(
+          context,
+          DownloadMonitorService::class.java
+        ).setAction(STOP_DOWNLOAD_SERVICE)
+      )
+    }
+  }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -52,7 +52,6 @@ import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.queryIntentActivitiesCompat
 import org.kiwix.kiwixmobile.core.compat.ResolveInfoFlagsCompat
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.APP_NAME_KEY
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
@@ -120,11 +119,6 @@ open class ErrorActivity : BaseActivity() {
       } else {
         null
       }
-    appName = if (extras != null && safeContains(extras, APP_NAME_KEY)) {
-      extras.getString(APP_NAME_KEY)
-    } else {
-      null
-    }
     setContent {
       val showDialog by showValidationDialog.collectAsState()
       ErrorActivityScreen(
@@ -137,6 +131,7 @@ open class ErrorActivity : BaseActivity() {
       ShowValidatingZimFilesDialog(showDialog)
     }
     lifecycleScope.launch {
+      appName = kiwixDataStore.appName.first()
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         validateZimViewModel.allZIMValidated
           .filter { it }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/help/HelpViewModel.kt
@@ -18,19 +18,15 @@
 
 package org.kiwix.kiwixmobile.core.help
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.APP_NAME_KEY
 import org.kiwix.kiwixmobile.core.error.DiagnosticReportActivity
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 
 abstract class HelpViewModel : ViewModel() {
   abstract suspend fun rawTitleDescriptionMap(context: Context): List<Pair<Int, Any>>
@@ -48,13 +44,7 @@ abstract class HelpViewModel : ViewModel() {
   }
 
   fun onSendReportButtonClick(context: Context) {
-    val activity = context as? Activity ?: return
-    val appName = (activity as? CoreMainActivity)?.appName
     val intent = Intent(context, DiagnosticReportActivity::class.java)
-    val extras = Bundle().apply {
-      putString(APP_NAME_KEY, appName)
-    }
-    intent.putExtras(extras)
     context.startActivity(intent)
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -30,7 +30,6 @@ import android.view.ActionMode
 import android.view.MenuItem
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.DrawerState
@@ -65,11 +64,8 @@ import org.kiwix.kiwixmobile.core.base.BackPressActivityExtensions
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.di.components.CoreActivityComponent
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.APP_NAME_KEY
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService.Companion.STOP_DOWNLOAD_SERVICE
-import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService.Companion.isDownloadMonitorServiceRunning
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorServiceManager
 import org.kiwix.kiwixmobile.core.error.ErrorActivity
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.setNavigationResultOnCurrent
 import org.kiwix.kiwixmobile.core.extensions.browserIntent
@@ -151,6 +147,9 @@ abstract class CoreMainActivity : BaseActivity() {
   @Inject
   lateinit var readerIntentManager: ReaderIntentManager
 
+  @Inject
+  lateinit var downloadMonitorServiceManager: DownloadMonitorServiceManager
+
   private var selectionActionModeListener: WebViewSelectionActionMode? = null
 
   /**
@@ -204,7 +203,6 @@ abstract class CoreMainActivity : BaseActivity() {
   abstract val readerScreenRoute: String
   abstract val cachedComponent: CoreActivityComponent
   abstract val topLevelDestinationsRoute: Set<String>
-  abstract val mainActivity: AppCompatActivity
   abstract val appName: String
 
   /**
@@ -234,7 +232,6 @@ abstract class CoreMainActivity : BaseActivity() {
         intent.putExtra(ErrorActivity.EXCEPTION_KEY, paramThrowable)
         val extras = Bundle()
         extras.putSerializable(ErrorActivity.EXCEPTION_KEY, paramThrowable)
-        extras.putString(APP_NAME_KEY, appName)
         intent.putExtras(extras)
         intent.addFlags(FLAG_ACTIVITY_NEW_TASK)
         appContext.startActivity(intent)
@@ -247,8 +244,6 @@ abstract class CoreMainActivity : BaseActivity() {
         exitProcess(KIWIX_INTERNAL_ERROR)
       }
     }
-
-    setMainActivityToCoreApp()
     lifecycleScope.launch(ioDispatcher) {
       setIsDebugBuild(BuildConfig.DEBUG)
       setAppName()
@@ -318,53 +313,8 @@ abstract class CoreMainActivity : BaseActivity() {
 
   override fun onResume() {
     super.onResume()
-    startDownloadMonitorServiceIfOngoingDownloads(true)
+    downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads(true)
     cancelBackgroundTimeoutNotification()
-  }
-
-  /**
-   * Stops the DownloadService if it is currently running,
-   * as the application is now in the foreground and can handle downloads directly.
-   */
-  private fun stopDownloadServiceIfRunning() {
-    if (isDownloadMonitorServiceRunning) {
-      startService(
-        Intent(
-          this,
-          DownloadMonitorService::class.java
-        ).setAction(STOP_DOWNLOAD_SERVICE)
-      )
-    }
-  }
-
-  /**
-   * Starts the [DownloadMonitorService] if there are any ongoing downloads.
-   *
-   * This method checks whether the download monitoring service is already running.
-   * If not, it queries the database for ongoing downloads on a background thread.
-   * When at least one active download is found, the service is started with the
-   * required app metadata. If no ongoing downloads exist, the service is stopped
-   * to avoid unnecessary background work.
-   */
-  fun startDownloadMonitorServiceIfOngoingDownloads(isAppStart: Boolean = false) {
-    if (!isDownloadMonitorServiceRunning) {
-      CoroutineScope(ioDispatcher).launch {
-        runCatching {
-          if (downloadRoomDao.getOngoingDownloads().isNotEmpty() || !isAppStart) {
-            startService(
-              Intent(
-                this@CoreMainActivity,
-                DownloadMonitorService::class.java
-              ).apply {
-                putExtra(APP_NAME_KEY, appName)
-              }
-            )
-          } else {
-            stopDownloadServiceIfRunning()
-          }
-        }
-      }
-    }
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -500,15 +450,11 @@ abstract class CoreMainActivity : BaseActivity() {
     disableLeftDrawer()
   }
 
-  private fun setMainActivityToCoreApp() {
-    (applicationContext as CoreApp).setMainActivity(this)
-  }
-
   private fun cancelBackgroundTimeoutNotification() {
     runCatching {
       val notificationManager =
-        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-      notificationManager.cancel(DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID)
+        getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+      notificationManager?.cancel(DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/KiwixDialog.kt
@@ -22,7 +22,6 @@ import android.app.Activity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DIALOG_CUSTOM_VIEW_BOTTOM_PADDING
 
@@ -295,11 +294,11 @@ sealed class KiwixDialog(
       neutralButtonText = R.string.rate_dialog_neutral
     ),
     HasBodyFormatArgs {
-    constructor(icon: IconItem?, activity: Activity) : this(
+    constructor(icon: IconItem?, activity: Activity, appName: String) : this(
       listOf(
         String.format(
           activity.getString(R.string.rate_dialog_msg),
-          (activity as CoreMainActivity).appName
+          appName
         )
       ),
       icon

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/downloader/DownloadManagerRequesterTest.kt
@@ -23,10 +23,8 @@ import com.tonyodev.fetch2.Fetch
 import com.tonyodev.fetch2.NetworkType
 import com.tonyodev.fetch2.Request
 import com.tonyodev.fetch2core.Func
-import io.mockk.Runs
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -42,6 +40,7 @@ import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.entities.DownloadRoomEntity
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadManagerRequester
+import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorServiceManager
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadRequest
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.AUTO_RETRY_MAX_ATTEMPTS
@@ -55,6 +54,7 @@ class DownloadManagerRequesterTest {
   private lateinit var downloadRoomDao: DownloadRoomDao
   private lateinit var requester: DownloadManagerRequester
   private lateinit var mainActivity: CoreMainActivity
+  private lateinit var downloadMonitorServiceManager: DownloadMonitorServiceManager
 
   @RegisterExtension
   @JvmField
@@ -67,10 +67,7 @@ class DownloadManagerRequesterTest {
     downloadRoomDao = mockk(relaxed = true)
     mainActivity = mockk(relaxed = true)
     context = mockk(relaxed = true)
-    every { context.getMainActivity() } returns mainActivity
-    every {
-      mainActivity.startDownloadMonitorServiceIfOngoingDownloads()
-    } just Runs
+    downloadMonitorServiceManager = mockk(relaxed = true)
     every { kiwixDataStore.selectedStorage } returns flowOf("/storage/emulated/0")
     every { kiwixDataStore.wifiOnly } returns flowOf(false)
   }
@@ -79,8 +76,8 @@ class DownloadManagerRequesterTest {
     requester = DownloadManagerRequester(
       fetch,
       kiwixDataStore,
-      context,
       downloadRoomDao,
+      downloadMonitorServiceManager,
       mainDispatcherRule.dispatcher
     )
   }
@@ -99,7 +96,7 @@ class DownloadManagerRequesterTest {
         func2 = any<Func<Error>>()
       )
     }
-    verify { mainActivity.startDownloadMonitorServiceIfOngoingDownloads() }
+    verify { downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads() }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -140,7 +137,7 @@ class DownloadManagerRequesterTest {
       )
     }
     advanceUntilIdle()
-    verify { mainActivity.startDownloadMonitorServiceIfOngoingDownloads() }
+    verify { downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads() }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -206,7 +203,7 @@ class DownloadManagerRequesterTest {
         func2 = any<Func<Error>>()
       )
     }
-    verify { mainActivity.startDownloadMonitorServiceIfOngoingDownloads() }
+    verify { downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads() }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -248,7 +245,7 @@ class DownloadManagerRequesterTest {
     requester.pauseResumeDownload(downloadId, isPause = false)
     advanceUntilIdle()
     verify { fetch.pause(id = downloadId.toInt()) }
-    verify { mainActivity.startDownloadMonitorServiceIfOngoingDownloads() }
+    verify { downloadMonitorServiceManager.startDownloadMonitorServiceIfOngoingDownloads() }
   }
 
   @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
Fixes #4983 

* Removed the `CoreMainActivity` dependency from `HotspotNotificationManager`. It now uses `PackageManager.getLaunchIntentForPackage()` to obtain the launcher activity intent.
* Fixed: Clicking the notification while the app is running in the background did not open the ZIM host screen.
* Removed the appName extra from `CoreMainActivity`, `ErrorActivity`, `HelpViewModel`, and `DownloadMonitorService`. Since the app name is now stored in `KiwixDataStore`, it can be retrieved directly when needed.
* Added `DownloadMonitorServiceManager` to manage starting and stopping `DownloadMonitorService`. This class is now injected into `CoreMainActivity` and `DownloadManagerRequester`, eliminating the need for an `Activity` reference.
* Refactored `DownloadManagerRequesterTest` to reflect these changes.