### PR TITLE
Recognize Wikipedia links and web-search intents as in-app searches

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,11 +161,22 @@
 
         <data android:scheme="zim" />
       </intent-filter>
-      <!--
-       Recognizes Wikipedia article/search links so they can be routed into the
-       app as a search of the currently open book, instead of a browser.
-       See https://github.com/kiwix/kiwix-android/issues/731
-      -->
+    </activity>
+    <!--
+     Recognizes Wikipedia article/search links so they can be routed into the
+     app as a search of the currently open book, instead of a browser.
+     See https://github.com/kiwix/kiwix-android/issues/731
+     Disabled by default (an always-on intent-filter can't be turned back off,
+     since the OS caches its resolution against this component); toggled at
+     runtime via PackageManager#setComponentEnabledSetting from the "Open
+     supported external links in the app" setting, same idiom as the
+     web-search alias below.
+    -->
+    <activity-alias
+      android:name=".main.KiwixMainActivityWikipediaLinks"
+      android:enabled="false"
+      android:exported="true"
+      android:targetActivity=".main.KiwixMainActivity">
       <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
 
@@ -174,13 +185,12 @@
 
         <data android:scheme="https" />
         <data android:scheme="http" />
-        <data android:host="*.wikipedia.fr" />
         <data android:host="*.wikipedia.org" />
-        <data android:host="*.wikipedia.com" />
-        <data android:host="*.wikipedia.de" />
+        <data android:host="wikipedia.org" />
+        <data android:host="wikipedia.com" />
         <data android:pathPattern=".*" />
       </intent-filter>
-    </activity>
+    </activity-alias>
     <!--
      Lets Kiwix register as a system "web search" handler (android.intent.action.WEB_SEARCH).
      Disabled by default; toggled at runtime via PackageManager#setComponentEnabledSetting

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,7 +161,42 @@
 
         <data android:scheme="zim" />
       </intent-filter>
+      <!--
+       Recognizes Wikipedia article/search links so they can be routed into the
+       app as a search of the currently open book, instead of a browser.
+       See https://github.com/kiwix/kiwix-android/issues/731
+      -->
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data android:scheme="https" />
+        <data android:scheme="http" />
+        <data android:host="*.wikipedia.fr" />
+        <data android:host="*.wikipedia.org" />
+        <data android:host="*.wikipedia.com" />
+        <data android:host="*.wikipedia.de" />
+        <data android:pathPattern=".*" />
+      </intent-filter>
     </activity>
+    <!--
+     Lets Kiwix register as a system "web search" handler (android.intent.action.WEB_SEARCH).
+     Disabled by default; toggled at runtime via PackageManager#setComponentEnabledSetting
+     from the "Use as a web search application" setting.
+    -->
+    <activity-alias
+      android:name=".main.KiwixMainActivityWebSearch"
+      android:enabled="false"
+      android:exported="true"
+      android:targetActivity=".main.KiwixMainActivity">
+      <intent-filter android:enabled="true">
+        <action android:name="android.intent.action.WEB_SEARCH" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity-alias>
 
     <receiver
       android:name=".main.KiwixSearchWidget"

--- a/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/settings/KiwixSettingsViewModel.kt
@@ -108,6 +108,14 @@ class KiwixSettingsViewModel @Inject constructor(
     settingsUiState.update { it.copy(shouldShowRatingCategory = kiwixDataStore.isPlayStoreBuild.first()) }
   }
 
+  override suspend fun showSupportedExternalLinksPreference() {
+    settingsUiState.update { it.copy(shouldShowSupportedExternalLinksPreference = true) }
+  }
+
+  override suspend fun showWebSearchIntentPreference() {
+    settingsUiState.update { it.copy(shouldShowWebSearchIntentPreference = true) }
+  }
+
   /**
    * Shows or hides the progress bar while the application is fetching
    * storage information in the background. The progress bar is displayed

--- a/branded/src/main/java/org/kiwix/kiwixmobile/custom/settings/BrandedSettingsViewModel.kt
+++ b/branded/src/main/java/org/kiwix/kiwixmobile/custom/settings/BrandedSettingsViewModel.kt
@@ -91,4 +91,18 @@ class BrandedSettingsViewModel @Inject constructor(
   override suspend fun showRatingCategory() {
     settingsUiState.update { it.copy(shouldShowRatingCategory = true) }
   }
+
+  /**
+   * The Wikipedia-link/web-search-intent manifest entries (AndroidManifest.xml
+   * autoVerify intent-filter and the `.main.KiwixMainActivityWebSearch`
+   * activity-alias) only exist in the main `app` module, not in custom/branded
+   * apps, so these preferences must stay hidden here.
+   */
+  override suspend fun showSupportedExternalLinksPreference() {
+    settingsUiState.update { it.copy(shouldShowSupportedExternalLinksPreference = false) }
+  }
+
+  override suspend fun showWebSearchIntentPreference() {
+    settingsUiState.update { it.copy(shouldShowWebSearchIntentPreference = false) }
+  }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
@@ -129,7 +129,10 @@ class PendingIntentParser @Inject constructor() {
   }
 
   companion object {
-    private val WIKIPEDIA_DOMAINS =
-      listOf("wikipedia.org", "wikipedia.com", "wikipedia.fr", "wikipedia.de")
+    // wikipedia.fr / wikipedia.de are Wikimedia chapter (fundraising/organizational)
+    // sites, not Wikipedia itself -- all language editions of Wikipedia are
+    // subdomains of wikipedia.org (e.g. de.wikipedia.org, fr.wikipedia.org),
+    // already covered by the ".wikipedia.org" suffix match below.
+    private val WIKIPEDIA_DOMAINS = listOf("wikipedia.org", "wikipedia.com")
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
@@ -18,13 +18,16 @@
 
 package org.kiwix.kiwixmobile.core.main.reader.helper.intent
 
+import android.app.SearchManager
 import android.content.Intent
+import android.net.Uri
 import org.kiwix.kiwixmobile.core.main.CoreSearchWidget
 import org.kiwix.kiwixmobile.core.main.ZIM_FILE_URI_KEY
 import org.kiwix.kiwixmobile.core.main.ZIM_HOST_DEEP_LINK_SCHEME
 import org.kiwix.kiwixmobile.core.main.reader.helper.intent.PendingIntentParser.ReaderIntentAction.None
 import org.kiwix.kiwixmobile.core.main.reader.helper.intent.PendingIntentParser.ReaderIntentAction.OpenBookmarks
 import org.kiwix.kiwixmobile.core.main.reader.helper.intent.PendingIntentParser.ReaderIntentAction.OpenSearch
+import java.net.URLDecoder
 import javax.inject.Inject
 
 class PendingIntentParser @Inject constructor() {
@@ -55,6 +58,17 @@ class PendingIntentParser @Inject constructor() {
 
       CoreSearchWidget.STAR_CLICKED -> OpenBookmarks
 
+      // Android routes a system-wide "web search" request here (e.g. from the
+      // assistant or another app asking to search the web). We can't search the
+      // web offline, so we redirect the query into our own, currently-open-book
+      // search instead of doing nothing with it.
+      Intent.ACTION_WEB_SEARCH ->
+        OpenSearch(
+          query = intent.getStringExtra(SearchManager.QUERY).orEmpty(),
+          isVoice = false,
+          isOpenedFromTabView = false
+        )
+
       Intent.ACTION_VIEW -> parseActionViewIntent(intent)
 
       else -> None
@@ -64,6 +78,12 @@ class PendingIntentParser @Inject constructor() {
   @Suppress("ReturnCount")
   private fun parseActionViewIntent(intent: Intent): ReaderIntentAction {
     if (intent.hasExtra(ZIM_FILE_URI_KEY)) return None
+
+    // Wikipedia links are recognised ahead of the generic scheme/type checks below,
+    // because the OS typically delivers them with no MIME type at all (which the
+    // generic checks below treat as "not a link we understand").
+    intent.data?.takeIf { isWikipediaHost(it.host) }?.let { return parseWikipediaUri(it) }
+
     val hasValidScheme =
       intent.scheme in listOf("file", "content", "zim", ZIM_HOST_DEEP_LINK_SCHEME)
     // Added condition to handle ZIM files. When opening from storage, the intent may
@@ -75,5 +95,41 @@ class PendingIntentParser @Inject constructor() {
 
     val searchString = if (intent.data == null) "" else intent.data?.lastPathSegment
     return OpenSearch(searchString.orEmpty(), false, isOpenedFromTabView = false)
+  }
+
+  private fun isWikipediaHost(host: String?): Boolean {
+    if (host == null) return false
+    val lowerHost = host.lowercase()
+    return WIKIPEDIA_DOMAINS.any { domain -> lowerHost == domain || lowerHost.endsWith(".$domain") }
+  }
+
+  /**
+   * Converts a recognised Wikipedia URL into a search query against the currently
+   * open book, matching the (only) working scope confirmed for this app today --
+   * see kiwix-android#731. We deliberately do not attempt to resolve the link to an
+   * exact page in a specific, possibly-not-open ZIM: there is no known-good way to
+   * pick which locally available ZIM contains a given Wikipedia article, and
+   * treating this as a plain search re-uses the reader's existing, working
+   * `OpenSearch` path instead.
+   */
+  private fun parseWikipediaUri(uri: Uri): ReaderIntentAction {
+    val query = uri.getQueryParameter("search") ?: uri.getQueryParameter("q")
+    val searchQuery = query ?: extractArticleTitleFromPath(uri.path)
+    return OpenSearch(searchQuery.orEmpty(), isVoice = false, isOpenedFromTabView = false)
+  }
+
+  private fun extractArticleTitleFromPath(path: String?): String? {
+    val marker = "/wiki/"
+    val markerIndex = path?.indexOf(marker) ?: -1
+    if (markerIndex == -1) return null
+    val rawTitle = path?.substring(markerIndex + marker.length)
+    if (rawTitle.isNullOrBlank()) return null
+    val decodedTitle = runCatching { URLDecoder.decode(rawTitle, "UTF-8") }.getOrDefault(rawTitle)
+    return decodedTitle.replace('_', ' ')
+  }
+
+  companion object {
+    private val WIKIPEDIA_DOMAINS =
+      listOf("wikipedia.org", "wikipedia.com", "wikipedia.fr", "wikipedia.de")
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParser.kt
@@ -121,11 +121,10 @@ class PendingIntentParser @Inject constructor() {
   private fun extractArticleTitleFromPath(path: String?): String? {
     val marker = "/wiki/"
     val markerIndex = path?.indexOf(marker) ?: -1
-    if (markerIndex == -1) return null
-    val rawTitle = path?.substring(markerIndex + marker.length)
-    if (rawTitle.isNullOrBlank()) return null
-    val decodedTitle = runCatching { URLDecoder.decode(rawTitle, "UTF-8") }.getOrDefault(rawTitle)
-    return decodedTitle.replace('_', ' ')
+    val rawTitle = if (markerIndex == -1) null else path?.substring(markerIndex + marker.length)
+    return rawTitle?.takeIf { it.isNotBlank() }
+      ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
+      ?.replace('_', ' ')
   }
 
   companion object {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -21,8 +21,10 @@ package org.kiwix.kiwixmobile.core.settings
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
 import android.app.Activity.RESULT_OK
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -520,6 +522,11 @@ private fun ExtrasCategory(
   val newTabInBackground by coreSettingsViewModel.newTabInBackground.collectAsStateWithLifecycle()
   val externalLinkPopup by coreSettingsViewModel.externalLinkPopup.collectAsStateWithLifecycle()
   val wifiOnly by coreSettingsViewModel.wifiOnly.collectAsStateWithLifecycle()
+  val supportedExternalLinksOpenInApp by
+    coreSettingsViewModel.supportedExternalLinksOpenInApp.collectAsStateWithLifecycle()
+  val enableWebSearchIntent by
+    coreSettingsViewModel.enableWebSearchIntent.collectAsStateWithLifecycle()
+  val context = LocalContext.current
   SettingsCategory(stringResource(R.string.pref_extras)) {
     SwitchPreference(
       title = stringResource(R.string.pref_newtab_background_title),
@@ -543,6 +550,50 @@ private fun ExtrasCategory(
         onCheckedChange = { coreSettingsViewModel.setWifiOnly(it) }
       )
     }
+    if (settingsUiState.shouldShowSupportedExternalLinksPreference) {
+      SwitchPreference(
+        title = stringResource(R.string.pref_supported_external_links_open_in_app_title),
+        summary = stringResource(R.string.pref_supported_external_links_open_in_app_summary),
+        checked = supportedExternalLinksOpenInApp,
+        onCheckedChange = { coreSettingsViewModel.setSupportedExternalLinksOpenInApp(it) }
+      )
+    }
+    if (settingsUiState.shouldShowWebSearchIntentPreference) {
+      SwitchPreference(
+        title = stringResource(R.string.pref_enable_web_search_intent_title),
+        summary = stringResource(R.string.pref_enable_web_search_intent_summary),
+        checked = enableWebSearchIntent,
+        onCheckedChange = { enabled ->
+          coreSettingsViewModel.setEnableWebSearchIntent(enabled)
+          setWebSearchComponentEnabled(context, enabled)
+        }
+      )
+    }
+  }
+}
+
+/**
+ * Enables/disables the `.main.KiwixMainActivityWebSearch` activity-alias declared in
+ * the app module's manifest, which is what actually makes Android offer Kiwix for
+ * android.intent.action.WEB_SEARCH requests. The component is resolved from the
+ * running app's own package name (rather than a hardcoded "org.kiwix.kiwixmobile"
+ * string) so this keeps working under applicationId suffixes (e.g. debug builds).
+ */
+private fun setWebSearchComponentEnabled(context: Context, enabled: Boolean) {
+  val component = ComponentName(
+    context.packageName,
+    "${context.packageName}.main.KiwixMainActivityWebSearch"
+  )
+  runCatching {
+    context.packageManager.setComponentEnabledSetting(
+      component,
+      if (enabled) {
+        PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+      } else {
+        PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+      },
+      PackageManager.DONT_KILL_APP
+    )
   }
 }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -555,7 +555,10 @@ private fun ExtrasCategory(
         title = stringResource(R.string.pref_supported_external_links_open_in_app_title),
         summary = stringResource(R.string.pref_supported_external_links_open_in_app_summary),
         checked = supportedExternalLinksOpenInApp,
-        onCheckedChange = { coreSettingsViewModel.setSupportedExternalLinksOpenInApp(it) }
+        onCheckedChange = { enabled ->
+          coreSettingsViewModel.setSupportedExternalLinksOpenInApp(enabled)
+          setWikipediaLinksComponentEnabled(context, enabled)
+        }
       )
     }
     if (settingsUiState.shouldShowWebSearchIntentPreference) {
@@ -580,10 +583,26 @@ private fun ExtrasCategory(
  * string) so this keeps working under applicationId suffixes (e.g. debug builds).
  */
 private fun setWebSearchComponentEnabled(context: Context, enabled: Boolean) {
-  val component = ComponentName(
-    context.packageName,
-    "${context.packageName}.main.KiwixMainActivityWebSearch"
+  setComponentEnabled(context, "${context.packageName}.main.KiwixMainActivityWebSearch", enabled)
+}
+
+/**
+ * Enables/disables the `.main.KiwixMainActivityWikipediaLinks` activity-alias, which is
+ * what actually makes Android route Wikipedia article/search links to Kiwix instead of
+ * a browser. This alias -- not a plain intent-filter -- is what backs the setting: an
+ * always-on manifest intent-filter can't be turned back off at runtime, since Android
+ * verifies/caches link resolution against the component that declares it.
+ */
+private fun setWikipediaLinksComponentEnabled(context: Context, enabled: Boolean) {
+  setComponentEnabled(
+    context,
+    "${context.packageName}.main.KiwixMainActivityWikipediaLinks",
+    enabled
   )
+}
+
+private fun setComponentEnabled(context: Context, componentClassName: String, enabled: Boolean) {
+  val component = ComponentName(context.packageName, componentClassName)
   runCatching {
     context.packageManager.setComponentEnabledSetting(
       component,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
@@ -96,7 +96,12 @@ abstract class CoreSettingsViewModel(
     val shouldShowPrefWifiOnlyPreference: Boolean = false,
     val versionInformation: String = "",
     val permissionItem: Pair<Boolean, String> = false to "",
-    val shouldShowRatingCategory: Boolean = false
+    val shouldShowRatingCategory: Boolean = false,
+    // The Wikipedia-link/web-search-intent manifest entries only exist in the
+    // main `app` module (see AndroidManifest.xml), so custom/branded apps built
+    // from this same Compose settings screen must not offer these toggles.
+    val shouldShowSupportedExternalLinksPreference: Boolean = false,
+    val shouldShowWebSearchIntentPreference: Boolean = false
   )
 
   abstract suspend fun setStorage()
@@ -105,6 +110,8 @@ abstract class CoreSettingsViewModel(
   abstract suspend fun showPermissionItem()
   abstract suspend fun showLanguageCategory()
   abstract suspend fun showRatingCategory()
+  abstract suspend fun showSupportedExternalLinksPreference()
+  abstract suspend fun showWebSearchIntentPreference()
 
   protected val settingsUiState = MutableStateFlow(SettingsUiState())
   val uiState: StateFlow<SettingsUiState> = settingsUiState.asStateFlow()
@@ -119,6 +126,8 @@ abstract class CoreSettingsViewModel(
     showPermissionItem()
     showLanguageCategory()
     showRatingCategory()
+    showSupportedExternalLinksPreference()
+    showWebSearchIntentPreference()
     setVersionCodeInformation()
   }
 
@@ -169,6 +178,21 @@ abstract class CoreSettingsViewModel(
       initialValue = true
     )
 
+  val supportedExternalLinksOpenInApp: StateFlow<Boolean> =
+    kiwixDataStore.supportedExternalLinksOpenInApp
+      .stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = false
+      )
+
+  val enableWebSearchIntent: StateFlow<Boolean> = kiwixDataStore.enableWebSearchIntent
+    .stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.Eagerly,
+      initialValue = false
+    )
+
   fun sendAction(action: Action) =
     viewModelScope.launch {
       _actions.emit(action)
@@ -215,6 +239,18 @@ abstract class CoreSettingsViewModel(
   fun setWifiOnly(wifiOnly: Boolean) {
     viewModelScope.launch {
       kiwixDataStore.setWifiOnly(wifiOnly)
+    }
+  }
+
+  fun setSupportedExternalLinksOpenInApp(enabled: Boolean) {
+    viewModelScope.launch {
+      kiwixDataStore.setSupportedExternalLinksOpenInApp(enabled)
+    }
+  }
+
+  fun setEnableWebSearchIntent(enabled: Boolean) {
+    viewModelScope.launch {
+      kiwixDataStore.setEnableWebSearchIntent(enabled)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -126,6 +126,29 @@ class KiwixDataStore @Inject constructor(
     }
   }
 
+  val supportedExternalLinksOpenInApp: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP] ?: false
+    }
+
+  suspend fun setSupportedExternalLinksOpenInApp(supportedExternalLinksOpenInApp: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP] =
+        supportedExternalLinksOpenInApp
+    }
+  }
+
+  val enableWebSearchIntent: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_ENABLE_WEB_SEARCH_INTENT] ?: false
+    }
+
+  suspend fun setEnableWebSearchIntent(enableWebSearchIntent: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_ENABLE_WEB_SEARCH_INTENT] = enableWebSearchIntent
+    }
+  }
+
   val wifiOnly: Flow<Boolean> =
     context.kiwixDataStore.data.map { prefs ->
       prefs[PreferencesKeys.PREF_WIFI_ONLY] ?: true
@@ -679,6 +702,9 @@ class KiwixDataStore @Inject constructor(
     const val PREF_BACK_TO_TOP = "pref_backtotop"
     const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"
     const val PREF_EXTERNAL_LINK_POPUP = "pref_external_link_popup"
+    const val PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP =
+      "pref_supported_external_links_open_in_app"
+    const val PREF_ENABLE_WEB_SEARCH_INTENT = "pref_enable_web_search_intent"
     const val PREF_SHOW_STORAGE_OPTION = "show_storgae_option"
     const val PREF_IS_FIRST_RUN = "isFirstRun"
     const val PREF_SHOW_BOOKMARKS_ALL_BOOKS = "show_bookmarks_current_book"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -32,6 +32,10 @@ object PreferencesKeys {
   val PREF_NEW_TAB_BACKGROUND = booleanPreferencesKey(KiwixDataStore.PREF_NEW_TAB_BACKGROUND)
   val PREF_EXTERNAL_LINK_POPUP =
     booleanPreferencesKey(KiwixDataStore.PREF_EXTERNAL_LINK_POPUP)
+  val PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP =
+    booleanPreferencesKey(KiwixDataStore.PREF_SUPPORTED_EXTERNAL_LINKS_OPEN_IN_APP)
+  val PREF_ENABLE_WEB_SEARCH_INTENT =
+    booleanPreferencesKey(KiwixDataStore.PREF_ENABLE_WEB_SEARCH_INTENT)
   val PREF_WIFI_ONLY = booleanPreferencesKey(KiwixDataStore.PREF_WIFI_ONLY)
   val PREF_THEME = stringPreferencesKey(KiwixDataStore.PREF_THEME)
   val PREF_SHOW_INTRO = booleanPreferencesKey(KiwixDataStore.PREF_SHOW_INTRO)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -188,6 +188,10 @@
   <string name="time_yesterday">Yesterday</string>
   <string name="pref_external_link_popup_title">Warn when entering external links</string>
   <string name="pref_external_link_popup_summary">Display popup to warn about additional costs or not working in offline links.</string>
+  <string name="pref_supported_external_links_open_in_app_title">Open supported links in app</string>
+  <string name="pref_supported_external_links_open_in_app_summary">Automatically open supported external links within the app</string>
+  <string name="pref_enable_web_search_intent_title">Use as a web search application</string>
+  <string name="pref_enable_web_search_intent_summary">When enabled Kiwix can be used when other applications request a web search</string>
   <string name="external_link_popup_dialog_title">Entering External Link!</string>
   <string name="external_link_popup_dialog_message">You are entering an external link. This could lead to additional costs for data transfer or will just not work when you are offline.\nDo you want to continue?</string>
   <string name="do_not_ask_anymore">Do not ask anymore</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParserTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParserTest.kt
@@ -266,9 +266,9 @@ class PendingIntentParserTest {
   }
 
   @Test
-  fun `wikipedia fr link with q query param returns OpenSearch with query`() {
+  fun `wikipedia fr subdomain link with q query param returns OpenSearch with query`() {
     val uri = mockk<Uri>()
-    every { uri.host } returns "fr.wikipedia.fr"
+    every { uri.host } returns "fr.wikipedia.org"
     every { uri.path } returns "/w/index.php"
     every { uri.getQueryParameter("search") } returns null
     every { uri.getQueryParameter("q") } returns "chat"
@@ -288,9 +288,9 @@ class PendingIntentParserTest {
   }
 
   @Test
-  fun `wikipedia de article link returns OpenSearch with decoded title`() {
+  fun `wikipedia de subdomain article link returns OpenSearch with decoded title`() {
     val uri = mockk<Uri>()
-    every { uri.host } returns "de.wikipedia.de"
+    every { uri.host } returns "de.wikipedia.org"
     every { uri.path } returns "/wiki/Berlin"
     every { uri.getQueryParameter("search") } returns null
     every { uri.getQueryParameter("q") } returns null

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParserTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/helper/intent/PendingIntentParserTest.kt
@@ -18,6 +18,7 @@
 
 package org.kiwix.kiwixmobile.core.main.reader.helper.intent
 
+import android.app.SearchManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -133,6 +134,7 @@ class PendingIntentParserTest {
     val intent = mockk<Intent>()
     every { intent.action } returns Intent.ACTION_VIEW
     every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns null
     every { intent.scheme } returns "file"
     every { intent.type } returns "text/plain"
 
@@ -147,6 +149,7 @@ class PendingIntentParserTest {
     val intent = mockk<Intent>()
     every { intent.action } returns Intent.ACTION_VIEW
     every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns null
     every { intent.scheme } returns "https"
     every { intent.type } returns "application/octet-stream"
 
@@ -169,6 +172,7 @@ class PendingIntentParserTest {
   @Test
   fun `ACTION_VIEW with search uri returns OpenSearch`() {
     val uri = mockk<Uri>()
+    every { uri.host } returns "example.com"
     every { uri.lastPathSegment } returns "Albert"
     val intent = mockk<Intent>()
     every { intent.action } returns Intent.ACTION_VIEW
@@ -182,6 +186,150 @@ class PendingIntentParserTest {
         "Albert",
         isVoice = false,
         false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `ACTION_WEB_SEARCH returns OpenSearch with the query extra`() {
+    val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
+      putExtra(SearchManager.QUERY, "hello world")
+    }
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "hello world",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `ACTION_WEB_SEARCH with no query extra returns empty OpenSearch`() {
+    val intent = Intent(Intent.ACTION_WEB_SEARCH)
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `wikipedia org article link with wiki path returns OpenSearch with decoded title`() {
+    val uri = mockk<Uri>()
+    every { uri.host } returns "en.wikipedia.org"
+    every { uri.path } returns "/wiki/Albert_Einstein"
+    every { uri.getQueryParameter("search") } returns null
+    every { uri.getQueryParameter("q") } returns null
+    val intent = mockk<Intent>()
+    every { intent.action } returns Intent.ACTION_VIEW
+    every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns uri
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "Albert Einstein",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `wikipedia com search link with search query param returns OpenSearch with query`() {
+    val uri = mockk<Uri>()
+    every { uri.host } returns "www.wikipedia.com"
+    every { uri.path } returns "/wiki/Special:Search"
+    every { uri.getQueryParameter("search") } returns "gravity"
+    every { uri.getQueryParameter("q") } returns null
+    val intent = mockk<Intent>()
+    every { intent.action } returns Intent.ACTION_VIEW
+    every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns uri
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "gravity",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `wikipedia fr link with q query param returns OpenSearch with query`() {
+    val uri = mockk<Uri>()
+    every { uri.host } returns "fr.wikipedia.fr"
+    every { uri.path } returns "/w/index.php"
+    every { uri.getQueryParameter("search") } returns null
+    every { uri.getQueryParameter("q") } returns "chat"
+    val intent = mockk<Intent>()
+    every { intent.action } returns Intent.ACTION_VIEW
+    every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns uri
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "chat",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `wikipedia de article link returns OpenSearch with decoded title`() {
+    val uri = mockk<Uri>()
+    every { uri.host } returns "de.wikipedia.de"
+    every { uri.path } returns "/wiki/Berlin"
+    every { uri.getQueryParameter("search") } returns null
+    every { uri.getQueryParameter("q") } returns null
+    val intent = mockk<Intent>()
+    every { intent.action } returns Intent.ACTION_VIEW
+    every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.data } returns uri
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "Berlin",
+        isVoice = false,
+        isOpenedFromTabView = false
+      ),
+      parser.parse(intent)
+    )
+  }
+
+  @Test
+  fun `wikipedia link is recognised even without a MIME type`() {
+    // Regression guard: links delivered from another app/browser typically carry
+    // no MIME type, which the generic ACTION_VIEW fallback treats as "unknown".
+    val uri = mockk<Uri>()
+    every { uri.host } returns "en.wikipedia.org"
+    every { uri.path } returns "/wiki/Kotlin_(programming_language)"
+    every { uri.getQueryParameter("search") } returns null
+    every { uri.getQueryParameter("q") } returns null
+    val intent = mockk<Intent>()
+    every { intent.action } returns Intent.ACTION_VIEW
+    every { intent.hasExtra(ZIM_FILE_URI_KEY) } returns false
+    every { intent.type } returns null
+    every { intent.scheme } returns "https"
+    every { intent.data } returns uri
+
+    assertEquals(
+      PendingIntentParser.ReaderIntentAction.OpenSearch(
+        "Kotlin (programming language)",
+        isVoice = false,
+        isOpenedFromTabView = false
       ),
       parser.parse(intent)
     )

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
@@ -87,7 +87,9 @@ class SettingsScreenTest {
     textZoom: Int = DEFAULT_ZOOM,
     newTabInBackground: Boolean = false,
     externalLinkPopup: Boolean = true,
-    wifiOnly: Boolean = true
+    wifiOnly: Boolean = true,
+    supportedExternalLinksOpenInApp: Boolean = true,
+    enableWebSearchIntent: Boolean = true
   ): CoreSettingsViewModel {
     val viewModel = mockk<CoreSettingsViewModel>(relaxed = true)
     every { viewModel.uiState } returns MutableStateFlow(uiState)
@@ -97,6 +99,9 @@ class SettingsScreenTest {
     every { viewModel.newTabInBackground } returns MutableStateFlow(newTabInBackground)
     every { viewModel.externalLinkPopup } returns MutableStateFlow(externalLinkPopup)
     every { viewModel.wifiOnly } returns MutableStateFlow(wifiOnly)
+    every { viewModel.supportedExternalLinksOpenInApp } returns
+      MutableStateFlow(supportedExternalLinksOpenInApp)
+    every { viewModel.enableWebSearchIntent } returns MutableStateFlow(enableWebSearchIntent)
     return viewModel
   }
 
@@ -357,6 +362,142 @@ class SettingsScreenTest {
     composeTestRule
       .onNodeWithContentDescription(context.getString(R.string.pref_wifi_only))
       .assertDoesNotExist()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_supportedExternalLinksPreference_visibleWhenEnabled() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowSupportedExternalLinksPreference = true)
+      )
+    )
+    scrollToContentDescription(
+      context.getString(R.string.pref_supported_external_links_open_in_app_title)
+    )
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_supported_external_links_open_in_app_title))
+      .assertIsDisplayed()
+      .assertIsOn()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_supportedExternalLinksPreference_reflectsStateChange() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowSupportedExternalLinksPreference = true),
+        supportedExternalLinksOpenInApp = false
+      )
+    )
+    scrollToContentDescription(
+      context.getString(R.string.pref_supported_external_links_open_in_app_title)
+    )
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_supported_external_links_open_in_app_title))
+      .assertIsDisplayed()
+      .assertIsOff()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_supportedExternalLinksPreference_hiddenWhenDisabled() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowSupportedExternalLinksPreference = false)
+      )
+    )
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_supported_external_links_open_in_app_title))
+      .assertDoesNotExist()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_webSearchIntentPreference_visibleWhenEnabled() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowWebSearchIntentPreference = true)
+      )
+    )
+    scrollToContentDescription(context.getString(R.string.pref_enable_web_search_intent_title))
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_enable_web_search_intent_title))
+      .assertIsDisplayed()
+      .assertIsOn()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_webSearchIntentPreference_reflectsStateChange() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowWebSearchIntentPreference = true),
+        enableWebSearchIntent = false
+      )
+    )
+    scrollToContentDescription(context.getString(R.string.pref_enable_web_search_intent_title))
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_enable_web_search_intent_title))
+      .assertIsDisplayed()
+      .assertIsOff()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_webSearchIntentPreference_hiddenWhenDisabled() {
+    renderSettingsScreen(
+      createMockViewModel(
+        uiState = SettingsUiState(shouldShowWebSearchIntentPreference = false)
+      )
+    )
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_enable_web_search_intent_title))
+      .assertDoesNotExist()
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_supportedExternalLinksToggle_triggersCallback() {
+    val viewModel = createMockViewModel(
+      uiState = SettingsUiState(shouldShowSupportedExternalLinksPreference = true),
+      supportedExternalLinksOpenInApp = true
+    )
+    renderSettingsScreen(viewModel)
+    scrollToText(context.getString(R.string.pref_supported_external_links_open_in_app_summary))
+    composeTestRule
+      .onNodeWithText(
+        context.getString(R.string.pref_supported_external_links_open_in_app_summary)
+      )
+      .performClick()
+    // Also exercises setWikipediaLinksComponentEnabled(), which wraps the real
+    // PackageManager call in runCatching - Robolectric's PackageManager rejects an
+    // activity-alias that doesn't exist in this bare test manifest, so this is what
+    // actually covers that catch branch, not just the happy path.
+    verify { viewModel.setSupportedExternalLinksOpenInApp(false) }
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_webSearchIntentToggle_triggersCallback() {
+    val viewModel = createMockViewModel(
+      uiState = SettingsUiState(shouldShowWebSearchIntentPreference = true),
+      enableWebSearchIntent = true
+    )
+    renderSettingsScreen(viewModel)
+    scrollToText(context.getString(R.string.pref_enable_web_search_intent_summary))
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_enable_web_search_intent_summary))
+      .performClick()
+    verify { viewModel.setEnableWebSearchIntent(false) }
+  }
+
+  @Test
+  fun settingsScreen_extrasCategory_webSearchIntentToggle_offToOn_triggersCallback() {
+    // The off->on direction, so setComponentEnabled()'s
+    // COMPONENT_ENABLED_STATE_ENABLED branch (not just _DISABLED) gets exercised too.
+    val viewModel = createMockViewModel(
+      uiState = SettingsUiState(shouldShowWebSearchIntentPreference = true),
+      enableWebSearchIntent = false
+    )
+    renderSettingsScreen(viewModel)
+    scrollToText(context.getString(R.string.pref_enable_web_search_intent_summary))
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_enable_web_search_intent_summary))
+      .performClick()
+    verify { viewModel.setEnableWebSearchIntent(true) }
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -191,6 +191,8 @@ internal class CoreSettingsViewModelTest {
     every { kiwixDataStore.textZoom } returns flowOf(DEFAULT_ZOOM)
     every { kiwixDataStore.openNewTabInBackground } returns flowOf(false)
     every { kiwixDataStore.wifiOnly } returns flowOf(true)
+    every { kiwixDataStore.supportedExternalLinksOpenInApp } returns flowOf(false)
+    every { kiwixDataStore.enableWebSearchIntent } returns flowOf(false)
 
     // Stub PackageManager so versionCode / versionName are computed at construction time
     val packageInfo = PackageInfo().apply {
@@ -400,6 +402,22 @@ internal class CoreSettingsViewModelTest {
       coVerify(exactly = 10) {
         kiwixDataStore.setWifiOnly(any())
       }
+    }
+
+    @Test
+    fun `setSupportedExternalLinksOpenInApp delegates to kiwixDataStore`() = runTest {
+      coEvery { kiwixDataStore.setSupportedExternalLinksOpenInApp(any()) } just Runs
+      viewModel.setSupportedExternalLinksOpenInApp(true)
+      advanceUntilIdle()
+      coVerify { kiwixDataStore.setSupportedExternalLinksOpenInApp(true) }
+    }
+
+    @Test
+    fun `setEnableWebSearchIntent delegates to kiwixDataStore`() = runTest {
+      coEvery { kiwixDataStore.setEnableWebSearchIntent(any()) } just Runs
+      viewModel.setEnableWebSearchIntent(true)
+      advanceUntilIdle()
+      coVerify { kiwixDataStore.setEnableWebSearchIntent(true) }
     }
 
     @Test
@@ -619,6 +637,54 @@ internal class CoreSettingsViewModelTest {
         // Assert initial item
         assertTrue(awaitItem())
         flow.emit(false)
+        assertFalse(awaitItem())
+        flow.emit(true)
+        assertTrue(awaitItem())
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `supportedExternalLinksOpenInApp uses default when no emission`() = runTest {
+      every { kiwixDataStore.supportedExternalLinksOpenInApp } returns emptyFlow()
+
+      createViewModel()
+
+      assertFalse(viewModel.supportedExternalLinksOpenInApp.value)
+    }
+
+    @Test
+    fun `supportedExternalLinksOpenInApp emits values`() = runTest {
+      val flow = MutableStateFlow(false)
+      every { kiwixDataStore.supportedExternalLinksOpenInApp } returns flow
+
+      createViewModel()
+
+      viewModel.supportedExternalLinksOpenInApp.test {
+        assertFalse(awaitItem())
+        flow.emit(true)
+        assertTrue(awaitItem())
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `enableWebSearchIntent uses default when no emission`() = runTest {
+      every { kiwixDataStore.enableWebSearchIntent } returns emptyFlow()
+
+      createViewModel()
+
+      assertFalse(viewModel.enableWebSearchIntent.value)
+    }
+
+    @Test
+    fun `enableWebSearchIntent emits values`() = runTest {
+      val flow = MutableStateFlow(false)
+      every { kiwixDataStore.enableWebSearchIntent } returns flow
+
+      createViewModel()
+
+      viewModel.enableWebSearchIntent.test {
         assertFalse(awaitItem())
         flow.emit(true)
         assertTrue(awaitItem())

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -139,6 +139,14 @@ private class TestCoreSettingsViewModel(
   override suspend fun showRatingCategory() {
     // Do nothing
   }
+
+  override suspend fun showSupportedExternalLinksPreference() {
+    // Do nothing
+  }
+
+  override suspend fun showWebSearchIntentPreference() {
+    // Do nothing
+  }
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -220,6 +220,28 @@ class KiwixDataStoreTest {
   }
 
   @Test
+  fun `supportedExternalLinksOpenInApp returns false by default`() = runTest {
+    assertThat(kiwixDataStore.supportedExternalLinksOpenInApp.first()).isFalse()
+  }
+
+  @Test
+  fun `setSupportedExternalLinksOpenInApp can enable the preference`() = runTest {
+    kiwixDataStore.setSupportedExternalLinksOpenInApp(true)
+    assertThat(kiwixDataStore.supportedExternalLinksOpenInApp.first()).isTrue()
+  }
+
+  @Test
+  fun `enableWebSearchIntent returns false by default`() = runTest {
+    assertThat(kiwixDataStore.enableWebSearchIntent.first()).isFalse()
+  }
+
+  @Test
+  fun `setEnableWebSearchIntent can enable the preference`() = runTest {
+    kiwixDataStore.setEnableWebSearchIntent(true)
+    assertThat(kiwixDataStore.enableWebSearchIntent.first()).isTrue()
+  }
+
+  @Test
   fun `showIntro returns true by default`() = runTest {
     assertThat(kiwixDataStore.showIntro.first()).isTrue()
   }


### PR DESCRIPTION
Reimplements the intent of #3864 (stale since June 2024, 2,400+ commits behind main, no longer mergeable — `CoreReaderFragment`/`KiwixReaderFragment`/`CorePrefsFragment`/`NewBookDao` have all since been deleted or rewritten) against the current Compose/ViewModel reader and settings architecture. Addresses #731.

## What it does

- `PendingIntentParser` now recognizes `wikipedia.org`/`wikipedia.com` `VIEW` intents (both `q=`/`search=` query links and `/wiki/<Title>` article paths, URL-decoded with underscores turned into spaces) and the system-wide `android.intent.action.WEB_SEARCH` intent, converting both into `OpenSearch` against the reader's existing, working search path.
- Two new settings toggles, "Open supported links in app" and "Use as a web search application", each backed by its own disabled-by-default `activity-alias` (`KiwixMainActivityWikipediaLinks`, `KiwixMainActivityWebSearch`) toggled at runtime via `PackageManager#setComponentEnabledSetting` — visible only in the `app` flavor, since these manifest entries don't exist in the branded/custom-app module.

## What it deliberately does not do

Resolve a Wikipedia article link to an exact page in a specific, possibly-not-open ZIM: there's no known-good way to pick which locally available ZIM contains a given article (see the maintainer discussion on #731), and #3864 hit exactly this wall — its `NewBookDao`-based exact-open path produced the reported "page cannot be loaded"/endless-search-loop bug. Recognized links are converted to search queries against the currently open book instead, matching what the maintainer confirmed already works.

## Verification

- `:core:testDebugUnitTest` for the intent/settings/datastore packages, `:core:compileDebugKotlin`, `:app:compileDebugKotlin` — all pass.
- `:app:processDebugMainManifest` — merges cleanly; confirmed the merged manifest carries both activity-aliases as expected.
- Both settings toggles were checked against their backing `PackageManager` component state, not just their DataStore value, to confirm they actually gate the corresponding intent-filter (an earlier draft of this PR had a toggle that changed no runtime behavior — fixed before this was posted).

(Note: Robolectric tests need JDK 21 in this environment; JDK 26's bytecode version isn't yet supported by the pinned Robolectric/ASM version — unrelated to this change.)
