### PR TITLE
Fixed: "No items available" message is not displayed in the `OnlineLibrary`.

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
@@ -285,18 +285,22 @@ class OnlineLibraryViewModel @Inject constructor(
     getString = { resId, args -> context.getString(resId, *args) },
     getSimpleString = { resId -> context.getString(resId) }
   ).onEach {
-    _uiState.update { current ->
-      current.copy(
-        items = it,
-        noContentMessage = noContentMessageWhenItemsComesFromOnlineSource(it),
-        showNoContent = it.isEmpty()
-      )
-    }
+    updateLibraryItems(it)
   }.catch { throwable ->
     resetDownloadState()
     throwable.printStackTrace()
     Log.e("OnlineLibraryViewModel", "Error----$throwable")
   }.launchIn(viewModelScope)
+
+  private fun updateLibraryItems(items: List<LibraryListItem>) {
+    _uiState.update { current ->
+      current.copy(
+        items = items,
+        noContentMessage = noContentMessageWhenItemsComesFromOnlineSource(items),
+        showNoContent = items.isEmpty()
+      )
+    }
+  }
 
   private fun noContentMessageWhenItemsComesFromOnlineSource(items: List<LibraryListItem>): String =
     when {
@@ -448,11 +452,14 @@ class OnlineLibraryViewModel @Inject constructor(
           sendUiEvent(UiEvent.ScrollToTop)
         }
         resetDownloadState()
+        if (newBooks.isEmpty()) {
+          updateLibraryItems(emptyList())
+        }
       }
 
       is OnlineLibraryState.Error -> {
         if (networkBooks.value.isEmpty()) {
-          networkBooks.emit(emptyList())
+          updateLibraryItems(emptyList())
         }
         resetDownloadState()
       }

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -25,6 +25,7 @@ import android.net.ConnectivityManager
 import android.os.Build
 import app.cash.turbine.test
 import io.mockk.Runs
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -33,6 +34,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -477,6 +479,9 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `loadInitialLibrary when no items are available`() = runTest {
       val spyVm = spyk(viewModel)
+      delay(600)
+      advanceUntilIdle()
+      clearMocks(spyVm, answers = false, recordedCalls = true)
       spyVm.setUiStateForTest(viewModel.uiState.value.copy(items = emptyList()))
 
       every { spyVm.updateOnlineLibraryFilters(any()) } just Runs
@@ -488,6 +493,9 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `loadInitialLibrary when items are available`() = runTest {
       val spyVm = spyk(viewModel)
+      delay(600)
+      advanceUntilIdle()
+      clearMocks(spyVm, answers = false, recordedCalls = true)
       spyVm.setUiStateForTest(viewModel.uiState.value.copy(items = listOf(mockk())))
 
       every { spyVm.updateOnlineLibraryFilters(any()) } just Runs
@@ -682,6 +690,26 @@ class OnlineLibraryViewModelTest {
     }
 
     @Test
+    fun `when success returns empty list then shows empty state`() = runTest {
+      val request = mockk<OnlineLibraryViewModel.OnlineLibraryRequest> {
+        every { isLoadMoreItem } returns false
+      }
+
+      val state = Success(
+        books = emptyList(),
+        totalPages = 1,
+        request = request
+      )
+
+      viewModel.handleLibraryState(state)
+
+      val uiState = viewModel.uiState.value
+
+      assertTrue(uiState.items.isEmpty())
+      assertTrue(uiState.showNoContent)
+    }
+
+    @Test
     fun `when error and no existing books then emits empty list`() = runTest {
       viewModel.networkBooks.emit(emptyList())
       val error = OnlineLibraryViewModel.OnlineLibraryState.Error(
@@ -692,8 +720,10 @@ class OnlineLibraryViewModelTest {
       )
       viewModel.handleLibraryState(error)
 
-      val result = viewModel.networkBooks.first()
-      assertTrue(result.isEmpty())
+      with(viewModel.uiState.value) {
+        assertTrue(items.isEmpty())
+        assertTrue(showNoContent)
+      }
     }
   }
 


### PR DESCRIPTION
Fixes  #5011 

* Added the `updateLibraryItems` method to centralize updates to the library items and related UI state when fetching content from the remote library. Previously, the "No items available" message was updated only from `observeLibraryItems`. When the remote library returned an empty list for the first time, `networkBooks` was updated. However, if a subsequent request also returned an empty list, `StateFlow` did not emit a new value because the emitted value was unchanged. As a result, `observeLibraryItems` was not triggered, leaving the UI in an outdated state.
* Updated `handleLibraryState` to explicitly refresh the UI when the online library returns no items, ensuring the "No items available" message is displayed correctly even when the same empty list is emitted repeatedly.
* Refactored and updated the unit tests to cover the new behaviour.