### PR TITLE
Added unit test cases for `ReadAloudManager`.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerRobot.kt
@@ -78,6 +78,7 @@ class CopyMoveFileHandlerRobot : BaseRobot() {
   fun assertStorageSelectionDialogDisplayed(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
       composeTestRule.apply {
+        waitForIdle()
         waitUntilTimeout()
         onNodeWithTag(STORAGE_SELECTION_DIALOG_TITLE_TESTING_TAG)
           .assertTextEquals(context.getString(R.string.choose_storage_to_copy_move_zim_file))

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -35,7 +35,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
@@ -231,28 +230,12 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
   private fun showMoveFileToPublicDirectoryDialog(urisList: List<Uri>) {
     composeTestRule.runOnIdle {
       kiwixMainActivity = composeTestRule.activity
-
       val localLibraryViewModel = ViewModelProvider(
-        kiwixMainActivity,
+        kiwixMainActivity.navController.getBackStackEntry(KiwixDestination.Library.route),
         kiwixMainActivity.viewModelFactory
       )[LocalLibraryViewModel::class.java]
-
-      val validateZimViewModel = ViewModelProvider(
-        kiwixMainActivity,
-        kiwixMainActivity.viewModelFactory
-      )[ValidateZimViewModel::class.java]
-      val storageDeviceList = runBlocking { kiwixMainActivity.getStorageDeviceList() }
-      localLibraryViewModel.initialize(
-        storageDeviceList = storageDeviceList,
-        validateZimViewModel = validateZimViewModel,
-        kiwixMainActivity.alertDialogShower,
-        kiwixMainActivity.snackBarHostState
-      )
       kiwixMainActivity.lifecycleScope.launch {
         localLibraryViewModel.handleSelectedFileUri(urisList)
-        localLibraryViewModel.sideEffects.collect { effect ->
-          effect.invokeWith(kiwixMainActivity)
-        }
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -33,7 +33,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
@@ -126,26 +125,11 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
       kiwixMainActivity = composeTestRule.activity
 
       val localLibraryViewModel = ViewModelProvider(
-        kiwixMainActivity,
+        kiwixMainActivity.navController.getBackStackEntry(KiwixDestination.Library.route),
         kiwixMainActivity.viewModelFactory
       )[LocalLibraryViewModel::class.java]
-
-      val validateZimViewModel = ViewModelProvider(
-        kiwixMainActivity,
-        kiwixMainActivity.viewModelFactory
-      )[ValidateZimViewModel::class.java]
-      val storageDeviceList = runBlocking { kiwixMainActivity.getStorageDeviceList() }
-      localLibraryViewModel.initialize(
-        storageDeviceList = storageDeviceList,
-        validateZimViewModel = validateZimViewModel,
-        kiwixMainActivity.alertDialogShower,
-        kiwixMainActivity.snackBarHostState
-      )
       kiwixMainActivity.lifecycleScope.launch {
         localLibraryViewModel.handleSelectedFileUri(urisList)
-        localLibraryViewModel.sideEffects.collect { effect ->
-          effect.invokeWith(kiwixMainActivity)
-        }
       }
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
@@ -79,9 +78,7 @@ class LocalLibraryTest : BaseActivityTest() {
         kiwixMainActivity,
         kiwixMainActivity.viewModelFactory
       )[ValidateZimViewModel::class.java]
-      val storageDeviceList = runBlocking { kiwixMainActivity.getStorageDeviceList() }
       localLibraryViewModel.initialize(
-        storageDeviceList = storageDeviceList,
         validateZimViewModel = validateZimViewModel,
         kiwixMainActivity.alertDialogShower,
         kiwixMainActivity.snackBarHostState

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -48,8 +48,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
-import eu.mhutti1.utils.storage.StorageDevice
-import eu.mhutti1.utils.storage.StorageDeviceUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -85,6 +83,7 @@ import org.kiwix.kiwixmobile.core.main.ZIM_FILE_URI_KEY
 import org.kiwix.kiwixmobile.core.main.ZIM_HOST_DEEP_LINK_SCHEME
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Companion.CONTENT_PREFIX
 import org.kiwix.kiwixmobile.core.utils.HUNDERED
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.kiwixActivityComponent
 import org.kiwix.kiwixmobile.ui.KiwixDestination
@@ -102,6 +101,8 @@ class KiwixMainActivity : CoreMainActivity() {
   @Inject lateinit var libkiwixBookOnDisk: LibkiwixBookOnDisk
 
   @Inject lateinit var libkiwixBookmarks: LibkiwixBookmarks
+
+  @Inject lateinit var storageDeviceProvider: StorageDeviceProvider
 
   @Inject
   @MainDispatcher
@@ -130,7 +131,6 @@ class KiwixMainActivity : CoreMainActivity() {
     NavController.OnDestinationChangedListener { _, _, _ ->
       actionMode?.finish()
     }
-  private val storageDeviceList = arrayListOf<StorageDevice>()
   private val pendingIntentFlow = MutableStateFlow<Intent?>(null)
 
   @OptIn(ExperimentalMaterial3Api::class)
@@ -242,7 +242,7 @@ class KiwixMainActivity : CoreMainActivity() {
   private suspend fun migrateInternalToPublicAppDirectory() {
     if (!kiwixDataStore.isAppDirectoryMigrated.first()) {
       val storagePath =
-        getStorageDeviceList()
+        storageDeviceProvider.getWritableStorage()
           .getOrNull(kiwixDataStore.selectedStoragePosition.first())
           ?.name
       storagePath?.let {
@@ -259,23 +259,6 @@ class KiwixMainActivity : CoreMainActivity() {
       )
       kiwixDataStore.putPerAppLanguageMigration(true)
     }
-  }
-
-  /**
-   * Fetches the storage device list once in the main activity and reuses it across all screens.
-   * This is necessary because retrieving the storage device list, especially on devices with large SD cards,
-   * is a resource-intensive operation. Performing this operation repeatedly in screens can negatively
-   * affect the user experience, as it takes time and can block the UI.
-   *
-   * If a screen is destroyed and we need to retrieve the device list again, performing the operation
-   * repeatedly leads to inefficiency. To optimize this, we fetch the storage device list once and reuse
-   * it in all screens, thereby reducing redundant processing and improving performance.
-   */
-  suspend fun getStorageDeviceList(): List<StorageDevice> {
-    if (storageDeviceList.isEmpty()) {
-      storageDeviceList.addAll(StorageDeviceUtils.getWritableStorage(this, ioDispatcher))
-    }
-    return storageDeviceList
   }
 
   override fun onStart() {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/CopyMoveFileHandler.kt
@@ -143,6 +143,10 @@ class CopyMoveFileHandler @Inject constructor(
     lifecycleScope = coroutineScope
   }
 
+  private fun requireLifeCycleScope() = requireNotNull(lifecycleScope) {
+    "LifecycleScope is not set. Call CopyMoveFileHandler.setLifeCycleScope before using it"
+  }
+
   fun showStorageSelectDialog(storageDeviceList: List<StorageDevice>) {
     val dialogConfig = StorageSelectDialogConfig(
       storageDeviceList = storageDeviceList,
@@ -151,7 +155,7 @@ class CopyMoveFileHandler @Inject constructor(
       kiwixDataStore = kiwixDataStore,
       storageCalculator = storageCalculator,
       onSelectAction = { storageDevice ->
-        lifecycleScope?.launch {
+        requireLifeCycleScope().launch {
           copyMoveZIMFileInSelectedStorage(storageDevice)
         }
       }
@@ -234,7 +238,7 @@ class CopyMoveFileHandler @Inject constructor(
 
   fun observeFileSystemState() {
     if (storageObservingJob?.isActive == true) return
-    storageObservingJob = lifecycleScope?.launch {
+    storageObservingJob = requireLifeCycleScope().launch {
       // Wait until filesystem detection completes
       fat32Checker.fileSystemStates.first { it != DetectingFileSystem }
       copyMoveProgressBarController.hidePreparingCopyMoveDialog()
@@ -263,13 +267,13 @@ class CopyMoveFileHandler @Inject constructor(
   }
 
   private fun onCopyClicked(showStorageSelectionDialog: Boolean) {
-    lifecycleScope?.launch {
+    requireLifeCycleScope().launch {
       performCopyOperation(showStorageSelectionDialog)
     }
   }
 
   private fun onMoveClicked(showStorageSelectionDialog: Boolean) {
-    lifecycleScope?.launch {
+    requireLifeCycleScope().launch {
       performMoveOperation(showStorageSelectionDialog)
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModel.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import eu.mhutti1.utils.storage.StorageDevice
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -204,7 +203,6 @@ class LocalLibraryViewModel @Inject constructor(
   internal val requestFileSystemCheck = MutableSharedFlow<Unit>()
 
   fun initialize(
-    storageDeviceList: List<StorageDevice>,
     validateZimViewModel: ValidateZimViewModel,
     alertDialogShower: AlertDialogShower,
     snackBarHostState: SnackbarHostState
@@ -213,7 +211,6 @@ class LocalLibraryViewModel @Inject constructor(
     this.alertDialogShower = alertDialogShower
     processSelectedZimFilesForStandalone.init(this)
     processSelectedZimFilesForPlayStore.init(
-      storageDeviceList = storageDeviceList,
       lifecycleScope = viewModelScope,
       alertDialogShower = alertDialogShower,
       snackBarHostState = snackBarHostState,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/ProcessSelectedZimFilesForPlayStore.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/ProcessSelectedZimFilesForPlayStore.kt
@@ -37,6 +37,7 @@ import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.ui.components.ONE
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
@@ -62,14 +63,14 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
   private val context: Context,
   private val copyMoveFileHandler: CopyMoveFileHandler,
-  private val storageCalculator: StorageCalculator
+  private val storageCalculator: StorageCalculator,
+  private val storageDeviceProvider: StorageDeviceProvider
 ) : CopyMoveFileHandler.FileCopyMoveCallback {
   private var snackBarHostState: SnackbarHostState? = null
   private var selectedZimFileCallback: SelectedZimFileCallback? = null
   private var lifecycleScope: CoroutineScope? = null
   private var alertDialogShower: AlertDialogShower? = null
   private var isSingleFileSelected = false
-  private var storageDeviceList: List<StorageDevice> = emptyList()
 
   /**
    * Manages the selected action by user when processing the multiple files.
@@ -83,13 +84,11 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
    * Must be called before using this class.
    */
   fun init(
-    storageDeviceList: List<StorageDevice>,
     lifecycleScope: CoroutineScope,
     alertDialogShower: AlertDialogShower,
     snackBarHostState: SnackbarHostState,
     selectedZimFileCallback: SelectedZimFileCallback
   ) {
-    this.storageDeviceList = storageDeviceList
     this.lifecycleScope = lifecycleScope
     this.selectedZimFileCallback = selectedZimFileCallback
     this.alertDialogShower = alertDialogShower
@@ -181,7 +180,7 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
     }
 
     copyMoveFileHandler.showMoveFileToPublicDirectoryDialog(
-      storageDeviceList,
+      storageDeviceProvider.getWritableStorage(),
       uri,
       documentFile,
       // pass if fileName is null then we will validate it after copying/moving
@@ -302,15 +301,18 @@ class ProcessSelectedZimFilesForPlayStore @Inject constructor(
       actionLabel = context.getString(string.change_storage),
       lifecycleScope = requireLifecycleScope(),
       actionClick = {
-        val dialogConfig = StorageSelectDialogConfig(
-          storageDeviceList = storageDeviceList,
-          title = context.getString(string.pref_storage),
-          shouldShowCheckboxSelected = true,
-          kiwixDataStore = kiwixDataStore,
-          storageCalculator = storageCalculator,
-          onSelectAction = ::storeDeviceInPreferences
-        )
-        showStorageSelectionDialog(dialogConfig)
+        requireLifecycleScope().runSafelyInLifecycleScope {
+          val storageDeviceList = storageDeviceProvider.getWritableStorage()
+          val dialogConfig = StorageSelectDialogConfig(
+            storageDeviceList = storageDeviceList,
+            title = context.getString(string.pref_storage),
+            shouldShowCheckboxSelected = true,
+            kiwixDataStore = kiwixDataStore,
+            storageCalculator = storageCalculator,
+            onSelectAction = ::storeDeviceInPreferences
+          )
+          showStorageSelectionDialog(dialogConfig)
+        }
       }
     )
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryRoute.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryRoute.kt
@@ -132,7 +132,6 @@ fun OnlineLibraryRoute(
       }
     },
     navHostController = navController,
-    activity = activity,
     navigationIcon = {
       NavigationIcon(
         iconItem = if (uiState.isSearchActive) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -98,7 +98,6 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.THREE_DP
 import org.kiwix.kiwixmobile.core.utils.FIVE
 import org.kiwix.kiwixmobile.core.utils.ZERO
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryUiState
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem
@@ -125,7 +124,6 @@ fun OnlineLibraryScreen(
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
   onUserBackPressed: () -> BackPressActivityExtensions.Super,
   navHostController: NavHostController,
-  activity: KiwixMainActivity,
   navigationIcon: @Composable () -> Unit
 ) {
   val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -162,8 +160,7 @@ fun OnlineLibraryScreen(
         paddingValues,
         onUserBackPressed,
         navHostController,
-        listState,
-        activity
+        listState
       )
     }
   }
@@ -177,8 +174,7 @@ private fun OnlineLibraryMainContent(
   paddingValues: PaddingValues,
   onUserBackPressed: () -> BackPressActivityExtensions.Super,
   navHostController: NavHostController,
-  listState: LazyListState,
-  activity: KiwixMainActivity
+  listState: LazyListState
 ) {
   SwipeRefreshLayout(
     isRefreshing = uiState.isRefreshing && !uiState.showScanningProgressBar,
@@ -193,7 +189,7 @@ private fun OnlineLibraryMainContent(
       )
   ) {
     OnBackPressed(onUserBackPressed, navHostController)
-    OnlineLibraryScreenContent(uiState, listState, onlineLibraryViewModel, activity)
+    OnlineLibraryScreenContent(uiState, listState, onlineLibraryViewModel)
   }
 }
 
@@ -256,8 +252,7 @@ private fun searchBarIfActive(
 private fun OnlineLibraryScreenContent(
   uiState: OnlineLibraryUiState,
   lazyListState: LazyListState,
-  onlineLibraryViewModel: OnlineLibraryViewModel,
-  activity: KiwixMainActivity
+  onlineLibraryViewModel: OnlineLibraryViewModel
 ) {
   Box(
     modifier = Modifier.fillMaxSize(),
@@ -266,7 +261,7 @@ private fun OnlineLibraryScreenContent(
     if (uiState.showNoContent) {
       NoContentView(uiState.noContentMessage)
     } else {
-      OnlineLibraryList(uiState, lazyListState, onlineLibraryViewModel, activity)
+      OnlineLibraryList(uiState, lazyListState, onlineLibraryViewModel)
     }
     if (uiState.showScanningProgressBar) {
       ShowFetchingLibraryLayout(uiState.scanningProgressBarMessage)
@@ -279,8 +274,7 @@ private fun OnlineLibraryScreenContent(
 private fun OnlineLibraryList(
   state: OnlineLibraryUiState,
   lazyListState: LazyListState,
-  onlineLibraryViewModel: OnlineLibraryViewModel,
-  activity: KiwixMainActivity
+  onlineLibraryViewModel: OnlineLibraryViewModel
 ) {
   LazyColumn(
     modifier = Modifier
@@ -297,7 +291,7 @@ private fun OnlineLibraryList(
           item = item,
           onlineLibraryViewModel.bookUtils,
           onlineLibraryViewModel.availableSpaceCalculator
-        ) { onlineLibraryViewModel.onBookItemClick(it, activity) }
+        ) { onlineLibraryViewModel.onBookItemClick(it) }
 
         is LibraryListItem.LibraryDownloadItem -> DownloadBookItem(
           index = index,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
@@ -63,6 +63,7 @@ import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -135,6 +136,7 @@ class OnlineLibraryViewModel @Inject constructor(
   private val observeOnlineLibrary: ObserveOnlineLibrary,
   private val refreshLibraryAction: ResolveRefreshLibraryAction,
   private val observeNetworkState: ObserveNetworkState,
+  private val storageDeviceProvider: StorageDeviceProvider,
   @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
   data class OnlineLibraryRequest(
@@ -564,15 +566,15 @@ class OnlineLibraryViewModel @Inject constructor(
     }
   }
 
-  fun onBookItemClick(item: BookItem, activity: KiwixMainActivity) {
+  fun onBookItemClick(item: BookItem) {
     viewModelScope.launch {
       downloadBookItem = item
       val action = resolveBookClickAction.onBookItemClick(
         item,
-        activity.getStorageDeviceList().size
+        storageDeviceProvider.getWritableStorage().size
       )
       when (action) {
-        ShowStorageSelection -> showStorageSelectDialog(activity, false)
+        ShowStorageSelection -> showStorageSelectDialog(false)
         is StartDownload -> downloadFile()
         NoInternet -> emitNoInternetSnackbar()
         RequestStoragePermission -> sendUiEvent(RequestPermission(WRITE_EXTERNAL_STORAGE))
@@ -592,18 +594,18 @@ class OnlineLibraryViewModel @Inject constructor(
           positiveAction = {
             viewModelScope.launch {
               kiwixDataStore.setWifiOnly(false)
-              onBookItemClick(item, activity)
+              onBookItemClick(item)
             }
           }
         )
 
         DisableStorageSelection -> {
           kiwixDataStore.setShowStorageOption(false)
-          onBookItemClick(item, activity)
+          onBookItemClick(item)
         }
 
         is NotEnoughSpace -> emitNoSpaceSnackbar(context, action.availableSpace) {
-          showStorageSelectDialog(activity, true)
+          showStorageSelectDialog(true)
         }
 
         else -> Unit
@@ -646,22 +648,22 @@ class OnlineLibraryViewModel @Inject constructor(
     sendUiEvent(NavigateToAppSettings)
   }
 
-  fun showStorageSelectDialog(activity: KiwixMainActivity, showCheckboxSelected: Boolean) {
+  private fun showStorageSelectDialog(showCheckboxSelected: Boolean) {
     viewModelScope.launch {
       val dialogConfig = StorageSelectDialogConfig(
         title = context.getString(R.string.choose_storage_to_download_book),
         titleSize = STORAGE_SELECT_STORAGE_TITLE_TEXTVIEW_SIZE,
-        storageDeviceList = activity.getStorageDeviceList(),
+        storageDeviceList = storageDeviceProvider.getWritableStorage(),
         storageCalculator = availableSpaceCalculator.storageCalculator,
         kiwixDataStore = kiwixDataStore,
         shouldShowCheckboxSelected = showCheckboxSelected,
-        onSelectAction = { onStorageDeviceClick(it, activity) }
+        onSelectAction = { onStorageDeviceClick(it) }
       )
       sendUiEvent(SideEffects(UISideEffects.StorageSelectionDialog(dialogConfig)))
     }
   }
 
-  private fun onStorageDeviceClick(device: StorageDevice, activity: KiwixMainActivity) {
+  private fun onStorageDeviceClick(device: StorageDevice) {
     viewModelScope.launch {
       kiwixDataStore.setShowStorageOption(false)
       kiwixDataStore.setSelectedStorage(
@@ -675,7 +677,7 @@ class OnlineLibraryViewModel @Inject constructor(
         }
       )
       downloadBookItem?.let {
-        onBookItemClick(it, activity)
+        onBookItemClick(it)
       }
     }
   }
@@ -794,7 +796,7 @@ class OnlineLibraryViewModel @Inject constructor(
 
   fun onNotificationPermissionResult(isGranted: Boolean, activity: KiwixMainActivity) {
     if (isGranted) {
-      downloadBookItem?.let { onBookItemClick(it, activity) }
+      downloadBookItem?.let { onBookItemClick(it) }
       return
     }
     if (!permissionChecker.shouldShowRationale(activity, POST_NOTIFICATIONS)) {
@@ -807,7 +809,7 @@ class OnlineLibraryViewModel @Inject constructor(
 
   fun onStoragePermissionResult(isGranted: Boolean, activity: KiwixMainActivity) {
     if (isGranted) {
-      downloadBookItem?.let { onBookItemClick(it, activity) }
+      downloadBookItem?.let { onBookItemClick(it) }
       return
     }
     if (permissionChecker.shouldShowRationale(activity, WRITE_EXTERNAL_STORAGE)) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsViewModel.kt
@@ -28,12 +28,11 @@ import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.data.DataSource
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.settings.viewmodel.CoreSettingsViewModel
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
-import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import javax.inject.Inject
 
 @Suppress("LongParameterList")
@@ -44,7 +43,8 @@ class KiwixSettingsViewModel @Inject constructor(
   storageCalculator: StorageCalculator,
   themeConfig: ThemeConfig,
   libkiwixBookmarks: LibkiwixBookmarks,
-  kiwixPermissionChecker: KiwixPermissionChecker
+  kiwixPermissionChecker: KiwixPermissionChecker,
+  storageDeviceProvider: StorageDeviceProvider
 ) : CoreSettingsViewModel(
     context,
     kiwixDataStore,
@@ -52,10 +52,11 @@ class KiwixSettingsViewModel @Inject constructor(
     storageCalculator,
     themeConfig,
     libkiwixBookmarks,
-    kiwixPermissionChecker
+    kiwixPermissionChecker,
+    storageDeviceProvider,
   ) {
   private var storageDeviceList: List<StorageDevice> = listOf()
-  override suspend fun setStorage(coreMainActivity: CoreMainActivity) {
+  override suspend fun setStorage() {
     settingsUiState.update { it.copy(shouldShowStorageCategory = true) }
     if (storageDeviceList.isNotEmpty()) {
       // update the storage when user switch to other storage.
@@ -63,7 +64,7 @@ class KiwixSettingsViewModel @Inject constructor(
       return
     }
     showHideProgressBarWhileFetchingStorageInfo(true)
-    storageDeviceList = (coreMainActivity as KiwixMainActivity).getStorageDeviceList()
+    storageDeviceList = storageDeviceProvider.getWritableStorage()
     showHideProgressBarWhileFetchingStorageInfo(false)
     setUpStoragePreference()
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/ui/KiwixNavGraph.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ui/KiwixNavGraph.kt
@@ -120,13 +120,11 @@ fun KiwixNavGraph(
         }
       )
     ) { backStackEntry ->
-      val activity = LocalActivity.current as KiwixMainActivity
       val validateZimViewModel: ValidateZimViewModel = viewModel(factory = viewModelFactory)
       val localLibraryViewModel: LocalLibraryViewModel = viewModel(factory = viewModelFactory)
       LaunchedEffect(Unit) {
         localLibraryViewModel.apply {
           initialize(
-            activity.getStorageDeviceList(),
             validateZimViewModel,
             alertDialogShower,
             snackBarHostState

--- a/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForPlayStoreTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForPlayStoreTest.kt
@@ -52,6 +52,7 @@ import org.kiwix.kiwixmobile.R.string
 import org.kiwix.kiwixmobile.core.extensions.snack
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.nav.destination.library.CopyMoveFileHandler
@@ -67,6 +68,7 @@ class ProcessSelectedZimFilesForPlayStoreTest {
   private val activity: Activity = mockk(relaxed = true)
   private val copyMoveFileHandler: CopyMoveFileHandler = mockk(relaxed = true)
   private val storageCalculator: StorageCalculator = mockk(relaxed = true)
+  private val storageDeviceProvider: StorageDeviceProvider = mockk(relaxed = true)
   private val alertDialogShower: AlertDialogShower = mockk(relaxed = true)
   private val snackBarHostState: SnackbarHostState = mockk(relaxed = true)
 
@@ -86,11 +88,11 @@ class ProcessSelectedZimFilesForPlayStoreTest {
       kiwixDataStore,
       activity,
       copyMoveFileHandler,
-      storageCalculator
+      storageCalculator,
+      storageDeviceProvider
     )
 
     processSelectedZimFiles.init(
-      emptyList(),
       testScope,
       alertDialogShower,
       snackBarHostState,
@@ -156,7 +158,7 @@ class ProcessSelectedZimFilesForPlayStoreTest {
       }
 
       actionClickSlot.captured?.invoke()
-
+      advanceUntilIdle()
       verify {
         selectedZimFileCallback.showStorageSelectionDialog(any())
       }

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryViewModelTest.kt
@@ -127,7 +127,6 @@ class LocalLibraryViewModelTest {
       mainDispatcherRule.dispatcher
     )
     vm.initialize(
-      emptyList(),
       validateZimViewModel,
       alertDialogShower,
       snackBarHostState
@@ -430,7 +429,6 @@ class LocalLibraryViewModelTest {
     }
     verify {
       processSelectedZimFilesForPlayStore.init(
-        storageDeviceList = any(),
         lifecycleScope = any(),
         alertDialogShower = alertDialogShower,
         snackBarHostState = snackBarHostState,

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreenTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreenTest.kt
@@ -112,7 +112,6 @@ class OnlineLibraryScreenTest {
         bottomAppBarScrollBehaviour = null,
         onUserBackPressed = onBackPressed,
         navHostController = navHostController,
-        activity = mockk(relaxed = true),
         navigationIcon = {}
       )
     }
@@ -372,7 +371,7 @@ class OnlineLibraryScreenTest {
       .onAllNodesWithTag(ONLINE_BOOK_ITEM_TESTING_TAG)[0]
       .performClick()
 
-    verify { viewModel.onBookItemClick(item, any()) }
+    verify { viewModel.onBookItemClick(item) }
   }
 
   @Test
@@ -389,7 +388,7 @@ class OnlineLibraryScreenTest {
       .onAllNodesWithTag(ONLINE_BOOK_ITEM_TESTING_TAG)[0]
       .performClick()
 
-    verify(exactly = ZERO) { viewModel.onBookItemClick(any(), any()) }
+    verify(exactly = ZERO) { viewModel.onBookItemClick(any()) }
   }
 
   @Test

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -55,6 +55,7 @@ import org.kiwix.kiwixmobile.core.downloader.Downloader
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.zim_manager.ConnectivityBroadcastReceiver
@@ -80,6 +81,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefres
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.WifiOnlyBlocked
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -92,7 +94,6 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibr
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowDialog
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowNoSpaceSnackbar
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowSnackbar
-import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem
 import org.kiwix.sharedFunctions.MainDispatcherRule
@@ -119,6 +120,7 @@ class OnlineLibraryViewModelTest {
   private val observeLibrary: ObserveOnlineLibrary = mockk(relaxed = true)
   private val refreshAction: ResolveRefreshLibraryAction = mockk(relaxed = true)
   private val observeNetwork: ObserveNetworkState = mockk(relaxed = true)
+  private val storageDeviceProvider: StorageDeviceProvider = mockk(relaxed = true)
   private lateinit var viewModel: OnlineLibraryViewModel
 
   @BeforeEach
@@ -153,6 +155,7 @@ class OnlineLibraryViewModelTest {
       observeLibrary,
       refreshAction,
       observeNetwork,
+      storageDeviceProvider,
       dispatcherRule.dispatcher
     )
     viewModel.networkBooks.tryEmit(emptyList())
@@ -241,12 +244,11 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is StartDownload then triggers download`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(item, any()) } returns
         StartDownload(item)
 
-      viewModel.onBookItemClick(item, activity)
+      viewModel.onBookItemClick(item)
 
       advanceUntilIdle()
 
@@ -256,12 +258,11 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is NoInternet then emits snackbar`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(any(), any()) } returns
         NoInternet
       viewModel.uiEvents.test {
-        viewModel.onBookItemClick(item, activity)
+        viewModel.onBookItemClick(item)
 
         advanceUntilIdle()
         val snackBar = awaitItem() as ShowSnackbar
@@ -274,12 +275,11 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is RequestStoragePermission then emits permission event`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(any(), any()) } returns RequestStoragePermission
 
       viewModel.uiEvents.test {
-        viewModel.onBookItemClick(item, activity)
+        viewModel.onBookItemClick(item)
         advanceUntilIdle()
         val permission = awaitItem() as RequestPermission
         assertTrue(permission.permission == WRITE_EXTERNAL_STORAGE)
@@ -291,11 +291,10 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is RequestNotificationPermission then emits permission event`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
       coEvery { resolveClick.onBookItemClick(any(), any()) } returns RequestNotificationPermission
 
       viewModel.uiEvents.test {
-        viewModel.onBookItemClick(item, activity)
+        viewModel.onBookItemClick(item)
         advanceUntilIdle()
         val permission = awaitItem() as RequestPermission
         assertTrue(permission.permission == POST_NOTIFICATIONS)
@@ -308,7 +307,6 @@ class OnlineLibraryViewModelTest {
     fun `when action is RequestManageExternalFilesPermission then emits permission event`() =
       runTest {
         val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-        val activity = mockk<KiwixMainActivity>(relaxed = true)
         coEvery {
           resolveClick.onBookItemClick(
             any(),
@@ -317,7 +315,7 @@ class OnlineLibraryViewModelTest {
         } returns RequestManageExternalFilesPermission
 
         viewModel.uiEvents.test {
-          viewModel.onBookItemClick(item, activity)
+          viewModel.onBookItemClick(item)
           advanceUntilIdle()
           val dialog = awaitItem() as ShowDialog
           assertTrue(dialog.dialog == KiwixDialog.ManageExternalFilesPermissionDialog)
@@ -330,12 +328,11 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is ShowWifiOnlyDialog then shows dialog`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(any(), any()) } returns ShowWifiOnlyDialog
 
       viewModel.uiEvents.test {
-        viewModel.onBookItemClick(item, activity)
+        viewModel.onBookItemClick(item)
         advanceUntilIdle()
 
         val dialog = awaitItem() as ShowDialog
@@ -347,12 +344,11 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is NotEnoughSpace then shows no space snackbar`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(any(), any()) } returns NotEnoughSpace("100MB")
 
       viewModel.uiEvents.test {
-        viewModel.onBookItemClick(item, activity)
+        viewModel.onBookItemClick(item)
         advanceUntilIdle()
         val snackBar = awaitItem() as ShowNoSpaceSnackbar
         assertTrue(snackBar.message.contains("100MB"))
@@ -363,13 +359,12 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when action is DisableStorageSelection then it sets the showStorageOption`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery { resolveClick.onBookItemClick(any(), any()) } returnsMany listOf(
         DisableStorageSelection,
         StartDownload(item)
       )
-      viewModel.onBookItemClick(item, activity)
+      viewModel.onBookItemClick(item)
       advanceUntilIdle()
       coVerify { kiwixDataStore.setShowStorageOption(false) }
       verify { downloader.download(item.book) }
@@ -524,6 +519,7 @@ class OnlineLibraryViewModelTest {
         observeLibrary,
         refreshAction,
         observeNetwork,
+        storageDeviceProvider,
         dispatcherRule.dispatcher
       )
       verify(exactly = 0) { downloaderProvider.get() }
@@ -532,7 +528,6 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `downloaderProvider is called only when download is triggered`() = runTest {
       val item = mockk<LibraryListItem.BookItem>(relaxed = true)
-      val activity = mockk<KiwixMainActivity>(relaxed = true)
 
       coEvery {
         resolveClick.onBookItemClick(item, any())
@@ -540,7 +535,7 @@ class OnlineLibraryViewModelTest {
 
       verify(exactly = 0) { downloaderProvider.get() }
 
-      viewModel.onBookItemClick(item, activity)
+      viewModel.onBookItemClick(item)
 
       advanceUntilIdle()
 
@@ -761,11 +756,11 @@ class OnlineLibraryViewModelTest {
       viewModel.downloadBookItem = item
 
       val spyVm = spyk(viewModel)
-      every { spyVm.onBookItemClick(item, activity) } just Runs
+      every { spyVm.onBookItemClick(item) } just Runs
 
       spyVm.onNotificationPermissionResult(true, activity)
 
-      verify { spyVm.onBookItemClick(item, activity) }
+      verify { spyVm.onBookItemClick(item) }
     }
 
     @Test
@@ -816,11 +811,11 @@ class OnlineLibraryViewModelTest {
       viewModel.downloadBookItem = item
 
       val spyVm = spyk(viewModel)
-      every { spyVm.onBookItemClick(item, activity) } just Runs
+      every { spyVm.onBookItemClick(item) } just Runs
 
       spyVm.onStoragePermissionResult(true, activity)
 
-      verify { spyVm.onBookItemClick(item, activity) }
+      verify { spyVm.onBookItemClick(item) }
     }
 
     @Test

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/settings/BrandedSettingsViewModel.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/settings/BrandedSettingsViewModel.kt
@@ -23,10 +23,10 @@ import kotlinx.coroutines.flow.update
 import org.kiwix.kiwixmobile.core.ThemeConfig
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.data.DataSource
-import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.settings.StorageCalculator
 import org.kiwix.kiwixmobile.core.settings.viewmodel.CoreSettingsViewModel
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.custom.BuildConfig
 import javax.inject.Inject
@@ -39,7 +39,8 @@ class BrandedSettingsViewModel @Inject constructor(
   storageCalculator: StorageCalculator,
   themeConfig: ThemeConfig,
   libkiwixBookmarks: LibkiwixBookmarks,
-  kiwixPermissionChecker: KiwixPermissionChecker
+  kiwixPermissionChecker: KiwixPermissionChecker,
+  storageDeviceProvider: StorageDeviceProvider
 ) : CoreSettingsViewModel(
     context,
     kiwixDataStore,
@@ -47,9 +48,10 @@ class BrandedSettingsViewModel @Inject constructor(
     storageCalculator,
     themeConfig,
     libkiwixBookmarks,
-    kiwixPermissionChecker
+    kiwixPermissionChecker,
+    storageDeviceProvider
   ) {
-  override suspend fun setStorage(coreMainActivity: CoreMainActivity) {
+  override suspend fun setStorage() {
     settingsUiState.update {
       it.copy(
         shouldShowStorageCategory = false,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/components/CoreComponent.kt
@@ -61,6 +61,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.search.viewmodel.SearchResultGenerator
 import org.kiwix.kiwixmobile.core.utils.BookUtils
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Singleton
 
@@ -126,4 +127,5 @@ interface CoreComponent {
   fun providePdfPrinter(): PdfPrint
   fun provideTabsManager(): TabsManager
   fun provideReaderIntentManager(): ReaderIntentManager
+  fun provideStorageDeviceProvider(): StorageDeviceProvider
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
@@ -1034,10 +1034,12 @@ abstract class CoreReaderViewModel(
 
   open suspend fun openZimFile(zimReaderSource: ZimReaderSource) {
     if (isBrandedApp() || kiwixPermissionChecker.hasReadExternalStoragePermission()) {
+      // Destroy all existing WebViews before opening a new ZIM file.
+      // Each WebView is associated with the currently opened archive, so they
+      // must be recreated to avoid retaining references to the previous ZIM.
+      readerWebViewManager.destroyAllTabs()
       val result =
-        zimFileManager.openZimFileInReader(zimReaderSource, shouldShowSpellCheckedSuggestions()) {
-          readerWebViewManager.destroyAllTabs()
-        }
+        zimFileManager.openZimFileInReader(zimReaderSource, shouldShowSpellCheckedSuggestions())
       when (result) {
         is Success -> {
           // Show content if there is `Open Library` button showing

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenRoute.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenRoute.kt
@@ -107,7 +107,7 @@ fun ReaderScreenRoute(
         viewModel.viewModelScope.launch {
           viewModel.readerWebViewManager.destroyAllTabs()
         }
-      }
+      }.onFailure { it.printStackTrace() }
     }
   }
   CollectFileSearched(navHostController, viewModel)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/ReadAloudManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/ReadAloudManager.kt
@@ -61,7 +61,6 @@ class ReadAloudManager @Inject constructor(
 
   private var ttsStateCallback: ((TtsState) -> Unit)? = null
   var tts: KiwixTextToSpeech? = null
-  private var isReadAloudServiceRunning = false
 
   // This is for if the read aloud is currently reading the selected text inside webView.
   private var isReadSelection = false
@@ -73,61 +72,66 @@ class ReadAloudManager @Inject constructor(
   }
 
   private fun requireTtsStateCallback() = requireNotNull(ttsStateCallback) {
-    "TtsState callback is set. Set ReadAloudManager.setTtsStateCallback before using it"
+    "TtsState callback is not set. Set ReadAloudManager.setTtsStateCallback before using it"
   }
 
   private fun requireTts() = requireNotNull(tts) {
     "KiwixTextToSpeech is not initialized. Call ReadAloudManager.setUpTTS before using it"
   }
 
+  private fun dispatchState(state: TtsState) {
+    requireTtsStateCallback().invoke(state)
+  }
+
   fun isTtsInitialed() = requireTts().isInitialized
+
+  private val initListener = object : OnInitSucceedListener {
+    override fun onInitSucceed() {
+      dispatchState(if (isReadSelection) StartReadSelection else StartReadAloud)
+    }
+  }
+
+  private val speakingListener = object : OnSpeakingListener {
+    override fun onSpeakingStarted() {
+      dispatchState(SpeakingStarted)
+      setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, false)
+    }
+
+    override fun onSpeakingEnded() {
+      dispatchState(SpeakingEnded)
+      setActionAndStartTTSService(ACTION_STOP_TTS)
+    }
+  }
+
+  private val audioFocusChangedListener = OnAudioFocusChangeListener { focusChange: Int ->
+    val tts = tts ?: return@OnAudioFocusChangeListener
+    Log.d(TAG_KIWIX, "Focus change: $focusChange")
+    tts.currentTTSTask?.let {
+      tts.stop()
+      setActionAndStartTTSService(ACTION_STOP_TTS)
+      return@OnAudioFocusChangeListener
+    }
+    when (focusChange) {
+      AudioManager.AUDIOFOCUS_LOSS -> {
+        if (tts.currentTTSTask?.paused == false) tts.pauseOrResume()
+        dispatchState(AudioFocusLoss)
+        setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, true)
+      }
+
+      AudioManager.AUDIOFOCUS_GAIN -> {
+        dispatchState(AudioFocusGain)
+        setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, false)
+      }
+    }
+  }
 
   fun setUpTTS() {
     tts =
       KiwixTextToSpeech(
         context,
-        object : OnInitSucceedListener {
-          override fun onInitSucceed() {
-            if (isReadSelection) {
-              requireTtsStateCallback().invoke(StartReadSelection)
-            } else {
-              requireTtsStateCallback().invoke(StartReadAloud)
-            }
-          }
-        },
-        object : OnSpeakingListener {
-          override fun onSpeakingStarted() {
-            requireTtsStateCallback().invoke(SpeakingStarted)
-            setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, false)
-          }
-
-          override fun onSpeakingEnded() {
-            requireTtsStateCallback().invoke(SpeakingEnded)
-            setActionAndStartTTSService(ACTION_STOP_TTS)
-          }
-        },
-        OnAudioFocusChangeListener label@{ focusChange: Int ->
-          if (tts != null) {
-            Log.d(TAG_KIWIX, "Focus change: $focusChange")
-            tts?.currentTTSTask?.let {
-              tts?.stop()
-              setActionAndStartTTSService(ACTION_STOP_TTS)
-              return@label
-            }
-            when (focusChange) {
-              AudioManager.AUDIOFOCUS_LOSS -> {
-                if (tts?.currentTTSTask?.paused == false) tts?.pauseOrResume()
-                requireTtsStateCallback().invoke(AudioFocusLoss)
-                setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, true)
-              }
-
-              AudioManager.AUDIOFOCUS_GAIN -> {
-                requireTtsStateCallback().invoke(AudioFocusGain)
-                setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, false)
-              }
-            }
-          }
-        },
+        initListener,
+        speakingListener,
+        audioFocusChangedListener,
         zimReaderContainer
       )
   }
@@ -144,7 +148,6 @@ class ReadAloudManager @Inject constructor(
   fun stopReadAloudSafely() {
     runCatching {
       ttsStateCallback = null
-      isReadAloudServiceRunning = false
       tts?.apply {
         setActionAndStartTTSService(ACTION_STOP_TTS)
         shutdown()
@@ -161,9 +164,7 @@ class ReadAloudManager @Inject constructor(
   private fun setActionAndStartTTSService(action: String, isPauseTTS: Boolean = false) {
     context.startService(
       createReadAloudIntent(action, isPauseTTS)
-    ).also {
-      isReadAloudServiceRunning = action == ACTION_PAUSE_OR_RESUME_TTS
-    }
+    )
   }
 
   private fun createReadAloudIntent(action: String, isPauseTTS: Boolean): Intent =
@@ -182,32 +183,28 @@ class ReadAloudManager @Inject constructor(
   fun startReadAloud(kiwixWebView: KiwixWebView, index: Int) {
     currentTtsIndex = index
     requireTts().readAloud(kiwixWebView) {
-      requireTtsStateCallback().invoke(ShowTTSLanguageDownloadDialog)
+      dispatchState(ShowTTSLanguageDownloadDialog)
     }
   }
 
   fun pauseTts() {
-    if (tts?.currentTTSTask == null) {
-      tts?.stop()
+    val tts = requireTts()
+    val task = tts.currentTTSTask
+    if (task == null) {
+      tts.stop()
       setActionAndStartTTSService(ACTION_STOP_TTS)
       return
     }
-    tts?.currentTTSTask?.let {
-      if (it.paused) {
-        tts?.pauseOrResume()
-        requireTtsStateCallback().invoke(TtsResumed)
-        setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, false)
-      } else {
-        tts?.pauseOrResume()
-        requireTtsStateCallback().invoke(TtsPaused)
-        setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, true)
-      }
-    }
+    val wasPaused = task.paused
+    tts.pauseOrResume()
+    dispatchState(if (wasPaused) TtsResumed else TtsPaused)
+    setActionAndStartTTSService(ACTION_PAUSE_OR_RESUME_TTS, !wasPaused)
   }
 
   fun stopReadAloud() {
-    requireTts().currentTTSTask?.let {
-      requireTts().stop()
+    val tts = requireTts()
+    tts.currentTTSTask?.let {
+      tts.stop()
       setActionAndStartTTSService(ACTION_STOP_TTS)
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/ZimFileManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/ZimFileManager.kt
@@ -28,11 +28,9 @@ import javax.inject.Inject
 class ZimFileManager @Inject constructor(private val zimReaderContainer: ZimReaderContainer) {
   suspend fun openZimFileInReader(
     source: ZimReaderSource,
-    showSearchSuggestionsSpellChecked: Boolean,
-    destroyAllWebViews: suspend () -> Unit
+    showSearchSuggestionsSpellChecked: Boolean
   ): OpenZimResult {
     if (!source.canOpenInLibkiwix()) return InvalidFile
-    clearWebViewListIfNotPreviouslyOpenZimFile(source, destroyAllWebViews)
     zimReaderContainer.setZimReaderSource(source, showSearchSuggestionsSpellChecked)
     return zimReaderContainer.zimFileReader?.let {
       Success(it)
@@ -50,18 +48,6 @@ class ZimFileManager @Inject constructor(private val zimReaderContainer: ZimRead
 
   val zimReaderSource: ZimReaderSource?
     get() = zimReaderContainer.zimReaderSource
-
-  private suspend fun clearWebViewListIfNotPreviouslyOpenZimFile(
-    newSource: ZimReaderSource?,
-    destroyAllWebViews: suspend () -> Unit
-  ) {
-    if (isNotPreviouslyOpenZim(newSource)) {
-      destroyAllWebViews.invoke()
-    }
-  }
-
-  private fun isNotPreviouslyOpenZim(newSource: ZimReaderSource?): Boolean =
-    newSource != null && newSource != zimReaderSource
 
   sealed interface OpenZimResult {
     data class Success(val zimFileReader: ZimFileReader) : OpenZimResult

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -182,7 +182,7 @@ private fun SetUpViewModelAndPermissionLauncher(
       }
     }
   LaunchedEffect(Unit) {
-    coreSettingsViewModel.initialize(activity = coreMainActivity)
+    coreSettingsViewModel.initialize()
     coreSettingsViewModel.actions
       .collect { action ->
         handleSettingsAction(
@@ -222,7 +222,7 @@ private suspend fun handleSettingsAction(
       showImportBookmarkDialog(viewModel, filePickerLauncher)
 
     is OnStorageItemClick ->
-      viewModel.onStorageDeviceSelected(action.storageDevice, activity)
+      viewModel.onStorageDeviceSelected(action.storageDevice)
 
     is ShowSnackbar ->
       showSnackbar(action.message, action.lifecycleScope, viewModel)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
@@ -59,6 +59,7 @@ import org.kiwix.kiwixmobile.core.settings.viewmodel.Action.ShowSnackbar
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.StorageUtils.isExternalStorageWritable
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
@@ -82,7 +83,8 @@ abstract class CoreSettingsViewModel(
   val storageCalculator: StorageCalculator,
   val themeConfig: ThemeConfig,
   val libkiwixBookmarks: LibkiwixBookmarks,
-  val kiwixPermissionChecker: KiwixPermissionChecker
+  val kiwixPermissionChecker: KiwixPermissionChecker,
+  val storageDeviceProvider: StorageDeviceProvider
 ) : ViewModel() {
   data class SettingsUiState(
     val storageDeviceList: List<StorageDevice> = emptyList(),
@@ -97,7 +99,7 @@ abstract class CoreSettingsViewModel(
     val shouldShowRatingCategory: Boolean = false
   )
 
-  abstract suspend fun setStorage(coreMainActivity: CoreMainActivity)
+  abstract suspend fun setStorage()
   abstract suspend fun showExternalLinksPreference()
   abstract suspend fun showPrefWifiOnlyPreference()
   abstract suspend fun showPermissionItem()
@@ -110,8 +112,8 @@ abstract class CoreSettingsViewModel(
   val actions: SharedFlow<Action> = _actions
   lateinit var alertDialogShower: AlertDialogShower
 
-  suspend fun initialize(activity: CoreMainActivity) {
-    setStorage(activity)
+  suspend fun initialize() {
+    setStorage()
     showExternalLinksPreference()
     showPrefWifiOnlyPreference()
     showPermissionItem()
@@ -429,7 +431,7 @@ abstract class CoreSettingsViewModel(
   }
 
   @Suppress("NestedBlockDepth")
-  fun onStorageDeviceSelected(storageDevice: StorageDevice, coreMainActivity: CoreMainActivity) {
+  fun onStorageDeviceSelected(storageDevice: StorageDevice) {
     viewModelScope.launch {
       kiwixDataStore.apply {
         setSelectedStorage(getPublicDirectoryPath(storageDevice.name))
@@ -441,7 +443,7 @@ abstract class CoreSettingsViewModel(
           }
         )
         setShowStorageOption()
-        setStorage(coreMainActivity)
+        setStorage()
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
@@ -1,0 +1,53 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils
+
+import android.content.Context
+import eu.mhutti1.utils.storage.StorageDevice
+import eu.mhutti1.utils.storage.StorageDeviceUtils
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StorageDeviceProvider @Inject constructor(
+  private val context: Context,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+  private val mutex = Mutex()
+  private var writableStorage: List<StorageDevice>? = null
+
+  /**
+   * Returns the writable storage devices, caching the result for the lifetime of the app process.
+   *
+   * Discovering writable storage devices is an expensive operation because it scans and validates
+   * the available storage locations on a background thread. Since the writable storage devices
+   * rarely change while the app is running, the result is computed once and reused across the
+   * application to avoid repeated scanning and improve performance.
+   */
+  suspend fun getWritableStorage(): List<StorageDevice> =
+    mutex.withLock {
+      writableStorage ?: StorageDeviceUtils
+        .getWritableStorage(context, ioDispatcher)
+        .also { writableStorage = it }
+    }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/ReadAloudManagerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/ReadAloudManagerTest.kt
@@ -1,0 +1,297 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.main.reader.helper
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.main.KiwixTextToSpeech
+import org.kiwix.kiwixmobile.core.main.KiwixWebView
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_PAUSE_OR_RESUME_TTS
+import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService.Companion.ACTION_STOP_TTS
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class ReadAloudManagerTest {
+  private lateinit var context: Context
+  private lateinit var readAloudManager: ReadAloudManager
+
+  private val zimReaderContainer = mockk<ZimReaderContainer>(relaxed = true)
+  private lateinit var tts: KiwixTextToSpeech
+
+  @Before
+  fun setup() {
+    clearAllMocks()
+    tts = mockk<KiwixTextToSpeech>(relaxed = true)
+    context = ApplicationProvider.getApplicationContext()
+    readAloudManager = ReadAloudManager(context, zimReaderContainer)
+    readAloudManager.tts = tts
+  }
+
+  @Test
+  fun `initializeTTS delegates to KiwixTextToSpeech`() {
+    every { tts.initializeTTS() } returns Unit
+
+    readAloudManager.initializeTTS(true)
+
+    verify(exactly = 1) {
+      tts.initializeTTS()
+    }
+  }
+
+  @Test
+  fun `isTtsInitialed returns initialization state`() {
+    every { tts.isInitialized } returns true
+
+    assertTrue(readAloudManager.isTtsInitialed())
+
+    verify(exactly = 1) {
+      tts.isInitialized
+    }
+  }
+
+  @Test
+  fun `initWebView delegates to KiwixTextToSpeech`() {
+    val webView = mockk<KiwixWebView>(relaxed = true)
+
+    readAloudManager.initWebView(webView)
+
+    verify(exactly = 1) {
+      tts.initWebView(webView)
+    }
+  }
+
+  @Test
+  fun `readSelection delegates to KiwixTextToSpeech`() {
+    val webView = mockk<KiwixWebView>(relaxed = true)
+
+    readAloudManager.readSelection(webView)
+
+    verify(exactly = 1) {
+      tts.readSelection(webView)
+    }
+  }
+
+  @Test
+  fun `pauseTts stops TTS when no task exists`() {
+    tts.currentTTSTask = null
+
+    readAloudManager.pauseTts()
+
+    verify(exactly = 1) {
+      tts.stop()
+    }
+
+    val intent = shadowOf(
+      ApplicationProvider.getApplicationContext<Application>()
+    ).nextStartedService
+
+    assertEquals(ACTION_STOP_TTS, intent.action)
+
+    assertFalse(
+      intent.getBooleanExtra(
+        ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
+        true
+      )
+    )
+  }
+
+  @Test
+  fun `stopReadAloud starts stop service`() {
+    val task = tts.TTSTask(listOf("Hello"))
+    tts.currentTTSTask = task
+
+    readAloudManager.stopReadAloud()
+
+    verify(exactly = 1) {
+      tts.stop()
+    }
+
+    val intent = shadowOf(
+      ApplicationProvider.getApplicationContext<Application>()
+    ).nextStartedService
+
+    assertEquals(ACTION_STOP_TTS, intent.action)
+
+    assertFalse(
+      intent.getBooleanExtra(
+        ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
+        true
+      )
+    )
+  }
+
+  @Test
+  fun `stopReadAloudSafely shuts down TTS and starts stop service`() {
+    every { tts.shutdown() } returns Unit
+
+    readAloudManager.stopReadAloudSafely()
+
+    verify {
+      tts.shutdown()
+    }
+
+    val intent = shadowOf(
+      ApplicationProvider.getApplicationContext<Application>()
+    ).nextStartedService
+
+    assertEquals(ACTION_STOP_TTS, intent.action)
+
+    assertFalse(
+      intent.getBooleanExtra(
+        ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
+        true
+      )
+    )
+
+    assertEquals(null, readAloudManager.tts)
+  }
+
+  @Test
+  fun `pauseTts resumes paused task`() {
+    val task = tts.TTSTask(listOf("Hello"))
+    task.paused = true
+    tts.currentTTSTask = task
+
+    var state: ReadAloudManager.TtsState? = null
+    readAloudManager.setTtsStateCallback { state = it }
+
+    readAloudManager.pauseTts()
+
+    verify(exactly = 1) {
+      tts.pauseOrResume()
+    }
+
+    assertEquals(
+      ReadAloudManager.TtsState.TtsResumed,
+      state
+    )
+
+    val intent = shadowOf(
+      ApplicationProvider.getApplicationContext<Application>()
+    ).nextStartedService
+
+    assertEquals(
+      ACTION_PAUSE_OR_RESUME_TTS,
+      intent.action
+    )
+
+    assertFalse(
+      intent.getBooleanExtra(
+        ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
+        true
+      )
+    )
+  }
+
+  @Test
+  fun `pauseTts pauses running task`() {
+    val task = tts.TTSTask(listOf("Hello"))
+    task.paused = false
+    tts.currentTTSTask = task
+
+    var state: ReadAloudManager.TtsState? = null
+
+    readAloudManager.setTtsStateCallback {
+      state = it
+    }
+
+    readAloudManager.pauseTts()
+
+    verify(exactly = 1) {
+      tts.pauseOrResume()
+    }
+
+    assertEquals(
+      ReadAloudManager.TtsState.TtsPaused,
+      state
+    )
+
+    val intent = shadowOf(
+      ApplicationProvider.getApplicationContext<Application>()
+    ).nextStartedService
+
+    assertEquals(
+      ACTION_PAUSE_OR_RESUME_TTS,
+      intent.action
+    )
+
+    assertTrue(
+      intent.getBooleanExtra(
+        ReadAloudService.IS_TTS_PAUSE_OR_RESUME,
+        false
+      )
+    )
+  }
+
+  @Test
+  fun `startReadAloud delegates to TTS and updates current index`() {
+    val webView = mockk<KiwixWebView>(relaxed = true)
+
+    every {
+      tts.readAloud(webView, any())
+    } returns Unit
+
+    readAloudManager.startReadAloud(webView, index = 5)
+
+    assertEquals(5, readAloudManager.currentTtsIndex)
+
+    verify(exactly = 1) {
+      tts.readAloud(webView, any())
+    }
+  }
+
+  @Test
+  fun `startReadAloud shows language download dialog`() {
+    val webView = mockk<KiwixWebView>(relaxed = true)
+
+    var state: ReadAloudManager.TtsState? = null
+    readAloudManager.setTtsStateCallback { state = it }
+
+    every {
+      tts.readAloud(webView, any())
+    } answers {
+      secondArg<() -> Unit>().invoke()
+    }
+
+    readAloudManager.startReadAloud(webView, 3)
+
+    assertEquals(3, readAloudManager.currentTtsIndex)
+    assertEquals(
+      ReadAloudManager.TtsState.ShowTTSLanguageDownloadDialog,
+      state
+    )
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/ZimFileManagerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/ZimFileManagerTest.kt
@@ -22,7 +22,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -36,7 +35,6 @@ class ZimFileManagerTest {
 
   private val zimReaderContainer = mockk<ZimReaderContainer>(relaxed = true)
   private val zimReader = mockk<ZimFileReader>(relaxed = true)
-  private val destroyWebViews: () -> Unit = mockk(relaxed = true)
 
   @Before
   fun setup() {
@@ -74,11 +72,7 @@ class ZimFileManagerTest {
 
     coEvery { source.canOpenInLibkiwix() } returns false
 
-    val result = manager.openZimFileInReader(
-      source,
-      false,
-      destroyWebViews
-    )
+    val result = manager.openZimFileInReader(source, false)
 
     assertThat(result).isEqualTo(ZimFileManager.OpenZimResult.InvalidFile)
 
@@ -95,11 +89,7 @@ class ZimFileManagerTest {
     every { zimReaderContainer.zimReaderSource } returns null
     every { zimReaderContainer.zimFileReader } returns zimReader
 
-    val result = manager.openZimFileInReader(
-      source,
-      true,
-      destroyWebViews
-    )
+    val result = manager.openZimFileInReader(source, true)
 
     assertThat(result)
       .isEqualTo(ZimFileManager.OpenZimResult.Success(zimReader))
@@ -117,54 +107,9 @@ class ZimFileManagerTest {
     every { zimReaderContainer.zimReaderSource } returns null
     every { zimReaderContainer.zimFileReader } returns null
 
-    val result = manager.openZimFileInReader(
-      source,
-      false,
-      destroyWebViews
-    )
+    val result = manager.openZimFileInReader(source, false)
 
     assertThat(result)
       .isEqualTo(ZimFileManager.OpenZimResult.InvalidFile)
-  }
-
-  @Test
-  fun `changing zim destroys webviews`() = runTest {
-    val oldSource = mockk<ZimReaderSource>()
-    val newSource = mockk<ZimReaderSource>()
-
-    coEvery { oldSource.canOpenInLibkiwix() } returns true
-    coEvery { newSource.canOpenInLibkiwix() } returns true
-
-    every { zimReaderContainer.zimReaderSource } returns oldSource
-    every { zimReaderContainer.zimFileReader } returns zimReader
-
-    manager.openZimFileInReader(
-      newSource,
-      false,
-      destroyWebViews
-    )
-
-    verify {
-      destroyWebViews.invoke()
-    }
-  }
-
-  @Test
-  fun `opening same zim does not destroy webviews`() = runTest {
-    val source = mockk<ZimReaderSource>()
-
-    coEvery { source.canOpenInLibkiwix() } returns true
-    every { zimReaderContainer.zimReaderSource } returns source
-    every { zimReaderContainer.zimFileReader } returns zimReader
-
-    manager.openZimFileInReader(
-      source,
-      false,
-      destroyWebViews
-    )
-
-    verify(exactly = 0) {
-      destroyWebViews.invoke()
-    }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -82,6 +82,7 @@ import org.kiwix.kiwixmobile.core.settings.viewmodel.Action.ShowSnackbar
 import org.kiwix.kiwixmobile.core.utils.EXTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.INTERNAL_SELECT_POSITION
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.StorageUtils
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore.Companion.DEFAULT_ZOOM
@@ -102,7 +103,8 @@ private class TestCoreSettingsViewModel(
   storageCalculator: StorageCalculator,
   themeConfig: ThemeConfig,
   libkiwixBookmarks: LibkiwixBookmarks,
-  kiwixPermissionChecker: KiwixPermissionChecker
+  kiwixPermissionChecker: KiwixPermissionChecker,
+  storageDeviceProvider: StorageDeviceProvider
 ) : CoreSettingsViewModel(
     context,
     kiwixDataStore,
@@ -110,9 +112,10 @@ private class TestCoreSettingsViewModel(
     storageCalculator,
     themeConfig,
     libkiwixBookmarks,
-    kiwixPermissionChecker
+    kiwixPermissionChecker,
+    storageDeviceProvider
   ) {
-  override suspend fun setStorage(coreMainActivity: CoreMainActivity) {
+  override suspend fun setStorage() {
     // Do nothing
   }
 
@@ -149,6 +152,7 @@ internal class CoreSettingsViewModelTest {
   private val themeConfig: ThemeConfig = mockk(relaxed = true)
   private val libkiwixBookmarks: LibkiwixBookmarks = mockk(relaxed = true)
   private val kiwixPermissionChecker: KiwixPermissionChecker = mockk(relaxed = true)
+  private val storageDeviceProvider: StorageDeviceProvider = mockk(relaxed = true)
   private val activity: CoreMainActivity = mockk(relaxed = true)
   private val contentResolver: ContentResolver = mockk(relaxed = true)
   private val tempDir = File(System.getProperty("java.io.tmpdir"))
@@ -225,7 +229,8 @@ internal class CoreSettingsViewModelTest {
       storageCalculator,
       themeConfig,
       libkiwixBookmarks,
-      kiwixPermissionChecker
+      kiwixPermissionChecker,
+      storageDeviceProvider
     )
   }
 
@@ -239,16 +244,16 @@ internal class CoreSettingsViewModelTest {
     @Test
     fun `initialize calls all required methods`() = runTest {
       val spyViewModel = spykViewModel()
-      coEvery { spyViewModel.setStorage(any()) } just Runs
+      coEvery { spyViewModel.setStorage() } just Runs
       coEvery { spyViewModel.showExternalLinksPreference() } just Runs
       coEvery { spyViewModel.showPrefWifiOnlyPreference() } just Runs
       coEvery { spyViewModel.showPermissionItem() } just Runs
       coEvery { spyViewModel.showLanguageCategory() } just Runs
       coEvery { spyViewModel.showRatingCategory() } just Runs
 
-      spyViewModel.initialize(activity)
+      spyViewModel.initialize()
 
-      coVerify(exactly = 1) { spyViewModel.setStorage(activity) }
+      coVerify(exactly = 1) { spyViewModel.setStorage() }
       coVerify(exactly = 1) { spyViewModel.showExternalLinksPreference() }
       coVerify(exactly = 1) { spyViewModel.showPrefWifiOnlyPreference() }
       coVerify(exactly = 1) { spyViewModel.showPermissionItem() }
@@ -262,7 +267,7 @@ internal class CoreSettingsViewModelTest {
     @Test
     fun `initialize fails if one method throws exception`() = runTest {
       val spyViewModel = spykViewModel()
-      coEvery { spyViewModel.setStorage(any()) } throws RuntimeException("failure")
+      coEvery { spyViewModel.setStorage() } throws RuntimeException("failure")
 
       coEvery { spyViewModel.showExternalLinksPreference() } just Runs
       coEvery { spyViewModel.showPrefWifiOnlyPreference() } just Runs
@@ -271,7 +276,7 @@ internal class CoreSettingsViewModelTest {
       coEvery { spyViewModel.showRatingCategory() } just Runs
 
       try {
-        spyViewModel.initialize(activity)
+        spyViewModel.initialize()
         fail("CoreViewModel should throw an error when the internal method throws an error. But no error was thrown.")
       } catch (e: RuntimeException) {
         assertEquals("failure", e.message)
@@ -1207,18 +1212,17 @@ internal class CoreSettingsViewModelTest {
     fun `internal storage device sets INTERNAL_SELECT_POSITION`() = runTest {
       val internalStoragePath = "/public/path"
       val storageDevice: StorageDevice = mockk()
-      val activity: CoreMainActivity = mockk(relaxed = true)
       every { storageDevice.isInternal } returns true
       every { storageDevice.name } returns internalStoragePath
       coEvery { kiwixDataStore.getPublicDirectoryPath(any()) } returns internalStoragePath
 
-      viewModel.onStorageDeviceSelected(storageDevice, activity)
+      viewModel.onStorageDeviceSelected(storageDevice)
       advanceUntilIdle()
       coVerify {
         kiwixDataStore.setSelectedStorage(internalStoragePath)
         kiwixDataStore.setSelectedStoragePosition(INTERNAL_SELECT_POSITION)
         kiwixDataStore.setShowStorageOption(false)
-        viewModel.setStorage(activity)
+        viewModel.setStorage()
       }
     }
 
@@ -1226,18 +1230,17 @@ internal class CoreSettingsViewModelTest {
     fun `external storage device sets EXTERNAL_SELECT_POSITION`() = runTest {
       val externalStoragePath = "/public/ext/path"
       val storageDevice: StorageDevice = mockk()
-      val activity: CoreMainActivity = mockk(relaxed = true)
       every { storageDevice.isInternal } returns false
       every { storageDevice.name } returns externalStoragePath
       coEvery { kiwixDataStore.getPublicDirectoryPath(any()) } returns externalStoragePath
 
-      viewModel.onStorageDeviceSelected(storageDevice, activity)
+      viewModel.onStorageDeviceSelected(storageDevice)
       advanceUntilIdle()
       coVerify {
         kiwixDataStore.setSelectedStorage(externalStoragePath)
         kiwixDataStore.setSelectedStoragePosition(EXTERNAL_SELECT_POSITION)
         kiwixDataStore.setShowStorageOption(false)
-        viewModel.setStorage(activity)
+        viewModel.setStorage()
       }
     }
   }


### PR DESCRIPTION
Fixes #4979 

* Added `ReadAloudManagerTest`.
* Improved the code of `ReadAloudManager` for better maintainability and readability.
* Removed `getStorageDeviceList()` from `KiwixMainActivity`, as requiring an `Activity` reference throughout the codebase was unnecessary, especially in components such as `ViewModels` and `ProcessSelectedZimFilesForPlayStore`.
* Introduced `StorageDeviceProvider` to provide the writable storage device list. Refactored the codebase to use this provider, removing unnecessary `Activity` dependencies and reducing the risk of memory leaks.
* Removed the need to initialize the storage device list during LocalLibraryViewModel initialization. The storage devices are now loaded only when required, simplifying test setup and improving the initial loading time of the Local Library screen.
* Improved error handling throughout the codebase by surfacing exceptions instead of silently skipping code paths, making failures easier to identify and debug in CI.
* Updated the test cases to retrieve the same `LocalLibraryViewModel` instance used by the Compose UI by obtaining it from the same `NavBackStackEntry`. Previously, the tests were creating a different ViewModel instance, resulting in inconsistent behavior. 
* Fixed: `testCopyingZimFileIntoPublicStorage`, and `testMovingZimFileIntoPublicDirectory` test cases, which are failing on CI.
* Always destroy and recreate the reader `WebViews` before opening a ZIM file. Previously, reopening the same ZIM skipped `WebView` recreation because the archive was already open. If the reader screen had been recreated, this resulted in attempting to render content using destroyed `WebView` instances, causing blank pages and failing UI tests. Because in CopyMoveFileHandler we are using the same ZIM file for validating the different scenarios in a single test.