### PR TITLE
Removed `Activity.isBrandedApp()` extension function.

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/ActivityExtensions.kt
@@ -108,12 +108,4 @@ object ActivityExtensions {
       )
     }
   }
-
-  /**
-   * Checks if the package name of the current activity's application is not equal to
-   * 'org.kiwix.kiwixmobile' or 'org.kiwix.kiwixmobile.standalone',
-   * indicating that it is a branded application.
-   */
-  fun Activity.isBrandedApp(): Boolean =
-    packageName != "org.kiwix.kiwixmobile" && packageName != "org.kiwix.kiwixmobile.standalone"
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
@@ -64,7 +64,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.Flow
 import org.kiwix.kiwixmobile.core.R
-import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isBrandedApp
 import org.kiwix.kiwixmobile.core.extensions.CollectSideEffectWithActivity
 import org.kiwix.kiwixmobile.core.extensions.bottomShadow
 import org.kiwix.kiwixmobile.core.extensions.hideKeyboardOnLazyColumnScroll
@@ -114,6 +113,7 @@ fun <T : Page, S : PageState<T>> PageScreenRoute(
 ) {
   val alertDialogShower = remember { AlertDialogShower() }
   val state by viewModel.state.collectAsStateWithLifecycle()
+  val isBrandedApp by viewModel.kiwixDataStore.isBrandedApp.collectAsStateWithLifecycle(initialValue = false)
   val activity = LocalActivity.current as CoreMainActivity
 
   var isSearchActive by rememberSaveable { mutableStateOf(false) }
@@ -166,7 +166,7 @@ fun <T : Page, S : PageState<T>> PageScreenRoute(
       isInSelectionMode = isInSelectionMode,
       selectedCount = selectedCount,
       switchIsCheckedFlow = switchIsCheckedFlow,
-      isBrandedApp = activity.isBrandedApp(),
+      isBrandedApp = isBrandedApp,
       navigationIcon = { NavigationIcon(onClick = { handleNavigationClick() }) },
       actionMenuItems = actionMenuList(
         deleteIconTitle = deleteIconTitle,
@@ -325,34 +325,33 @@ private fun PageSwitchRow(
   isBrandedApp: Boolean = false
 ) {
   // hide switches for custom apps, see more info here https://github.com/kiwix/kiwix-android/issues/3523
-  if (!isBrandedApp) {
-    val isChecked by switchIsCheckedFlow.collectAsState(true)
-    Surface(modifier = Modifier.bottomShadow(KIWIX_TOOLBAR_SHADOW_ELEVATION)) {
-      Row(
+  if (isBrandedApp) return
+  val isChecked by switchIsCheckedFlow.collectAsState(true)
+  Surface(modifier = Modifier.bottomShadow(KIWIX_TOOLBAR_SHADOW_ELEVATION)) {
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .background(MaterialTheme.colorScheme.onPrimary)
+        .padding(bottom = PAGE_SWITCH_ROW_BOTTOM_MARGIN),
+      horizontalArrangement = Arrangement.Absolute.Right,
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      Text(
+        text = switchString,
+        color = MaterialTheme.colorScheme.onBackground,
+        style = TextStyle(fontSize = FOURTEEN_SP),
+        modifier = Modifier.testTag(SWITCH_TEXT_TESTING_TAG)
+      )
+      Switch(
+        checked = isChecked,
+        onCheckedChange = onSwitchCheckedChange,
+        enabled = switchIsEnabled,
         modifier = Modifier
-          .fillMaxWidth()
-          .background(MaterialTheme.colorScheme.onPrimary)
-          .padding(bottom = PAGE_SWITCH_ROW_BOTTOM_MARGIN),
-        horizontalArrangement = Arrangement.Absolute.Right,
-        verticalAlignment = Alignment.CenterVertically
-      ) {
-        Text(
-          text = switchString,
-          color = MaterialTheme.colorScheme.onBackground,
-          style = TextStyle(fontSize = FOURTEEN_SP),
-          modifier = Modifier.testTag(SWITCH_TEXT_TESTING_TAG)
+          .padding(horizontal = PAGE_SWITCH_LEFT_RIGHT_MARGIN),
+        colors = SwitchDefaults.colors(
+          uncheckedTrackColor = White
         )
-        Switch(
-          checked = isChecked,
-          onCheckedChange = onSwitchCheckedChange,
-          enabled = switchIsEnabled,
-          modifier = Modifier
-            .padding(horizontal = PAGE_SWITCH_LEFT_RIGHT_MARGIN),
-          colors = SwitchDefaults.colors(
-            uncheckedTrackColor = White
-          )
-        )
-      }
+      )
     }
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandler.kt
@@ -31,7 +31,6 @@ import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.getPackageInform
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
 import org.kiwix.kiwixmobile.core.di.ActivityScope
-import org.kiwix.kiwixmobile.core.extensions.ActivityExtensions.isBrandedApp
 import org.kiwix.kiwixmobile.core.main.CoreMainActivity
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import javax.inject.Inject
@@ -99,7 +98,7 @@ class RateDialogHandler @Inject constructor(
 
   internal suspend fun isZimFilesAvailableInLibrary(): Boolean {
     // If it is a custom app, return true since custom apps always have the ZIM file.
-    if (activity.isBrandedApp()) return true
+    if (kiwixDataStore.isBrandedApp.first()) return true
     // For Kiwix app, check if there are ZIM files available in the library.
     return libkiwixBookOnDisk.getBooks().isNotEmpty()
   }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/dialog/RateDialogHandlerTest.kt
@@ -63,8 +63,8 @@ class RateDialogHandlerTest {
     activity = mockk(relaxed = true)
     packageManager = mockk(relaxed = true)
     every { activity.packageManager } returns packageManager
-    every { activity.packageName } returns "org.kiwix.kiwixmobile"
     kiwixDataStore = mockk(relaxed = true)
+    coEvery { kiwixDataStore.isBrandedApp } returns flowOf(false)
     coEvery { kiwixDataStore.isPlayStoreBuild } returns flowOf(true)
     coEvery { kiwixDataStore.rateAppCount } returns flowOf(0)
     coEvery { kiwixDataStore.rateAppDownloadCompleted } returns flowOf(true)
@@ -233,7 +233,7 @@ class RateDialogHandlerTest {
   @Test
   fun `isZimFilesAvailableInLibrary returns true when isBrandedApp is true`() =
     runTest {
-      every { activity.packageName } returns "org.kiwix.kiwixcustom"
+      coEvery { kiwixDataStore.isBrandedApp } returns flowOf(true)
       val result = rateDialogHandler.isZimFilesAvailableInLibrary()
       assertTrue(result)
     }
@@ -241,7 +241,7 @@ class RateDialogHandlerTest {
   @Test
   fun `isZimFilesAvailableInLibrary returns false when no books and isBrandedApp is false`() =
     runTest {
-      every { activity.packageName } returns "org.kiwix.kiwixmobile"
+      coEvery { kiwixDataStore.isBrandedApp } returns flowOf(false)
       coEvery { libkiwixBookOnDisk.getBooks() } returns emptyList()
       val result = rateDialogHandler.isZimFilesAvailableInLibrary()
       assertFalse(result)
@@ -250,7 +250,7 @@ class RateDialogHandlerTest {
   @Test
   fun `isZimFilesAvailableInLibrary returns true when books available and isBrandedApp is false`() =
     runTest {
-      every { activity.packageName } returns "org.kiwix.kiwixmobile"
+      coEvery { kiwixDataStore.isBrandedApp } returns flowOf(false)
       coEvery { libkiwixBookOnDisk.getBooks() } returns listOf(mockk())
       val result = rateDialogHandler.isZimFilesAvailableInLibrary()
       assertTrue(result)

--- a/team-props/git-hooks/pre-commit.sh
+++ b/team-props/git-hooks/pre-commit.sh
@@ -14,8 +14,8 @@ else
     echo 1>&2 "Static analysis found violations and attempted to autofix, please commit these autoformat changes"
     echo "
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------
-    If the build failed with '.../.gradle/daemon/8.4/branded/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK17
-    Please make sure JAVA_HOME is set to JDK17
+    If the build failed with '.../.gradle/daemon/9.5.0/branded/scr/customexample/info.json No File Found' then you do not have JAVA_HOME set to JDK21
+    Please make sure JAVA_HOME is set to JDK21
     ---------------------------IMPORTANT FOR KIWIX DEVELOPERS----------------------------------------------"
 
     exit 1


### PR DESCRIPTION
Fixes #5048 

* Refactored the `RateDialogHandler` and `PageScreen` classes to use the KiwixDataStore's `isBrandedApp` property instead of this extension function.
* Refactored the test cases to use dataStore instead of the extension function.
* Updated the message of the `pre-commit.sh` file as we have upgraded Gradle and JDK.
