### PR TITLE
fix(reader): use the JNI-provided fd for direct-access reads instead of reopening by path

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibrary.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibrary.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -25,12 +26,14 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.nav.destination.library.online.repository.OnlineLibraryRepository
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.WifiOnlyException
@@ -39,7 +42,8 @@ import javax.inject.Inject
 class ObserveOnlineLibrary @Inject constructor(
   private val repository: OnlineLibraryRepository,
   private val kiwixDataStore: KiwixDataStore,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   @OptIn(ExperimentalCoroutinesApi::class)
   operator fun invoke(
@@ -48,6 +52,10 @@ class ObserveOnlineLibrary @Inject constructor(
     return requests
       .flatMapLatest { request ->
         flow {
+          if (context.isAirplaneModeOn()) {
+            emit(AirplaneModeEnabled)
+            return@flow
+          }
           if (!connectivityManager.isNetworkAvailable()) {
             emit(NoInternetConnection)
             return@flow

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickAction.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickAction.kt
@@ -18,16 +18,19 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Status
 import kotlinx.coroutines.flow.first
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
 import org.kiwix.kiwixmobile.core.ui.components.ONE
 import org.kiwix.kiwixmobile.core.utils.KiwixPermissionChecker
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.CancelDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.DisableStorageSelection
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.NoInternet
@@ -51,7 +54,8 @@ class ResolveBookClickAction @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
   private val permissionChecker: KiwixPermissionChecker,
   private val availableSpaceCalculator: AvailableSpaceCalculator,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   sealed class LibraryActionResult {
     object RequestNotificationPermission : LibraryActionResult()
@@ -62,6 +66,7 @@ class ResolveBookClickAction @Inject constructor(
     data class NotEnoughSpace(val availableSpace: String) : LibraryActionResult()
     data class StartDownload(val item: BookItem) : LibraryActionResult()
     object NoInternet : LibraryActionResult()
+    object AirplaneModeEnabled : LibraryActionResult()
     object DisableStorageSelection : LibraryActionResult()
     data class PauseResume(val downloadId: Long, val isPaused: Boolean) : LibraryActionResult()
     data class RetryDownload(val downloadId: Long) : LibraryActionResult()
@@ -74,6 +79,8 @@ class ResolveBookClickAction @Inject constructor(
   ): LibraryActionResult {
     return if (!permissionChecker.hasNotificationPermission()) {
       RequestNotificationPermission
+    } else if (context.isAirplaneModeOn()) {
+      AirplaneModeEnabled
     } else if (!connectivityManager.isNetworkAvailable()) {
       NoInternet
     } else if (kiwixDataStore.wifiOnly.first() && !connectivityManager.isWifi()) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryAction.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryAction.kt
@@ -18,11 +18,14 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import kotlinx.coroutines.flow.first
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
@@ -31,17 +34,21 @@ import javax.inject.Inject
 
 class ResolveRefreshLibraryAction @Inject constructor(
   private val kiwixDataStore: KiwixDataStore,
-  private val connectivityManager: ConnectivityManager
+  private val connectivityManager: ConnectivityManager,
+  private val context: Context
 ) {
   sealed class Result {
     object Proceed : Result()
     object NoInternetWithContent : Result()
     object NoInternetWithEmptyContent : Result()
     object WifiOnlyBlocked : Result()
+    object AirplaneModeBlocked : Result()
   }
 
   suspend operator fun invoke(hasItems: Boolean): Result {
-    return if (!connectivityManager.isNetworkAvailable()) {
+    return if (context.isAirplaneModeOn()) {
+      AirplaneModeBlocked
+    } else if (!connectivityManager.isNetworkAvailable()) {
       if (hasItems) {
         NoInternetWithContent
       } else {

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModel.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.dao.DownloadRoomDao
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
@@ -88,10 +89,12 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookCl
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.ShowWifiOnlyDialog
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.StartDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.WifiOnlyBlocked
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -164,6 +167,7 @@ class OnlineLibraryViewModel @Inject constructor(
 
     object WifiOnlyException : OnlineLibraryState()
     object NoInternetConnection : OnlineLibraryState()
+    object AirplaneModeEnabled : OnlineLibraryState()
     data class Parsing(val isLoadMore: Boolean) : OnlineLibraryState()
   }
 
@@ -304,10 +308,10 @@ class OnlineLibraryViewModel @Inject constructor(
 
   private fun noContentMessageWhenItemsComesFromOnlineSource(items: List<LibraryListItem>): String =
     when {
-      items.isEmpty() -> if (connectivityManager.isNetworkAvailable()) {
-        context.getString(R.string.no_items_msg)
-      } else {
-        context.getString(R.string.no_network_connection)
+      items.isEmpty() -> when {
+        context.isAirplaneModeOn() -> context.getString(R.string.airplane_mode_not_supported)
+        connectivityManager.isNetworkAvailable() -> context.getString(R.string.no_items_msg)
+        else -> context.getString(R.string.no_network_connection)
       }
 
       else -> ""
@@ -419,6 +423,15 @@ class OnlineLibraryViewModel @Inject constructor(
       }
 
       NoInternetConnection -> {
+        _uiState.update {
+          it.copy(
+            showScanningProgressBar = false,
+            isLoadingMore = false
+          )
+        }
+      }
+
+      AirplaneModeEnabled -> {
         _uiState.update {
           it.copy(
             showScanningProgressBar = false,
@@ -579,6 +592,8 @@ class OnlineLibraryViewModel @Inject constructor(
         ShowStorageSelection -> showStorageSelectDialog(false)
         is StartDownload -> downloadFile()
         NoInternet -> emitNoInternetSnackbar()
+        ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled ->
+          emitToast(context.getString(R.string.airplane_mode_not_supported))
         RequestStoragePermission -> sendUiEvent(RequestPermission(WRITE_EXTERNAL_STORAGE))
         RequestNotificationPermission -> if (isAndroid13OrAbove) {
           sendUiEvent(RequestPermission(POST_NOTIFICATIONS))
@@ -702,6 +717,17 @@ class OnlineLibraryViewModel @Inject constructor(
                 scanningProgressBarMessage = context.getString(R.string.reaching_remote_library)
               )
             }
+          }
+        }
+
+        AirplaneModeBlocked -> {
+          _uiState.update {
+            it.copy(
+              noContentMessage = context.getString(R.string.airplane_mode_not_supported),
+              showNoContent = true,
+              isRefreshing = false,
+              showScanningProgressBar = false
+            )
           }
         }
 

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ObserveOnlineLibraryTest.kt
@@ -18,13 +18,18 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,6 +42,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,6 +52,7 @@ import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.nav.destination.library.online.repository.OnlineLibraryRepository
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryRequest
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState
+import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Idle
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.Loading
 import org.kiwix.kiwixmobile.nav.destination.library.online.viewmodel.OnlineLibraryViewModel.OnlineLibraryState.NoInternetConnection
@@ -57,16 +64,40 @@ class ObserveOnlineLibraryTest {
   private val repository: OnlineLibraryRepository = mockk()
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
 
   private lateinit var observeOnlineLibrary: ObserveOnlineLibrary
 
   @BeforeEach
   fun setup() {
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
     observeOnlineLibrary = ObserveOnlineLibrary(
       repository,
       kiwixDataStore,
-      connectivityManager
+      connectivityManager,
+      context
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
+  }
+
+  @Test
+  fun `airplane mode emits AirplaneModeEnabled and skips repository`() = runTest {
+    every { any<Context>().isAirplaneModeOn() } returns true
+    val request = onlineLibraryRequest()
+    val result = observeOnlineLibrary(
+      flowOf(request)
+    ).first()
+
+    assertThat(AirplaneModeEnabled).isEqualTo(result)
+
+    coVerify(exactly = 0) {
+      repository.fetchOnlineLibrary(request)
+    }
   }
 
   private fun onlineLibraryRequest(

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickActionTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveBookClickActionTest.kt
@@ -18,18 +18,24 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import com.tonyodev.fetch2.Error
 import com.tonyodev.fetch2.Status
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.downloader.model.DownloadState
@@ -40,6 +46,7 @@ import org.kiwix.kiwixmobile.zimManager.libraryView.AvailableSpaceCalculator.Ava
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem.BookItem
 import org.kiwix.kiwixmobile.zimManager.libraryView.LibraryListItem.LibraryDownloadItem
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.AirplaneModeEnabled
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.CancelDownload
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.NoInternet
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveBookClickAction.LibraryActionResult.RetryDownload
@@ -60,18 +67,27 @@ class ResolveBookClickActionTest {
   private val permissionChecker: KiwixPermissionChecker = mockk()
   private val availableSpaceCalculator: AvailableSpaceCalculator = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
   private val bookItem = mockk<BookItem>(relaxed = true)
 
   private lateinit var resolver: ResolveBookClickAction
 
   @BeforeEach
   fun setup() {
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
     resolver = ResolveBookClickAction(
       kiwixDataStore,
       permissionChecker,
       availableSpaceCalculator,
-      connectivityManager
+      connectivityManager,
+      context
     )
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
   }
 
   @Test
@@ -81,6 +97,16 @@ class ResolveBookClickActionTest {
     val result = resolver.onBookItemClick(bookItem, 1)
 
     assertEquals(RequestNotificationPermission, result)
+  }
+
+  @Test
+  fun `returns AirplaneModeEnabled when airplane mode is on`() = runTest {
+    coEvery { permissionChecker.hasNotificationPermission() } returns true
+    every { any<Context>().isAirplaneModeOn() } returns true
+
+    val result = resolver.onBookItemClick(bookItem, 1)
+
+    assertEquals(AirplaneModeEnabled, result)
   }
 
   @Test

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryActionTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/helper/ResolveRefreshLibraryActionTest.kt
@@ -18,18 +18,25 @@
 
 package org.kiwix.kiwixmobile.nav.destination.library.online.helper
 
+import android.content.Context
 import android.net.ConnectivityManager
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.compat.CompatHelper
+import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isAirplaneModeOn
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isNetworkAvailable
 import org.kiwix.kiwixmobile.core.compat.CompatHelper.Companion.isWifi
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.AirplaneModeBlocked
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.NoInternetWithEmptyContent
 import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefreshLibraryAction.Result.Proceed
@@ -39,12 +46,28 @@ import org.kiwix.kiwixmobile.nav.destination.library.online.helper.ResolveRefres
 class ResolveRefreshLibraryActionTest {
   private val kiwixDataStore: KiwixDataStore = mockk()
   private val connectivityManager: ConnectivityManager = mockk()
+  private val context: Context = mockk()
 
   private lateinit var resolver: ResolveRefreshLibraryAction
 
   @BeforeEach
   fun setup() {
-    resolver = ResolveRefreshLibraryAction(kiwixDataStore, connectivityManager)
+    mockkObject(CompatHelper.Companion)
+    every { any<Context>().isAirplaneModeOn() } returns false
+    resolver = ResolveRefreshLibraryAction(kiwixDataStore, connectivityManager, context)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkObject(CompatHelper.Companion)
+  }
+
+  @Test
+  fun `returns AirplaneModeBlocked when airplane mode is on`() = runTest {
+    every { any<Context>().isAirplaneModeOn() } returns true
+
+    val result = resolver(hasItems = true)
+    assertEquals(AirplaneModeBlocked, result)
   }
 
   @Test

--- a/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/nav/destination/library/online/viewmodel/OnlineLibraryViewModelTest.kt
@@ -129,7 +129,9 @@ class OnlineLibraryViewModelTest {
   fun setup() {
     every { connectivityReceiver.networkStates } returns MutableStateFlow(NetworkState.NOT_CONNECTED)
     every { observeItems.invoke(any(), any(), any(), any(), any()) } returns emptyFlow()
-    every { observeLibrary.invoke(any()) } returns flowOf(mockk(relaxed = true))
+    // Real state, not a relaxed mock - relaxed mock of a sealed class picks a random
+    // concrete subtype, breaking object-identity `when` branches.
+    every { observeLibrary.invoke(any()) } returns flowOf(NoInternetConnection)
     every { observeNetwork.invoke(any()) } returns emptyFlow()
     every { kiwixDataStore.selectedOnlineContentCategory } returns MutableStateFlow("")
     every { kiwixDataStore.selectedOnlineContentLanguage } returns MutableStateFlow("")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/compat/CompatHelper.kt
@@ -18,12 +18,14 @@
 
 package org.kiwix.kiwixmobile.core.compat
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.ConnectivityManager
 import android.os.Build
+import android.provider.Settings
 
 class CompatHelper private constructor() {
   // Note: Needs ": Compat" or the type system assumes `Compat21`
@@ -76,6 +78,16 @@ class CompatHelper private constructor() {
 
     fun ConnectivityManager.isWifi(): Boolean =
       compat.isWifi(this)
+
+    /**
+     * Airplane mode, read directly from Settings.Global. ConnectivityManager's network-capability
+     * checks can lag behind the actual airplane-mode toggle (or report internet available if the
+     * OEM keeps WiFi radio state ambiguous during the switch), so callers that need to
+     * distinguish "no internet" from "user explicitly enabled airplane mode" should check this
+     * first. See #5036.
+     */
+    fun Context.isAirplaneModeOn(): Boolean =
+      Settings.Global.getInt(contentResolver, Settings.Global.AIRPLANE_MODE_ON, 0) != 0
 
     fun String.convertToLocal() = compat.convertToLocal(this)
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -280,8 +280,9 @@ class ZimFileReader(
           // Retrieve direct access information for the item
           val infoPair = getDirectAccessInfoOfItem(item, uri)
           val file = infoPair?.filename?.let(::File)
-          // If no file found or file does not exist, return input stream from item data
-          if (infoPair == null || file == null || !file.exists()) {
+          // If no file found, and there's no already-open descriptor for it either,
+          // return input stream from item data.
+          if (infoPair == null || file == null || (infoPair.fd < 0 && !file.exists())) {
             return@loadContent ByteArrayInputStream(item.data?.data)
           }
           // Return the input stream from the direct access information
@@ -343,7 +344,7 @@ class ZimFileReader(
         }
       val infoPair = getDirectAccessInfoOfItem(item, uri)
       val file = infoPair?.filename?.let(::File)
-      if (infoPair == null || file == null || !file.exists()) {
+      if (infoPair == null || file == null || (infoPair.fd < 0 && !file.exists())) {
         return@withContext loadAssetFromCache(uri)
       }
       return@withContext getInputStreamFromDirectAccessInfo(item, file, infoPair)
@@ -368,7 +369,7 @@ class ZimFileReader(
   ): InputStream? =
     item?.itemSize()?.let {
       AssetFileDescriptor(
-        parcelFileDescriptor(file),
+        parcelFileDescriptor(file, infoPair.fd),
         infoPair.offset,
         it
       ).createInputStream()
@@ -502,8 +503,20 @@ val String.truncateMimeType: String
 val String.replaceWithEncodedString: String
   get() = replace("?", "%3F")
 
-private fun parcelFileDescriptor(file: File): ParcelFileDescriptor? =
-  ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+/**
+ * Prefers an already-open descriptor handed to us via JNI over (re)opening [file] by
+ * path. libzim/java-libkiwix dup() that descriptor for us before crossing the JNI
+ * boundary, so we own [fd] independently and adoptFd() is safe. This matters because
+ * [file] may be a synthetic path (e.g. `/dev/fd/N`) that isn't guaranteed to be safely
+ * re-openable - some Android content-provider descriptors reject that reopen with
+ * EACCES. See openzim/libzim#852.
+ */
+private fun parcelFileDescriptor(file: File, fd: Int = -1): ParcelFileDescriptor? =
+  if (fd >= 0) {
+    ParcelFileDescriptor.adoptFd(fd)
+  } else {
+    ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+  }
 
 // Default illustration size for ZIM file favicons
 const val ILLUSTRATION_SIZE = 48

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
   <string name="wifi_only_title">Allow downloading content via mobile network?</string>
   <string name="wifi_only_msg">If you choose “Yes” you won\’t be warned in future. However, you can always change this in Settings</string>
   <string name="pref_wifi_only">Download content only via WiFi</string>
+  <string name="airplane_mode_not_supported">Online catalog is not available in Airplane mode</string>
   <string name="time_day" tools:keep="@string/time_day">day</string>
   <string name="time_hour" tools:keep="@string/time_hour">h</string>
   <string name="time_minute" tools:keep="@string/time_minute">min</string>


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Draft — depends on kiwix/java-libkiwix#151, not asking for a merge yet.

## Summary

kiwix/java-libkiwix#151 (itself following openzim/libzim#1119) adds `DirectAccessInfo.fd`: an already-open, independently-owned descriptor for a direct-access item's backing file, dup()'d across the JNI boundary so Java can safely own and close it.

`ZimFileReader.parcelFileDescriptor()` reopened `infoPair.filename` by path on every direct-access read for large media items (>1MB, uncompressed). That path can be a synthetic `/dev/fd/N` string that isn't guaranteed to be safely re-openable - some Android content-provider (SAF, `ACTION_OPEN_DOCUMENT`) descriptors reject the reopen with `EACCES` even though the original fd is directly readable. This is the exact failure reported in #3636 / #3628.

## Fix

- `parcelFileDescriptor()` now prefers `ParcelFileDescriptor.adoptFd(fd)` when `infoPair.fd >= 0`, falling back to opening by path only when no fd was provided.
- Relaxed the direct-access gate in `loadContent()`/`loadAsset()`: a valid fd alone is now enough to take the direct-access path, without also requiring `File.exists()` to succeed on what may be a synthetic path.

## Why not ready to merge

`org.kiwix:libkiwix:2.6.0` (current published artifact) doesn't have `DirectAccessInfo.fd` yet - this needs kiwix/java-libkiwix#151 (which itself needs openzim/libzim#1119) to land and ship a release before this compiles against the real dependency, let alone before the actual SAF-descriptor scenario from #3636/#3628 can be exercised on-device.

## Test plan

- [ ] Blocked on the dependency chain above for a real build/device test.
- [ ] Once unblocked: reproduce #3636/#3628's SAF-opened-archive scenario on an affected arch (arm64-v8a/x86/x86_64) and confirm a large media item now loads via direct access instead of falling back to full item-data read.

## Related

- kiwix/java-libkiwix#151 (draft, this depends on it)
- openzim/libzim#1119, openzim/libzim#852
- #3636, #3628 (the original EACCES reports, this repo)
