### PR TITLE
Replace completed occurence of Dispatchers.IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,8 @@ captures/
 !/.idea/copyright/
 !/.idea/kotlinCodeInsightSettings.xml
 app/jacoco.exec
+core/src/main/res/values-b+be+tarask/strings.xml
+core/src/main/res/values-b+be+tarask+old/strings.xml
 
 # F-Droid auto-publish file
 VERSION_INFO

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderContainerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderContainerTest.kt
@@ -42,7 +42,6 @@ import org.kiwix.libzim.Archive
 import org.kiwix.libzim.SuggestionSearcher
 import java.io.File
 
-@Suppress("InjectDispatcher")
 @RunWith(AndroidJUnit4::class)
 class ZimReaderContainerTest {
   private lateinit var container: ZimReaderContainer

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderSourceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimReaderSourceTest.kt
@@ -42,7 +42,6 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils.getZimFileFromResourceFolder
 import java.io.File
 
-@Suppress("InjectDispatcher")
 @RunWith(AndroidJUnit4::class)
 class ZimReaderSourceTest {
   private lateinit var testZimFile: File

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/KiwixServer.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/KiwixServer.kt
@@ -47,7 +47,7 @@ class KiwixServer @Inject constructor(
     private val zimReaderContainer: ZimReaderContainer,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
   ) {
-    @Suppress("NestedBlockDepth", "InjectDispatcher")
+    @Suppress("NestedBlockDepth")
     suspend fun createKiwixServer(selectedBooksPath: ArrayList<String>): KiwixServer =
       withContext(ioDispatcher) {
         val kiwixLibrary = Library()

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/WebServerHelper.kt
@@ -19,7 +19,6 @@ package org.kiwix.kiwixmobile.webserver
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -122,7 +121,6 @@ class WebServerHelper @Inject constructor(
    * - If a valid IP is found, invokes [IpAddressCallbacks.onIpAddressInvalid].
    * - If no valid IP is found within [FINDING_IP_ADDRESS_TIMEOUT] seconds,
    * invokes [IpAddressCallbacks.onIpAddressInvalid].
-   * - The flow runs on [Dispatchers.IO] and results are collected on the Main thread.
    * - Automatically cancels if [serviceScope] is cancelled (e.g. lifecycle aware).
    */
   @OptIn(FlowPreview::class)
@@ -143,7 +141,6 @@ class WebServerHelper @Inject constructor(
   /**
    * Creates a [Flow] that emits the current IP address every [FINDING_IP_ADDRESS_RETRY_TIME] milliseconds.
    * - If the returned IP is not [INVALID_IP], the flow completes.
-   * - The flow runs entirely on [Dispatchers.IO].
    */
   @Suppress("TooGenericExceptionCaught")
   private fun ipPollingFlow(): Flow<String?> = flow {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -22,7 +22,6 @@ import android.os.Build
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -79,10 +78,9 @@ class LibkiwixBookmarks @Inject constructor(
   private val initMutex = Mutex()
   private var initialized: Boolean = false
 
-  @Suppress("InjectDispatcher")
   private val bookmarkListFlow: MutableStateFlow<List<LibkiwixBookmarkItem>> by lazy {
     MutableStateFlow<List<LibkiwixBookmarkItem>>(emptyList()).also { flow ->
-      CoroutineScope(Dispatchers.IO).launch {
+      CoroutineScope(ioDispatcher).launch {
         runCatching {
           val bookmarks = getBookmarksList()
           flow.emit(bookmarks)
@@ -109,9 +107,8 @@ class LibkiwixBookmarks @Inject constructor(
 
   /**
    * Ensure initialization runs once. This method performs all file I/O and manager setup
-   * on Dispatchers.IO so it won't block the main thread. It is safe to call multiple times.
    */
-  private suspend fun ensureInitialized(ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
+  private suspend fun ensureInitialized() {
     if (initialized) return
 
     initMutex.withLock {
@@ -141,10 +138,9 @@ class LibkiwixBookmarks @Inject constructor(
   override fun deletePages(pagesToDelete: List<Page>) =
     deleteBookmarks(pagesToDelete as List<LibkiwixBookmarkItem>)
 
-  @Suppress("InjectDispatcher")
   suspend fun getCurrentZimBookmarksUrl(zimFileReader: ZimFileReader?): List<String> {
     ensureInitialized()
-    return withContext(Dispatchers.IO) {
+    return withContext(ioDispatcher) {
       zimFileReader?.let { reader ->
         getBookmarksList()
           .filter { it.zimId == reader.id }
@@ -153,13 +149,12 @@ class LibkiwixBookmarks @Inject constructor(
     }
   }
 
-  @Suppress("InjectDispatcher")
   fun bookmarkUrlsForCurrentBook(zimId: String): Flow<List<String>> =
     bookmarkListFlow
       .map { bookmarksList ->
         bookmarksList.filter { it.zimId == zimId }
           .map(LibkiwixBookmarkItem::bookmarkUrl)
-      }.flowOn(Dispatchers.IO)
+      }.flowOn(ioDispatcher)
 
   /**
    * Saves bookmarks in libkiwix. The use of `shouldWriteBookmarkToFile` is primarily
@@ -278,15 +273,14 @@ class LibkiwixBookmarks @Inject constructor(
   }
 
   fun deleteBookmarks(
-    bookmarks: List<LibkiwixBookmarkItem>,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    bookmarks: List<LibkiwixBookmarkItem>
   ) {
     CoroutineScope(ioDispatcher).launch {
       ensureInitialized()
       bookmarks.map { library.removeBookmark(it.zimId, it.bookmarkUrl) }
       writeBookMarksAndSaveLibraryToFile()
       updateFlowBookmarkList()
-      removeBookFromLibraryIfNoRelatedBookmarksAreStored(ioDispatcher, bookmarks)
+      removeBookFromLibraryIfNoRelatedBookmarksAreStored(bookmarks)
     }
   }
 
@@ -300,11 +294,9 @@ class LibkiwixBookmarks @Inject constructor(
    * This function checks if any of the books associated with the given deleted bookmarks
    * are still referenced by other existing bookmarks. If not, those books are removed from the library.
    *
-   * @param ioDispatcher The coroutine dispatcher to run the operation on (typically Dispatchers.IO).
    * @param deletedBookmarks The list of bookmarks that were just deleted.
    */
   private suspend fun removeBookFromLibraryIfNoRelatedBookmarksAreStored(
-    ioDispatcher: CoroutineDispatcher,
     deletedBookmarks: List<LibkiwixBookmarkItem>
   ) {
     ensureInitialized()
@@ -469,10 +461,8 @@ class LibkiwixBookmarks @Inject constructor(
     }
   }
 
-  @Suppress("InjectDispatcher")
   private suspend fun exportedFile(
-    fileName: String,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    fileName: String
   ): File {
     val rootFolder = File(EXPORT_BOOK_MARK_PATH)
     if (!rootFolder.isFileExist(ioDispatcher)) rootFolder.mkdir()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/di/modules/DownloaderModule.kt
@@ -27,7 +27,6 @@ import dagger.Module
 import dagger.Provides
 import okhttp3.OkHttpClient
 import org.kiwix.kiwixmobile.core.BuildConfig
-import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.downloader.DownloadRequester
 import org.kiwix.kiwixmobile.core.downloader.Downloader
@@ -49,6 +48,10 @@ abstract class DownloaderModule {
   @Binds
   @Singleton
   abstract fun bindDownloadRequester(impl: DownloadManagerRequester): DownloadRequester
+
+  @Binds
+  @Singleton
+  abstract fun bindFetchNotificationManager(impl: FetchDownloadNotificationManager): FetchNotificationManager
 
   companion object {
     @Provides
@@ -83,10 +86,5 @@ abstract class DownloaderModule {
         .followSslRedirects(true)
         .build()
     )
-
-    @Provides
-    @Singleton
-    fun provideFetchDownloadNotificationManager(context: Context, downloadRoomDao: DownloadRoomDao):
-      FetchNotificationManager = FetchDownloadNotificationManager(context, downloadRoomDao)
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -72,7 +72,6 @@ const val DOWNLOAD_TIMEOUT_LIMIT_REACH_NOTIFICATION_ID = 2
 const val DOWNLOAD_TIMEOUT_NOTIFICATION_YES_REQUEST_CODE = 2001
 const val DOWNLOAD_TIMEOUT_NOTIFICATION_NO_REQUEST_CODE = 2002
 
-@Suppress("InjectDispatcher")
 class DownloadMonitorService : Service() {
   private val taskFlow = MutableSharedFlow<suspend () -> Unit>(extraBufferCapacity = Int.MAX_VALUE)
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/FetchDownloadNotificationManager.kt
@@ -58,15 +58,16 @@ import com.tonyodev.fetch2.R.drawable
 import com.tonyodev.fetch2.R.string
 import com.tonyodev.fetch2.Status
 import com.tonyodev.fetch2.util.DEFAULT_NOTIFICATION_TIMEOUT_AFTER_RESET
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.core.CoreApp
-import org.kiwix.kiwixmobile.core.utils.ZERO
-import org.kiwix.kiwixmobile.core.utils.HUNDERED
 import org.kiwix.kiwixmobile.core.Intents
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
+import org.kiwix.kiwixmobile.core.utils.HUNDERED
+import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.zim_manager.Byte
 import javax.inject.Inject
 
@@ -75,7 +76,8 @@ const val DOWNLOAD_NOTIFICATION_ID = "DOWNLOAD_NOTIFICATION_ID"
 
 class FetchDownloadNotificationManager @Inject constructor(
   val context: Context,
-  private val downloadRoomDao: DownloadRoomDao
+  private val downloadRoomDao: DownloadRoomDao,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : DefaultFetchNotificationManager(context) {
   private val notificationBuilderLock = Any()
 
@@ -306,7 +308,6 @@ class FetchDownloadNotificationManager @Inject constructor(
     downloadNotificationManager.notify(download.id, pauseNotification)
   }
 
-  @Suppress("InjectDispatcher")
   private fun getPauseNotification(
     fetch: Fetch,
     download: Download,
@@ -315,7 +316,7 @@ class FetchDownloadNotificationManager @Inject constructor(
     synchronized(notificationBuilderLock) {
       val downloadTitle = getDownloadNotificationTitle(download)
       val notificationTitle =
-        runBlocking(Dispatchers.IO) {
+        runBlocking(ioDispatcher) {
           downloadRoomDao.getEntityForFileName(downloadTitle)?.title
             ?: downloadTitle
         }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -52,6 +51,7 @@ import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getVersionCode
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.queryIntentActivitiesCompat
 import org.kiwix.kiwixmobile.core.compat.ResolveInfoFlagsCompat
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.viewModel
 import org.kiwix.kiwixmobile.core.extensions.toast
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
@@ -86,6 +86,10 @@ open class ErrorActivity : BaseActivity() {
 
   @Inject
   lateinit var mountPointProducer: MountPointProducer
+
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
 
   @Inject
   lateinit var fileLogger: FileLogger
@@ -202,10 +206,10 @@ open class ErrorActivity : BaseActivity() {
     }
   }
 
-  private suspend fun startValidatingZIMFiles(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-    val zimBooks = withContext(dispatcher) { libkiwixBookOnDisk.getBooks() }
+  private suspend fun startValidatingZIMFiles() {
+    val zimBooks = withContext(ioDispatcher) { libkiwixBookOnDisk.getBooks() }
     showValidationDialog.value = true
-    CoroutineScope(dispatcher).launch {
+    CoroutineScope(ioDispatcher).launch {
       val isBrandedApp = kiwixDataStore.isBrandedApp.first()
       validateZimViewModel.startValidation(zimBooks, isBrandedApp)
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreMainActivity.kt
@@ -215,7 +215,6 @@ abstract class CoreMainActivity : BaseActivity() {
    */
   private var wasLeftDrawerOpen = false
 
-  @Suppress("InjectDispatcher")
   override fun onCreate(savedInstanceState: Bundle?) {
     val splashScreen = installSplashScreen()
     splashScreen.setKeepOnScreenCondition {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -183,7 +183,6 @@ open class KiwixWebView constructor(
 
       val appContext = ContextCompat.getContextForLanguage(instance)
 
-      @Suppress("InjectDispatcher")
       CoroutineScope(ioDispatcher).launch {
         val result = FileUtils.downloadFileFromUrl(
           context = appContext,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
 import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects.ShowDeleteBookmarksDialog
 import org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects.UpdateAllBookmarksPreference
@@ -30,15 +31,18 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.PageViewModel
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 
 class BookmarkViewModel @Inject constructor(
   libkiwixBookmarks: LibkiwixBookmarks,
   zimReaderContainer: ZimReaderContainer,
-  kiwixDataStore: KiwixDataStore
+  kiwixDataStore: KiwixDataStore,
+  @IoDispatcher ioDispatcher: CoroutineDispatcher
 ) : PageViewModel<LibkiwixBookmarkItem, BookmarkState>(
     libkiwixBookmarks,
     kiwixDataStore,
-    zimReaderContainer
+    zimReaderContainer,
+    ioDispatcher
   ) {
   override fun initialState(): BookmarkState {
     val showAll = runBlocking { kiwixDataStore.showBookmarksOfAllBooks.first() }
@@ -75,7 +79,14 @@ class BookmarkViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: BookmarkState, viewModelScope: CoroutineScope) =
-    ShowDeleteBookmarksDialog(effects, state, pageDao, viewModelScope, requireAlertDialogShower())
+    ShowDeleteBookmarksDialog(
+      effects,
+      state,
+      pageDao,
+      viewModelScope,
+      requireAlertDialogShower(),
+      ioDispatcher
+    )
 
   override fun copyWithNewItems(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialog.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel.effects
  */
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.kiwix.kiwixmobile.core.base.SideEffect
@@ -35,12 +36,13 @@ data class ShowDeleteBookmarksDialog(
   private val state: PageState<LibkiwixBookmarkItem>,
   private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope,
-  var dialogShower: DialogShower
+  var dialogShower: DialogShower,
+  private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedBookmarks else DeleteAllBookmarks,
-      { effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope)) }
+      { effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope, ioDispatcher)) }
     )
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem.HistoryItem
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.ShowDeleteHistoryDialog
 import org.kiwix.kiwixmobile.core.page.history.viewmodel.effects.UpdateAllHistoryPreference
@@ -30,12 +31,19 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.PageViewModel
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 
 class HistoryViewModel @Inject constructor(
   historyRoomDao: HistoryRoomDao,
   zimReaderContainer: ZimReaderContainer,
-  kiwixDataStore: KiwixDataStore
-) : PageViewModel<HistoryItem, HistoryState>(historyRoomDao, kiwixDataStore, zimReaderContainer) {
+  kiwixDataStore: KiwixDataStore,
+  @IoDispatcher ioDispatcher: CoroutineDispatcher
+) : PageViewModel<HistoryItem, HistoryState>(
+    historyRoomDao,
+    kiwixDataStore,
+    zimReaderContainer,
+    ioDispatcher
+  ) {
   override fun initialState(): HistoryState {
     val showAll = runBlocking { kiwixDataStore.showHistoryOfAllBooks.first() }
     return HistoryState(emptyList(), showAll, zimReaderContainer.id)
@@ -65,7 +73,14 @@ class HistoryViewModel @Inject constructor(
     state: HistoryState,
     viewModelScope: CoroutineScope
   ) =
-    ShowDeleteHistoryDialog(effects, state, pageDao, viewModelScope, requireAlertDialogShower())
+    ShowDeleteHistoryDialog(
+      effects,
+      state,
+      pageDao,
+      viewModelScope,
+      requireAlertDialogShower(),
+      ioDispatcher
+    )
 
   override fun deselectAllPages(state: HistoryState): HistoryState =
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialog.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.core.page.history.viewmodel.effects
  */
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.kiwix.kiwixmobile.core.base.SideEffect
@@ -34,11 +35,12 @@ data class ShowDeleteHistoryDialog(
   private val state: HistoryState,
   private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope,
-  var dialogShower: DialogShower
+  var dialogShower: DialogShower,
+  private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     dialogShower.show(if (state.isInSelectionState) DeleteSelectedHistory else DeleteAllHistory, {
-      effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope))
+      effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope, ioDispatcher))
     })
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.main.note.AddNoteViewModel
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
@@ -34,13 +35,20 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.PageViewModelClickListener
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
 
 class NotesViewModel @Inject constructor(
   notesRoomDao: NotesRoomDao,
   zimReaderContainer: ZimReaderContainer,
   kiwixDataStore: KiwixDataStore,
-  addNoteViewModel: AddNoteViewModel
-) : PageViewModel<NoteListItem, NotesState>(notesRoomDao, kiwixDataStore, zimReaderContainer),
+  addNoteViewModel: AddNoteViewModel,
+  @IoDispatcher ioDispatcher: CoroutineDispatcher
+) : PageViewModel<NoteListItem, NotesState>(
+    notesRoomDao,
+    kiwixDataStore,
+    zimReaderContainer,
+    ioDispatcher
+  ),
   PageViewModelClickListener {
   init {
     setOnItemClickListener(this)
@@ -75,7 +83,14 @@ class NotesViewModel @Inject constructor(
     state.copy(pageItems = state.pageItems.map { it.copy(isSelected = false) })
 
   override fun createDeletePageDialogEffect(state: NotesState, viewModelScope: CoroutineScope) =
-    ShowDeleteNotesDialog(effects, state, pageDao, viewModelScope, requireAlertDialogShower())
+    ShowDeleteNotesDialog(
+      effects,
+      state,
+      pageDao,
+      viewModelScope,
+      requireAlertDialogShower(),
+      ioDispatcher
+    )
 
   override fun onItemClick(page: Page) =
     ShowOpenNoteDialog(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/effects/ShowDeleteNotesDialog.kt
@@ -19,6 +19,7 @@ package org.kiwix.kiwixmobile.core.page.notes.viewmodel.effects
  */
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.kiwix.kiwixmobile.core.base.SideEffect
@@ -34,13 +35,14 @@ data class ShowDeleteNotesDialog(
   private val state: NotesState,
   private val pageDao: PageDao,
   private val viewModelScope: CoroutineScope,
-  private val dialogShower: DialogShower
+  private val dialogShower: DialogShower,
+  private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     dialogShower.show(
       if (state.isInSelectionState) DeleteSelectedNotes else DeleteAllNotes,
       {
-        effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope))
+        effects.tryEmit(DeletePageItems(state, pageDao, viewModelScope, ioDispatcher))
       }
     )
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +34,7 @@ import kotlinx.coroutines.flow.onEach
 import org.jetbrains.annotations.VisibleForTesting
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.PageDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.main.note.AddNoteViewModel
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.Exit
@@ -55,7 +55,8 @@ import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 abstract class PageViewModel<T : Page, S : PageState<T>>(
   protected val pageDao: PageDao,
   val kiwixDataStore: KiwixDataStore,
-  val zimReaderContainer: ZimReaderContainer
+  val zimReaderContainer: ZimReaderContainer,
+  @IoDispatcher protected val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
   abstract fun initialState(): S
 
@@ -118,7 +119,7 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
       .onEach { newState -> _state.value = newState }
       .launchIn(viewModelScope)
 
-  private fun observePages(ioDispatcher: CoroutineDispatcher = Dispatchers.IO) =
+  private fun observePages() =
     pageDao.pages()
       .flowOn(ioDispatcher)
       .onEach { actions.tryEmit(UpdatePages(it)) }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -19,22 +19,22 @@
 package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.viewmodel.PageState
 
-@Suppress("InjectDispatcher")
 data class DeletePageItems(
   private val state: PageState<*>,
   private val pageDao: PageDao,
-  private val viewModelScope: CoroutineScope
+  private val viewModelScope: CoroutineScope,
+  private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       if (state.isInSelectionState) {
         pageDao.deletePages(state.pageItems.filter(Page::isSelected))
       } else {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -330,7 +330,6 @@ class ZimFileReader(
   private fun extractQueryParam(url: String): String =
     "?" + url.substringAfterLast("?", "")
 
-  @Suppress("InjectDispatcher")
   private suspend fun loadAsset(
     uri: String
   ): InputStream? =
@@ -392,7 +391,6 @@ class ZimFileReader(
       null
     }
 
-  @Suppress("InjectDispatcher")
   private suspend fun generateZimContentBytes(item: Item?, uri: String): ByteArrayInputStream =
     withContext(ioDispatcher) {
       runCatching {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -38,7 +38,6 @@ class ZimReaderContainer @Inject constructor(
       field = value
     }
 
-  @Suppress("InjectDispatcher")
   suspend fun setZimReaderSource(
     zimReaderSource: ZimReaderSource?,
     showSearchSuggestionsSpellChecked: Boolean = false

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/integrity/ZimIntegrityChecker.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/integrity/ZimIntegrityChecker.kt
@@ -19,14 +19,17 @@
 package org.kiwix.kiwixmobile.core.reader.integrity
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.libzim.Archive
 import javax.inject.Inject
 
-class ZimIntegrityChecker @Inject constructor(private val zimReaderContainer: ZimReaderContainer) {
+class ZimIntegrityChecker @Inject constructor(
+  private val zimReaderContainer: ZimReaderContainer,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
   /**
    * Validates a ZIM file and returns its verification result.
    *
@@ -51,7 +54,6 @@ class ZimIntegrityChecker @Inject constructor(private val zimReaderContainer: Zi
   suspend fun validateZIMFile(
     zimReaderSource: ZimReaderSource,
     isBrandedApp: Boolean,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
   ): ZimFileValidationResult =
     withContext(ioDispatcher) {
       var archive: Archive? = null

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -240,7 +240,7 @@ class SearchViewModel @Inject constructor(
 
   private fun deleteItemAndShowToast(it: ConfirmedDelete) {
     _effects.tryEmit(
-      DeleteRecentSearch(it.searchListItem, recentSearchRoomDao, viewModelScope)
+      DeleteRecentSearch(it.searchListItem, recentSearchRoomDao, viewModelScope, ioDispatcher)
     )
     _effects.tryEmit(ShowToast(R.string.delete_specific_search_toast))
   }
@@ -261,7 +261,8 @@ class SearchViewModel @Inject constructor(
         recentSearchRoomDao,
         searchListItem,
         zimReaderContainer.id,
-        viewModelScope
+        viewModelScope,
+        ioDispatcher
       )
     )
     _effects.tryEmit(OpenSearchItem(searchListItem, openInNewTab))

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearch.kt
@@ -19,21 +19,22 @@
 package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.search.SearchListItem
 
-@Suppress("InjectDispatcher")
 data class DeleteRecentSearch(
   private val searchListItem: SearchListItem,
   private val recentSearchRoomDao: RecentSearchRoomDao,
-  private val viewModelScope: CoroutineScope
+  private val viewModelScope: CoroutineScope,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
-    viewModelScope.launch(Dispatchers.IO) {
+    viewModelScope.launch(ioDispatcher) {
       recentSearchRoomDao.deleteSearchString(searchListItem.value)
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecents.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecents.kt
@@ -19,24 +19,25 @@
 package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.addContentPrefix
 import org.kiwix.kiwixmobile.core.search.SearchListItem
 
-@Suppress("InjectDispatcher")
 data class SaveSearchToRecents(
   private val recentSearchRoomDao: RecentSearchRoomDao,
   private val searchListItem: SearchListItem,
   private val id: String?,
-  private val viewModelScope: CoroutineScope
+  private val viewModelScope: CoroutineScope,
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : SideEffect<Unit> {
   override fun invokeWith(activity: AppCompatActivity) {
     id?.let {
-      viewModelScope.launch(Dispatchers.IO) {
+      viewModelScope.launch(ioDispatcher) {
         recentSearchRoomDao.saveSearch(
           searchListItem.value,
           it,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -52,6 +53,7 @@ internal class BookmarkViewModelTest {
   @RegisterExtension
   val mainDispatcherRule = MainDispatcherRule()
   private val testDispatcher = mainDispatcherRule.dispatcher
+  private val testScope = CoroutineScope(testDispatcher)
   private val libkiwixBookMarks: LibkiwixBookmarks = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
@@ -78,6 +80,7 @@ internal class BookmarkViewModelTest {
         testDispatcher
       ).apply {
         setAlertDialogShower(dialogShower)
+        setLifeCycleScope(testScope)
       }
   }
 
@@ -121,7 +124,7 @@ internal class BookmarkViewModelTest {
         UpdateAllBookmarksPreference(
           kiwixDataStore,
           false,
-          this
+          testScope
         )
       )
       cancelAndIgnoreRemainingEvents()
@@ -186,13 +189,13 @@ internal class BookmarkViewModelTest {
   @Test
   internal fun `createDeletePageDialogEffect returns correct dialog`() = runTest {
     assertThat(
-      viewModel.createDeletePageDialogEffect(bookmarkState(), this)
+      viewModel.createDeletePageDialogEffect(bookmarkState(), testScope)
     ).isEqualTo(
       ShowDeleteBookmarksDialog(
         viewModel.effects,
         bookmarkState(),
         libkiwixBookMarks,
-        this,
+        testScope,
         dialogShower,
         testDispatcher
       )

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -22,7 +22,6 @@ import app.cash.turbine.test
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -52,11 +51,11 @@ internal class BookmarkViewModelTest {
   @JvmField
   @RegisterExtension
   val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.dispatcher
   private val libkiwixBookMarks: LibkiwixBookmarks = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val dialogShower: AlertDialogShower = mockk()
-  private val viewModelScope = CoroutineScope(mainDispatcherRule.dispatcher)
 
   private lateinit var viewModel: BookmarkViewModel
 
@@ -72,9 +71,13 @@ internal class BookmarkViewModelTest {
     every { libkiwixBookMarks.bookmarks() } returns itemsFromDb
     every { libkiwixBookMarks.pages() } returns libkiwixBookMarks.bookmarks()
     viewModel =
-      BookmarkViewModel(libkiwixBookMarks, zimReaderContainer, kiwixDataStore).apply {
+      BookmarkViewModel(
+        libkiwixBookMarks,
+        zimReaderContainer,
+        kiwixDataStore,
+        testDispatcher
+      ).apply {
         setAlertDialogShower(dialogShower)
-        setLifeCycleScope(viewModelScope)
       }
   }
 
@@ -118,7 +121,7 @@ internal class BookmarkViewModelTest {
         UpdateAllBookmarksPreference(
           kiwixDataStore,
           false,
-          viewModelScope
+          this
         )
       )
       cancelAndIgnoreRemainingEvents()
@@ -181,20 +184,20 @@ internal class BookmarkViewModelTest {
   }
 
   @Test
-  internal fun `createDeletePageDialogEffect returns correct dialog`() =
-    runTest {
-      assertThat(
-        viewModel.createDeletePageDialogEffect(bookmarkState(), viewModelScope)
-      ).isEqualTo(
-        ShowDeleteBookmarksDialog(
-          viewModel.effects,
-          bookmarkState(),
-          libkiwixBookMarks,
-          viewModelScope,
-          dialogShower
-        )
+  internal fun `createDeletePageDialogEffect returns correct dialog`() = runTest {
+    assertThat(
+      viewModel.createDeletePageDialogEffect(bookmarkState(), this)
+    ).isEqualTo(
+      ShowDeleteBookmarksDialog(
+        viewModel.effects,
+        bookmarkState(),
+        libkiwixBookMarks,
+        this,
+        dialogShower,
+        testDispatcher
       )
-    }
+    )
+  }
 
   @Test
   internal fun `copyWithNewItems returns state with copied items`() {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialogTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/effects/ShowDeleteBookmarksDialogTest.kt
@@ -22,11 +22,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -37,56 +37,72 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteAllBookmarks
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteSelectedBookmarks
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.util.UUID
 
 internal class ShowDeleteBookmarksDialogTest {
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.mainDispatcher
+
   val effects = mockk<MutableSharedFlow<SideEffect<*>>>(relaxed = true)
   private val libkiwixBookmark = mockk<LibkiwixBookmarks>()
   val activity = mockk<CoreMainActivity>()
   private val dialogShower = mockk<DialogShower>(relaxed = true)
-  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   @Test
-  fun `invoke with shows dialog that offers ConfirmDelete action`() {
+  fun `invoke with shows dialog that offers ConfirmDelete action`() = runTest {
+    val testScope = this
     val showDeleteBookmarksDialog =
       ShowDeleteBookmarksDialog(
         effects,
         bookmarkState(),
         libkiwixBookmark,
-        viewModelScope,
-        dialogShower
+        testScope,
+        dialogShower,
+        testDispatcher
       )
     val lambdaSlot = slot<() -> Unit>()
     showDeleteBookmarksDialog.invokeWith(activity)
     verify { dialogShower.show(any(), capture(lambdaSlot)) }
     lambdaSlot.captured.invoke()
-    verify { effects.tryEmit(DeletePageItems(bookmarkState(), libkiwixBookmark, viewModelScope)) }
+    verify {
+      effects.tryEmit(
+        DeletePageItems(
+          bookmarkState(),
+          libkiwixBookmark,
+          testScope,
+          testDispatcher
+        )
+      )
+    }
   }
 
   @Test
-  fun `invoke with selected items shows dialog with DeleteSelectedBookmarks title`() =
-    runBlocking {
-      val zimReaderSource: ZimReaderSource = mockk()
-      every { zimReaderSource.toDatabase() } returns ""
-      val showDeleteBookmarksDialog =
-        ShowDeleteBookmarksDialog(
-          effects,
-          bookmarkState(
-            listOf(
-              libkiwixBookmarkItem(
-                isSelected = true,
-                databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE,
-                zimReaderSource = zimReaderSource
-              )
+  fun `invoke with selected items shows dialog with DeleteSelectedBookmarks title`() = runTest {
+    val zimReaderSource: ZimReaderSource = mockk()
+    every { zimReaderSource.toDatabase() } returns ""
+    val showDeleteBookmarksDialog =
+      ShowDeleteBookmarksDialog(
+        effects,
+        bookmarkState(
+          listOf(
+            libkiwixBookmarkItem(
+              isSelected = true,
+              databaseId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE,
+              zimReaderSource = zimReaderSource
             )
-          ),
-          libkiwixBookmark,
-          viewModelScope,
-          dialogShower
-        )
-      showDeleteBookmarksDialog.invokeWith(activity)
-      verify { dialogShower.show(DeleteSelectedBookmarks, any()) }
-    }
+          )
+        ),
+        libkiwixBookmark,
+        this,
+        dialogShower,
+        testDispatcher
+      )
+    showDeleteBookmarksDialog.invokeWith(activity)
+    verify { dialogShower.show(DeleteSelectedBookmarks, any()) }
+  }
 
   @Test
   fun `invoke with no selected items shows dialog with DeleteAllBookmarks title`() =
@@ -105,8 +121,9 @@ internal class ShowDeleteBookmarksDialogTest {
             )
           ),
           libkiwixBookmark,
-          viewModelScope,
-          dialogShower
+          this,
+          dialogShower,
+          testDispatcher
         )
       showDeleteBookmarksDialog.invokeWith(activity)
       verify { dialogShower.show(DeleteAllBookmarks, any()) }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -31,6 +32,7 @@ internal class HistoryViewModelTest {
   @JvmField
   val mainDispatcherRule = MainDispatcherRule()
   private val testDispatcher = mainDispatcherRule.dispatcher
+  private val testScope = CoroutineScope(testDispatcher)
   private val historyRoomDao: HistoryRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
@@ -53,6 +55,7 @@ internal class HistoryViewModelTest {
     viewModel =
       HistoryViewModel(historyRoomDao, zimReaderContainer, kiwixDataStore, testDispatcher).apply {
         setAlertDialogShower(dialogShower)
+        setLifeCycleScope(testScope)
       }
   }
 
@@ -90,7 +93,7 @@ internal class HistoryViewModelTest {
         historyState()
       )
       assertThat(awaitItem()).isEqualTo(
-        UpdateAllHistoryPreference(kiwixDataStore, false, this)
+        UpdateAllHistoryPreference(kiwixDataStore, false, testScope)
       )
       cancelAndIgnoreRemainingEvents()
     }
@@ -135,12 +138,12 @@ internal class HistoryViewModelTest {
   @Test
   fun `createDeletePageDialogEffect returns ShowDeleteHistoryDialog`() =
     runTest {
-      assertThat(viewModel.createDeletePageDialogEffect(historyState(), this)).isEqualTo(
+      assertThat(viewModel.createDeletePageDialogEffect(historyState(), testScope)).isEqualTo(
         ShowDeleteHistoryDialog(
           viewModel.effects,
           historyState(),
           historyRoomDao,
-          this,
+          testScope,
           dialogShower,
           testDispatcher
         )

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModelTest.kt
@@ -4,8 +4,6 @@ import app.cash.turbine.test
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -32,11 +30,11 @@ internal class HistoryViewModelTest {
   @RegisterExtension
   @JvmField
   val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.dispatcher
   private val historyRoomDao: HistoryRoomDao = mockk()
   private val zimReaderContainer: ZimReaderContainer = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val dialogShower = mockk<AlertDialogShower>(relaxed = true)
-  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   private lateinit var viewModel: HistoryViewModel
   private val zimReaderSource: ZimReaderSource = mockk()
@@ -52,10 +50,10 @@ internal class HistoryViewModelTest {
     every { kiwixDataStore.showHistoryOfAllBooks } returns flowOf(true)
     every { historyRoomDao.history() } returns itemsFromDb
     every { historyRoomDao.pages() } returns historyRoomDao.history()
-    viewModel = HistoryViewModel(historyRoomDao, zimReaderContainer, kiwixDataStore).apply {
-      setAlertDialogShower(dialogShower)
-      setLifeCycleScope(viewModelScope)
-    }
+    viewModel =
+      HistoryViewModel(historyRoomDao, zimReaderContainer, kiwixDataStore, testDispatcher).apply {
+        setAlertDialogShower(dialogShower)
+      }
   }
 
   @Test
@@ -92,7 +90,7 @@ internal class HistoryViewModelTest {
         historyState()
       )
       assertThat(awaitItem()).isEqualTo(
-        UpdateAllHistoryPreference(kiwixDataStore, false, viewModelScope)
+        UpdateAllHistoryPreference(kiwixDataStore, false, this)
       )
       cancelAndIgnoreRemainingEvents()
     }
@@ -137,13 +135,14 @@ internal class HistoryViewModelTest {
   @Test
   fun `createDeletePageDialogEffect returns ShowDeleteHistoryDialog`() =
     runTest {
-      assertThat(viewModel.createDeletePageDialogEffect(historyState(), viewModelScope)).isEqualTo(
+      assertThat(viewModel.createDeletePageDialogEffect(historyState(), this)).isEqualTo(
         ShowDeleteHistoryDialog(
           viewModel.effects,
           historyState(),
           historyRoomDao,
-          viewModelScope,
-          dialogShower
+          this,
+          dialogShower,
+          testDispatcher
         )
       )
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialogTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/effects/ShowDeleteHistoryDialogTest.kt
@@ -3,11 +3,10 @@ package org.kiwix.kiwixmobile.core.page.history.viewmodel.effects
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
@@ -17,59 +16,73 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.effects.DeletePageItems
 import org.kiwix.kiwixmobile.core.utils.dialog.DialogShower
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteAllHistory
 import org.kiwix.kiwixmobile.core.utils.dialog.KiwixDialog.DeleteSelectedHistory
+import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class ShowDeleteHistoryDialogTest {
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.dispatcher
   val effects = mockk<MutableSharedFlow<SideEffect<*>>>(relaxed = true)
   private val historyRoomDao = mockk<HistoryRoomDao>()
   val activity = mockk<CoreMainActivity>()
   private val dialogShower = mockk<DialogShower>(relaxed = true)
-  private val viewModelScope = CoroutineScope(Dispatchers.IO)
 
   @Test
-  fun `invoke with shows dialog that offers ConfirmDelete action`() =
-    runBlocking {
-      val showDeleteHistoryDialog =
-        ShowDeleteHistoryDialog(
-          effects,
+  fun `invoke with shows dialog that offers ConfirmDelete action`() = runTest {
+    val testScope = this
+    val showDeleteHistoryDialog =
+      ShowDeleteHistoryDialog(
+        effects,
+        historyState(),
+        historyRoomDao,
+        testScope,
+        dialogShower,
+        testDispatcher
+      )
+    val lambdaSlot = slot<() -> Unit>()
+    showDeleteHistoryDialog.invokeWith(activity)
+    verify { dialogShower.show(any(), capture(lambdaSlot)) }
+    lambdaSlot.captured.invoke()
+    verify {
+      effects.tryEmit(
+        DeletePageItems(
           historyState(),
           historyRoomDao,
-          viewModelScope,
-          dialogShower
+          testScope,
+          testDispatcher
         )
-      val lambdaSlot = slot<() -> Unit>()
-      showDeleteHistoryDialog.invokeWith(activity)
-      verify { dialogShower.show(any(), capture(lambdaSlot)) }
-      lambdaSlot.captured.invoke()
-      verify { effects.tryEmit(DeletePageItems(historyState(), historyRoomDao, viewModelScope)) }
+      )
     }
+  }
 
   @Test
-  fun `invoke with selected item shows dialog with delete selected items title`() =
-    runBlocking {
-      val showDeleteHistoryDialog =
-        ShowDeleteHistoryDialog(
-          effects,
-          historyState(listOf(historyItem(isSelected = true, zimReaderSource = mockk()))),
-          historyRoomDao,
-          viewModelScope,
-          dialogShower
-        )
-      showDeleteHistoryDialog.invokeWith(activity)
-      verify { dialogShower.show(DeleteSelectedHistory, any()) }
-    }
+  fun `invoke with selected item shows dialog with delete selected items title`() = runTest {
+    val showDeleteHistoryDialog =
+      ShowDeleteHistoryDialog(
+        effects,
+        historyState(listOf(historyItem(isSelected = true, zimReaderSource = mockk()))),
+        historyRoomDao,
+        this,
+        dialogShower,
+        testDispatcher
+      )
+    showDeleteHistoryDialog.invokeWith(activity)
+    verify { dialogShower.show(DeleteSelectedHistory, any()) }
+  }
 
   @Test
-  fun `invoke with no selected items shows dialog with delete all items title`() =
-    runBlocking {
-      val showDeleteHistoryDialog =
-        ShowDeleteHistoryDialog(
-          effects,
-          historyState(),
-          historyRoomDao,
-          viewModelScope,
-          dialogShower
-        )
-      showDeleteHistoryDialog.invokeWith(activity)
-      verify { dialogShower.show(DeleteAllHistory, any()) }
-    }
+  fun `invoke with no selected items shows dialog with delete all items title`() = runTest {
+    val showDeleteHistoryDialog =
+      ShowDeleteHistoryDialog(
+        effects,
+        historyState(),
+        historyRoomDao,
+        this,
+        dialogShower,
+        testDispatcher
+      )
+    showDeleteHistoryDialog.invokeWith(activity)
+    verify { dialogShower.show(DeleteAllHistory, any()) }
+  }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModelTest.kt
@@ -72,7 +72,12 @@ internal class PageViewModelTest {
     every { zimReaderContainer.name } returns "zimName"
     coEvery { kiwixDataStore.showHistoryOfAllBooks } returns flowOf(true)
     every { pageDao.pages() } returns itemsFromDb
-    viewModel = TestablePageViewModel(zimReaderContainer, kiwixDataStore, pageDao)
+    viewModel = TestablePageViewModel(
+      zimReaderContainer,
+      kiwixDataStore,
+      pageDao,
+      mainDispatcherRule.dispatcher
+    )
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/TestablePageClasses.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/TestablePageClasses.kt
@@ -19,9 +19,11 @@
 package org.kiwix.kiwixmobile.core.page.viewmodel
 
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import org.kiwix.kiwixmobile.core.base.SideEffect
 import org.kiwix.kiwixmobile.core.dao.PageDao
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.adapter.PageRelated
 import org.kiwix.kiwixmobile.core.page.pageState
@@ -31,8 +33,9 @@ import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 class TestablePageViewModel(
   zimReaderContainer: ZimReaderContainer,
   kiwixDataStore: KiwixDataStore,
-  val dao: PageDao
-) : PageViewModel<Page, TestablePageState>(dao, kiwixDataStore, zimReaderContainer) {
+  val dao: PageDao,
+  @IoDispatcher ioDispatcher: CoroutineDispatcher
+) : PageViewModel<Page, TestablePageState>(dao, kiwixDataStore, zimReaderContainer, ioDispatcher) {
   var createDeletePageDialogEffectCalled = false
 
   override fun initialState(): TestablePageState = pageState()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -21,18 +21,20 @@ package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.runBlocking
-import org.junit.Rule
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.dao.PageDao
 import org.kiwix.kiwixmobile.core.page.historyItem
 import org.kiwix.kiwixmobile.core.page.historyState
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.sharedFunctions.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class DeletePageItemsTest {
-  @Rule
+  @RegisterExtension
   @JvmField
   val mainDispatcherRule = MainDispatcherRule()
   private val pageDao: PageDao = mockk(relaxed = true)
@@ -40,51 +42,30 @@ internal class DeletePageItemsTest {
   private val zimReaderSource: ZimReaderSource = mockk()
   private val item1 = historyItem(zimReaderSource = zimReaderSource)
   private val item2 = historyItem(zimReaderSource = zimReaderSource)
-  private val viewModelScope = CoroutineScope(mainDispatcherRule.dispatcher)
 
   @Test
-  fun `delete with selected items only deletes the selected items`() =
-    runBlocking {
-      retryTest {
-        item1.isSelected = true
-        DeletePageItems(
-          historyState(listOf(item1, item2)),
-          pageDao,
-          viewModelScope,
-          mainDispatcherRule.dispatcher
-        ).invokeWith(activity)
-        verify { pageDao.deletePages(listOf(item1)) }
-      }
-    }
+  fun `delete with selected items only deletes the selected items`() = runTest {
+    item1.isSelected = true
+    DeletePageItems(
+      historyState(listOf(item1, item2)),
+      pageDao,
+      this,
+      mainDispatcherRule.dispatcher
+    ).invokeWith(activity)
+    advanceUntilIdle()
+    verify { pageDao.deletePages(listOf(item1)) }
+  }
 
   @Test
-  fun `delete with no selected items deletes all items`() =
-    runBlocking {
-      retryTest {
-        item1.isSelected = false
-        DeletePageItems(
-          historyState(listOf(item1, item2)),
-          pageDao,
-          viewModelScope,
-          mainDispatcherRule.dispatcher
-        ).invokeWith(activity)
-        verify { pageDao.deletePages(listOf(item1, item2)) }
-      }
-    }
-
-  private fun retryTest(maxRetries: Int = 5, block: () -> Unit) {
-    var currentAttempt = 0
-    var success = false
-    while (currentAttempt < maxRetries && !success) {
-      try {
-        block()
-        success = true
-      } catch (e: AssertionError) {
-        currentAttempt++
-        if (currentAttempt >= maxRetries) {
-          throw e
-        }
-      }
-    }
+  fun `delete with no selected items deletes all items`() = runTest {
+    item1.isSelected = false
+    DeletePageItems(
+      historyState(listOf(item1, item2)),
+      pageDao,
+      this,
+      mainDispatcherRule.dispatcher
+    ).invokeWith(activity)
+    advanceUntilIdle()
+    verify { pageDao.deletePages(listOf(item1, item2)) }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -50,7 +50,8 @@ internal class DeletePageItemsTest {
         DeletePageItems(
           historyState(listOf(item1, item2)),
           pageDao,
-          viewModelScope
+          viewModelScope,
+          mainDispatcherRule.dispatcher
         ).invokeWith(activity)
         verify { pageDao.deletePages(listOf(item1)) }
       }
@@ -64,7 +65,8 @@ internal class DeletePageItemsTest {
         DeletePageItems(
           historyState(listOf(item1, item2)),
           pageDao,
-          viewModelScope
+          viewModelScope,
+          mainDispatcherRule.dispatcher
         ).invokeWith(activity)
         verify { pageDao.deletePages(listOf(item1, item2)) }
       }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -368,7 +368,8 @@ internal class SearchViewModelTest {
             recentSearchRoomDao,
             searchListItem,
             "id",
-            viewModel.viewModelScope
+            viewModel.viewModelScope,
+            mainDispatcherRule.dispatcher
           ),
           OpenSearchItem(searchListItem, false)
         )
@@ -384,7 +385,8 @@ internal class SearchViewModelTest {
             recentSearchRoomDao,
             searchListItem,
             "id",
-            viewModel.viewModelScope
+            viewModel.viewModelScope,
+            mainDispatcherRule.dispatcher
           ),
           OpenSearchItem(searchListItem, true)
         )
@@ -406,7 +408,12 @@ internal class SearchViewModelTest {
         val searchListItem = RecentSearchListItem("", "")
         actionResultsInEffects(
           ConfirmedDelete(searchListItem),
-          DeleteRecentSearch(searchListItem, recentSearchRoomDao, viewModel.viewModelScope),
+          DeleteRecentSearch(
+            searchListItem,
+            recentSearchRoomDao,
+            viewModel.viewModelScope,
+            mainDispatcherRule.dispatcher
+          ),
           ShowToast(R.string.delete_specific_search_toast)
         )
       }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/DeleteRecentSearchTest.kt
@@ -21,29 +21,32 @@ package org.kiwix.kiwixmobile.core.search.viewmodel.effects
 import androidx.appcompat.app.AppCompatActivity
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.search.SearchListItem
 import org.kiwix.kiwixmobile.core.search.SearchListItem.RecentSearchListItem
+import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class DeleteRecentSearchTest {
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+
   @Test
-  fun `invoke with deletes a search`() =
-    runBlocking {
-      val searchListItem: SearchListItem = RecentSearchListItem("", "")
-      val recentSearchDao: RecentSearchRoomDao = mockk()
-      val activity: AppCompatActivity = mockk()
-      val viewModelScope = CoroutineScope(Dispatchers.IO)
-      DeleteRecentSearch(
-        searchListItem = searchListItem,
-        recentSearchRoomDao = recentSearchDao,
-        viewModelScope = viewModelScope
-      ).invokeWith(activity)
-      delay(50)
-      verify { recentSearchDao.deleteSearchString(searchListItem.value) }
-    }
+  fun `invoke with deletes a search`() = runTest {
+    val searchListItem: SearchListItem = RecentSearchListItem("", "")
+    val recentSearchDao: RecentSearchRoomDao = mockk()
+    val activity: AppCompatActivity = mockk()
+    DeleteRecentSearch(
+      searchListItem = searchListItem,
+      recentSearchRoomDao = recentSearchDao,
+      viewModelScope = this,
+      ioDispatcher = mainDispatcherRule.dispatcher
+    ).invokeWith(activity)
+    delay(50)
+    verify { recentSearchDao.deleteSearchString(searchListItem.value) }
+  }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/effects/SaveSearchToRecentsTest.kt
@@ -23,48 +23,54 @@ import io.mockk.Called
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.dao.RecentSearchRoomDao
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader
 import org.kiwix.kiwixmobile.core.search.SearchListItem.RecentSearchListItem
+import org.kiwix.sharedFunctions.MainDispatcherRule
 
 internal class SaveSearchToRecentsTest {
   private val newRecentSearchDao: RecentSearchRoomDao = mockk()
   private val searchListItem = RecentSearchListItem("", ZimFileReader.CONTENT_PREFIX)
 
   private val activity: AppCompatActivity = mockk()
-  private val testDispatcher = CoroutineScope(Dispatchers.IO)
+
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.dispatcher
+  private val testScope = CoroutineScope(testDispatcher)
 
   @Test
-  fun `invoke with null Id does nothing`() =
-    runBlocking {
-      SaveSearchToRecents(
-        newRecentSearchDao,
-        searchListItem,
-        null,
-        testDispatcher
-      ).invokeWith(
-        activity
-      )
-      verify { newRecentSearchDao wasNot Called }
-    }
+  fun `invoke with null Id does nothing`() = runTest {
+    SaveSearchToRecents(
+      newRecentSearchDao,
+      searchListItem,
+      null,
+      this,
+      testDispatcher
+    ).invokeWith(
+      activity
+    )
+    verify { newRecentSearchDao wasNot Called }
+  }
 
   @Test
-  fun `invoke with non null Id saves search`() =
-    runBlocking {
-      val id = "8812214350305159407L"
-      SaveSearchToRecents(
-        newRecentSearchDao,
-        searchListItem,
-        id,
-        testDispatcher
-      ).invokeWith(activity)
-      delay(50)
-      verify {
-        newRecentSearchDao.saveSearch(searchListItem.value, id, ZimFileReader.CONTENT_PREFIX)
-      }
+  fun `invoke with non null Id saves search`() = runTest {
+    val id = "8812214350305159407L"
+    SaveSearchToRecents(
+      newRecentSearchDao,
+      searchListItem,
+      id,
+      testScope,
+      testDispatcher
+    ).invokeWith(activity)
+    delay(50)
+    verify {
+      newRecentSearchDao.saveSearch(searchListItem.value, id, ZimFileReader.CONTENT_PREFIX)
     }
+  }
 }


### PR DESCRIPTION
Fixes: #4940
- Updated .ignore file to stop tracking old strings
- Removed suppress warnings for `DispatcherInjection`
- Used proper CoroutineScope where requried
-  Removed Custom Retry Logic in `DeletePageItemsTest`


