### PR TITLE
Reset rateAppDownloadCompleted in resetRateAppTriggers

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -655,11 +655,12 @@ class KiwixDataStore @Inject constructor(
     prefs[PreferencesKeys.RATE_APP_PROMPT_SHOWN] ?: false
   }
 
-  suspend fun setRateAppPromptShown(shown: Boolean = true) {
+  suspend fun setRateAppPromptShown() {
     context.kiwixDataStore.edit { prefs ->
-      prefs[PreferencesKeys.RATE_APP_PROMPT_SHOWN] = shown
+      prefs[PreferencesKeys.RATE_APP_PROMPT_SHOWN] = true
     }
   }
+
   companion object {
     // Prefs
     const val PREF_LANG = "pref_language_chooser"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -651,13 +651,15 @@ class KiwixDataStore @Inject constructor(
     }
   }
 
-  suspend fun resetRateAppTriggers() {
-    context.kiwixDataStore.edit { prefs ->
-      prefs[PreferencesKeys.RATE_APP_COUNT] = 0
-      prefs[PreferencesKeys.RATE_APP_READING_COUNT] = 0
-    }
+  val rateAppPromptShown: Flow<Boolean> = context.kiwixDataStore.data.map { prefs ->
+    prefs[PreferencesKeys.RATE_APP_PROMPT_SHOWN] ?: false
   }
 
+  suspend fun setRateAppPromptShown(shown: Boolean = true) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.RATE_APP_PROMPT_SHOWN] = shown
+    }
+  }
   companion object {
     // Prefs
     const val PREF_LANG = "pref_language_chooser"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -86,4 +86,5 @@ object PreferencesKeys {
   val RATE_APP_COUNT = intPreferencesKey("rate_app_count")
   val RATE_APP_DOWNLOAD_COMPLETED = booleanPreferencesKey("rate_app_download_completed")
   val RATE_APP_READING_COUNT = intPreferencesKey("rate_app_reading_count")
+  val RATE_APP_PROMPT_SHOWN = booleanPreferencesKey("rate_app_prompt_shown")
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
@@ -51,7 +51,7 @@ class RateDialogHandler @Inject constructor(
       val newCount = kiwixDataStore.incrementRateAppVisitCount()
 
       if (shouldShowRateDialog(newCount) && connectivityManager.isNetworkAvailable()) {
-        kiwixDataStore.resetRateAppTriggers()
+        kiwixDataStore.setRateAppPromptShown()
         launchInAppReviewFlow()
       }
     }
@@ -80,12 +80,16 @@ class RateDialogHandler @Inject constructor(
   }
 
   internal suspend fun shouldShowRateDialog(newCount: Int): Boolean {
+    val isPromptShown = kiwixDataStore.rateAppPromptShown.first()
     val meetVisitCount = newCount >= VISITS_REQUIRED_TO_SHOW_RATE_DIALOG
     val meetDownload = kiwixDataStore.rateAppDownloadCompleted.first()
     val meetReading = kiwixDataStore.rateAppReadingCount.first() >= READING_MILESTONE_THRESHOLD
 
-    return isPlayStoreVariant() &&
-      (meetVisitCount || meetDownload || meetReading) &&
+    return !isPromptShown &&
+      isPlayStoreVariant() &&
+      meetVisitCount &&
+      meetDownload &&
+      meetReading &&
       isTwoWeekPassed() &&
       isZimFilesAvailableInLibrary()
   }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -836,21 +836,9 @@ class KiwixDataStoreTest {
   }
 
   @Test
-  fun `resetRateAppTriggers resets all triggers to default`() = runTest {
-    kiwixDataStore.incrementRateAppVisitCount()
-    kiwixDataStore.incrementRateAppReadingCount()
-    kiwixDataStore.setRateAppDownloadCompleted()
-
-    assertThat(kiwixDataStore.rateAppCount.first()).isEqualTo(1)
-    assertThat(kiwixDataStore.rateAppReadingCount.first()).isEqualTo(1)
-    assertThat(kiwixDataStore.rateAppDownloadCompleted.first()).isTrue()
-
-    kiwixDataStore.resetRateAppTriggers()
-
-    assertThat(kiwixDataStore.rateAppCount.first()).isEqualTo(0)
-    assertThat(kiwixDataStore.rateAppReadingCount.first()).isEqualTo(0)
-    // Download completed state should be preserved since the user
-    // already downloaded a ZIM file. Only visit and reading counts reset.
-    assertThat(kiwixDataStore.rateAppDownloadCompleted.first()).isTrue()
+  fun `setRateAppPromptShown sets prompt shown flag to true`() = runTest {
+    assertThat(kiwixDataStore.rateAppPromptShown.first()).isFalse()
+    kiwixDataStore.setRateAppPromptShown()
+    assertThat(kiwixDataStore.rateAppPromptShown.first()).isTrue()
   }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
@@ -70,7 +70,7 @@ class RateDialogHandlerTest {
     coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(true)
     coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(10)
     coEvery { kiwixDataStore.rateAppPromptShown } returns flowOf(false)
-    coEvery { kiwixDataStore.setRateAppPromptShown(any()) } returns Unit
+    coEvery { kiwixDataStore.setRateAppPromptShown() } returns Unit
     libkiwixBookOnDisk = mockk(relaxed = true)
     connectivityManager = mockk(relaxed = true)
 
@@ -197,7 +197,7 @@ class RateDialogHandlerTest {
     rateDialogHandler.checkForRateDialog()
 
     verify(exactly = 0) { ReviewManagerFactory.create(any()) }
-    coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown(any()) }
+    coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown() }
   }
 
   @Test
@@ -213,7 +213,7 @@ class RateDialogHandlerTest {
       rateDialogHandler.checkForRateDialog()
 
       verify(exactly = 0) { ReviewManagerFactory.create(any()) }
-      coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown(any()) }
+      coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown() }
     }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
@@ -67,8 +67,10 @@ class RateDialogHandlerTest {
     kiwixDataStore = mockk(relaxed = true)
     coEvery { kiwixDataStore.isPlayStoreBuild } returns flowOf(true)
     coEvery { kiwixDataStore.rateAppCount } returns flowOf(0)
-    coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(false)
-    coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(0)
+    coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(true)
+    coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(10)
+    coEvery { kiwixDataStore.rateAppPromptShown } returns flowOf(false)
+    coEvery { kiwixDataStore.setRateAppPromptShown(any()) } returns Unit
     libkiwixBookOnDisk = mockk(relaxed = true)
     connectivityManager = mockk(relaxed = true)
 
@@ -112,8 +114,29 @@ class RateDialogHandlerTest {
   }
 
   @Test
+  fun `shouldShowRateDialog returns false when prompt was already shown`() = runTest {
+    coEvery { kiwixDataStore.rateAppPromptShown } returns flowOf(true)
+    val result = rateDialogHandler.shouldShowRateDialog(20)
+    assertFalse(result)
+  }
+
+  @Test
   fun `shouldShowRateDialog returns false when visit count is less than 20`() = runTest {
     val result = rateDialogHandler.shouldShowRateDialog(19)
+    assertFalse(result)
+  }
+
+  @Test
+  fun `shouldShowRateDialog returns false when downloadCompleted is false`() = runTest {
+    coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(false)
+    val result = rateDialogHandler.shouldShowRateDialog(20)
+    assertFalse(result)
+  }
+
+  @Test
+  fun `shouldShowRateDialog returns false when readingCount is less than threshold`() = runTest {
+    coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(9)
+    val result = rateDialogHandler.shouldShowRateDialog(20)
     assertFalse(result)
   }
 
@@ -147,7 +170,7 @@ class RateDialogHandlerTest {
   }
 
   @Test
-  fun `checkForRateDialog launches review flow when all conditions are met and network is available`() =
+  fun `checkForRateDialog launches review flow when all conditions met and network is available`() =
     runTest {
       coEvery { kiwixDataStore.incrementRateAppVisitCount() } returns 20
 
@@ -159,7 +182,7 @@ class RateDialogHandlerTest {
 
       verify { ReviewManagerFactory.create(activity) }
       verify { mockReviewManager.requestReviewFlow() }
-      coVerify { kiwixDataStore.resetRateAppTriggers() }
+      coVerify { kiwixDataStore.setRateAppPromptShown() }
     }
 
   @Test
@@ -174,13 +197,14 @@ class RateDialogHandlerTest {
     rateDialogHandler.checkForRateDialog()
 
     verify(exactly = 0) { ReviewManagerFactory.create(any()) }
-    coVerify(exactly = 0) { kiwixDataStore.resetRateAppTriggers() }
+    coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown(any()) }
   }
 
   @Test
   fun `checkForRateDialog does not launch review flow when shouldShowRateDialog is false`() =
     runTest {
       coEvery { kiwixDataStore.incrementRateAppVisitCount() } returns 6
+      coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(0)
 
       val mockReviewManager = mockk<ReviewManager>(relaxed = true)
       mockkStatic(ReviewManagerFactory::class)
@@ -189,7 +213,7 @@ class RateDialogHandlerTest {
       rateDialogHandler.checkForRateDialog()
 
       verify(exactly = 0) { ReviewManagerFactory.create(any()) }
-      coVerify(exactly = 0) { kiwixDataStore.resetRateAppTriggers() }
+      coVerify(exactly = 0) { kiwixDataStore.setRateAppPromptShown(any()) }
     }
 
   @Test
@@ -254,21 +278,4 @@ class RateDialogHandlerTest {
     val result = rateDialogHandler.isTwoWeekPassed()
     assertFalse(result)
   }
-
-  @Test
-  fun `shouldShowRateDialog returns true when downloadCompletedState is true`() = runTest {
-    coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(true)
-
-    val result = rateDialogHandler.shouldShowRateDialog(5)
-    assertTrue(result)
-  }
-
-  @Test
-  fun `shouldShowRateDialog returns true when readingCount is greater than or equal to threshold`() =
-    runTest {
-      coEvery { kiwixDataStore.rateAppReadingCount } returns flowOf(10)
-
-      val result = rateDialogHandler.shouldShowRateDialog(5)
-      assertTrue(result)
-    }
 }


### PR DESCRIPTION
Fixes #5025

Previously, `shouldShowRateDialog()` triggered if any single milestone was met, and reset the counters after displaying the review flow. Because the completed download flag remained set, it could trigger the review flow repeatedly on app startup.

Per review feedback:
- Updated `shouldShowRateDialog()` to require all preconditions and milestone conditions (`meetVisitCount && meetDownload && meetReading && isTwoWeekPassed() && isZimFilesAvailableInLibrary() && isPlayStoreVariant()`) to be met simultaneously before showing the prompt.
- Added `RATE_APP_PROMPT_SHOWN` in `KiwixDataStore` so once the prompt is shown, the flow is marked completed and will not automatically show again.
- Removed unused `resetRateAppTriggers()` and updated unit tests accordingly.