### PR TITLE
Fixed: Code coverage report not including the core and migration module in report.

### DIFF
--- a/contrib/instrumentation-brandedapps.sh
+++ b/contrib/instrumentation-brandedapps.sh
@@ -93,7 +93,6 @@ while [ $retry -le 3 ]; do
       adb uninstall "${TEST_ORCHESTRATOR_PACKAGE}"
     fi
     ./gradlew --stop
-    ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png

--- a/contrib/instrumentation-file-opening-on-tablet.sh
+++ b/contrib/instrumentation-file-opening-on-tablet.sh
@@ -73,7 +73,6 @@ while [ $retry -le 3 ]; do
       adb uninstall "${TEST_ORCHESTRATOR_PACKAGE}"
     fi
     ./gradlew --stop
-    ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png

--- a/contrib/instrumentation-release.sh
+++ b/contrib/instrumentation-release.sh
@@ -77,7 +77,6 @@ while [ $retry -le 3 ]; do
       adb uninstall "${TEST_ORCHESTRATOR_PACKAGE}"
     fi
     ./gradlew --stop
-    ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -75,7 +75,6 @@ while [ $retry -le 3 ]; do
       adb uninstall "${TEST_ORCHESTRATOR_PACKAGE}"
     fi
     ./gradlew --stop
-    ./gradlew clean
     retry=$(( retry + 1 ))
     if [ $retry -eq 3 ]; then
       adb exec-out screencap -p >screencap.png

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -33,7 +33,7 @@ tasks.register('jacocoInstrumentationTestReport', JacocoReport) {
   reports {
     xml.required.set(true)
     html.required.set(true)
-    html.outputLocation.set(file("${rootProject.buildDir}/coverage-report"))
+    html.outputLocation.set(rootProject.layout.buildDirectory.dir("coverage-report"))
   }
   def javaClasses = []
   def kotlinClasses = []
@@ -45,16 +45,21 @@ tasks.register('jacocoInstrumentationTestReport', JacocoReport) {
 
   rootProject.subprojects.each { proj ->
     if (proj.name != "defaultmigration") {
-      javaClasses << fileTree(dir: "$proj.buildDir/intermediates/javac/debug", excludes: fileFilter)
-      kotlinClasses << fileTree(dir: "$proj.buildDir/tmp/kotlin-classes/debug",
+      // "branded" builds the "customexample" flavor, so its variant is "customexampleDebug"
+      // rather than plain "debug" like every other module.
+      def variant = proj.name == "branded" ? "customexampleDebug" : "debug"
+      def variantCap = variant.capitalize()
+      def projBuildDir = proj.layout.buildDirectory.get().asFile
+      javaClasses << fileTree(dir: "$projBuildDir/intermediates/javac/$variant", excludes: fileFilter)
+      kotlinClasses << fileTree(dir: "$projBuildDir/intermediates/built_in_kotlinc/$variant/compile${variantCap}Kotlin/classes",
         excludes: fileFilter)
       javaSrc << "$proj.projectDir/src/main/java"
       kotlinSrc << "$proj.projectDir/src/main/kotlin"
-      execution << fileTree(dir: proj.buildDir,
-        includes: ['outputs/unit_test_code_coverage/**/*.exec',
-          'jacoco/testDebugUnitTest.exec',
-          'outputs/code-coverage/connected/*coverage.ec',
-          'outputs/code_coverage/debugAndroidTest/connected/**/*.ec'])
+      execution << fileTree(dir: projBuildDir,
+        includes: ["outputs/unit_test_code_coverage/**/*.exec",
+          "jacoco/test${variantCap}UnitTest.exec",
+          "outputs/code-coverage/connected/*coverage.ec",
+          "outputs/code_coverage/${variant}AndroidTest/connected/**/*.ec"])
     }
   }
   sourceDirectories.from = files(javaSrc, kotlinSrc)


### PR DESCRIPTION
Fixes #5044 

*  AGP 9 made built-in Kotlin compilation mandatory, so compiled Kotlin classes moved from `tmp/kotlin-classes/<variant>` to `intermediates/built_in_kotlinc/<variant>/compile<Variant>Kotlin/classes`. The old hardcoded path meant no module's Kotlin classes were being picked up; `app` still showed some coverage only because enough Dagger-generated Java classes remained under `intermediates/javac/debug`, while `core` and the migration modules (almost entirely Kotlin) effectively vanished from the report.
* `branded` was still missing after that fix because it builds the `customexample` flavor, so its variant is `customexampleDebug`, not `debug` like every other module - none of the class/exec paths ever matched it. (This module was not included in code coverage before).
* Also replaced the deprecated `buildDir` getter (removed in Gradle 10) with `layout.buildDirectory`.