### PR TITLE
Fixed: Emulator/action sometimes getting stuck after completing the test cases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
           disable-animations: false
           heap-size: 1024M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+            echo "Generated AVD snapshot for caching."
 
       - name: Create instrumentation coverage
         uses: reactivecircus/android-emulator-runner@v2
@@ -128,6 +130,7 @@ jobs:
           force-avd-creation: false
           heap-size: 1024M
           script: |
+            trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
             ./gradlew :benchmark:connectedBenchmarkAndroidTest
 
       - name: Upload coverage to Codecov
@@ -203,7 +206,9 @@ jobs:
           disable-animations: false
           heap-size: 1024M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+            echo "Generated AVD snapshot for caching."
 
       - name: Create instrumentation coverage for PlayStore variant
         uses: reactivecircus/android-emulator-runner@v2
@@ -284,7 +289,9 @@ jobs:
           disable-animations: false
           heap-size: 1024M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+            echo "Generated AVD snapshot for caching."
 
       - name: Test branded app
         uses: reactivecircus/android-emulator-runner@v2
@@ -365,7 +372,9 @@ jobs:
           disable-animations: false
           heap-size: 1024M
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+            echo "Generated AVD snapshot for caching."
 
       - name: File Opening test on Tablet
         uses: reactivecircus/android-emulator-runner@v2

--- a/contrib/instrumentation-brandedapps.sh
+++ b/contrib/instrumentation-brandedapps.sh
@@ -18,6 +18,12 @@
 #
 #
 
+# The emulator's crashpad_handler subprocess can survive `adb emu kill` and
+# hang the android-emulator-runner action's teardown
+# (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).
+# Kill it once this script exits, regardless of the test outcome.
+trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+
 # Enable Wi-Fi on the emulator
 adb shell svc wifi enable
 adb logcat -c

--- a/contrib/instrumentation-file-opening-on-tablet.sh
+++ b/contrib/instrumentation-file-opening-on-tablet.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# The emulator's crashpad_handler subprocess can survive `adb emu kill` and
+# hang the android-emulator-runner action's teardown
+# (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).
+# Kill it once this script exits, regardless of the test outcome.
+trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+
 # Enable Wi-Fi on the emulator
 adb shell svc wifi enable
 adb logcat -c

--- a/contrib/instrumentation-release.sh
+++ b/contrib/instrumentation-release.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# The emulator's crashpad_handler subprocess can survive `adb emu kill` and
+# hang the android-emulator-runner action's teardown
+# (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).
+# Kill it once this script exits, regardless of the test outcome.
+trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
 
 TEST_CLASSES="org.kiwix.kiwixmobile.download.DownloadTest,\
 org.kiwix.kiwixmobile.onlineCategory.OnlineCategoryTest,\

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# The emulator's crashpad_handler subprocess can survive `adb emu kill` and
+# hang the android-emulator-runner action's teardown
+# (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).
+# Kill it once this script exits, regardless of the test outcome.
+trap 'killall -INT crashpad_handler 2>/dev/null || true' EXIT
+
 # Enable Wi-Fi on the emulator
 adb shell svc wifi enable
 adb logcat -c


### PR DESCRIPTION
Fixes #5042 

*  The `android-emulator-runner` action's `adb emu kill` command does not reliably terminate the emulator's `crashpad_handler` subprocess, so the action's teardown waits forever for it to terminate (see ReactiveCircus/android-emulator-runner#385).
*  We now kill `crashpad_handler` once the test run finishes, regardless of whether it passed or failed.

See all other repos also fix this issue like this:

* https://github.com/devinbileck/bisqremote_Android/commit/da1b4167d282a5ff2451bf1993da8e3ee12f4d3a
* https://github.com/Jaehwa-Noh/nowinandroid/commit/5a19241d1066cbde6130661cdbea25f3f2acfb6b
* https://github.com/PinKushin/PokemonBattleJournal/commit/e21c6295eb2df6f3fa6336047b7e15cb59d14cad
* https://github.com/cgeo/cgeo/pull/17066/changes
