### PR TITLE
Fixed: Emulator sometimes crashing with ServiceNotFoundException before tests could run.

### DIFF
--- a/.github/actions/android-emulator-runner/action.yml
+++ b/.github/actions/android-emulator-runner/action.yml
@@ -1,0 +1,189 @@
+name: Android Emulator Test
+description: Run tests on an Android emulator with retry for emulator startup failures
+
+inputs:
+  api-level:
+    description: Android API level
+    required: true
+
+  target:
+    description: Android emulator target
+    required: true
+
+  arch:
+    description: Android emulator architecture
+    required: true
+
+  profile:
+    description: Android emulator profile
+    required: true
+
+  script:
+    description: Script to execute after the emulator starts
+    required: true
+
+  ram-size:
+    description: Emulator RAM size
+    required: false
+    default: 4096M
+
+  cores:
+    description: Number of emulator CPU cores
+    required: false
+    default: "4"
+
+  heap-size:
+    description: Emulator heap size
+    required: false
+    default: 1024M
+
+  gradle-opts:
+    description: Value for the GRADLE_OPTS environment variable during the emulator script
+    required: false
+    default: ""
+
+runs:
+  using: composite
+
+  steps:
+
+    # ---------------------------------------------------------
+    # Attempt 1
+    # ---------------------------------------------------------
+    - name: Emulator test - attempt 1
+      id: attempt-1
+      continue-on-error: true
+      uses: reactivecircus/android-emulator-runner@v2
+      env:
+        GRADLE_OPTS: ${{ inputs.gradle-opts }}
+      with:
+        api-level: ${{ inputs.api-level }}
+        target: ${{ inputs.target }}
+        arch: ${{ inputs.arch }}
+        profile: ${{ inputs.profile }}
+        ram-size: ${{ inputs.ram-size }}
+        cores: ${{ inputs.cores }}
+        heap-size: ${{ inputs.heap-size }}
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        sdcard-path-or-size: 1024M
+        disable-animations: true
+        force-avd-creation: false
+        emulator-boot-timeout: 1200
+        script: |
+          bash -c '${{ inputs.script }}'
+
+    # ---------------------------------------------------------
+    # Check whether attempt 1 failed before the test script
+    # started.
+    # ---------------------------------------------------------
+    - name: Check attempt 1
+      id: check-attempt-1
+      if: steps.attempt-1.outcome == 'failure'
+      shell: bash
+      run: |
+        if [ -f /tmp/emulator_script_started ]; then
+          echo "script_started=true" >> "$GITHUB_OUTPUT"
+          echo "Instrumentation script started."
+        else
+          echo "script_started=false" >> "$GITHUB_OUTPUT"
+          echo "Emulator runner failed before instrumentation script started."
+        fi
+
+    # ---------------------------------------------------------
+    # Attempt 2
+    # Only retry when the emulator runner failed before the
+    # instrumentation script started.
+    # ---------------------------------------------------------
+    - name: Emulator test - attempt 2
+      id: attempt-2
+      if: |
+        steps.attempt-1.outcome == 'failure' &&
+        steps.check-attempt-1.outputs.script_started == 'false'
+      continue-on-error: true
+      uses: reactivecircus/android-emulator-runner@v2
+      env:
+        GRADLE_OPTS: ${{ inputs.gradle-opts }}
+      with:
+        api-level: ${{ inputs.api-level }}
+        target: ${{ inputs.target }}
+        arch: ${{ inputs.arch }}
+        profile: ${{ inputs.profile }}
+        ram-size: ${{ inputs.ram-size }}
+        cores: ${{ inputs.cores }}
+        heap-size: ${{ inputs.heap-size }}
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        sdcard-path-or-size: 1024M
+        disable-animations: true
+        force-avd-creation: false
+        emulator-boot-timeout: 1200
+        script: |
+          bash -c '${{ inputs.script }}'
+
+    # ---------------------------------------------------------
+    # Check attempt 2
+    # ---------------------------------------------------------
+    - name: Check attempt 2
+      id: check-attempt-2
+      if: steps.attempt-2.outcome == 'failure'
+      shell: bash
+      run: |
+        if [ -f /tmp/emulator_script_started ]; then
+          echo "script_started=true" >> "$GITHUB_OUTPUT"
+          echo "Instrumentation script started."
+        else
+          echo "script_started=false" >> "$GITHUB_OUTPUT"
+          echo "Emulator runner failed before instrumentation script started."
+        fi
+
+    # ---------------------------------------------------------
+    # Attempt 3
+    # ---------------------------------------------------------
+    - name: Emulator test - attempt 3
+      id: attempt-3
+      if: |
+        steps.attempt-2.outcome == 'failure' &&
+        steps.check-attempt-2.outputs.script_started == 'false'
+      uses: reactivecircus/android-emulator-runner@v2
+      env:
+        GRADLE_OPTS: ${{ inputs.gradle-opts }}
+      with:
+        api-level: ${{ inputs.api-level }}
+        target: ${{ inputs.target }}
+        arch: ${{ inputs.arch }}
+        profile: ${{ inputs.profile }}
+        ram-size: ${{ inputs.ram-size }}
+        cores: ${{ inputs.cores }}
+        heap-size: ${{ inputs.heap-size }}
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        sdcard-path-or-size: 1024M
+        disable-animations: true
+        force-avd-creation: false
+        emulator-boot-timeout: 1200
+        script: |
+          bash -c '${{ inputs.script }}'
+
+    # ---------------------------------------------------------
+    # Final result
+    #
+    # Important:
+    # If the script started and failed, this is a genuine test
+    # failure. If all emulator startup retries failed, fail too.
+    # ---------------------------------------------------------
+    - name: Fail if emulator/test failed
+      if: always()
+      shell: bash
+      run: |
+        if [ "${{ steps.attempt-1.outcome }}" = "success" ]; then
+          exit 0
+        fi
+
+        if [ "${{ steps.attempt-2.outcome }}" = "success" ]; then
+          exit 0
+        fi
+
+        if [ "${{ steps.attempt-3.outcome }}" = "success" ]; then
+          exit 0
+        fi
+
+        echo "Android emulator test failed."
+        exit 1

--- a/.github/actions/android-emulator-runner/action.yml
+++ b/.github/actions/android-emulator-runner/action.yml
@@ -48,6 +48,13 @@ runs:
   steps:
 
     # ---------------------------------------------------------
+    # Reset marker file used to detect whether the test script started.
+    # ---------------------------------------------------------
+    - name: Reset emulator script marker
+      shell: bash
+      run: rm -f /tmp/emulator_script_started
+
+    # ---------------------------------------------------------
     # Attempt 1
     # ---------------------------------------------------------
     - name: Emulator test - attempt 1

--- a/.github/actions/android-emulator-runner/action.yml
+++ b/.github/actions/android-emulator-runner/action.yml
@@ -99,7 +99,10 @@ runs:
     # ---------------------------------------------------------
     # Attempt 2
     # Only retry when the emulator runner failed before the
-    # instrumentation script started.
+    # instrumentation script started. force-avd-creation/-no-snapshot
+    # ensure this boots a genuinely fresh AVD instead of resuming the
+    # same (possibly poisoned) cached snapshot that attempt 1 just
+    # failed against, which would otherwise fail identically again.
     # ---------------------------------------------------------
     - name: Emulator test - attempt 2
       id: attempt-2
@@ -118,10 +121,10 @@ runs:
         ram-size: ${{ inputs.ram-size }}
         cores: ${{ inputs.cores }}
         heap-size: ${{ inputs.heap-size }}
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         sdcard-path-or-size: 1024M
         disable-animations: true
-        force-avd-creation: false
+        force-avd-creation: true
         emulator-boot-timeout: 1200
         script: |
           bash -c '${{ inputs.script }}'
@@ -161,10 +164,10 @@ runs:
         ram-size: ${{ inputs.ram-size }}
         cores: ${{ inputs.cores }}
         heap-size: ${{ inputs.heap-size }}
-        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
+        emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
         sdcard-path-or-size: 1024M
         disable-animations: true
-        force-avd-creation: false
+        force-avd-creation: true
         emulator-boot-timeout: 1200
         script: |
           bash -c '${{ inputs.script }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,7 @@ jobs:
             echo "Generated AVD snapshot for caching."
 
       - name: Create instrumentation coverage
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+        uses: ./.github/actions/android-emulator-runner
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -97,14 +95,8 @@ jobs:
           profile: pixel_2
           ram-size: 4096M
           cores: 4
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          sdcard-path-or-size: 1024M
-          disable-animations: true
-          force-avd-creation: false
-          heap-size: 1024M
-          emulator-boot-timeout: 1200
-          script: |
-            bash contrib/instrumentation.sh
+          gradle-opts: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          script: bash contrib/instrumentation.sh
 
       - name: Upload screenshot result
         uses: actions/upload-artifact@v6
@@ -211,9 +203,7 @@ jobs:
             echo "Generated AVD snapshot for caching."
 
       - name: Create instrumentation coverage for PlayStore variant
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+        uses: ./.github/actions/android-emulator-runner
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -221,14 +211,8 @@ jobs:
           profile: pixel_2
           ram-size: 4096M
           cores: 4
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          sdcard-path-or-size: 1024M
-          disable-animations: true
-          force-avd-creation: false
-          heap-size: 1024M
-          emulator-boot-timeout: 1200
-          script: |
-            bash contrib/instrumentation-release.sh
+          gradle-opts: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          script: bash contrib/instrumentation-release.sh
 
   automated-tests-branded-apps:
     name: Automated tests for Branded app
@@ -294,9 +278,7 @@ jobs:
             echo "Generated AVD snapshot for caching."
 
       - name: Test branded app
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+        uses: ./.github/actions/android-emulator-runner
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -304,14 +286,8 @@ jobs:
           profile: pixel_2
           ram-size: 4096M
           cores: 4
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          disable-animations: true
-          force-avd-creation: false
-          sdcard-path-or-size: 1024M
-          emulator-boot-timeout: 1200
-          heap-size: 1024M
-          script: |
-            bash contrib/instrumentation-brandedapps.sh
+          gradle-opts: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          script: bash contrib/instrumentation-brandedapps.sh
 
   automated-tests-on-tablet:
     name: Automated tests on Tablet
@@ -377,9 +353,7 @@ jobs:
             echo "Generated AVD snapshot for caching."
 
       - name: File Opening test on Tablet
-        uses: reactivecircus/android-emulator-runner@v2
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+        uses: ./.github/actions/android-emulator-runner
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
@@ -387,14 +361,8 @@ jobs:
           profile: pixel_c
           ram-size: 4096M
           cores: 4
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
-          disable-animations: true
-          force-avd-creation: false
-          sdcard-path-or-size: 1024M
-          emulator-boot-timeout: 1200
-          heap-size: 1024M
-          script: |
-            bash contrib/instrumentation-file-opening-on-tablet.sh
+          gradle-opts: "-Dorg.gradle.internal.http.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.network.retry.max.attempts=6 -Dorg.gradle.internal.network.retry.initial.backOff=2000"
+          script: bash contrib/instrumentation-file-opening-on-tablet.sh
 
   code-formatting-job:
     name: Code Formatting

--- a/contrib/instrumentation-brandedapps.sh
+++ b/contrib/instrumentation-brandedapps.sh
@@ -18,6 +18,13 @@
 #
 #
 
+# Marks that this script actually started running, i.e. the emulator finished
+# booting and reactivecircus/android-emulator-runner handed control to us.
+# .github/actions/android-emulator-runner checks for this file to tell an
+# emulator boot-time crash (e.g. kiwix/kiwix-android#5047) apart from a
+# genuine test failure, and only retries the whole step for the former.
+touch /tmp/emulator_script_started
+
 # The emulator's crashpad_handler subprocess can survive `adb emu kill` and
 # hang the android-emulator-runner action's teardown
 # (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).

--- a/contrib/instrumentation-file-opening-on-tablet.sh
+++ b/contrib/instrumentation-file-opening-on-tablet.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+#
+# Kiwix Android
+# Copyright (c) 2026 Kiwix <android.kiwix.org>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Marks that this script actually started running, i.e. the emulator finished
+# booting and reactivecircus/android-emulator-runner handed control to us.
+# .github/actions/android-emulator-runner checks for this file to tell an
+# emulator boot-time crash (e.g. kiwix/kiwix-android#5047) apart from a
+# genuine test failure, and only retries the whole step for the former.
+touch /tmp/emulator_script_started
+
 # The emulator's crashpad_handler subprocess can survive `adb emu kill` and
 # hang the android-emulator-runner action's teardown
 # (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).

--- a/contrib/instrumentation-release.sh
+++ b/contrib/instrumentation-release.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+#
+# Kiwix Android
+# Copyright (c) 2026 Kiwix <android.kiwix.org>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Marks that this script actually started running, i.e. the emulator finished
+# booting and reactivecircus/android-emulator-runner handed control to us.
+# .github/actions/android-emulator-runner checks for this file to tell an
+# emulator boot-time crash (e.g. kiwix/kiwix-android#5047) apart from a
+# genuine test failure, and only retries the whole step for the former.
+touch /tmp/emulator_script_started
+
 # The emulator's crashpad_handler subprocess can survive `adb emu kill` and
 # hang the android-emulator-runner action's teardown
 # (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).

--- a/contrib/instrumentation.sh
+++ b/contrib/instrumentation.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+#
+# Kiwix Android
+# Copyright (c) 2026 Kiwix <android.kiwix.org>
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Marks that this script actually started running, i.e. the emulator finished
+# booting and reactivecircus/android-emulator-runner handed control to us.
+# .github/actions/android-emulator-runner checks for this file to tell an
+# emulator boot-time crash (e.g. kiwix/kiwix-android#5047) apart from a
+# genuine test failure, and only retries the whole step for the former.
+touch /tmp/emulator_script_started
+
 # The emulator's crashpad_handler subprocess can survive `adb emu kill` and
 # hang the android-emulator-runner action's teardown
 # (https://github.com/ReactiveCircus/android-emulator-runner/issues/385).


### PR DESCRIPTION
Fixes #5047 

* There are no fixes on upstream for this issue. It is failing because `input keyevent 82` fails to find the `InputManager` service in emualtor, and it can not unlock the device without this. So it crashes. Retrying the workflow works(it finds this service and runs the test cases). So we have only this option to fix this issue.
* Extracted the emulator boot + test-run step into a local composite action (.github/actions/android-emulator-runner) that retries up to 3 times when the emulator crashes during reactivecircus/android-emulator-runner's own post-boot setup (ServiceNotFoundException: No service published for: input, kiwix/kiwix-android#5047) - a known upstream flake, not a genuine test failure. A retry only fires when /tmp/emulator_script_started is still absent; once the instrumentation script has actually started, a failure is treated as a real test failure and fails fast instead of burning further attempts.
* When it retries when there is an emulator failure. It creates a fresh AVD instance(because the previous one gives the same issue when retrying, seems the AVD is corrupted).