### PR TITLE
fix(reader): stop reopening SAF fds by path just to check they're readable

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
@@ -74,8 +74,9 @@ class ZimReaderSource(
       when {
         file?.canReadFile(ioDispatcher) == true -> true
         assetFileDescriptorList?.isNotEmpty() == true &&
-          assetFileDescriptorList.first().parcelFileDescriptor?.fd
-            ?.let(::isFileDescriptorCanOpenWithLibkiwix) == true -> true
+          isFileDescriptorCanOpenWithLibkiwix(
+            assetFileDescriptorList.first().parcelFileDescriptor.fileDescriptor
+          ) -> true
 
         else -> false
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -31,6 +31,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.os.Environment.DIRECTORY_DOWNLOADS
+import android.os.ParcelFileDescriptor
 import android.os.storage.StorageManager
 import android.os.storage.StorageVolume
 import android.provider.DocumentsContract
@@ -55,6 +56,7 @@ import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
 import org.kiwix.kiwixmobile.core.utils.TAG_KIWIX
 import java.io.BufferedReader
 import java.io.File
+import java.io.FileDescriptor
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -993,7 +995,9 @@ object FileUtils {
       val assetFileDescriptor = context.contentResolver.openAssetFileDescriptor(uri, "r")
       // Verify whether libkiwix can successfully open this file descriptor or not.
       return if (
-        isFileDescriptorCanOpenWithLibkiwix(assetFileDescriptor?.parcelFileDescriptor?.fd)
+        assetFileDescriptor?.let {
+          isFileDescriptorCanOpenWithLibkiwix(it.parcelFileDescriptor.fileDescriptor)
+        } == true
       ) {
         assetFileDescriptor?.let(::listOf)
       } else {
@@ -1011,15 +1015,22 @@ object FileUtils {
   }
 
   @JvmStatic
-  fun isFileDescriptorCanOpenWithLibkiwix(fdNumber: Int?): Boolean {
+  fun isFileDescriptorCanOpenWithLibkiwix(fileDescriptor: FileDescriptor?): Boolean {
+    if (fileDescriptor?.valid() != true) {
+      return false
+    }
     return try {
-      // Attempt to create a FileInputStream object using the specified path.
-      // Since libkiwix utilizes this path to create the archive object internally,
-      // it is crucial to verify if we can successfully read the file descriptor (fd)
-      // via the given file path before passing it to libkiwix.
-      // This precaution helps prevent runtime crashes.
-      // For more details, refer to https://github.com/kiwix/kiwix-android/pull/3636.
-      FileInputStream("dev/fd/$fdNumber")
+      // Verify the fd is actually readable before handing it to libkiwix, to prevent
+      // runtime crashes. dup() it first so this check doesn't disturb the file position
+      // of the fd the caller is about to pass on, and don't reopen it by path - some
+      // Android content-provider fds reject that reopen with EACCES even though the fd
+      // itself is perfectly readable. For more details, see
+      // https://github.com/kiwix/kiwix-android/pull/3636.
+      // dup(FileDescriptor) never returns null -- it throws IOException on failure --
+      // so a plain try/catch around it is all the null-handling this needs.
+      ParcelFileDescriptor.dup(fileDescriptor).use { duped ->
+        FileInputStream(duped.fileDescriptor).use { it.read(ByteArray(1)) }
+      }
       true
     } catch (ignore: Exception) {
       ignore.printStackTrace()

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceFileDescriptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceFileDescriptorTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import android.content.res.AssetFileDescriptor
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.sharedFunctions.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * canOpenInLibkiwix()'s fd-list branch goes through isFileDescriptorCanOpenWithLibkiwix(),
+ * which needs ParcelFileDescriptor.dup() - a real Android/JNI call not available under a
+ * plain JVM unit test. Same reasoning as FileUtilsFileDescriptorTest.kt, which covers the
+ * matching branch in FileUtils directly.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(
+  sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.N_MR1],
+  manifest = Config.NONE,
+  application = TestApplication::class
+)
+class ZimReaderSourceFileDescriptorTest {
+  private val tempFile = File.createTempFile("valid", ".zim").apply { writeBytes(byteArrayOf(1)) }
+
+  @After
+  fun tearDown() {
+    tempFile.delete()
+  }
+
+  @Test
+  fun canOpenInLibkiwix_whenDescriptorListHasReadableFd_returnsTrue() = runTest {
+    ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+      val source = ZimReaderSource(
+        assetFileDescriptorList = listOf(
+          AssetFileDescriptor(pfd, 0, AssetFileDescriptor.UNKNOWN_LENGTH)
+        )
+      )
+      assertTrue(source.canOpenInLibkiwix(Dispatchers.IO))
+    }
+  }
+
+  /**
+   * Distinct from an empty/null descriptor list (already covered elsewhere): here the list
+   * is non-empty, but its fd is closed, so isFileDescriptorCanOpenWithLibkiwix() reports it
+   * unreadable and the `when` falls through to `else -> false` instead of the `-> true`
+   * branch.
+   */
+  @Test
+  fun canOpenInLibkiwix_whenDescriptorListHasClosedFd_returnsFalse() = runTest {
+    val closedPfd =
+      ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY).apply { close() }
+    val source = ZimReaderSource(
+      assetFileDescriptorList = listOf(
+        AssetFileDescriptor(closedPfd, 0, AssetFileDescriptor.UNKNOWN_LENGTH)
+      )
+    )
+    assertFalse(source.canOpenInLibkiwix(Dispatchers.IO))
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsFileDescriptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsFileDescriptorTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils.files
+
+import android.content.ContentResolver
+import android.content.Context
+import android.content.res.AssetFileDescriptor
+import android.net.Uri
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kiwix.sharedFunctions.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * isFileDescriptorCanOpenWithLibkiwix()'s valid-fd success path goes through
+ * ParcelFileDescriptor.dup(), a real Android/JNI call FileUtilsTest can't exercise under
+ * a plain JVM unit test (it returns null there, see that class's comment on the same
+ * branch). Robolectric shadows ParcelFileDescriptor with real file-backed behavior, so
+ * this covers that branch separately rather than pulling Robolectric into the whole,
+ * much larger FileUtilsTest.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(
+  sdk = [Build.VERSION_CODES.TIRAMISU, Build.VERSION_CODES.N_MR1],
+  manifest = Config.NONE,
+  application = TestApplication::class
+)
+class FileUtilsFileDescriptorTest {
+  private val tempFile = File.createTempFile("valid", ".zim").apply { writeBytes(byteArrayOf(1)) }
+
+  @After
+  fun tearDown() {
+    tempFile.delete()
+  }
+
+  @Test
+  fun isFileDescriptorCanOpenWithLibkiwix_whenFileDescriptorIsValid_returnsTrue() {
+    ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+      assertTrue(FileUtils.isFileDescriptorCanOpenWithLibkiwix(pfd.fileDescriptor))
+    }
+  }
+
+  /**
+   * getAssetFileDescriptorFromUri()'s success branch (it returns the descriptor list only
+   * once isFileDescriptorCanOpenWithLibkiwix() has confirmed the fd is readable) needs a
+   * real ContentResolver-backed AssetFileDescriptor, which is exactly what this class's
+   * Robolectric setup already provides for the fd check itself.
+   */
+  @Test
+  fun getAssetFileDescriptorFromUri_whenFileIsReadable_returnsDescriptorList() {
+    val context = ApplicationProvider.getApplicationContext<TestApplication>()
+    val result = FileUtils.getAssetFileDescriptorFromUri(context, Uri.fromFile(tempFile))
+    assertNotNull(result)
+    assertEquals(1, result?.size)
+  }
+
+  @Test
+  fun getAssetFileDescriptorFromUri_whenFileDoesNotExist_returnsNull() {
+    val context = ApplicationProvider.getApplicationContext<TestApplication>()
+    val missingFile = File(tempFile.parentFile, "does-not-exist.zim")
+    assertNull(FileUtils.getAssetFileDescriptorFromUri(context, Uri.fromFile(missingFile)))
+  }
+
+  /**
+   * Distinct from the "file does not exist" case above: here the ContentResolver
+   * successfully returns an AssetFileDescriptor (assetFileDescriptor is non-null), but its
+   * underlying fd is closed, so isFileDescriptorCanOpenWithLibkiwix() reports it unreadable
+   * and getAssetFileDescriptorFromUri() takes its `else -> null` branch instead of the
+   * FileNotFoundException catch block.
+   */
+  @Test
+  fun getAssetFileDescriptorFromUri_whenFileDescriptorIsClosed_returnsNull() {
+    val context = mockk<Context>()
+    val contentResolver = mockk<ContentResolver>()
+    every { context.contentResolver } returns contentResolver
+    val closedParcelFileDescriptor =
+      ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY).apply { close() }
+    val assetFileDescriptor =
+      AssetFileDescriptor(closedParcelFileDescriptor, 0, AssetFileDescriptor.UNKNOWN_LENGTH)
+    every { contentResolver.openAssetFileDescriptor(any(), "r") } returns assetFileDescriptor
+    assertNull(FileUtils.getAssetFileDescriptorFromUri(context, Uri.fromFile(tempFile)))
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
@@ -38,14 +38,19 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.io.TempDir
 import org.kiwix.kiwixmobile.core.CoreApp
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.extensions.deleteFile
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
 import org.kiwix.sharedFunctions.MainDispatcherRule
 import java.io.File
+import java.io.FileInputStream
 
 class FileUtilsTest {
+  @TempDir
+  lateinit var tempDir: File
+
   @RegisterExtension
   @JvmField
   val mainDispatcherRule = MainDispatcherRule()
@@ -354,4 +359,22 @@ class FileUtilsTest {
       FileUtils.getSafeFileNameAndSourceFromUrlOrSrc("https://kiwix.org/file:name.epub", null)
     assertEquals("filename.epub", result?.first)
   }
+
+  // ======== isFileDescriptorCanOpenWithLibkiwix ========
+
+  @Test
+  fun isFileDescriptorCanOpenWithLibkiwix_whenFileDescriptorIsNull_returnsFalse() {
+    assertFalse(FileUtils.isFileDescriptorCanOpenWithLibkiwix(null))
+  }
+
+  @Test
+  fun isFileDescriptorCanOpenWithLibkiwix_whenFileDescriptorIsClosed_returnsFalse() {
+    val file = File(tempDir, "closed.zim").apply { writeBytes(byteArrayOf(1)) }
+    val fd = FileInputStream(file).use { it.fd }
+    assertFalse(FileUtils.isFileDescriptorCanOpenWithLibkiwix(fd))
+  }
+
+  // The valid-fd success path goes through ParcelFileDescriptor.dup(), a real Android/JNI
+  // call not available under a plain JVM unit test (requires Robolectric or a device/emulator
+  // run). Covered on-device the same way as the dup()-based fix in kiwix/java-libkiwix#151.
 }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

`FileUtils.isFileDescriptorCanOpenWithLibkiwix()` opens a synthetic relative path (`"dev/fd/$fdNumber"`) to "verify" a fd is readable before trusting it - its own comment cites #3636, the PR where that exact reopen-by-path operation was the root cause of an `EACCES` on arm64-v8a/x86/x86_64 for some Android content-provider descriptors.

This function gates the no-copy direct-read path: `ZimReaderSource(uri)` -> `getAssetFileDescriptorFromUri()`, used for note/history/bookmark reopening and any URI not routed through the copy/move flow added in #4430. A descriptor that fails this reopen gets silently treated as unopenable and the app falls back / errors out, even though the fd itself is perfectly readable - same failure class as #3636, just relocated from "archive open crashes" to "this pre-flight check quietly says no."

Unlike #4430's copy/move flow, this keeps the no-copy path working rather than avoiding it.

## Fix

- `isFileDescriptorCanOpenWithLibkiwix()` now `dup()`s the fd and reads from the duplicate, instead of reopening by path. `dup()` on a fd we already have open can't fail with a permission error the way `open()` on a provider-backed path can, and it doesn't disturb the file position of the original fd, which the caller goes on to hand to libkiwix.
- Signature changed from a bare `Int` fd number to the actual `FileDescriptor` - `dup()` needs the object, not just the number.
- Updated both call sites (`getAssetFileDescriptorFromUri`, `ZimReaderSource.canOpenInLibkiwix`) accordingly.

## Test plan

- [x] `:core:compileDebugKotlin :app:compileDebugKotlin` - clean.
- [x] Added unit tests for the null-fd and closed/invalid-fd branches.
- [ ] The valid-fd success path exercises a real Android/JNI call (`ParcelFileDescriptor.dup()`) not available under a plain JVM unit test - same guarantee already relied on by the `dup()`-based fix in kiwix/java-libkiwix#151 (itself following openzim/libzim#1119).

## Related

- #3636 (root cause this function's own comment cites)
- #4430 (the copy/move alternative that sidesteps this path entirely)
- kiwix/java-libkiwix#151, openzim/libzim#1119 (same `dup()`-over-reopen pattern, different layer of the stack)
