### PR TITLE
Fixed: HTML pages are zoomed out instead of showing a horizontal scrollbar.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -52,8 +52,6 @@ import org.kiwix.kiwixmobile.core.utils.files.SaveResult
 import org.kiwix.videowebview.VideoEnabledWebChromeClient.ToggledFullscreenCallback
 import org.kiwix.videowebview.VideoEnabledWebView
 
-private const val INITIAL_SCALE = 100
-
 @SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
 @Suppress("LongParameterList")
 open class KiwixWebView constructor(
@@ -83,10 +81,10 @@ open class KiwixWebView constructor(
       useWideViewPort = true
       builtInZoomControls = true
       displayZoomControls = false
+      isHorizontalScrollBarEnabled = true
       @Suppress("DEPRECATION")
       allowUniversalAccessFromFileURLs = true
     }
-    setInitialScale(INITIAL_SCALE)
     clearCache(true)
     webViewClient = coreWebViewClient
     kiwixWebChromeClient =


### PR DESCRIPTION
Fixes #5019 

* Removed the `setInitialScale` call from the WebView, allowing it to determine the appropriate initial page scale automatically.
* Enabled the horizontal scrollbar for pages with horizontally scrollable content.

See https://github.com/kiwix/kiwix-android/issues/5019#issuecomment-5165477561 for more details.

https://github.com/user-attachments/assets/e27883e2-d603-4d72-8b3b-a4b62a7848d0