### PR TITLE
Fixed: Nightly APKs were not being uploaded to the correct location on the server.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,17 +64,18 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
           APK_BUILD: "true"
+          KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
         run: ./gradlew assembleNightly
 
       - name: Publish nightly APK to master.download.kiwix.org
         if: ${{ github.event_name == 'schedule' }}
         env:
           UNIVERSAL_DEBUG_APK: app/build/outputs/apk/nightly/*universal*.apk
-          KIWIX_ANDROID_RELEASE_DATE: ${{ env.KIWIX_ANDROID_RELEASE_DATE }}
         run: |
-          mkdir $KIWIX_ANDROID_RELEASE_DATE
-          cp $UNIVERSAL_DEBUG_APK $KIWIX_ANDROID_RELEASE_DATE
-          scp -P 30322 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no $KIWIX_ANDROID_RELEASE_DATE kiwix-android@master.download.kiwix.org:/data/kiwix/nightly/
+          NIGHTLY_DATE=$(date -u +%Y-%m-%d)
+          mkdir $NIGHTLY_DATE
+          cp $UNIVERSAL_DEBUG_APK $NIGHTLY_DATE
+          scp -P 30322 -vrp -i "$KIWIX_FILE_UPLOAD_SSH_KEY_PATH" -o StrictHostKeyChecking=no $NIGHTLY_DATE kiwix-android@master.download.kiwix.org:/data/kiwix/nightly/
 
       - name: Publish release APK to master.download.kiwix.org
         if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
Fixes #5009 

* The issue was that the server folder was being created using the date of the last Git commit. If there were no new commits for several days, the workflow continued using the same commit date and uploaded all nightly APKs to that existing folder. As a result, multiple nightly APKs were stored in the same directory.
* This has been fixed by using the current build date to create the upload directory. Nightly APKs are now uploaded to a folder for the current date, restoring the expected day-wise upload behaviour.