### PR TITLE
ci: Update codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.api-level==30 }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
#### Description
This PR updates the Codecov GitHub Action (`codecov/codecov-action`) from version `v5` to the latest stable major version (`v7`).

#### Why is this change needed?
Lately, we have observed some incorrect project coverage values in PRs. Since older versions of the uploader can have key verification or environment detection issues, I think updating the Codecov action to the latest stable version could help address this.
