### PR TITLE
Fix external link popup action when clicking do not ask anymore

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
@@ -986,7 +986,7 @@ abstract class CoreReaderViewModel(
 
   override fun openExternalUrl(intent: Intent) {
     launchInViewModelScope {
-      externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+      externalLinkOpener.openExternalUrl(intent)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpener.kt
@@ -21,7 +21,8 @@ package org.kiwix.kiwixmobile.core.utils
 import android.app.Activity
 import android.content.Intent
 import android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
-import kotlinx.coroutines.CoroutineScope
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
@@ -47,16 +48,15 @@ class ExternalLinkOpener @Inject constructor(
   }
 
   private fun requireActivity() = requireNotNull(activity) {
-    "Activity is not not. Call ExternalLinkOpener.initialize before calling it"
+    "Activity is not set. Call ExternalLinkOpener.initialize before calling it"
   }
 
   suspend fun openExternalUrl(
-    intent: Intent,
-    lifecycleScope: CoroutineScope
+    intent: Intent
   ) {
     if (intent.resolveActivity(requireActivity().packageManager) != null) {
       if (kiwixDataStore.externalLinkPopup.first()) {
-        requestOpenLink(intent, lifecycleScope)
+        requestOpenLink(intent)
       } else {
         openLink(intent)
       }
@@ -69,15 +69,15 @@ class ExternalLinkOpener @Inject constructor(
     requireActivity().startActivity(intent)
   }
 
-  private fun requestOpenLink(intent: Intent, lifecycleScope: CoroutineScope) {
+  private fun requestOpenLink(intent: Intent) {
     requireAlertDialogShower().show(
       KiwixDialog.ExternalLinkPopup,
       { openLink(intent) },
       { },
       {
-        lifecycleScope.launch {
+        openLink(intent)
+        (requireActivity() as ComponentActivity).lifecycleScope.launch {
           kiwixDataStore.setExternalLinkPopup(false)
-          openLink(intent)
         }
       },
       uri = intent.data

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/AlertDialogShower.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -382,7 +383,8 @@ private fun ShowUri(
   )
 }
 
-@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+@Suppress("LongMethod")
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun UriDisplayRow(
   uri: Uri,
@@ -394,6 +396,9 @@ private fun UriDisplayRow(
     MineShaftGray850
   } else {
     LightGrey
+  }
+  val displayUriText = remember(uri) {
+    Uri.decode("$uri")
   }
   Surface(
     modifier = Modifier
@@ -418,7 +423,7 @@ private fun UriDisplayRow(
         )
     ) {
       Text(
-        text = "$uri",
+        text = displayUriText,
         color = MaterialTheme.colorScheme.primary,
         textDecoration = TextDecoration.Underline,
         fontSize = DIALOG_URI_TEXT_SIZE,

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
@@ -18,12 +18,12 @@
 
 package org.kiwix.kiwixmobile.core.utils
 
-import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Build
+import androidx.activity.ComponentActivity
 import androidx.compose.material3.ExperimentalMaterial3Api
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -66,13 +66,13 @@ class ExternalLinkOpenerTest {
   val mainDispatcherRule = MainDispatcherRule()
   private lateinit var kiwixDataStore: KiwixDataStore
   private val alertDialogShower = AlertDialogShower()
-  private lateinit var activity: Activity
-  private lateinit var activityController: ActivityController<Activity>
+  private lateinit var activity: ComponentActivity
+  private lateinit var activityController: ActivityController<ComponentActivity>
 
   @Before
   fun setUp() {
     kiwixDataStore = mockk()
-    activityController = Robolectric.buildActivity(Activity::class.java)
+    activityController = Robolectric.buildActivity(ComponentActivity::class.java)
     activity = activityController.setup().get()
   }
 
@@ -97,7 +97,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
       initialize(activity, alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+    externalLinkOpener.openExternalUrl(intent)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -127,7 +127,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
       initialize(activity, alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+    externalLinkOpener.openExternalUrl(intent)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -154,7 +154,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
       initialize(activity, alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+    externalLinkOpener.openExternalUrl(intent)
     val dialogData = alertDialogShower.dialogState.value
     assertNotNull(dialogData)
     val (dialog, listeners, _) = dialogData!!
@@ -182,18 +182,18 @@ class ExternalLinkOpenerTest {
       val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
         initialize(activity, alertDialogShower)
       }
-      externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+      externalLinkOpener.openExternalUrl(intent)
       val dialogData = alertDialogShower.dialogState.value
       assertNotNull(dialogData)
       val (dialog, listeners, _) = dialogData!!
       assert(dialog == KiwixDialog.ExternalLinkPopup)
       listeners[2].invoke()
+      val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
+      assertNotNull(startedIntent)
       advanceUntilIdle()
       coVerify {
         kiwixDataStore.setExternalLinkPopup(false)
       }
-      val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
-      assertNotNull(startedIntent)
     }
 
   @Test
@@ -212,7 +212,7 @@ class ExternalLinkOpenerTest {
     val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
       initialize(activity, alertDialogShower)
     }
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+    externalLinkOpener.openExternalUrl(intent)
     val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
     assertNotNull(startedIntent)
     assert(startedIntent.dataString == "https://github.com/")
@@ -228,7 +228,7 @@ class ExternalLinkOpenerTest {
       initialize(activity, alertDialogShower)
     }
 
-    externalLinkOpener.openExternalUrl(intent, lifecycleScope = this)
+    externalLinkOpener.openExternalUrl(intent)
     val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
     assertNull(startedIntent)
     assert(

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/ExternalLinkOpenerTest.kt
@@ -197,6 +197,38 @@ class ExternalLinkOpenerTest {
     }
 
   @Test
+  fun neutralButtonClickPersistsPreferenceWhenActivityIsPaused() = runTest {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
+    Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(
+      intent,
+      ResolveInfo().apply {
+        activityInfo = ActivityInfo().apply {
+          packageName = "com.example"
+          name = "ExampleActivity"
+        }
+      }
+    )
+    every { kiwixDataStore.externalLinkPopup } returns flowOf(true)
+    coJustRun { kiwixDataStore.setExternalLinkPopup(any()) }
+    val externalLinkOpener = ExternalLinkOpener(kiwixDataStore).apply {
+      initialize(activity, alertDialogShower)
+    }
+    externalLinkOpener.openExternalUrl(intent)
+    val dialogData = alertDialogShower.dialogState.value
+    assertNotNull(dialogData)
+    val (_, listeners, _) = dialogData!!
+    listeners[2].invoke()
+    activityController.pause()
+    advanceUntilIdle()
+    coVerify {
+      kiwixDataStore.setExternalLinkPopup(false)
+    }
+    val startedIntent = Shadows.shadowOf(activity).nextStartedActivity
+    assertNotNull(startedIntent)
+    assert(startedIntent.dataString == "https://github.com/")
+  }
+
+  @Test
   fun intentIsStartedIfExternalLinkPopupPreferenceIsFalse() = runTest {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/"))
     Shadows.shadowOf(activity.packageManager).addResolveInfoForIntent(


### PR DESCRIPTION
fix #5026
Passing viewModelScope to openExternalUrl caused DataStore writes to get cancelled when launching the browser. We considered using withContext(NonCancellable) as an alternative, but we chose to launch the coroutine directly on the Activity's scope ((requireActivity() as ComponentActivity).lifecycleScope) via (LifecycleOwner = second approach we can think.). This approach is cleaner, respects structured concurrency, removes the unnecessary lifecycleScope parameter from openExternalUrl, and guarantees the preference saves when switching to the browser. Additionally, the displayed link text in AlertDialogShower is now URL decoded using Uri.decode("$uri").







https://github.com/user-attachments/assets/b7939dbf-82c8-4ee0-9ba9-5e486984ab08



