### PR TITLE
fix(online-catalog): detect airplane mode explicitly

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibrary.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibrary.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -25,12 +26,14 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.nav.destination.library.online.repository.OnlineLibraryRepository
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.WifiOnlyException
@@ -39,7 +42,8 @@ import javax.inject.Inject
 class ObserveOnlineLibrary @Inject constructor(
   private val repository: OnlineLibraryRepository,
   private val kiwixDataStore: KiwixDataStore,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   @OptIn(ExperimentalCoroutinesApi::class)
   operator fun invoke(
@@ -48,6 +52,10 @@ class ObserveOnlineLibrary @Inject constructor(
     return requests
       .flatMapLatest { request ->
         flow {
+          if (context.isAirplaneModeOn()) {
+            emit(AirplaneModeEnabled)
+            return@flow
+          }
           if (!connectivityManager.isNetworkAvailable()) {
             emit(NoInternetConnection)
             return@flow

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickAction.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickAction.kt
@@ -18,16 +18,19 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Status
 import kotlinx.coroutines.flow.first
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
 import org.kiwix.kiwixmobile.core.ui.components.ONE
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.CancelDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.DisableStorageSelection
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.NoInternet
@@ -51,7 +54,8 @@ class ResolveBookClickAction @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
   private val permissionChecker: KiwixPermissionChecker,
   private val availableSpaceCalculator: AvailableSpaceCalculator,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   sealed class LibraryActionResult {
     object RequestNotificationPermission : LibraryActionResult()
@@ -62,6 +66,7 @@ class ResolveBookClickAction @Inject constructor(
     data class NotEnoughSpace(val availableSpace: String) : LibraryActionResult()
     data class StartDownload(val item: BookItem) : LibraryActionResult()
     object NoInternet : LibraryActionResult()
+    object AirplaneModeEnabled : LibraryActionResult()
     object DisableStorageSelection : LibraryActionResult()
     data class PauseResume(val downloadId: Long, val isPaused: Boolean) : LibraryActionResult()
     data class RetryDownload(val downloadId: Long) : LibraryActionResult()
@@ -74,6 +79,8 @@ class ResolveBookClickAction @Inject constructor(
   ): LibraryActionResult {
     return if (!permissionChecker.hasNotificationPermission()) {
       RequestNotificationPermission
+    } else if (context.isAirplaneModeOn()) {
+      AirplaneModeEnabled
     } else if (!connectivityManager.isNetworkAvailable()) {
       NoInternet
     } else if (kiwixDataStore.wifiOnly.first() && !connectivityManager.isWifi()) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryAction.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryAction.kt
@@ -18,11 +18,14 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import kotlinx.coroutines.flow.first
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
@@ -31,17 +34,21 @@ import javax.inject.Inject
 
 class ResolveRefreshLibraryAction @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   sealed class Result {
     object Proceed : Result()
     object NoInternetWithContent : Result()
     object NoInternetWithEmptyContent : Result()
     object WifiOnlyBlocked : Result()
+    object AirplaneModeBlocked : Result()
   }
 
   suspend operator fun invoke(hasItems: Boolean): Result {
-    return if (!connectivityManager.isNetworkAvailable()) {
+    return if (context.isAirplaneModeOn()) {
+      AirplaneModeBlocked
+    } else if (!connectivityManager.isNetworkAvailable()) {
       if (hasItems) {
         NoInternetWithContent
       } else {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
@@ -422,16 +422,7 @@ class OnlineLibraryViewModel @Inject constructor(
         showWifiOnlyDialog()
       }
 
-      NoInternetConnection -> {
-        _uiState.update {
-          it.copy(
-            showScanningProgressBar = false,
-            isLoadingMore = false
-          )
-        }
-      }
-
-      AirplaneModeEnabled -> {
+      NoInternetConnection, AirplaneModeEnabled -> {
         _uiState.update {
           it.copy(
             showScanningProgressBar = false,

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
@@ -88,10 +89,12 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookCl
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.ShowWifiOnlyDialog
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.StartDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.WifiOnlyBlocked
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -164,6 +167,7 @@ class OnlineLibraryViewModel @Inject constructor(
 
     object WifiOnlyException : OnlineLibraryState()
     object NoInternetConnection : OnlineLibraryState()
+    object AirplaneModeEnabled : OnlineLibraryState()
     data class Parsing(val isLoadMore: Boolean) : OnlineLibraryState()
   }
 
@@ -304,10 +308,10 @@ class OnlineLibraryViewModel @Inject constructor(
 
   private fun noContentMessageWhenItemsComesFromOnlineSource(items: List<LibraryListItem>): String =
     when {
-      items.isEmpty() -> if (connectivityManager.isNetworkAvailable()) {
-        context.getString(R.string.no_items_msg)
-      } else {
-        context.getString(R.string.no_network_connection)
+      items.isEmpty() -> when {
+        context.isAirplaneModeOn() -> context.getString(R.string.airplane_mode_not_supported)
+        connectivityManager.isNetworkAvailable() -> context.getString(R.string.no_items_msg)
+        else -> context.getString(R.string.no_network_connection)
       }
 
       else -> ""
@@ -419,6 +423,15 @@ class OnlineLibraryViewModel @Inject constructor(
       }
 
       NoInternetConnection -> {
+        _uiState.update {
+          it.copy(
+            showScanningProgressBar = false,
+            isLoadingMore = false
+          )
+        }
+      }
+
+      AirplaneModeEnabled -> {
         _uiState.update {
           it.copy(
             showScanningProgressBar = false,
@@ -579,6 +592,8 @@ class OnlineLibraryViewModel @Inject constructor(
         ShowStorageSelection -> showStorageSelectDialog(false)
         is StartDownload -> downloadFile()
         NoInternet -> emitNoInternetSnackbar()
+        ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled ->
+          emitToast(context.getString(R.string.airplane_mode_not_supported))
         RequestStoragePermission -> sendUiEvent(RequestPermission(WRITE_EXTERNAL_STORAGE))
         RequestNotificationPermission -> if (isAndroid13OrAbove) {
           sendUiEvent(RequestPermission(POST_NOTIFICATIONS))
@@ -702,6 +717,17 @@ class OnlineLibraryViewModel @Inject constructor(
                 scanningProgressBarMessage = context.getString(R.string.reaching_remote_library)
               )
             }
+          }
+        }
+
+        AirplaneModeBlocked -> {
+          _uiState.update {
+            it.copy(
+              noContentMessage = context.getString(R.string.airplane_mode_not_supported),
+              showNoContent = true,
+              isRefreshing = false,
+              showScanningProgressBar = false
+            )
           }
         }
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryTest.kt
@@ -18,13 +18,18 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,6 +42,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,6 +52,7 @@ import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.nav.destination.library.online.repository.OnlineLibraryRepository
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -57,16 +64,40 @@ class ObserveOnlineLibraryTest {
   private val repository: OnlineLibraryRepository = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
 
   private lateinit var observeOnlineLibrary: ObserveOnlineLibrary
 
   @BeforeEach
   fun setup() {
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
     observeOnlineLibrary = ObserveOnlineLibrary(
       repository,
       kiwixDataStore,
-      connectivityManager
+      connectivityManager,
+      context
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
+  }
+
+  @Test
+  fun `airplane mode emits AirplaneModeEnabled and skips repository`() = runTest {
+    every { any<Context>().isAirplaneModeOn() } returns true
+    val request = onlineLibraryRequest()
+    val result = observeOnlineLibrary(
+      flowOf(request)
+    ).first()
+
+    assertThat(AirplaneModeEnabled).isEqualTo(result)
+
+    coVerify(exactly = 0) {
+      repository.fetchOnlineLibrary(request)
+    }
   }
 
   private fun onlineLibraryRequest(

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickActionTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickActionTest.kt
@@ -18,18 +18,24 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Status
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
@@ -40,6 +46,7 @@ import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator.Ava
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem.BookItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem.LibraryDownloadItem
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.CancelDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.NoInternet
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.RetryDownload
@@ -60,18 +67,27 @@ class ResolveBookClickActionTest {
   private val permissionChecker: KiwixPermissionChecker = mockk()
   private val availableSpaceCalculator: AvailableSpaceCalculator = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
   private val bookItem = mockk<BookItem>(relaxed = true)
 
   private lateinit var resolver: ResolveBookClickAction
 
   @BeforeEach
   fun setup() {
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
     resolver = ResolveBookClickAction(
       kiwixDataStore,
       permissionChecker,
       availableSpaceCalculator,
-      connectivityManager
+      connectivityManager,
+      context
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
   }
 
   @Test
@@ -81,6 +97,16 @@ class ResolveBookClickActionTest {
     val result = resolver.onBookItemClick(bookItem, 1)
 
     assertEquals(RequestNotificationPermission, result)
+  }
+
+  @Test
+  fun `returns AirplaneModeEnabled when airplane mode is on`() = runTest {
+    coEvery { permissionChecker.hasNotificationPermission() } returns true
+    every { any<Context>().isAirplaneModeOn() } returns true
+
+    val result = resolver.onBookItemClick(bookItem, 1)
+
+    assertEquals(AirplaneModeEnabled, result)
   }
 
   @Test

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryActionTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryActionTest.kt
@@ -18,18 +18,25 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
@@ -39,12 +46,28 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefres
 class ResolveRefreshLibraryActionTest {
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
 
   private lateinit var resolver: ResolveRefreshLibraryAction
 
   @BeforeEach
   fun setup() {
-    resolver = ResolveRefreshLibraryAction(kiwixDataStore, connectivityManager)
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
+    resolver = ResolveRefreshLibraryAction(kiwixDataStore, connectivityManager, context)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
+  }
+
+  @Test
+  fun `returns AirplaneModeBlocked when airplane mode is on`() = runTest {
+    every { any<Context>().isAirplaneModeOn() } returns true
+
+    val result = resolver(hasItems = true)
+    assertEquals(AirplaneModeBlocked, result)
   }
 
   @Test

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -84,6 +84,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefres
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.WifiOnlyBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -595,6 +596,15 @@ class OnlineLibraryViewModelTest {
     @Test
     fun `when state is NoInternetConnection then stops loading`() = runTest {
       viewModel.handleLibraryState(NoInternetConnection)
+
+      val state = viewModel.uiState.value
+      assertFalse(state.showScanningProgressBar)
+      assertFalse(state.isLoadingMore)
+    }
+
+    @Test
+    fun `when state is AirplaneModeEnabled then stops loading`() = runTest {
+      viewModel.handleLibraryState(AirplaneModeEnabled)
 
       val state = viewModel.uiState.value
       assertFalse(state.showScanningProgressBar)

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -31,7 +31,9 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.spyk
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -51,6 +53,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
 import org.kiwix.kiwixmobile.core.downloader.Downloader
@@ -79,6 +84,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookCl
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.ShowWifiOnlyDialog
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.StartDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
@@ -97,6 +103,7 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibr
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowDialog
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowNoSpaceSnackbar
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowSnackbar
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.UiEvent.ShowToast
 import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem
 import org.kiwix.sharedFunctions.MainDispatcherRule
@@ -128,6 +135,8 @@ class OnlineLibraryViewModelTest {
 
   @BeforeEach
   fun setup() {
+    mockkObject(CompatHelper.Companion)
+    every { context.isAirplaneModeOn() } returns false
     every { connectivityReceiver.networkStates } returns MutableStateFlow(NetworkState.NOT_CONNECTED)
     every { observeItems.invoke(any(), any(), any(), any(), any()) } returns emptyFlow()
     // Real state, not a relaxed mock - relaxed mock of a sealed class picks a random
@@ -169,6 +178,7 @@ class OnlineLibraryViewModelTest {
   @AfterEach
   fun dispose() {
     viewModel.onClearedExposed()
+    unmockkObject(CompatHelper.Companion)
   }
 
   @Nested
@@ -242,6 +252,21 @@ class OnlineLibraryViewModelTest {
 
       assertTrue(viewModel.uiState.value.showNoContent)
     }
+
+    @Test
+    fun `given airplane mode blocked when refreshScreen then show no content`() = runTest {
+      coEvery { refreshAction.invoke(any()) } returns AirplaneModeBlocked
+
+      viewModel.refreshScreen(true)
+      advanceUntilIdle()
+
+      val uiState = viewModel.uiState.value
+      assertTrue(uiState.showNoContent)
+      assertEquals(
+        context.getString(R.string.airplane_mode_not_supported),
+        uiState.noContentMessage
+      )
+    }
   }
 
   @Nested
@@ -272,6 +297,23 @@ class OnlineLibraryViewModelTest {
         advanceUntilIdle()
         val snackBar = awaitItem() as ShowSnackbar
         assertTrue(snackBar.message == context.getString(R.string.no_network_connection))
+
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `when action is AirplaneModeEnabled then emits toast`() = runTest {
+      val item = mockk<LibraryListItem.BookItem>(relaxed = true)
+
+      coEvery { resolveClick.onBookItemClick(any(), any()) } returns
+        ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled
+      viewModel.uiEvents.test {
+        viewModel.onBookItemClick(item)
+
+        advanceUntilIdle()
+        val toast = awaitItem() as ShowToast
+        assertTrue(toast.message == context.getString(R.string.airplane_mode_not_supported))
 
         cancelAndIgnoreRemainingEvents()
       }
@@ -720,6 +762,56 @@ class OnlineLibraryViewModelTest {
       assertTrue(uiState.items.isEmpty())
       assertTrue(uiState.showNoContent)
     }
+
+    @Test
+    fun `when success returns empty list and network is available then shows no items message`() =
+      runTest {
+        every { connectivityManager.isNetworkAvailable() } returns true
+        val request = mockk<OnlineLibraryViewModel.OnlineLibraryRequest> {
+          every { isLoadMoreItem } returns false
+        }
+
+        val state = Success(
+          books = emptyList(),
+          totalPages = 1,
+          request = request
+        )
+
+        viewModel.handleLibraryState(state)
+
+        val uiState = viewModel.uiState.value
+
+        assertTrue(uiState.showNoContent)
+        assertEquals(
+          context.getString(R.string.no_items_msg),
+          uiState.noContentMessage
+        )
+      }
+
+    @Test
+    fun `when success returns empty list and airplane mode is on then shows airplane message`() =
+      runTest {
+        every { context.isAirplaneModeOn() } returns true
+        val request = mockk<OnlineLibraryViewModel.OnlineLibraryRequest> {
+          every { isLoadMoreItem } returns false
+        }
+
+        val state = Success(
+          books = emptyList(),
+          totalPages = 1,
+          request = request
+        )
+
+        viewModel.handleLibraryState(state)
+
+        val uiState = viewModel.uiState.value
+
+        assertTrue(uiState.showNoContent)
+        assertEquals(
+          context.getString(R.string.airplane_mode_not_supported),
+          uiState.noContentMessage
+        )
+      }
 
     @Test
     fun `when error and no existing books then emits empty list`() = runTest {

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -129,7 +129,9 @@ class OnlineLibraryViewModelTest {
   fun setup() {
     every { connectivityReceiver.networkStates } returns MutableStateFlow(NetworkState.NOT_CONNECTED)
     every { observeItems.invoke(any(), any(), any(), any(), any()) } returns emptyFlow()
-    every { observeLibrary.invoke(any()) } returns flowOf(mockk(relaxed = true))
+    // Real state, not a relaxed mock - relaxed mock of a sealed class picks a random
+    // concrete subtype, breaking object-identity `when` branches.
+    every { observeLibrary.invoke(any()) } returns flowOf(NoInternetConnection)
     every { observeNetwork.invoke(any()) } returns emptyFlow()
     every { kiwixDataStore.selectedOnlineContentCategory } returns MutableStateFlow("")
     every { kiwixDataStore.selectedOnlineContentLanguage } returns MutableStateFlow("")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -18,12 +18,14 @@
 
 package org.kiwix.kiwixmobile.core.compat
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.ConnectivityManager
 import android.os.Build
+import android.provider.Settings
 
 class CompatHelper private constructor() {
   // Note: Needs ": Compat" or the type system assumes `Compat21`
@@ -76,6 +78,16 @@ class CompatHelper private constructor() {
 
     fun ConnectivityManager.isWifi(): Boolean =
       compat.isWifi(this)
+
+    /**
+     * Airplane mode, read directly from Settings.Global. ConnectivityManager's network-capability
+     * checks can lag behind the actual airplane-mode toggle (or report internet available if the
+     * OEM keeps WiFi radio state ambiguous during the switch), so callers that need to
+     * distinguish "no internet" from "user explicitly enabled airplane mode" should check this
+     * first. See #5036.
+     */
+    fun Context.isAirplaneModeOn(): Boolean =
+      Settings.Global.getInt(contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
 
     fun String.convertToLocal() = compat.convertToLocal(this)
   }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
   <string name="wifi_only_title">Allow downloading content via mobile network?</string>
   <string name="wifi_only_msg">If you choose “Yes” you won\’t be warned in future. However, you can always change this in Settings</string>
   <string name="pref_wifi_only">Download content only via WiFi</string>
+  <string name="airplane_mode_not_supported">Online catalog is not available in Airplane mode</string>
   <string name="time_day" tools:keep="@string/time_day">day</string>
   <string name="time_hour" tools:keep="@string/time_hour">h</string>
   <string name="time_minute" tools:keep="@string/time_minute">min</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/compat/CompatHelperTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/compat/CompatHelperTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.compat
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * isAirplaneModeOn() reads Settings.Global directly rather than going through
+ * ConnectivityManager (see its own doc comment for why - #5036), so it needs a real
+ * ContentResolver to exercise, unlike the helpers that just mock this extension out.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CompatHelperTest {
+  private val context = ApplicationProvider.getApplicationContext<Context>()
+
+  @Test
+  fun `isAirplaneModeOn returns false when the setting is off`() {
+    Settings.Global.putInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0)
+    assertFalse(context.isAirplaneModeOn())
+  }
+
+  @Test
+  fun `isAirplaneModeOn returns true when the setting is on`() {
+    Settings.Global.putInt(context.contentResolver, Settings.Global.AIRPLANE_MODE_ON, 1)
+    assertTrue(context.isAirplaneModeOn())
+  }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Fixes #5036. Online catalog didn't reliably detect airplane mode: `ConnectivityManager`'s capability check can lag the actual toggle or briefly report inconsistent internet/wifi state during the switch, which let the wifi-only "allow mobile data?" dialog pop up while offline instead of a message saying the catalog isn't available.

Added `Context.isAirplaneModeOn()` (reads `Settings.Global` directly) and check it first, ahead of the wifi-only branch, in the three places that gate catalog behavior:
- `ObserveOnlineLibrary` (loading the catalog)
- `ResolveRefreshLibraryAction` (pull-to-refresh)
- `ResolveBookClickAction` (tapping a book to download)

New string: `airplane_mode_not_supported`.

## Test plan

- [x] Unit tests added for all three airplane-mode branches.
- [x] `:core:testDebugUnitTest :app:testDebugUnitTest` - full suite green except pre-existing Compose/Robolectric failures unrelated to this change (ASM/JDK version mismatch in this sandbox).
- [x] Fixed a latent bug in `OnlineLibraryViewModelTest`'s `observeLibrary` stub found while testing this: it returned `flowOf(mockk(relaxed = true))` for the sealed `OnlineLibraryState`, and MockK's relaxed mock of a sealed class backs itself with an arbitrary concrete subtype - adding the new `AirplaneModeEnabled` case made it pick a subtype whose `when` branch matches on object identity, which a mock proxy fails. Replaced with a real `NoInternetConnection` state.

## Related

- #5036
