### PR TITLE
Using DI provided dispatcher instead of hardcoded dispatcher.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -52,8 +52,11 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 @RunWith(AndroidJUnit4::class)
 abstract class BaseActivityTest {
   protected lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+  protected val ioDispatcher by lazy {
+    Dispatchers.IO
+  }
   protected val kiwixDataStore by lazy {
-    KiwixDataStore(context, Dispatchers.IO)
+    KiwixDataStore(context, ioDispatcher)
   }
 
   open fun permissions(): Array<String> =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -37,6 +37,7 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
 import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
 import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.Matchers.anyOf
 import org.junit.After
@@ -52,7 +53,7 @@ import org.kiwix.kiwixmobile.testutils.TestUtils
 abstract class BaseActivityTest {
   protected lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
   protected val kiwixDataStore by lazy {
-    KiwixDataStore(context)
+    KiwixDataStore(context, Dispatchers.IO)
   }
 
   open fun permissions(): Array<String> =

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -190,7 +190,10 @@ class ObjectBoxToRoomMigratorTest : BaseActivityTest() {
       recentSearchRoomDao().deleteSearchHistory()
       historyRoomDao().deleteAllHistory()
       notesRoomDao()
-        .deletePages(kiwixRoomDatabase.notesRoomDao().notes().first())
+        .deletePages(
+          kiwixRoomDatabase.notesRoomDao().notes().first(),
+          ioDispatcher = ioDispatcher
+        )
     }
     box.removeAll()
   }

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/main/DownloadServiceTestForBrandedApps.kt
@@ -102,7 +102,7 @@ class DownloadServiceTestForBrandedApps {
         }
         waitForIdle()
       }
-    KiwixDataStore(context).apply {
+    KiwixDataStore(context, Dispatchers.IO).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()

--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
@@ -113,7 +113,7 @@ class SearchScreenTestForBrandedApp {
         }
         waitForIdle()
       }
-    KiwixDataStore(context).apply {
+    KiwixDataStore(context, Dispatchers.IO).apply {
       lifeCycleScope.launch {
         setWifiOnly(false)
         setIntroShown()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDao.kt
@@ -24,6 +24,7 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.TypeConverter
 import androidx.room.Update
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
@@ -54,7 +55,7 @@ abstract class HistoryRoomDao : PageDao {
     }
 
   override fun pages() = history()
-  override fun deletePages(pagesToDelete: List<Page>) =
+  override suspend fun deletePages(pagesToDelete: List<Page>, ioDispatcher: CoroutineDispatcher) =
     deleteHistory(pagesToDelete as List<HistoryListItem.HistoryItem>)
 
   @Query(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -135,7 +135,7 @@ class LibkiwixBookmarks @Inject constructor(
 
   override fun pages(): Flow<List<Page>> = bookmarks()
 
-  override fun deletePages(pagesToDelete: List<Page>) =
+  override suspend fun deletePages(pagesToDelete: List<Page>, ioDispatcher: CoroutineDispatcher) =
     deleteBookmarks(pagesToDelete as List<LibkiwixBookmarkItem>)
 
   suspend fun getCurrentZimBookmarksUrl(zimFileReader: ZimFileReader?): List<String> {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -24,20 +24,25 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.entities.NotesRoomEntity
+import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.deleteFile
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource.Companion.fromDatabaseValue
 import java.io.File
+import javax.inject.Inject
 
 @Dao
 abstract class NotesRoomDao : PageDao {
+  @Inject
+  @IoDispatcher
+  lateinit var ioDispatcher: CoroutineDispatcher
+
   @Query("SELECT * FROM NotesRoomEntity ORDER BY NotesRoomEntity.noteTitle")
   abstract fun notesAsEntity(): Flow<List<NotesRoomEntity>>
 
@@ -90,10 +95,7 @@ abstract class NotesRoomDao : PageDao {
    * the associated file should also be removed from storage,
    * as it is no longer needed.
    */
-  private fun removeNoteFileFromStorage(
-    noteFilePath: String,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-  ) {
+  private fun removeNoteFileFromStorage(noteFilePath: String) {
     CoroutineScope(ioDispatcher).launch {
       val noteFile = File(noteFilePath)
       if (noteFile.isFileExist(ioDispatcher)) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/NotesRoomDao.kt
@@ -23,26 +23,18 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.entities.NotesRoomEntity
-import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.extensions.deleteFile
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource.Companion.fromDatabaseValue
 import java.io.File
-import javax.inject.Inject
 
 @Dao
 abstract class NotesRoomDao : PageDao {
-  @Inject
-  @IoDispatcher
-  lateinit var ioDispatcher: CoroutineDispatcher
-
   @Query("SELECT * FROM NotesRoomEntity ORDER BY NotesRoomEntity.noteTitle")
   abstract fun notesAsEntity(): Flow<List<NotesRoomEntity>>
 
@@ -60,8 +52,8 @@ abstract class NotesRoomDao : PageDao {
     }
 
   override fun pages(): Flow<List<Page>> = notes()
-  override fun deletePages(pagesToDelete: List<Page>) =
-    deleteNotes(pagesToDelete as List<NoteListItem>)
+  override suspend fun deletePages(pagesToDelete: List<Page>, ioDispatcher: CoroutineDispatcher) =
+    deleteNotes(pagesToDelete as List<NoteListItem>, ioDispatcher)
 
   fun saveNote(noteItem: NoteListItem) {
     val notesEntity = NotesRoomEntity(noteItem)
@@ -81,11 +73,11 @@ abstract class NotesRoomDao : PageDao {
   @Query("DELETE FROM NotesRoomEntity WHERE noteTitle=:noteTitle")
   abstract fun deleteNote(noteTitle: String)
 
-  fun deleteNotes(notesList: List<NoteListItem>) {
+  suspend fun deleteNotes(notesList: List<NoteListItem>, ioDispatcher: CoroutineDispatcher) {
     notesList.forEachIndexed { _, note ->
       val notesRoomEntity = NotesRoomEntity(note)
       deleteNote(noteTitle = notesRoomEntity.noteTitle)
-      removeNoteFileFromStorage(notesRoomEntity.noteFilePath)
+      removeNoteFileFromStorage(notesRoomEntity.noteFilePath, ioDispatcher)
     }
   }
 
@@ -95,12 +87,13 @@ abstract class NotesRoomDao : PageDao {
    * the associated file should also be removed from storage,
    * as it is no longer needed.
    */
-  private fun removeNoteFileFromStorage(noteFilePath: String) {
-    CoroutineScope(ioDispatcher).launch {
-      val noteFile = File(noteFilePath)
-      if (noteFile.isFileExist(ioDispatcher)) {
-        noteFile.deleteFile(ioDispatcher)
-      }
+  private suspend fun removeNoteFileFromStorage(
+    noteFilePath: String,
+    ioDispatcher: CoroutineDispatcher
+  ) {
+    val noteFile = File(noteFilePath)
+    if (noteFile.isFileExist(ioDispatcher)) {
+      noteFile.deleteFile(ioDispatcher)
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/PageDao.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.dao
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import org.kiwix.kiwixmobile.core.page.adapter.Page
 
 interface PageDao {
   fun pages(): Flow<List<Page>>
-  fun deletePages(pagesToDelete: List<Page>)
+  suspend fun deletePages(pagesToDelete: List<Page>, ioDispatcher: CoroutineDispatcher)
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -133,7 +133,7 @@ class Repository @Inject internal constructor(
   override suspend fun clearNotes() =
     withContext(ioDispatcher) {
       val notesList = notesRoomDao.notes().first().map { it as NoteListItem }
-      notesRoomDao.deleteNotes(notesList)
+      notesRoomDao.deleteNotes(notesList, ioDispatcher)
     }
 
   override suspend fun insertWebViewPageHistoryItems(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItems.kt
@@ -36,9 +36,9 @@ data class DeletePageItems(
   override fun invokeWith(activity: AppCompatActivity) {
     viewModelScope.launch(ioDispatcher) {
       if (state.isInSelectionState) {
-        pageDao.deletePages(state.pageItems.filter(Page::isSelected))
+        pageDao.deletePages(state.pageItems.filter(Page::isSelected), ioDispatcher)
       } else {
-        pageDao.deletePages(state.pageItems)
+        pageDao.deletePages(state.pageItems, ioDispatcher)
       }
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -27,7 +27,6 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -59,7 +58,7 @@ val Context.kiwixDataStore by preferencesDataStore(
 @Singleton
 class KiwixDataStore @Inject constructor(
   val context: Context,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
   val textZoom: Flow<Int> = context.kiwixDataStore.data.map { prefs ->
     prefs[PreferencesKeys.TEXT_ZOOM] ?: DEFAULT_ZOOM

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/HistoryRoomDaoTest.kt
@@ -23,17 +23,19 @@ import android.os.Build
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
-import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabaseTest.Companion.getHistoryItem
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabaseTest.Companion.getHistoryItem
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.kiwix.sharedFunctions.TestApplication
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -41,6 +43,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R], application = TestApplication::class)
 class HistoryRoomDaoTest {
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
   private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
   private lateinit var historyRoomDao: HistoryRoomDao
 
@@ -60,7 +65,7 @@ class HistoryRoomDaoTest {
 
   @Test
   fun testHistoryRoomDao() =
-    runBlocking {
+    runTest(mainDispatcherRule.dispatcher) {
       // delete all the history from database to properly run the test cases.
       historyRoomDao.deleteAllHistory()
       val historyItem =
@@ -151,7 +156,7 @@ class HistoryRoomDaoTest {
 
       // Test deletePages function
       historyRoomDao.saveHistory(historyItem)
-      historyRoomDao.deletePages(listOf(historyItem, historyItem2))
+      historyRoomDao.deletePages(listOf(historyItem, historyItem2), mainDispatcherRule.dispatcher)
       historyList = historyRoomDao.historyRoomEntity().first()
       assertThat(historyList.size, equalTo(0))
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.os.Build
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
@@ -51,6 +52,7 @@ class NoteRoomDaoTest {
       .allowMainThreadQueries()
       .build()
     notesRoomDao = kiwixRoomDatabase.notesRoomDao()
+    notesRoomDao.ioDispatcher = Dispatchers.IO
   }
 
   @After

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import android.os.Build
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
@@ -31,11 +30,13 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabaseTest.Companion.getNoteListItem
 import org.kiwix.sharedFunctions.TestApplication
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -45,6 +46,10 @@ class NoteRoomDaoTest {
   private lateinit var kiwixRoomDatabase: KiwixRoomDatabase
   private lateinit var notesRoomDao: NotesRoomDao
 
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
+
   @Before
   fun setUp() {
     val context = ApplicationProvider.getApplicationContext<Context>()
@@ -52,7 +57,7 @@ class NoteRoomDaoTest {
       .allowMainThreadQueries()
       .build()
     notesRoomDao = kiwixRoomDatabase.notesRoomDao()
-    notesRoomDao.ioDispatcher = Dispatchers.IO
+    notesRoomDao.ioDispatcher = mainDispatcherRule.dispatcher
   }
 
   @After

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/dao/NoteRoomDaoTest.kt
@@ -22,21 +22,23 @@ import android.content.Context
 import android.os.Build
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
-import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabaseTest.Companion.getNoteListItem
-import org.kiwix.sharedFunctions.TestApplication
 import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabase
+import org.kiwix.kiwixmobile.core.data.KiwixRoomDatabaseTest.Companion.getNoteListItem
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.sharedFunctions.MainDispatcherRule
+import org.kiwix.sharedFunctions.TestApplication
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -57,7 +59,6 @@ class NoteRoomDaoTest {
       .allowMainThreadQueries()
       .build()
     notesRoomDao = kiwixRoomDatabase.notesRoomDao()
-    notesRoomDao.ioDispatcher = mainDispatcherRule.dispatcher
   }
 
   @After
@@ -65,9 +66,10 @@ class NoteRoomDaoTest {
     kiwixRoomDatabase.close()
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Test
   fun testNotesRoomDao() =
-    runBlocking {
+    runTest(mainDispatcherRule.dispatcher) {
       clearNotes()
       val noteItem =
         getNoteListItem(
@@ -100,13 +102,15 @@ class NoteRoomDaoTest {
 
       // delete with deletePages method
       notesRoomDao.saveNote(noteItem)
-      notesRoomDao.deletePages(listOf(noteItem))
+      notesRoomDao.deletePages(listOf(noteItem), mainDispatcherRule.dispatcher)
+      advanceUntilIdle()
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 0)
 
       // delete with list of NoteListItem
       notesRoomDao.saveNote(noteItem)
-      notesRoomDao.deleteNotes(listOf(noteItem))
+      notesRoomDao.deleteNotes(listOf(noteItem), mainDispatcherRule.dispatcher)
+      advanceUntilIdle()
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 0)
 
@@ -159,6 +163,9 @@ class NoteRoomDaoTest {
     }
 
   private suspend fun clearNotes() {
-    notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
+    notesRoomDao.deleteNotes(
+      notesRoomDao.notes().first() as List<NoteListItem>,
+      mainDispatcherRule.dispatcher
+    )
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabaseTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabaseTest.kt
@@ -30,6 +30,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
@@ -38,6 +39,7 @@ import org.kiwix.kiwixmobile.core.dao.entities.RecentSearchRoomEntity
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem
 import org.kiwix.kiwixmobile.core.page.notes.models.NoteListItem
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
+import org.kiwix.sharedFunctions.MainDispatcherRule
 import org.kiwix.sharedFunctions.TestApplication
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -52,6 +54,10 @@ class KiwixRoomDatabaseTest {
   private lateinit var notesRoomDao: NotesRoomDao
   private lateinit var context: Context
   private lateinit var databaseFile: File
+
+  @RegisterExtension
+  @JvmField
+  val mainDispatcherRule = MainDispatcherRule()
 
   @Before
   fun setUpDatabase() {
@@ -160,6 +166,7 @@ class KiwixRoomDatabaseTest {
   fun testNoteRoomDao() =
     runBlocking {
       notesRoomDao = db.notesRoomDao()
+      notesRoomDao.ioDispatcher = mainDispatcherRule.dispatcher
       // delete all the notes from database to properly run the test cases.
       notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
       val noteItem =

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabaseTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/data/KiwixRoomDatabaseTest.kt
@@ -24,6 +24,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.After
@@ -164,11 +165,13 @@ class KiwixRoomDatabaseTest {
 
   @Test
   fun testNoteRoomDao() =
-    runBlocking {
+    runTest(mainDispatcherRule.dispatcher) {
       notesRoomDao = db.notesRoomDao()
-      notesRoomDao.ioDispatcher = mainDispatcherRule.dispatcher
       // delete all the notes from database to properly run the test cases.
-      notesRoomDao.deleteNotes(notesRoomDao.notes().first() as List<NoteListItem>)
+      notesRoomDao.deleteNotes(
+        notesRoomDao.notes().first() as List<NoteListItem>,
+        mainDispatcherRule.dispatcher
+      )
       val noteItem =
         getNoteListItem(
           zimUrl = "http://kiwix.app/MainPage",
@@ -189,7 +192,7 @@ class KiwixRoomDatabaseTest {
       assertEquals(notesList.size, 1)
 
       // test deleting the history
-      notesRoomDao.deleteNotes(listOf(noteItem))
+      notesRoomDao.deleteNotes(listOf(noteItem), mainDispatcherRule.dispatcher)
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 0)
 
@@ -203,7 +206,7 @@ class KiwixRoomDatabaseTest {
       )
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 2)
-      notesRoomDao.deletePages(notesRoomDao.notes().first())
+      notesRoomDao.deletePages(notesRoomDao.notes().first(), mainDispatcherRule.dispatcher)
       notesList = notesRoomDao.notes().first() as List<NoteListItem>
       assertEquals(notesList.size, 0)
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/data/RepositoryTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/data/RepositoryTest.kt
@@ -339,24 +339,27 @@ class RepositoryTest {
       val note2: NoteListItem = mockk()
       // notes() returns Flow<List<Page>>, first() is used in the impl
       every { notesRoomDao.notes() } returns flowOf(listOf(note1, note2))
-      every { notesRoomDao.deleteNotes(any()) } just Runs
+      coEvery { notesRoomDao.deleteNotes(any(), any()) } just Runs
 
       repository.clearNotes()
 
       verify(exactly = 1) { notesRoomDao.notes() }
-      verify(exactly = 1) {
-        notesRoomDao.deleteNotes(match { it.size == 2 && it.containsAll(listOf(note1, note2)) })
+      coVerify(exactly = 1) {
+        notesRoomDao.deleteNotes(
+          match { it.size == 2 && it.containsAll(listOf(note1, note2)) },
+          any()
+        )
       }
     }
 
     @Test
     fun `clearNotes with empty notes list`() = runTest {
       every { notesRoomDao.notes() } returns flowOf(emptyList())
-      every { notesRoomDao.deleteNotes(any()) } just Runs
+      coEvery { notesRoomDao.deleteNotes(any(), any()) } just Runs
 
       repository.clearNotes()
 
-      verify(exactly = 1) { notesRoomDao.deleteNotes(emptyList()) }
+      coVerify(exactly = 1) { notesRoomDao.deleteNotes(emptyList(), any()) }
     }
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/viewmodel/effects/DeletePageItemsTest.kt
@@ -19,8 +19,9 @@
 package org.kiwix.kiwixmobile.core.page.viewmodel.effects
 
 import androidx.appcompat.app.AppCompatActivity
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -30,7 +31,6 @@ import org.kiwix.kiwixmobile.core.page.historyItem
 import org.kiwix.kiwixmobile.core.page.historyState
 import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
 import org.kiwix.sharedFunctions.MainDispatcherRule
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class DeletePageItemsTest {
@@ -53,7 +53,7 @@ internal class DeletePageItemsTest {
       mainDispatcherRule.dispatcher
     ).invokeWith(activity)
     advanceUntilIdle()
-    verify { pageDao.deletePages(listOf(item1)) }
+    coVerify { pageDao.deletePages(listOf(item1), mainDispatcherRule.dispatcher) }
   }
 
   @Test
@@ -66,6 +66,6 @@ internal class DeletePageItemsTest {
       mainDispatcherRule.dispatcher
     ).invokeWith(activity)
     advanceUntilIdle()
-    verify { pageDao.deletePages(listOf(item1, item2)) }
+    coVerify { pageDao.deletePages(listOf(item1, item2), mainDispatcherRule.dispatcher) }
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -63,7 +63,7 @@ class KiwixDataStoreTest {
   fun setUp() = runTest {
     context = ApplicationProvider.getApplicationContext()
     context.kiwixDataStore.edit { it.clear() }
-    kiwixDataStore = KiwixDataStore(context)
+    kiwixDataStore = KiwixDataStore(context, mainDispatcherRule.dispatcher)
   }
 
   private fun expectedDefaultPublicStorage(storageContext: Context): String {
@@ -86,7 +86,7 @@ class KiwixDataStoreTest {
       override fun getExternalFilesDirs(type: String?): Array<File> = arrayOf(externalFilesDir)
     }
     storageContext.kiwixDataStore.edit { it.clear() }
-    return storageContext to KiwixDataStore(storageContext)
+    return storageContext to KiwixDataStore(storageContext, mainDispatcherRule.dispatcher)
   }
 
   @Test


### PR DESCRIPTION
Fixes #4781 

* Removed default parameter from KiwixDataStore, since it is already provided by the DI.
* Injected `IoDispatcher` into `NotesRoomDao` and removed the hardcoded dispatcher.
* Refactored the codebase to provide the ioDispatcher as a parameter instead of injecting it into the DAO, since it was sometimes uninitialized in unit test cases.
* Used `mainDispatcherRule. dispatcher` in all the unit test cases instead of the hardcoded dispatcher.