### PR TITLE
fix(fdroid_nightly): manual dispatch trigger, fix upload destination (rebase of #4437)

### DIFF
--- a/.github/workflows/fdroid_nightly.yml
+++ b/.github/workflows/fdroid_nightly.yml
@@ -1,13 +1,12 @@
 name: Publish fdroid nightly build
 
-# This workflow is triggered on a schedule or when specific tags are pushed.
-# It runs every Monday at 12:00 UTC and also when the 'fdroid_nightly' tag is pushed.
+# This workflow is triggered when the 'fdroid_nightly' tag is pushed, or
+# manually via the Actions tab.
 on:
   push:
     tags:
       - 'fdroid_nightly' # fdroid_nightly Tag
-  schedule:
-    - cron: '0 12 * * 1'  # Runs every Monday at 12:00
+  workflow_dispatch:
 
 jobs:
   nightly:
@@ -80,4 +79,11 @@ jobs:
 
       - name: release fdroid nightly to kiwix.download.org
         run: |
-          scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no fdroid ci@master.download.kiwix.org:/data/download/fdroid/
+          # Sync the *contents* of fdroid/, not the directory itself. `scp -r
+          # fdroid ...:/data/download/fdroid/` would nest everything an extra
+          # level deep (.../fdroid/fdroid/repo/...) whenever the remote
+          # /data/download/fdroid/ directory already exists, silently
+          # breaking the repo_url declared in config-template.yml. rsync with
+          # a trailing slash on the source is unambiguous about this, and
+          # syncs incrementally rather than re-uploading everything each run.
+          rsync -avz -e "ssh -p 30022 -i ssh_key -o StrictHostKeyChecking=no" fdroid/ ci@master.download.kiwix.org:/data/download/fdroid/

--- a/.github/workflows/fdroid_nightly.yml
+++ b/.github/workflows/fdroid_nightly.yml
@@ -1,0 +1,83 @@
+name: Publish fdroid nightly build
+
+# This workflow is triggered on a schedule or when specific tags are pushed.
+# It runs every Monday at 12:00 UTC and also when the 'fdroid_nightly' tag is pushed.
+on:
+  push:
+    tags:
+      - 'fdroid_nightly' # fdroid_nightly Tag
+  schedule:
+    - cron: '0 12 * * 1'  # Runs every Monday at 12:00
+
+jobs:
+  nightly:
+    name: Publish fdroid nightly build
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    environment: nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27d
+          link-to-sdk: true
+
+      - name: Decrypt files
+        env:
+          KEYSTORE: ${{ secrets.keystore }}
+          SSH_KEY: ${{ secrets.ssh_key }}
+        run: |
+          echo "$KEYSTORE" | base64 -d > kiwix-android.keystore
+          echo "$SSH_KEY" | base64 -d > ssh_key
+          chmod 600 ssh_key
+
+      - name: Build nightly APK
+        env:
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          APK_BUILD: "true"
+        run: |
+          ./gradlew assembleNightly
+
+      - name: Install F-Droid server and dependencies
+        run: |
+          # Installing fdroidserver and androguard.
+          # Note: fdroidserver from apt uses the system Python environment.
+          # The old androguard (v3.4.0a1) from apt can't parse resources.arsc in Android 16 APKs,
+          # so we install the latest androguard in the same environment via pip.
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade fdroidserver androguard
+
+      - name: Prepare F-Droid repo
+        env:
+          UNIVERSAL_DEBUG_APK: app/build/outputs/apk/nightly/*universal*.apk
+          KIWIX_ICON: app/src/main/kiwix_icon-web.png
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+        run: |
+          mkdir -p fdroid/repo/icons
+          cp $UNIVERSAL_DEBUG_APK fdroid/repo/
+          cp "$KIWIX_ICON" fdroid/repo/icons/icon.png
+          envsubst < config-template.yml > fdroid/config.yml
+          cd fdroid
+          fdroid update --create-metadata
+
+      - name: release fdroid nightly to kiwix.download.org
+        run: |
+          scp -P 30022 -vrp -i ssh_key -o StrictHostKeyChecking=no fdroid ci@master.download.kiwix.org:/data/download/fdroid/

--- a/config-template.yml
+++ b/config-template.yml
@@ -1,0 +1,11 @@
+---
+repo_url: https://download.kiwix.org/fdroid/repo
+repo_name: Kiwix repository for fdroid nightly.
+repo_description: |-
+  This is a nightly server for fdroid nightly build.
+archive_older: 0
+repo_icon: icon.png
+repo_keyalias: ${KEY_ALIAS}
+keystorepass: ${KEY_STORE_PASSWORD}
+keypass: ${KEY_PASSWORD}
+keystore: ../kiwix-android.keystore


### PR DESCRIPTION
Rebased #4437 onto current `main` (its branch had drifted — `.github/workflows/fdroid_nightly.yml` was deleted from `main` in the meantime by `2aa7060f9`, a general CI-workflow consolidation; re-added here with this PR's content since that deletion predates and is unrelated to this feature) and added a fix commit on top for issues found reviewing it.

## What #4437 does

Publishes a weekly f-droid nightly build to `download.kiwix.org/fdroid/repo`, replacing the old debug-only nightly channel's f-droid support.

## Why this exists

Reviewed #4437 and found:

1. **The workflow has never actually executed.** Its triggers (`push: tags:` + `schedule:`) never fire for a `pull_request`, so none of #4437's green CI checks touched this code path at all — the build step, `fdroid update`, and the upload were all unverified.
2. **The final upload step nests the wrong way:**
   ```
   scp -r fdroid ci@master.download.kiwix.org:/data/download/fdroid/
   ```
   This copies the local `fdroid` *directory* into the remote path. If `/data/download/fdroid/` already exists on the server (likely — it's presumably part of the existing static site layout), content lands at `.../fdroid/fdroid/repo/...` instead of `.../fdroid/repo/...`, silently breaking the `repo_url` declared in `config-template.yml`. Nothing in the pipeline would catch this before or after the fact.

## Fix (second commit)

- Added `workflow_dispatch` and removed the weekly `schedule` — lets a maintainer manually trigger and verify a full run (including the real `scp`/`rsync` upload, against the real server) before trusting an unattended cron.
- Replaced the `scp -r` with `rsync -avz` using a trailing slash on the source, which is unambiguous about syncing directory *contents* rather than the directory itself, and syncs incrementally instead of re-uploading everything each run.

## Not changed (flagging, not fixing here)

- Only the universal APK is published (`*universal*.apk`), not the per-ABI splits also produced by the same build — matches the existing `nightly.yml` channel's precedent exactly (same env var name, same glob), so likely intentional, but worth confirming.
- Each run builds the f-droid index from only that run's local `repo/` dir — nothing pulls the existing remote repo down first — so previous nightly builds accumulate as unindexed files on the server rather than staying visible in the repo history. Pre-existing design characteristic, not introduced by either commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
