### PR TITLE
Fixed: Stop showing data warning when not in "Downloads" tab.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadRobot.kt
@@ -54,6 +54,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.ONLINE_LIBRARY_SEARC
 import org.kiwix.kiwixmobile.nav.destination.library.online.ONLINE_LIBRARY_SEARCH_VIEW_TESTING_TAG
 import org.kiwix.kiwixmobile.nav.destination.library.online.SHOW_FETCHING_LIBRARY_LAYOUT_TESTING_TAG
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.FIVE_SECOND_DELAY
 import org.kiwix.kiwixmobile.testutils.TestUtils.refresh
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
@@ -119,6 +120,9 @@ class DownloadRobot : BaseRobot() {
     language: String
   ) {
     composeTestRule.apply {
+      waitUntil(FIVE_SECOND_DELAY) {
+        onNodeWithTag(ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG).isDisplayed()
+      }
       onNodeWithTag(ONLINE_DIVIDER_ITEM_TEXT_TESTING_TAG).assertTextEquals(language)
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LibraryRobot.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -30,10 +31,10 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTouchInput
 import applyWithViewHierarchyPrinting
-import com.adevinta.android.barista.interaction.BaristaSleepInteractions
 import org.kiwix.kiwixmobile.BaseRobot
 import org.kiwix.kiwixmobile.R
 import org.kiwix.kiwixmobile.core.R.string
+import org.kiwix.kiwixmobile.core.page.DELETE_MENU_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.ui.components.CONTENT_LOADING_PROGRESS_BAR_TESTING_TAG
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.dialog.ALERT_DIALOG_CONFIRM_BUTTON_TESTING_TAG
@@ -44,7 +45,6 @@ import org.kiwix.kiwixmobile.localFileTransfer.LocalFileTransferRobot
 import org.kiwix.kiwixmobile.localFileTransfer.localFileTransfer
 import org.kiwix.kiwixmobile.main.BOTTOM_NAV_LIBRARY_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.main.BOTTOM_NAV_READER_ITEM_TESTING_TAG
-import org.kiwix.kiwixmobile.core.page.DELETE_MENU_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.nav.destination.library.local.BOOK_LIST_TESTING_TAG
 import org.kiwix.kiwixmobile.nav.destination.library.local.LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.nav.destination.library.local.NO_FILE_TEXT_TESTING_TAG
@@ -65,7 +65,9 @@ class LibraryRobot : BaseRobot() {
   fun assertGetZimNearbyDeviceDisplayed(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
       composeTestRule.apply {
-        waitForIdle()
+        waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG).isDisplayed()
+        }
         onNodeWithTag(LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG).assertIsDisplayed()
       }
     })
@@ -76,7 +78,9 @@ class LibraryRobot : BaseRobot() {
     func: LocalFileTransferRobot.() -> Unit
   ) {
     composeTestRule.apply {
-      waitUntilTimeout()
+      waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+        onNodeWithTag(LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG).isDisplayed()
+      }
       onNodeWithTag(LOCAL_FILE_TRANSFER_MENU_BUTTON_TESTING_TAG).performClick()
     }
     localFileTransfer(func)
@@ -84,8 +88,12 @@ class LibraryRobot : BaseRobot() {
 
   fun assertLibraryListDisplayed(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
-      composeTestRule.waitForIdle()
-      composeTestRule.onNodeWithTag(BOOK_LIST_TESTING_TAG).assertIsDisplayed()
+      composeTestRule.apply {
+        waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          composeTestRule.onNodeWithTag(BOOK_LIST_TESTING_TAG).isDisplayed()
+        }
+        onNodeWithTag(BOOK_LIST_TESTING_TAG).assertIsDisplayed()
+      }
     })
   }
 
@@ -116,7 +124,9 @@ class LibraryRobot : BaseRobot() {
 
   fun waitUntilZimFilesRefreshing(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
-      composeTestRule.waitUntilTimeout()
+      composeTestRule.waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+        composeTestRule.onNodeWithTag(CONTENT_LOADING_PROGRESS_BAR_TESTING_TAG).isNotDisplayed()
+      }
       composeTestRule.onNodeWithTag(CONTENT_LOADING_PROGRESS_BAR_TESTING_TAG)
         .assertIsNotDisplayed()
     })
@@ -143,7 +153,7 @@ class LibraryRobot : BaseRobot() {
       }
       clickOnFileDeleteIcon(composeTestRule)
       clickOnDeleteZimFile(composeTestRule)
-      pauseForBetterTestPerformance()
+      composeTestRule.waitUntilTimeout()
       assertNoFilesTextDisplayed(composeTestRule)
     } catch (e: AssertionError) {
       Log.i(
@@ -155,9 +165,13 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnFileDeleteIcon(composeTestRule: ComposeContentTestRule) {
-    pauseForBetterTestPerformance()
     testFlakyView({
-      composeTestRule.onNodeWithTag(DELETE_MENU_ICON_TESTING_TAG).performClick()
+      composeTestRule.apply {
+        waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(DELETE_MENU_ICON_TESTING_TAG).isDisplayed()
+        }
+        onNodeWithTag(DELETE_MENU_ICON_TESTING_TAG).performClick()
+      }
     })
   }
 
@@ -169,6 +183,9 @@ class LibraryRobot : BaseRobot() {
     testFlakyView({
       composeTestRule.apply {
         waitForIdle()
+        waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(ALERT_DIALOG_TITLE_TEXT_TESTING_TAG).isDisplayed()
+        }
         onNodeWithTag(ALERT_DIALOG_TITLE_TEXT_TESTING_TAG)
           .assertTextEquals(context.getString(string.file_system_scan_dialog_title))
       }
@@ -196,8 +213,9 @@ class LibraryRobot : BaseRobot() {
   fun assertManageExternalPermissionDialogDisplayed(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
       composeTestRule.apply {
-        waitForIdle()
-        composeTestRule.mainClock.advanceTimeByFrame()
+        waitUntil(TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(ALERT_DIALOG_TITLE_TEXT_TESTING_TAG).isDisplayed()
+        }
         onNodeWithTag(ALERT_DIALOG_TITLE_TEXT_TESTING_TAG)
           .assertTextEquals(context.getString(string.all_files_permission_needed))
       }
@@ -216,7 +234,9 @@ class LibraryRobot : BaseRobot() {
   fun clickOnReaderScreen(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
       composeTestRule.apply {
-        waitUntilTimeout()
+        waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).isDisplayed()
+        }
         onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).performClick()
       }
     })
@@ -225,7 +245,9 @@ class LibraryRobot : BaseRobot() {
   fun clickOnLocalLibraryScreen(composeTestRule: ComposeContentTestRule) {
     testFlakyView({
       composeTestRule.apply {
-        waitUntilTimeout()
+        waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(BOTTOM_NAV_LIBRARY_ITEM_TESTING_TAG).isDisplayed()
+        }
         onNodeWithTag(BOTTOM_NAV_LIBRARY_ITEM_TESTING_TAG).performClick()
       }
     })
@@ -249,7 +271,7 @@ class LibraryRobot : BaseRobot() {
     }
     clickOnValidateZimFileIcon(composeTestRule)
     clickOnYesDialogButton(composeTestRule)
-    pauseForBetterTestPerformance()
+    composeTestRule.waitUntilTimeout()
     assertZIMFileValidatingDialogDisplayed(composeTestRule)
     clickOnYesDialogButton(composeTestRule)
   }
@@ -267,17 +289,17 @@ class LibraryRobot : BaseRobot() {
   }
 
   private fun clickOnValidateZimFileIcon(composeTestRule: ComposeContentTestRule) {
-    pauseForBetterTestPerformance()
     testFlakyView({
-      composeTestRule.onNodeWithTag(VALIDATE_ZIM_FILES_MENU_BUTTON_TESTING_TAG).performClick()
+      composeTestRule.apply {
+        waitUntil(TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+          onNodeWithTag(VALIDATE_ZIM_FILES_MENU_BUTTON_TESTING_TAG).isDisplayed()
+        }
+        onNodeWithTag(VALIDATE_ZIM_FILES_MENU_BUTTON_TESTING_TAG).performClick()
+      }
     })
   }
 
   private fun clickOnYesDialogButton(composeTestRule: ComposeContentTestRule) {
     clickOnDialogConfirmButton(composeTestRule)
-  }
-
-  private fun pauseForBetterTestPerformance() {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS.toLong())
   }
 }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -21,20 +21,15 @@ package org.kiwix.kiwixmobile.nav.destination.library
 import android.os.Build
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.launch
 import leakcanary.LeakAssertions
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
-import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
-import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
@@ -64,31 +59,6 @@ class LocalLibraryTest : BaseActivityTest() {
     }
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
-  }
-
-  private fun observeLocalLibraryActions() {
-    composeTestRule.runOnIdle {
-      val kiwixMainActivity = composeTestRule.activity
-      val localLibraryViewModel = ViewModelProvider(
-        kiwixMainActivity,
-        kiwixMainActivity.viewModelFactory
-      )[LocalLibraryViewModel::class.java]
-
-      val validateZimViewModel = ViewModelProvider(
-        kiwixMainActivity,
-        kiwixMainActivity.viewModelFactory
-      )[ValidateZimViewModel::class.java]
-      localLibraryViewModel.initialize(
-        validateZimViewModel = validateZimViewModel,
-        kiwixMainActivity.alertDialogShower,
-        kiwixMainActivity.snackBarHostState
-      )
-      kiwixMainActivity.lifecycleScope.launch {
-        localLibraryViewModel.sideEffects.collect { effect ->
-          effect.invokeWith(kiwixMainActivity)
-        }
-      }
-    }
   }
 
   @Test
@@ -136,7 +106,6 @@ class LocalLibraryTest : BaseActivityTest() {
       )
       clickOnReaderScreen(composeTestRule)
       clickOnLocalLibraryScreen(composeTestRule)
-      observeLocalLibraryActions()
       composeTestRule.waitUntilTimeout()
       // Assert scan dialog visible.
       assertScanFileSystemDialogDisplayed(composeTestRule)
@@ -148,7 +117,6 @@ class LocalLibraryTest : BaseActivityTest() {
       // Assert scan dialog does not show again.
       clickOnReaderScreen(composeTestRule)
       clickOnLocalLibraryScreen(composeTestRule)
-      observeLocalLibraryActions()
       assertScanDialogNotDisplayed(composeTestRule)
       // Assert When there are ZIM files in local library screen then this dialog does not display.
       // Set to not show the "All files permission" dialog.
@@ -169,7 +137,6 @@ class LocalLibraryTest : BaseActivityTest() {
         isPlayStoreBuild = false
       )
       clickOnLocalLibraryScreen(composeTestRule)
-      observeLocalLibraryActions()
       assertScanDialogNotDisplayed(composeTestRule)
     }
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
@@ -54,9 +54,11 @@ import org.kiwix.kiwixmobile.main.topLevel
 import org.kiwix.kiwixmobile.page.bookmarks.bookmarks
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.FIVE_SECOND_DELAY
 import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 import java.io.FileOutputStream
@@ -113,6 +115,8 @@ class KiwixReaderScreenTest : BaseActivityTest() {
       openSearchWithQuery("Android", zimFile)
       openAndroidArticleInNewTab(composeTestRule)
       checkZimFileLoadedSuccessful(composeTestRule, "Android_(operating_system)")
+      // Wait a bit to properly saving the history.
+      composeTestRule.waitUntilTimeout(FIVE_SECOND_DELAY)
       // open bookmark screen.
       bookmarks {
         openBookmarkScreen(kiwixMainActivity as CoreMainActivity, composeTestRule)
@@ -140,6 +144,8 @@ class KiwixReaderScreenTest : BaseActivityTest() {
       openSearchWithQuery("Android", zimFile)
       openAndroidArticleInNewTab(composeTestRule)
       checkZimFileLoadedSuccessful(composeTestRule, "Android_(operating_system)")
+      // Wait a bit to properly saving the history.
+      composeTestRule.waitUntilTimeout(FIVE_SECOND_DELAY)
       // open local library screen.
       openLocalLibraryScreenViaBottomAppBar(composeTestRule)
       composeTestRule.waitForIdle()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchRobot.kt
@@ -22,6 +22,7 @@ import android.view.KeyEvent
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -40,7 +41,7 @@ import org.kiwix.kiwixmobile.core.search.SEARCH_FIELD_TESTING_TAG
 import org.kiwix.kiwixmobile.core.search.SEARCH_ITEM_TESTING_TAG
 import org.kiwix.kiwixmobile.core.ui.components.NAVIGATION_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.main.BOTTOM_NAV_READER_ITEM_TESTING_TAG
-import org.kiwix.kiwixmobile.testutils.TestUtils
+import org.kiwix.kiwixmobile.testutils.TestUtils.FIVE_SECOND_DELAY
 import org.kiwix.kiwixmobile.testutils.TestUtils.TEST_PAUSE_MS
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
@@ -54,18 +55,25 @@ class SearchRobot : BaseRobot() {
   val searchResultForDownloadedZimFile = "A Fool for You"
 
   fun clickOnSearchItemInSearchList(composeTestRule: ComposeContentTestRule) {
-    composeTestRule.apply {
-      waitUntilTimeout()
-      onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)[0].performClick()
-    }
+    testFlakyView({
+      composeTestRule.apply {
+        waitUntil(FIVE_SECOND_DELAY) {
+          onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)[0].performClick()
+      }
+    })
   }
 
   fun checkZimFileSearchSuccessful(composeTestRule: ComposeContentTestRule) {
-    BaristaSleepInteractions.sleep(TestUtils.TEST_PAUSE_MS_FOR_SEARCH_TEST.toLong())
-    composeTestRule.apply {
-      waitUntilTimeout()
-      onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).assertIsDisplayed()
-    }
+    testFlakyView({
+      composeTestRule.apply {
+        waitUntil(FIVE_SECOND_DELAY) {
+          onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).isDisplayed()
+        }
+        onNodeWithTag(BOTTOM_NAV_READER_ITEM_TESTING_TAG).assertIsDisplayed()
+      }
+    })
   }
 
   fun searchWithFrequentlyTypedWords(
@@ -89,17 +97,19 @@ class SearchRobot : BaseRobot() {
   }
 
   fun assertSearchSuccessful(searchResult: String, composeTestRule: ComposeContentTestRule) {
-    composeTestRule.apply {
-      waitUntil(
-        timeoutMillis = TEST_PAUSE_MS.toLong(),
-        condition = {
-          onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)
-            .fetchSemanticsNodes().isNotEmpty()
-        }
-      )
-      onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)[0]
-        .assert(hasText(searchResult))
-    }
+    testFlakyView({
+      composeTestRule.apply {
+        waitUntil(
+          timeoutMillis = TEST_PAUSE_MS.toLong(),
+          condition = {
+            onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)
+              .fetchSemanticsNodes().isNotEmpty()
+          }
+        )
+        onAllNodesWithTag(SEARCH_ITEM_TESTING_TAG)[0]
+          .assert(hasText(searchResult))
+      }
+    })
   }
 
   fun deleteSearchedQueryFrequently(
@@ -126,7 +136,12 @@ class SearchRobot : BaseRobot() {
   private fun openSearchScreen(composeTestRule: ComposeContentTestRule) {
     testFlakyView(
       {
-        composeTestRule.onNodeWithTag(SEARCH_ICON_TESTING_TAG).performClick()
+        composeTestRule.apply {
+          waitUntil(FIVE_SECOND_DELAY) {
+            onNodeWithTag(SEARCH_ICON_TESTING_TAG).isDisplayed()
+          }
+          onNodeWithTag(SEARCH_ICON_TESTING_TAG).performClick()
+        }
       }
     )
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
@@ -43,6 +43,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.getOkkHttpClientForTesting
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import org.kiwix.kiwixmobile.testutils.TestUtils.testFlakyView
+import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import java.io.File
 import java.io.FileOutputStream
@@ -284,6 +285,10 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
   private fun openKiwixReaderScreenWithFile(zimFile: File) {
     composeTestRule.runOnUiThread {
       kiwixMainActivity.openZimFromFilePath(zimFile.absolutePath)
+    }
+    composeTestRule.apply {
+      waitForIdle()
+      waitUntilTimeout()
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRoute.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferRoute.kt
@@ -24,6 +24,7 @@ import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -52,6 +53,7 @@ import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.localFileTransfer.UiEvent.NavigateBack
 import org.kiwix.kiwixmobile.localFileTransfer.UiEvent.RequestPermission
@@ -61,9 +63,11 @@ import org.kiwix.kiwixmobile.localFileTransfer.UiEvent.ShowDialog
 @Composable
 internal fun LocalFileTransferScreenRoute(
   viewModel: LocalFileTransferViewModel,
-  alertDialogShower: AlertDialogShower,
-  navigateBack: () -> Unit
+  navigateBack: () -> Unit,
+  uris: List<Uri>
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
+  viewModel.initialize(uris, alertDialogShower)
   val context = LocalContext.current
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val locationPermission = rememberPermissionState(viewModel.locationPermission)
@@ -113,6 +117,7 @@ internal fun LocalFileTransferScreenRoute(
         )
       }
     )
+    DialogHost(alertDialogShower)
   }
 }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferScreen.kt
@@ -66,7 +66,6 @@ import org.kiwix.kiwixmobile.core.ui.components.KiwixShowCaseView
 import org.kiwix.kiwixmobile.core.ui.components.ShowcaseProperty
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.theme.DodgerBlue
-import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DEFAULT_TEXT_ALPHA
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FIFTEEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FILE_FOR_TRANSFER_SHOW_CASE_VIEW_SIZE
@@ -105,57 +104,55 @@ fun LocalFileTransferScreen(
 ) {
   val targets = remember { mutableStateMapOf<String, ShowcaseProperty>() }
   val context = LocalContext.current
-  KiwixTheme {
-    Scaffold(
-      topBar = {
-        KiwixAppBar(
-          title = stringResource(getAppBarTitle(state.isReceiver)),
-          actionMenuItems = actionMenuItems.map {
-            it.copy(
-              modifier =
-                Modifier.onGloballyPositioned { coordinates ->
-                  targets[SEARCH_ICON_TESTING_TAG] = ShowcaseProperty(
-                    index = ZERO,
-                    coordinates = coordinates,
-                    showCaseMessage = context.getString(string.click_nearby_devices_message)
-                  )
-                }
-            )
-          },
-          navigationIcon = navigationIcon
-        )
-      }
-    ) { padding ->
-      Column(
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(padding)
-          .background(Color.Transparent)
-      ) {
-        YourDeviceHeader(state.deviceName, context, targets)
-        HorizontalDivider(
-          color = DodgerBlue,
-          thickness = ONE_DP,
-          modifier = Modifier.padding(horizontal = FIVE_DP)
-        )
-        NearbyDevicesSection(
-          state.peers,
-          state.isPeerSearching,
-          onDeviceItemClick,
-          context,
-          targets
-        )
-        HorizontalDivider(
-          color = DodgerBlue,
-          thickness = ONE_DP,
-          modifier = Modifier
-            .padding(horizontal = FIVE_DP)
-        )
-        TransferFilesSection(state.transferFiles, context, targets)
-      }
+  Scaffold(
+    topBar = {
+      KiwixAppBar(
+        title = stringResource(getAppBarTitle(state.isReceiver)),
+        actionMenuItems = actionMenuItems.map {
+          it.copy(
+            modifier =
+              Modifier.onGloballyPositioned { coordinates ->
+                targets[SEARCH_ICON_TESTING_TAG] = ShowcaseProperty(
+                  index = ZERO,
+                  coordinates = coordinates,
+                  showCaseMessage = context.getString(string.click_nearby_devices_message)
+                )
+              }
+          )
+        },
+        navigationIcon = navigationIcon
+      )
     }
-    ShowShowCaseToUserIfNotShown(targets, state.shouldShowShowCase, onShowCaseDisplayed)
+  ) { padding ->
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(padding)
+        .background(Color.Transparent)
+    ) {
+      YourDeviceHeader(state.deviceName, context, targets)
+      HorizontalDivider(
+        color = DodgerBlue,
+        thickness = ONE_DP,
+        modifier = Modifier.padding(horizontal = FIVE_DP)
+      )
+      NearbyDevicesSection(
+        state.peers,
+        state.isPeerSearching,
+        onDeviceItemClick,
+        context,
+        targets
+      )
+      HorizontalDivider(
+        color = DodgerBlue,
+        thickness = ONE_DP,
+        modifier = Modifier
+          .padding(horizontal = FIVE_DP)
+      )
+      TransferFilesSection(state.transferFiles, context, targets)
+    }
   }
+  ShowShowCaseToUserIfNotShown(targets, state.shouldShowShowCase, onShowCaseDisplayed)
 }
 
 private fun getAppBarTitle(isReceiver: Boolean) =

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -162,7 +162,6 @@ class KiwixMainActivity : CoreMainActivity() {
         shouldShowBottomAppBar = shouldShowBottomAppBar.value,
         bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour,
         viewModelFactory = viewModelFactory,
-        alertDialogShower = alertDialogShower,
         snackBarHostState = snackBarHostState
       )
       LaunchedEffect(Unit) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivityScreen.kt
@@ -57,7 +57,6 @@ import org.kiwix.kiwixmobile.core.main.DrawerMenuGroup
 import org.kiwix.kiwixmobile.core.main.LeftDrawerMenu
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.ui.theme.White
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.ui.KiwixNavGraph
 
@@ -79,7 +78,6 @@ fun KiwixMainActivityScreen(
   shouldShowBottomAppBar: Boolean,
   bottomAppBarScrollBehaviour: BottomAppBarScrollBehavior?,
   viewModelFactory: ViewModelProvider.Factory,
-  alertDialogShower: AlertDialogShower,
   snackBarHostState: SnackbarHostState
 ) {
   val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -122,7 +120,6 @@ fun KiwixMainActivityScreen(
             startDestination = startDestination,
             modifier = Modifier.fillMaxSize(),
             viewModelFactory = viewModelFactory,
-            alertDialogShower = alertDialogShower,
             snackBarHostState = snackBarHostState
           )
         }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryRoute.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryRoute.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -50,10 +51,14 @@ import org.kiwix.kiwixmobile.core.extensions.handlePermissionRequest
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.note.SHARE_MENU_BUTTON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.page.DELETE_MENU_ICON_TESTING_TAG
+import org.kiwix.kiwixmobile.core.reader.integrity.ValidateZimViewModel
 import org.kiwix.kiwixmobile.core.ui.components.NavigationIcon
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
+import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
+import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.SelectionMode
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel.LocalLibraryUiActions.RequestReadWritePermission
@@ -69,13 +74,25 @@ const val VALIDATE_ZIM_FILES_MENU_BUTTON_TESTING_TAG = "validateZimFilesMenuButt
  * multiple app-level concerns that shouldn't be split.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
+@Suppress("LongMethod")
 @Composable
 fun LocalLibraryRoute(
   localLibraryViewModel: LocalLibraryViewModel,
+  validateZimViewModel: ValidateZimViewModel,
   navController: NavHostController,
   zimFileUriArg: String,
   snackBarHostState: SnackbarHostState
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
+  LaunchedEffect(Unit) {
+    localLibraryViewModel.apply {
+      initialize(
+        validateZimViewModel,
+        alertDialogShower,
+        snackBarHostState
+      )
+    }
+  }
   val mainActivity = LocalActivity.current as KiwixMainActivity
   val uiState = localLibraryViewModel.uiState.collectAsStateWithLifecycle()
   val readWritePermission =
@@ -95,33 +112,36 @@ fun LocalLibraryRoute(
   BackHandler(enabled = uiState.value.fileSelectListState.selectionMode == SelectionMode.MULTI) {
     localLibraryViewModel.finishMultiModeFinished()
   }
-  LocalLibraryScreen(
-    state = uiState.value,
-    actionMenuItems = actionMenuItems(
-      navController = navController,
-      selectionMode = uiState.value.fileSelectListState.selectionMode,
-      localLibraryViewModel = localLibraryViewModel
-    ) {
-      localLibraryViewModel.filePickerMenuButtonClick(filePickerLauncher)
-    },
-    listState = rememberLazyListState(),
-    snackbarHostState = snackBarHostState,
-    onRefresh = localLibraryViewModel::onSwipeRefresh,
-    onDownloadButtonClick = localLibraryViewModel::onDownloadButtonClick,
-    onClick = localLibraryViewModel::onBookItemClick,
-    onLongClick = localLibraryViewModel::onBookItemLongClick,
-    onMultiSelect = localLibraryViewModel::onMultiSelect,
-    bottomAppBarScrollBehaviour = mainActivity.bottomAppBarScrollBehaviour,
-    onUserBackPressed = localLibraryViewModel::handleUserBackPressed,
-    navHostController = navController,
-    navigationIcon = {
-      NavigationIcon(
-        iconItem = navigationIconItem(uiState.value.fileSelectListState.selectionMode == SelectionMode.MULTI),
-        contentDescription = string.open_drawer,
-        onClick = localLibraryViewModel::onNavigationIconClick
-      )
-    }
-  )
+  KiwixTheme {
+    LocalLibraryScreen(
+      state = uiState.value,
+      actionMenuItems = actionMenuItems(
+        navController = navController,
+        selectionMode = uiState.value.fileSelectListState.selectionMode,
+        localLibraryViewModel = localLibraryViewModel
+      ) {
+        localLibraryViewModel.filePickerMenuButtonClick(filePickerLauncher)
+      },
+      listState = rememberLazyListState(),
+      snackbarHostState = snackBarHostState,
+      onRefresh = localLibraryViewModel::onSwipeRefresh,
+      onDownloadButtonClick = localLibraryViewModel::onDownloadButtonClick,
+      onClick = localLibraryViewModel::onBookItemClick,
+      onLongClick = localLibraryViewModel::onBookItemLongClick,
+      onMultiSelect = localLibraryViewModel::onMultiSelect,
+      bottomAppBarScrollBehaviour = mainActivity.bottomAppBarScrollBehaviour,
+      onUserBackPressed = localLibraryViewModel::handleUserBackPressed,
+      navHostController = navController,
+      navigationIcon = {
+        NavigationIcon(
+          iconItem = navigationIconItem(uiState.value.fileSelectListState.selectionMode == SelectionMode.MULTI),
+          contentDescription = string.open_drawer,
+          onClick = localLibraryViewModel::onNavigationIconClick
+        )
+      }
+    )
+    DialogHost(alertDialogShower)
+  }
   LaunchedEffect(zimFileUriArg) {
     LanguageUtils(mainActivity).changeFont(mainActivity, localLibraryViewModel.kiwixDataStore)
     localLibraryViewModel.processZimFileArguments(zimFileUriArg)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/LocalLibraryScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -46,7 +46,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomAppBarScrollBehavior
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +53,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -78,7 +78,6 @@ import org.kiwix.kiwixmobile.R.drawable
 import org.kiwix.kiwixmobile.R.string
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.BackPressActivityExtensions
-import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.main.reader.OnBackPressed
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
@@ -88,19 +87,19 @@ import org.kiwix.kiwixmobile.core.ui.components.KiwixSnackbarHost
 import org.kiwix.kiwixmobile.core.ui.components.ProgressBarStyle
 import org.kiwix.kiwixmobile.core.ui.components.SwipeRefreshLayout
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
-import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.EIGHT_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FOUR_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIX_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TWENTY_DP
+import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
+import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel.LocalLibraryUiState
+import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel.NoFileView
 import org.kiwix.kiwixmobile.ui.BookItem
 import org.kiwix.kiwixmobile.ui.ZimFilesLanguageHeader
 import org.kiwix.kiwixmobile.zimManager.fileselectView.FileSelectListState
-import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel.LocalLibraryUiState
-import org.kiwix.kiwixmobile.nav.destination.library.local.LocalLibraryViewModel.NoFileView
 import kotlin.math.roundToInt
 
 const val NO_FILE_TEXT_TESTING_TAG = "noFileTextTestingTag"
@@ -131,45 +130,43 @@ fun LocalLibraryScreen(
   navigationIcon: @Composable () -> Unit
 ) {
   val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-  KiwixTheme {
-    Scaffold(
-      snackbarHost = { KiwixSnackbarHost(snackbarHostState = snackbarHostState) },
-      topBar = {
-        KiwixAppBar(
-          title = screenTitle(state.fileSelectListState),
-          navigationIcon = navigationIcon,
-          actionMenuItems = actionMenuItems,
-          topAppBarScrollBehavior = scrollBehavior
-        )
-      },
-      floatingActionButton = {
-        LocalLibraryBackToTopButton(
-          listState = listState,
-          scrollBehavior = scrollBehavior,
-          bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
-        )
-      },
-      modifier = Modifier
-        .nestedScroll(scrollBehavior.nestedScrollConnection)
-        .let { baseModifier ->
-          bottomAppBarScrollBehaviour?.let {
-            baseModifier.nestedScroll(it.nestedScrollConnection)
-          } ?: baseModifier
-        }
-    ) { contentPadding ->
-      LocalLibraryMainContent(
-        state,
-        onRefresh,
-        contentPadding,
-        onUserBackPressed,
-        navHostController,
-        onDownloadButtonClick,
-        onClick,
-        onLongClick,
-        onMultiSelect,
-        listState
+  Scaffold(
+    snackbarHost = { KiwixSnackbarHost(snackbarHostState = snackbarHostState) },
+    topBar = {
+      KiwixAppBar(
+        title = screenTitle(state.fileSelectListState),
+        navigationIcon = navigationIcon,
+        actionMenuItems = actionMenuItems,
+        topAppBarScrollBehavior = scrollBehavior
       )
-    }
+    },
+    floatingActionButton = {
+      LocalLibraryBackToTopButton(
+        listState = listState,
+        scrollBehavior = scrollBehavior,
+        bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
+      )
+    },
+    modifier = Modifier
+      .nestedScroll(scrollBehavior.nestedScrollConnection)
+      .let { baseModifier ->
+        bottomAppBarScrollBehaviour?.let {
+          baseModifier.nestedScroll(it.nestedScrollConnection)
+        } ?: baseModifier
+      }
+  ) { contentPadding ->
+    LocalLibraryMainContent(
+      state,
+      onRefresh,
+      contentPadding,
+      onUserBackPressed,
+      navHostController,
+      onDownloadButtonClick,
+      onClick,
+      onLongClick,
+      onMultiSelect,
+      listState
+    )
   }
 }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryRoute.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryRoute.kt
@@ -56,9 +56,11 @@ import org.kiwix.kiwixmobile.core.page.SEARCH_ICON_TESTING_TAG
 import org.kiwix.kiwixmobile.core.ui.components.NavigationIcon
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
+import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.TEN_DP
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixBasicDialogFrame
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.CategoryViewModel
@@ -76,10 +78,10 @@ const val CATEGORY_MENU_ICON_TESTING_TAG = "categoryMenuIconTestingTag"
 fun OnlineLibraryRoute(
   onlineLibraryViewModel: OnlineLibraryViewModel,
   categoryViewModel: CategoryViewModel,
-  alertDialogShower: AlertDialogShower,
   navController: NavHostController,
   activity: KiwixMainActivity
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
   val uiState by onlineLibraryViewModel.uiState.collectAsState()
   val notificationPermission = if (onlineLibraryViewModel.isAndroid13OrAbove) {
     rememberPermissionState(POST_NOTIFICATIONS) {
@@ -118,42 +120,44 @@ fun OnlineLibraryRoute(
   LaunchedEffect(Unit) {
     onlineLibraryViewModel.loadInitialLibrary()
   }
-
-  OnlineLibraryScreen(
-    uiState = uiState,
-    onlineLibraryViewModel = onlineLibraryViewModel,
-    actionMenuItems = actionMenuItems,
-    listState = lazyListState,
-    snackBarHostState = snackbarHostState,
-    bottomAppBarScrollBehaviour = activity.bottomAppBarScrollBehaviour,
-    onUserBackPressed = {
-      handleBackPress(activity, uiState.isSearchActive) {
-        onlineLibraryViewModel.closeSearchView()
-      }
-    },
-    navHostController = navController,
-    navigationIcon = {
-      NavigationIcon(
-        iconItem = if (uiState.isSearchActive) {
-          IconItem.Vector(Icons.AutoMirrored.Filled.ArrowBack)
-        } else {
-          IconItem.Vector(Icons.Filled.Menu)
-        },
-        contentDescription = string.open_drawer,
-        onClick = {
-          if (uiState.isSearchActive) {
-            onlineLibraryViewModel.closeSearchView()
+  KiwixTheme {
+    OnlineLibraryScreen(
+      uiState = uiState,
+      onlineLibraryViewModel = onlineLibraryViewModel,
+      actionMenuItems = actionMenuItems,
+      listState = lazyListState,
+      snackBarHostState = snackbarHostState,
+      bottomAppBarScrollBehaviour = activity.bottomAppBarScrollBehaviour,
+      onUserBackPressed = {
+        handleBackPress(activity, uiState.isSearchActive) {
+          onlineLibraryViewModel.closeSearchView()
+        }
+      },
+      navHostController = navController,
+      navigationIcon = {
+        NavigationIcon(
+          iconItem = if (uiState.isSearchActive) {
+            IconItem.Vector(Icons.AutoMirrored.Filled.ArrowBack)
           } else {
-            if (activity.navigationDrawerIsOpen()) {
-              activity.closeNavigationDrawer()
+            IconItem.Vector(Icons.Filled.Menu)
+          },
+          contentDescription = string.open_drawer,
+          onClick = {
+            if (uiState.isSearchActive) {
+              onlineLibraryViewModel.closeSearchView()
             } else {
-              activity.openNavigationDrawer()
+              if (activity.navigationDrawerIsOpen()) {
+                activity.closeNavigationDrawer()
+              } else {
+                activity.openNavigationDrawer()
+              }
             }
           }
-        }
-      )
-    }
-  )
+        )
+      }
+    )
+    DialogHost(alertDialogShower)
+  }
 
   ShowCategoryDialog(categoryViewModel, uiState.showCategoryDialog) {
     onlineLibraryViewModel.setShowCategoryDialog(false)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/OnlineLibraryScreen.kt
@@ -83,7 +83,6 @@ import org.kiwix.kiwixmobile.core.ui.components.KiwixSearchView
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSnackbarHost
 import org.kiwix.kiwixmobile.core.ui.components.SwipeRefreshLayout
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
-import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.ui.theme.MineShaftGray700
 import org.kiwix.kiwixmobile.core.ui.theme.White
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.DOWNLOADING_LIBRARY_MESSAGE_TEXT_SIZE
@@ -127,42 +126,40 @@ fun OnlineLibraryScreen(
   navigationIcon: @Composable () -> Unit
 ) {
   val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-  KiwixTheme {
-    Scaffold(
-      snackbarHost = { KiwixSnackbarHost(snackbarHostState = snackBarHostState) },
-      topBar = {
-        KiwixAppBar(
-          title = stringResource(string.download),
-          navigationIcon = navigationIcon,
-          actionMenuItems = actionMenuItems,
-          topAppBarScrollBehavior = scrollBehavior,
-          searchBar = searchBarIfActive(uiState, onlineLibraryViewModel)
-        )
-      },
-      floatingActionButton = {
-        OnlineLibraryBackToTopButton(
-          listState = listState,
-          scrollBehavior = scrollBehavior,
-          bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
-        )
-      },
-      modifier = Modifier
-        .nestedScroll(scrollBehavior.nestedScrollConnection)
-        .let { baseModifier ->
-          bottomAppBarScrollBehaviour?.let {
-            baseModifier.nestedScroll(it.nestedScrollConnection)
-          } ?: baseModifier
-        }
-    ) { paddingValues ->
-      OnlineLibraryMainContent(
-        uiState,
-        onlineLibraryViewModel,
-        paddingValues,
-        onUserBackPressed,
-        navHostController,
-        listState
+  Scaffold(
+    snackbarHost = { KiwixSnackbarHost(snackbarHostState = snackBarHostState) },
+    topBar = {
+      KiwixAppBar(
+        title = stringResource(string.download),
+        navigationIcon = navigationIcon,
+        actionMenuItems = actionMenuItems,
+        topAppBarScrollBehavior = scrollBehavior,
+        searchBar = searchBarIfActive(uiState, onlineLibraryViewModel)
       )
-    }
+    },
+    floatingActionButton = {
+      OnlineLibraryBackToTopButton(
+        listState = listState,
+        scrollBehavior = scrollBehavior,
+        bottomAppBarScrollBehaviour = bottomAppBarScrollBehaviour
+      )
+    },
+    modifier = Modifier
+      .nestedScroll(scrollBehavior.nestedScrollConnection)
+      .let { baseModifier ->
+        bottomAppBarScrollBehaviour?.let {
+          baseModifier.nestedScroll(it.nestedScrollConnection)
+        } ?: baseModifier
+      }
+  ) { paddingValues ->
+    OnlineLibraryMainContent(
+      uiState,
+      onlineLibraryViewModel,
+      paddingValues,
+      onUserBackPressed,
+      navHostController,
+      listState
+    )
   }
 }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/ui/KiwixNavGraph.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/ui/KiwixNavGraph.kt
@@ -22,7 +22,6 @@ import android.net.Uri
 import androidx.activity.compose.LocalActivity
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModelProvider
@@ -66,7 +65,6 @@ import org.kiwix.kiwixmobile.core.search.SearchScreenRoute
 import org.kiwix.kiwixmobile.core.settings.SettingsScreenRoute
 import org.kiwix.kiwixmobile.core.utils.EXTRA_IS_WIDGET_VOICE
 import org.kiwix.kiwixmobile.core.utils.TAG_FROM_TAB_SWITCHER
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.help.KiwixHelpViewModel
 import org.kiwix.kiwixmobile.intro.IntroScreenRoute
 import org.kiwix.kiwixmobile.language.LanguageScreenRoute
@@ -91,7 +89,6 @@ fun KiwixNavGraph(
   startDestination: String,
   modifier: Modifier = Modifier,
   viewModelFactory: ViewModelProvider.Factory,
-  alertDialogShower: AlertDialogShower,
   snackBarHostState: SnackbarHostState
 ) {
   NavHost(
@@ -107,7 +104,6 @@ fun KiwixNavGraph(
         viewModel = kiwixReaderViewModel,
         addNoteViewModel = addNoteViewModel,
         navHostController = navController,
-        alertDialogShower = alertDialogShower,
         activity = activity,
       )
     }
@@ -122,18 +118,10 @@ fun KiwixNavGraph(
     ) { backStackEntry ->
       val validateZimViewModel: ValidateZimViewModel = viewModel(factory = viewModelFactory)
       val localLibraryViewModel: LocalLibraryViewModel = viewModel(factory = viewModelFactory)
-      LaunchedEffect(Unit) {
-        localLibraryViewModel.apply {
-          initialize(
-            validateZimViewModel,
-            alertDialogShower,
-            snackBarHostState
-          )
-        }
-      }
       val zimFileUri = backStackEntry.arguments?.getString(ZIM_FILE_URI_KEY).orEmpty()
       LocalLibraryRoute(
         localLibraryViewModel = localLibraryViewModel,
+        validateZimViewModel = validateZimViewModel,
         navController = navController,
         zimFileUriArg = zimFileUri,
         snackBarHostState = snackBarHostState
@@ -149,7 +137,6 @@ fun KiwixNavGraph(
       OnlineLibraryRoute(
         onlineLibraryViewModel = onlineLibraryViewModel,
         categoryViewModel = categoryViewModel,
-        alertDialogShower = alertDialogShower,
         navController = navController,
         activity = activity
       )
@@ -158,16 +145,14 @@ fun KiwixNavGraph(
       val bookmarkViewModel: BookmarkViewModel = viewModel(factory = viewModelFactory)
       BookmarkScreenRoute(
         navigateBack = navController::popBackStack,
-        viewModel = bookmarkViewModel,
-        alertDialogShower = alertDialogShower
+        viewModel = bookmarkViewModel
       )
     }
     composable(KiwixDestination.Notes.route) {
       val notesViewModel: NotesViewModel = viewModel(factory = viewModelFactory)
       NotesScreenRoute(
         navigateBack = navController::popBackStack,
-        notesViewModel = notesViewModel,
-        alertDialogShower = alertDialogShower
+        notesViewModel = notesViewModel
       )
     }
     composable(KiwixDestination.Intro.route) {
@@ -185,8 +170,7 @@ fun KiwixNavGraph(
       val historyViewModel: HistoryViewModel = viewModel(factory = viewModelFactory)
       HistoryScreenRoute(
         navigateBack = navController::popBackStack,
-        viewModel = historyViewModel,
-        alertDialogShower = alertDialogShower
+        viewModel = historyViewModel
       )
     }
     composable(KiwixDestination.Language.route) {
@@ -201,7 +185,7 @@ fun KiwixNavGraph(
     ) {
       val activity = LocalActivity.current as KiwixMainActivity
       val viewModel: ZimHostViewModel = viewModel(factory = viewModelFactory)
-      ZimHostRoute(viewModel, alertDialogShower, activity)
+      ZimHostRoute(viewModel, activity)
     }
     composable(KiwixDestination.Help.route) {
       val kiwixHelpViewModel: KiwixHelpViewModel = viewModel(factory = viewModelFactory)
@@ -212,7 +196,6 @@ fun KiwixNavGraph(
     }
     composable(KiwixDestination.Settings.route) {
       val kiwixSettingsViewModel: KiwixSettingsViewModel = viewModel(factory = viewModelFactory)
-      kiwixSettingsViewModel.setAlertDialog(alertDialogShower)
       SettingsScreenRoute(
         kiwixSettingsViewModel,
         navController::popBackStack
@@ -240,7 +223,6 @@ fun KiwixNavGraph(
 
       SearchScreenRoute(
         viewModelFactory = viewModelFactory,
-        dialogShower = alertDialogShower,
         arguments = backStackEntry.arguments,
         coreMainActivity = coreMainActivity
       )
@@ -264,12 +246,10 @@ fun KiwixNavGraph(
         .orEmpty()
 
       val viewModel: LocalFileTransferViewModel = viewModel(factory = viewModelFactory)
-      viewModel.initialize(uris, alertDialogShower)
-
       LocalFileTransferScreenRoute(
         navigateBack = navController::popBackStack,
         viewModel = viewModel,
-        alertDialogShower = alertDialogShower
+        uris = uris
       )
     }
   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostRoute.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostRoute.kt
@@ -53,7 +53,9 @@ import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.NavigationIcon
+import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.SelectionMode
 import org.kiwix.kiwixmobile.webserver.ZimHostViewModel.Event
@@ -79,12 +81,10 @@ const val SELECTED_ZIM_PATHS_KEY = "selected_zim_paths"
 const val RESTART_SERVER = "restart_server"
 
 @OptIn(ExperimentalPermissionsApi::class)
+@Suppress("LongMethod")
 @Composable
-fun ZimHostRoute(
-  viewModel: ZimHostViewModel,
-  alertDialogShower: AlertDialogShower,
-  activity: CoreMainActivity
-) {
+fun ZimHostRoute(viewModel: ZimHostViewModel, activity: CoreMainActivity) {
+  val alertDialogShower = remember { AlertDialogShower() }
   val lifecycleOwner = LocalLifecycleOwner.current
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
   val notificationPermission = if (viewModel.isAndroid13OrAbove) {
@@ -114,31 +114,34 @@ fun ZimHostRoute(
       }
     }
   }
-  ZimHostScreen(
-    serverIpText = uiState.serverIpDisplayText,
-    showShareIcon = uiState.showShareIcon,
-    shareIconClick = {
-      activity.startActivity(
-        Intent(Intent.ACTION_SEND).apply {
-          type = "text/plain"
-          putExtra(Intent.EXTRA_TEXT, uiState.serverIpAddress)
-        }
-      )
-    },
-    qrImageItem = uiState.qrVisible to uiState.qrIcon,
-    booksList = uiState.books,
-    startServerButtonItem = Triple(
-      stringResource(uiState.startServerButtonTextRes),
-      uiState.startServerButtonColor
-    ) { viewModel.startServerButtonClick() },
-    selectionMode = SelectionMode.MULTI,
-    onMultiSelect = { viewModel.onBookSelected(it) },
-    navigationIcon = {
-      NavigationIcon(onClick = {
-        activity.onBackPressedDispatcher.onBackPressed()
-      })
-    }
-  )
+  KiwixTheme {
+    ZimHostScreen(
+      serverIpText = uiState.serverIpDisplayText,
+      showShareIcon = uiState.showShareIcon,
+      shareIconClick = {
+        activity.startActivity(
+          Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, uiState.serverIpAddress)
+          }
+        )
+      },
+      qrImageItem = uiState.qrVisible to uiState.qrIcon,
+      booksList = uiState.books,
+      startServerButtonItem = Triple(
+        stringResource(uiState.startServerButtonTextRes),
+        uiState.startServerButtonColor
+      ) { viewModel.startServerButtonClick() },
+      selectionMode = SelectionMode.MULTI,
+      onMultiSelect = { viewModel.onBookSelected(it) },
+      navigationIcon = {
+        NavigationIcon(onClick = {
+          activity.onBackPressedDispatcher.onBackPressed()
+        })
+      }
+    )
+    DialogHost(alertDialogShower)
+  }
 }
 
 @Composable

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostScreen.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostScreen.kt
@@ -57,16 +57,15 @@ import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixButton
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
 import org.kiwix.kiwixmobile.core.ui.models.toPainter
-import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FOUR_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MATERIAL_MINIMUM_HEIGHT_AND_WIDTH
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MAXIMUM_HEIGHT_OF_QR_CODE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MINIMUM_HEIGHT_OF_BOOKS_LIST
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.MINIMUM_HEIGHT_OF_QR_CODE
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIXTEEN_DP
-import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.SelectionMode
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
+import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.SelectionMode
 import org.kiwix.kiwixmobile.ui.BookItem
 import org.kiwix.kiwixmobile.ui.ZimFilesLanguageHeader
 
@@ -92,50 +91,48 @@ fun ZimHostScreen(
   onMultiSelect: ((BookOnDisk) -> Unit)? = null,
   navigationIcon: @Composable () -> Unit
 ) {
-  KiwixTheme {
-    Scaffold(
-      topBar = {
-        KiwixAppBar(
-          title = stringResource(R.string.menu_wifi_hotspot),
-          navigationIcon = navigationIcon
-        )
-      },
-      modifier = Modifier.testTag(ZIM_HOST_SCREEN_TESTING_TAG)
-    ) { contentPadding ->
-      Column(
+  Scaffold(
+    topBar = {
+      KiwixAppBar(
+        title = stringResource(R.string.menu_wifi_hotspot),
+        navigationIcon = navigationIcon
+      )
+    },
+    modifier = Modifier.testTag(ZIM_HOST_SCREEN_TESTING_TAG)
+  ) { contentPadding ->
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(contentPadding)
+    ) {
+      Row(
         modifier = Modifier
-          .fillMaxSize()
-          .padding(contentPadding)
+          .fillMaxWidth()
+          .padding(horizontal = SIXTEEN_DP),
+        verticalAlignment = Alignment.CenterVertically
       ) {
-        Row(
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SIXTEEN_DP),
-          verticalAlignment = Alignment.CenterVertically
-        ) {
-          ServerIpText(serverIpText, Modifier.weight(1f), LocalContext.current)
-          ShareIcon(showShareIcon, shareIconClick)
-        }
-        Box(modifier = Modifier.weight(1f)) {
-          BookItemList(
-            booksList,
-            selectionMode,
-            qrImageItem,
-            onClick,
-            onLongClick,
-            onMultiSelect
-          )
-        }
-        KiwixButton(
-          startServerButtonItem.first,
-          startServerButtonItem.third,
-          modifier = Modifier
-            .fillMaxWidth()
-            .padding(FOUR_DP)
-            .testTag(START_SERVER_BUTTON_TESTING_TAG),
-          buttonBackgroundColor = startServerButtonItem.second
+        ServerIpText(serverIpText, Modifier.weight(1f), LocalContext.current)
+        ShareIcon(showShareIcon, shareIconClick)
+      }
+      Box(modifier = Modifier.weight(1f)) {
+        BookItemList(
+          booksList,
+          selectionMode,
+          qrImageItem,
+          onClick,
+          onLongClick,
+          onMultiSelect
         )
       }
+      KiwixButton(
+        startServerButtonItem.first,
+        startServerButtonItem.third,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(FOUR_DP)
+          .testTag(START_SERVER_BUTTON_TESTING_TAG),
+        buttonBackgroundColor = startServerButtonItem.second
+      )
     }
   }
 }

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivity.kt
@@ -82,8 +82,7 @@ class BrandedMainActivity : CoreMainActivity() {
         enableLeftDrawer = enableLeftDrawer.value,
         uiCoroutineScope = uiCoroutineScope,
         customBackHandler = customBackHandler,
-        viewModelFactory = viewModelFactory,
-        alertDialogShower = alertDialogShower
+        viewModelFactory = viewModelFactory
       )
       DialogHost(alertDialogShower)
       LaunchedEffect(Unit) {

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivityScreen.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedMainActivityScreen.kt
@@ -41,7 +41,6 @@ import org.kiwix.kiwixmobile.core.base.BackPressActivityExtensions
 import org.kiwix.kiwixmobile.core.main.DrawerMenuGroup
 import org.kiwix.kiwixmobile.core.main.LeftDrawerMenu
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 
 @Suppress("LongParameterList")
 @Composable
@@ -53,8 +52,7 @@ fun BrandedMainActivityScreen(
   enableLeftDrawer: Boolean,
   customBackHandler: MutableState<(() -> BackPressActivityExtensions.Super)?>,
   uiCoroutineScope: CoroutineScope,
-  viewModelFactory: ViewModelProvider.Factory,
-  alertDialogShower: AlertDialogShower
+  viewModelFactory: ViewModelProvider.Factory
 ) {
   val navBackStackEntry by navController.currentBackStackEntryAsState()
   val currentRoute = navBackStackEntry?.destination?.route
@@ -90,8 +88,7 @@ fun BrandedMainActivityScreen(
           BrandedNavGraph(
             navController = navController,
             modifier = Modifier.fillMaxSize(),
-            viewModelFactory = viewModelFactory,
-            alertDialogShower = alertDialogShower
+            viewModelFactory = viewModelFactory
           )
         }
       }

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedNavGraph.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/main/BrandedNavGraph.kt
@@ -51,7 +51,6 @@ import org.kiwix.kiwixmobile.core.search.SearchScreenRoute
 import org.kiwix.kiwixmobile.core.settings.SettingsScreenRoute
 import org.kiwix.kiwixmobile.core.utils.EXTRA_IS_WIDGET_VOICE
 import org.kiwix.kiwixmobile.core.utils.TAG_FROM_TAB_SWITCHER
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.custom.download.BrandedDownloadRoute
 import org.kiwix.kiwixmobile.custom.download.BrandedDownloadViewModel
 import org.kiwix.kiwixmobile.custom.help.BrandedHelpViewModel
@@ -62,8 +61,7 @@ import org.kiwix.kiwixmobile.custom.settings.BrandedSettingsViewModel
 fun BrandedNavGraph(
   navController: NavHostController,
   modifier: Modifier = Modifier,
-  viewModelFactory: ViewModelProvider.Factory,
-  alertDialogShower: AlertDialogShower
+  viewModelFactory: ViewModelProvider.Factory
 ) {
   NavHost(
     navController = navController,
@@ -78,7 +76,6 @@ fun BrandedNavGraph(
         viewModel = brandedReaderViewModel,
         addNoteViewModel = addNoteViewModel,
         navHostController = navController,
-        alertDialogShower = alertDialogShower,
         activity = activity,
       )
     }
@@ -86,24 +83,21 @@ fun BrandedNavGraph(
       val historyViewModel: HistoryViewModel = viewModel(factory = viewModelFactory)
       HistoryScreenRoute(
         navigateBack = navController::popBackStack,
-        viewModel = historyViewModel,
-        alertDialogShower = alertDialogShower
+        viewModel = historyViewModel
       )
     }
     composable(CustomDestination.Notes.route) {
       val notesViewModel: NotesViewModel = viewModel(factory = viewModelFactory)
       NotesScreenRoute(
         navigateBack = navController::popBackStack,
-        notesViewModel = notesViewModel,
-        alertDialogShower = alertDialogShower
+        notesViewModel = notesViewModel
       )
     }
     composable(CustomDestination.Bookmarks.route) {
       val bookmarkViewModel: BookmarkViewModel = viewModel(factory = viewModelFactory)
       BookmarkScreenRoute(
         navigateBack = navController::popBackStack,
-        viewModel = bookmarkViewModel,
-        alertDialogShower = alertDialogShower
+        viewModel = bookmarkViewModel
       )
     }
     composable(CustomDestination.Help.route) {
@@ -115,7 +109,6 @@ fun BrandedNavGraph(
     }
     composable(CustomDestination.Settings.route) {
       val brandedSettingsViewModel: BrandedSettingsViewModel = viewModel(factory = viewModelFactory)
-      brandedSettingsViewModel.setAlertDialog(alertDialogShower)
       SettingsScreenRoute(
         brandedSettingsViewModel,
         navController::popBackStack
@@ -123,9 +116,7 @@ fun BrandedNavGraph(
     }
     composable(CustomDestination.Downloads.route) {
       val brandedDownloadViewModel: BrandedDownloadViewModel = viewModel(factory = viewModelFactory)
-      BrandedDownloadRoute(
-        brandedDownloadViewModel
-      )
+      BrandedDownloadRoute(brandedDownloadViewModel)
     }
     composable(
       route = CustomDestination.Search.route,
@@ -150,7 +141,6 @@ fun BrandedNavGraph(
 
       SearchScreenRoute(
         viewModelFactory = viewModelFactory,
-        dialogShower = alertDialogShower,
         arguments = backStackEntry.arguments,
         coreMainActivity = coreMainActivity
       )

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenRoute.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreenRoute.kt
@@ -69,10 +69,12 @@ import org.kiwix.kiwixmobile.core.page.history.NavigationHistoryDialog
 import org.kiwix.kiwixmobile.core.read_aloud.ReadAloudService
 import org.kiwix.kiwixmobile.core.search.viewmodel.effects.SearchItemToOpen
 import org.kiwix.kiwixmobile.core.ui.components.NavigationIcon
+import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.TAG_FILE_SEARCHED
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
 import java.io.File
 import java.io.IOException
@@ -84,9 +86,9 @@ fun ReaderScreenRoute(
   viewModel: CoreReaderViewModel,
   addNoteViewModel: AddNoteViewModel,
   activity: CoreMainActivity,
-  alertDialogShower: AlertDialogShower,
   navHostController: NavHostController
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
   val uiState by viewModel.uiState.collectAsState()
   val lifeCycleScope = rememberCoroutineScope()
   val snackBarHostState = remember { SnackbarHostState() }
@@ -133,16 +135,19 @@ fun ReaderScreenRoute(
     readPermissionState,
     notificationPermission
   )
-  ReaderScreen(
-    state = uiState,
-    snackBarHost = snackBarHostState,
-    actionMenuItems = viewModel.readerMenuState?.menuItems.orEmpty(),
-    onReaderAction = viewModel::onAction,
-    onUserBackPressed = { viewModel.onUserBackPressed(activity) },
-    navHostController = navHostController,
-    mainActivityBottomAppBarScrollBehaviour = activity.bottomAppBarScrollBehaviour,
-    navigationIcon = { NavigationItem(viewModel, activity) }
-  )
+  KiwixTheme {
+    ReaderScreen(
+      state = uiState,
+      snackBarHost = snackBarHostState,
+      actionMenuItems = viewModel.readerMenuState?.menuItems.orEmpty(),
+      onReaderAction = viewModel::onAction,
+      onUserBackPressed = { viewModel.onUserBackPressed(activity) },
+      navHostController = navHostController,
+      mainActivityBottomAppBarScrollBehaviour = activity.bottomAppBarScrollBehaviour,
+      navigationIcon = { NavigationItem(viewModel, activity) }
+    )
+    DialogHost(alertDialogShower)
+  }
 }
 
 @Composable

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
@@ -88,6 +88,7 @@ import org.kiwix.kiwixmobile.core.utils.ComposeDimens.PAGE_SWITCH_LEFT_RIGHT_MAR
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.PAGE_SWITCH_ROW_BOTTOM_MARGIN
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.SIXTEEN_DP
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.DateTimeParseException
@@ -108,10 +109,10 @@ fun <T : Page, S : PageState<T>> PageScreenRoute(
   deleteIconTitle: Int,
   noItemsString: String,
   switchIsCheckedFlow: Flow<Boolean>,
-  alertDialogShower: AlertDialogShower,
   navigateBack: () -> Unit,
   viewModel: PageViewModel<T, S>
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
   val state by viewModel.state.collectAsStateWithLifecycle()
   val activity = LocalActivity.current as CoreMainActivity
 
@@ -153,52 +154,54 @@ fun <T : Page, S : PageState<T>> PageScreenRoute(
   }
 
   BackHandler(enabled = isSearchActive || isInSelectionMode) { handleNavigationClick() }
-
-  PageScreen(
-    state = state,
-    searchText = searchText,
-    screenTitle = screenTitle,
-    switchString = switchString,
-    noItemsString = noItemsString,
-    searchQueryHint = searchQueryHint,
-    isSearchBarActive = isSearchActive,
-    isInSelectionMode = isInSelectionMode,
-    selectedCount = selectedCount,
-    switchIsCheckedFlow = switchIsCheckedFlow,
-    isBrandedApp = activity.isBrandedApp(),
-    navigationIcon = { NavigationIcon(onClick = { handleNavigationClick() }) },
-    actionMenuItems = actionMenuList(
-      deleteIconTitle = deleteIconTitle,
-      isSearchActive = isSearchActive,
+  KiwixTheme {
+    PageScreen(
+      state = state,
+      searchText = searchText,
+      screenTitle = screenTitle,
+      switchString = switchString,
+      noItemsString = noItemsString,
+      searchQueryHint = searchQueryHint,
+      isSearchBarActive = isSearchActive,
       isInSelectionMode = isInSelectionMode,
-      onSearchClick = {
-        isSearchActive = true
+      selectedCount = selectedCount,
+      switchIsCheckedFlow = switchIsCheckedFlow,
+      isBrandedApp = activity.isBrandedApp(),
+      navigationIcon = { NavigationIcon(onClick = { handleNavigationClick() }) },
+      actionMenuItems = actionMenuList(
+        deleteIconTitle = deleteIconTitle,
+        isSearchActive = isSearchActive,
+        isInSelectionMode = isInSelectionMode,
+        onSearchClick = {
+          isSearchActive = true
+        },
+        onDeleteClick = {
+          viewModel.actions.tryEmit(Action.UserClickedDeleteButton)
+        },
+        onSelectionDeleteClick = {
+          viewModel.actions.tryEmit(Action.UserClickedDeleteSelectedPages)
+        }
+      ),
+      onClearSearch = {
+        searchText = ""
+        viewModel.actions.tryEmit(Action.Filter(""))
       },
-      onDeleteClick = {
-        viewModel.actions.tryEmit(Action.UserClickedDeleteButton)
+      onSearchTextChange = { newText ->
+        searchText = newText
+        viewModel.actions.tryEmit(Action.Filter(newText.trim()))
       },
-      onSelectionDeleteClick = {
-        viewModel.actions.tryEmit(Action.UserClickedDeleteSelectedPages)
-      }
-    ),
-    onClearSearch = {
-      searchText = ""
-      viewModel.actions.tryEmit(Action.Filter(""))
-    },
-    onSearchTextChange = { newText ->
-      searchText = newText
-      viewModel.actions.tryEmit(Action.Filter(newText.trim()))
-    },
-    onSwitchCheckedChange = { isChecked ->
-      viewModel.actions.tryEmit(Action.UserClickedShowAllToggle(isChecked))
-    },
-    onItemLongClick = { page ->
-      viewModel.actions.tryEmit(Action.OnItemLongClick(page))
-    },
-    onItemClick = { page ->
-      viewModel.actions.tryEmit(Action.OnItemClick(page))
-    },
-  )
+      onSwitchCheckedChange = { isChecked ->
+        viewModel.actions.tryEmit(Action.UserClickedShowAllToggle(isChecked))
+      },
+      onItemLongClick = { page ->
+        viewModel.actions.tryEmit(Action.OnItemLongClick(page))
+      },
+      onItemClick = { page ->
+        viewModel.actions.tryEmit(Action.OnItemClick(page))
+      },
+    )
+    DialogHost(alertDialogShower)
+  }
 }
 
 @Suppress("ComposableLambdaParameterNaming", "LongParameterList", "LongMethod")
@@ -225,62 +228,60 @@ fun <T : Page, S : PageState<T>> PageScreen(
   actionMenuItems: List<ActionMenuItem>,
   navigationIcon: @Composable () -> Unit
 ) {
-  KiwixTheme {
-    Scaffold(
-      topBar = {
-        Column {
-          KiwixAppBar(
-            title = if (isInSelectionMode) {
-              stringResource(R.string.selected_items, selectedCount)
-            } else {
-              screenTitle
-            },
-            navigationIcon = navigationIcon,
-            actionMenuItems = actionMenuItems,
-            searchBar = searchBarIfActive(
-              isSearchBarActive = isSearchBarActive,
-              isInSelectionMode = isInSelectionMode,
-              searchQueryHint = searchQueryHint,
-              searchText = searchText,
-              onSearchTextChange = onSearchTextChange,
-              onClearSearch = onClearSearch
-            )
+  Scaffold(
+    topBar = {
+      Column {
+        KiwixAppBar(
+          title = if (isInSelectionMode) {
+            stringResource(R.string.selected_items, selectedCount)
+          } else {
+            screenTitle
+          },
+          navigationIcon = navigationIcon,
+          actionMenuItems = actionMenuItems,
+          searchBar = searchBarIfActive(
+            isSearchBarActive = isSearchBarActive,
+            isInSelectionMode = isInSelectionMode,
+            searchQueryHint = searchQueryHint,
+            searchText = searchText,
+            onSearchTextChange = onSearchTextChange,
+            onClearSearch = onClearSearch
           )
-          PageSwitchRow(
-            switchString = switchString,
-            switchIsEnabled = !isInSelectionMode,
-            switchIsCheckedFlow = switchIsCheckedFlow,
-            onSwitchCheckedChange = onSwitchCheckedChange,
-            isBrandedApp = isBrandedApp
-          )
-        }
+        )
+        PageSwitchRow(
+          switchString = switchString,
+          switchIsEnabled = !isInSelectionMode,
+          switchIsCheckedFlow = switchIsCheckedFlow,
+          onSwitchCheckedChange = onSwitchCheckedChange,
+          isBrandedApp = isBrandedApp
+        )
       }
-    ) { padding ->
-      val items = state.pageItems
-      Box(
-        modifier = Modifier
-          .padding(
-            top = padding.calculateTopPadding(),
-            start = padding.calculateStartPadding(LocalLayoutDirection.current),
-            end = padding.calculateEndPadding(LocalLayoutDirection.current)
-          )
-          .fillMaxSize()
-      ) {
-        if (items.isEmpty()) {
-          Text(
-            text = noItemsString,
-            style = MaterialTheme.typography.headlineSmall,
-            modifier = Modifier
-              .align(Alignment.Center)
-              .semantics { testTag = NO_ITEMS_TEXT_TESTING_TAG }
-          )
-        } else {
-          PageList(
-            visiblePageItems = state.visiblePageItems,
-            onItemClick = onItemClick,
-            onItemLongClick = onItemLongClick
-          )
-        }
+    }
+  ) { padding ->
+    val items = state.pageItems
+    Box(
+      modifier = Modifier
+        .padding(
+          top = padding.calculateTopPadding(),
+          start = padding.calculateStartPadding(LocalLayoutDirection.current),
+          end = padding.calculateEndPadding(LocalLayoutDirection.current)
+        )
+        .fillMaxSize()
+    ) {
+      if (items.isEmpty()) {
+        Text(
+          text = noItemsString,
+          style = MaterialTheme.typography.headlineSmall,
+          modifier = Modifier
+            .align(Alignment.Center)
+            .semantics { testTag = NO_ITEMS_TEXT_TESTING_TAG }
+        )
+      } else {
+        PageList(
+          visiblePageItems = state.visiblePageItems,
+          onItemClick = onItemClick,
+          onItemLongClick = onItemLongClick
+        )
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarkScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/BookmarkScreen.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.core.page.bookmark
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.page.PageScreenRoute
 import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.BookmarkViewModel
@@ -28,8 +27,7 @@ import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.BookmarkViewModel
 @Composable
 fun BookmarkScreenRoute(
   navigateBack: () -> Unit,
-  viewModel: BookmarkViewModel,
-  alertDialogShower: AlertDialogShower
+  viewModel: BookmarkViewModel
 ) {
   PageScreenRoute(
     navigateBack = navigateBack,
@@ -39,7 +37,6 @@ fun BookmarkScreenRoute(
     switchString = stringResource(R.string.bookmarks_from_current_book),
     searchQueryHint = stringResource(R.string.search_bookmarks),
     deleteIconTitle = R.string.pref_clear_all_bookmarks_title,
-    switchIsCheckedFlow = viewModel.kiwixDataStore.showBookmarksOfAllBooks,
-    alertDialogShower = alertDialogShower,
+    switchIsCheckedFlow = viewModel.kiwixDataStore.showBookmarksOfAllBooks
   )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/HistoryScreen.kt
@@ -20,7 +20,6 @@ package org.kiwix.kiwixmobile.core.page.history
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.page.PageScreenRoute
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.HistoryViewModel
@@ -28,8 +27,7 @@ import org.kiwix.kiwixmobile.core.page.history.viewmodel.HistoryViewModel
 @Composable
 fun HistoryScreenRoute(
   navigateBack: () -> Unit,
-  viewModel: HistoryViewModel,
-  alertDialogShower: AlertDialogShower
+  viewModel: HistoryViewModel
 ) {
   PageScreenRoute(
     navigateBack = navigateBack,
@@ -39,7 +37,6 @@ fun HistoryScreenRoute(
     switchString = stringResource(R.string.history_from_current_book),
     searchQueryHint = stringResource(R.string.search_history),
     deleteIconTitle = R.string.pref_clear_all_history_title,
-    switchIsCheckedFlow = viewModel.kiwixDataStore.showHistoryOfAllBooks,
-    alertDialogShower = alertDialogShower,
+    switchIsCheckedFlow = viewModel.kiwixDataStore.showHistoryOfAllBooks
   )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/NotesScreen.kt
@@ -20,16 +20,14 @@ package org.kiwix.kiwixmobile.core.page.notes
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import org.kiwix.kiwixmobile.core.page.notes.viewmodel.NotesViewModel
-import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.page.PageScreenRoute
+import org.kiwix.kiwixmobile.core.page.notes.viewmodel.NotesViewModel
 
 @Composable
 fun NotesScreenRoute(
   navigateBack: () -> Unit,
-  notesViewModel: NotesViewModel,
-  alertDialogShower: AlertDialogShower
+  notesViewModel: NotesViewModel
 ) {
   PageScreenRoute(
     navigateBack = navigateBack,
@@ -39,7 +37,6 @@ fun NotesScreenRoute(
     switchString = stringResource(R.string.notes_from_all_books),
     searchQueryHint = stringResource(R.string.search_notes),
     deleteIconTitle = R.string.pref_clear_notes,
-    switchIsCheckedFlow = notesViewModel.kiwixDataStore.showNotesOfAllBooks,
-    alertDialogShower = alertDialogShower,
+    switchIsCheckedFlow = notesViewModel.kiwixDataStore.showNotesOfAllBooks
   )
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreen.kt
@@ -76,7 +76,6 @@ import org.kiwix.kiwixmobile.core.ui.components.ContentLoadingProgressBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixAppBar
 import org.kiwix.kiwixmobile.core.ui.components.KiwixSearchView
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
-import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.EIGHT_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FIFTEEN_DP
 import org.kiwix.kiwixmobile.core.utils.ComposeDimens.FOUR_DP
@@ -108,28 +107,26 @@ fun SearchScreen(
   navigationIcon: @Composable() () -> Unit
 ) {
   val lazyListState = rememberLazyListState()
-  KiwixTheme {
-    Scaffold(
-      topBar = {
-        KiwixAppBar(
-          title = stringResource(R.string.empty_string),
-          navigationIcon = navigationIcon,
-          actionMenuItems = actionMenuItemList,
-          searchBar = {
-            KiwixSearchView(
-              value = state.searchText,
-              searchViewTextFiledTestTag = SEARCH_FIELD_TESTING_TAG,
-              onValueChange = { searchViewModel.onSearchValueChanged(it) },
-              onClearClick = { searchViewModel.onSearchClear() },
-              modifier = Modifier,
-              onKeyboardSubmitButtonClick = { searchViewModel.onKeyboardSubmitButtonClick(it) }
-            )
-          }
-        )
-      }
-    ) { innerPadding ->
-      SearchScreenContent(state, searchViewModel, innerPadding, lazyListState)
+  Scaffold(
+    topBar = {
+      KiwixAppBar(
+        title = stringResource(R.string.empty_string),
+        navigationIcon = navigationIcon,
+        actionMenuItems = actionMenuItemList,
+        searchBar = {
+          KiwixSearchView(
+            value = state.searchText,
+            searchViewTextFiledTestTag = SEARCH_FIELD_TESTING_TAG,
+            onValueChange = { searchViewModel.onSearchValueChanged(it) },
+            onClearClick = { searchViewModel.onSearchClear() },
+            modifier = Modifier,
+            onKeyboardSubmitButtonClick = { searchViewModel.onKeyboardSubmitButtonClick(it) }
+          )
+        }
+      )
     }
+  ) { innerPadding ->
+    SearchScreenContent(state, searchViewModel, innerPadding, lazyListState)
   }
   InfiniteListHandler(
     listState = lazyListState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreenRoute.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/SearchScreenRoute.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -34,18 +35,19 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.SearchViewModel
 import org.kiwix.kiwixmobile.core.ui.components.NavigationIcon
 import org.kiwix.kiwixmobile.core.ui.models.ActionMenuItem
 import org.kiwix.kiwixmobile.core.ui.models.IconItem
+import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
-import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 
 const val NAV_ARG_SEARCH_STRING = "searchString"
 
 @Composable
 fun SearchScreenRoute(
   viewModelFactory: ViewModelProvider.Factory,
-  dialogShower: DialogShower,
   arguments: Bundle?,
   coreMainActivity: CoreMainActivity
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
   val viewModel: SearchViewModel = viewModel(factory = viewModelFactory)
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -73,25 +75,28 @@ fun SearchScreenRoute(
 
   // Search Results
   LaunchedEffect(Unit) {
-    viewModel.setAlertDialogShower(dialogShower as AlertDialogShower)
+    viewModel.setAlertDialogShower(alertDialogShower)
     viewModel.actions.tryEmit(
       Action.CreatedWithArguments(Bundle(arguments))
     )
   }
 
-  SearchScreen(
-    uiState,
-    viewModel,
-    buildActionMenuItems(viewModel),
-    {
-      NavigationIcon(
-        onClick = {
-          viewModel.closeKeyboard()
-          coreMainActivity.onBackPressedDispatcher.onBackPressed()
-        }
-      )
-    }
-  )
+  KiwixTheme {
+    SearchScreen(
+      uiState,
+      viewModel,
+      buildActionMenuItems(viewModel),
+      {
+        NavigationIcon(
+          onClick = {
+            viewModel.closeKeyboard()
+            coreMainActivity.onBackPressedDispatcher.onBackPressed()
+          }
+        )
+      }
+    )
+    DialogHost(alertDialogShower)
+  }
 }
 
 private fun buildActionMenuItems(viewModel: SearchViewModel): List<ActionMenuItem> {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -120,7 +120,9 @@ import org.kiwix.kiwixmobile.core.utils.LanguageUtils
 import org.kiwix.kiwixmobile.core.utils.SIX
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogConfirmButton
+import org.kiwix.kiwixmobile.core.utils.dialog.DialogHost
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogTitle
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixBasicDialogFrame
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog
@@ -142,6 +144,8 @@ fun SettingsScreenRoute(
   coreSettingsViewModel: CoreSettingsViewModel,
   navigateBack: () -> Unit
 ) {
+  val alertDialogShower = remember { AlertDialogShower() }
+  coreSettingsViewModel.setAlertDialog(alertDialogShower)
   val activity = LocalActivity.current as CoreMainActivity
   // Not placing condition here. Because viewModel already verify whether
   // we should ask this permission or not. Compose suggested to avoid using remember inside conditionals.
@@ -150,7 +154,10 @@ fun SettingsScreenRoute(
   }
   // Setup viewModel data version name, observing the click events, etc.
   SetUpViewModelAndPermissionLauncher(coreSettingsViewModel, activity, writePermissionState)
-  SettingsScreen(coreSettingsViewModel) { NavigationIcon(onClick = navigateBack) }
+  KiwixTheme {
+    SettingsScreen(coreSettingsViewModel) { NavigationIcon(onClick = navigateBack) }
+    DialogHost(alertDialogShower)
+  }
   // Change font according to app language.
   ChangeFontAccordingToLanguage(activity, coreSettingsViewModel.kiwixDataStore)
 }
@@ -297,39 +304,37 @@ internal fun SettingsScreen(
   navigationIcon: @Composable() () -> Unit
 ) {
   val uiState by coreSettingsViewModel.uiState.collectAsStateWithLifecycle()
-  KiwixTheme {
-    Scaffold(
-      snackbarHost = { KiwixSnackbarHost(snackbarHostState = uiState.snackbarHostState) },
-      topBar = {
-        KiwixAppBar(
-          title = stringResource(R.string.menu_settings),
-          navigationIcon = navigationIcon
-        )
-      }
-    ) { innerPadding ->
-      LazyColumn(
-        modifier = Modifier
-          .fillMaxSize()
-          .padding(innerPadding)
-          .semantics {
-            testTag = SETTINGS_LIST_TESTING_TAG
-          }
-      ) {
-        item { DisplayCategory(coreSettingsViewModel) }
-        item { ExtrasCategory(coreSettingsViewModel, uiState) }
-        storageCategory(uiState, coreSettingsViewModel)
-        item { HistoryCategory(coreSettingsViewModel) }
-        item { NotesCategory(coreSettingsViewModel) }
-        item { BookmarksCategory(coreSettingsViewModel) }
-        item { PermissionCategory(coreSettingsViewModel, uiState) }
-        if (uiState.shouldShowLanguageCategory) {
-          item { LanguageCategory(uiState, coreSettingsViewModel) }
+  Scaffold(
+    snackbarHost = { KiwixSnackbarHost(snackbarHostState = uiState.snackbarHostState) },
+    topBar = {
+      KiwixAppBar(
+        title = stringResource(R.string.menu_settings),
+        navigationIcon = navigationIcon
+      )
+    }
+  ) { innerPadding ->
+    LazyColumn(
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(innerPadding)
+        .semantics {
+          testTag = SETTINGS_LIST_TESTING_TAG
         }
-        if (uiState.shouldShowRatingCategory) {
-          item { RatingCategory(coreSettingsViewModel) }
-        }
-        informationCategory(coreSettingsViewModel, uiState)
+    ) {
+      item { DisplayCategory(coreSettingsViewModel) }
+      item { ExtrasCategory(coreSettingsViewModel, uiState) }
+      storageCategory(uiState, coreSettingsViewModel)
+      item { HistoryCategory(coreSettingsViewModel) }
+      item { NotesCategory(coreSettingsViewModel) }
+      item { BookmarksCategory(coreSettingsViewModel) }
+      item { PermissionCategory(coreSettingsViewModel, uiState) }
+      if (uiState.shouldShowLanguageCategory) {
+        item { LanguageCategory(uiState, coreSettingsViewModel) }
       }
+      if (uiState.shouldShowRatingCategory) {
+        item { RatingCategory(coreSettingsViewModel) }
+      }
+      informationCategory(coreSettingsViewModel, uiState)
     }
   }
 }
@@ -646,7 +651,9 @@ private fun SwitchPreference(
       Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
-        modifier = Modifier.semantics { contentDescription = title }.testTag(title)
+        modifier = Modifier
+          .semantics { contentDescription = title }
+          .testTag(title)
       )
     }
   }


### PR DESCRIPTION
Fixes #5003 

* The issue was caused by using the activity-level `AlertDialogShower`, which exists independently of the composable lifecycle. As a result, if a dialog was requested and the user navigated away before it was displayed, it could appear on a different screen.
* Replaced the activity-level `AlertDialogShower` in composable screens with screen-scoped `AlertDialogShower` instances. Each screen now owns its own dialog host, making dialog presentation lifecycle-aware. `Dialogs` are only shown while the owning screen is visible, and pending dialogs are ignored if the user navigates away.
* Refactored the codebase to adopt the new screen-scoped dialog architecture.
* Fixed `testScanStorageDialog`, which was failing after these changes.
* Improved the `LibraryRobot`, `SearchRobot`, and `DownloadRobot` code to make view assertions more robust. The CI occasionally failed due to weak assertions, so the assertions have been updated to better align with the Jetpack Compose architecture.
* Improved `testTabsRestoredAfterNavigatingLeftDrawerScreens`, and `testTabsRestoredWhenNavigatingToOtherScreenViaBottomAppBar` tests, which sometimes failed on API level 25.
