### PR TITLE
fix(test): make hiltRule.inject() safe under RetryRule's retries

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/BaseActivityTest.kt
@@ -37,6 +37,7 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.checks.DuplicateClickableBoundsCheck
 import com.google.android.apps.common.testing.accessibility.framework.checks.SpeakableTextPresentCheck
 import com.google.android.apps.common.testing.accessibility.framework.integrations.espresso.AccessibilityValidator
+import dagger.hilt.android.testing.HiltAndroidRule
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.Matchers.anyOf
@@ -46,10 +47,12 @@ import org.junit.runner.RunWith
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.TestUtils
+import java.util.concurrent.atomic.AtomicBoolean
 
 @RunWith(AndroidJUnit4::class)
 abstract class BaseActivityTest {
   protected lateinit var activityScenario: ActivityScenario<KiwixMainActivity>
+  private val hiltInjected = AtomicBoolean(false)
   protected val ioDispatcher by lazy {
     Dispatchers.IO
   }
@@ -79,6 +82,24 @@ abstract class BaseActivityTest {
   open fun waitForIdle() {
     prepareDevice()
     setupCommonDataStore()
+  }
+
+  /**
+   * Calls [HiltAndroidRule.inject], but only the first time it's invoked for this
+   * test instance.
+   *
+   * RetryRule wraps `@Before`/`@Test`/`@After` (rule order can't put it outside
+   * them - `@Before` methods are always inside every `@Rule`, regardless of
+   * order) and re-runs that whole chain on failure. Subclasses call
+   * `hiltRule.injectOnce()` from `@Before`, so a retry calls it again on the same
+   * Hilt test component, which throws "Called inject() multiple times". This
+   * makes retries safe without changing what gets injected or when, for the
+   * first (non-retried) run.
+   */
+  protected fun HiltAndroidRule.injectOnce() {
+    if (hiltInjected.compareAndSet(false, true)) {
+      inject()
+    }
   }
 
   private fun prepareDevice() {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToLibkiwixMigratorTest.kt
@@ -124,7 +124,7 @@ class ObjectBoxToLibkiwixMigratorTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity {
       it.navigate(KiwixDestination.Library.route)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/ObjectBoxToRoomMigratorTest.kt
@@ -61,7 +61,7 @@ class ObjectBoxToRoomMigratorTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity {
       it.navigate(KiwixDestination.Library.route)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/SharedPreferenceToDatastoreMigratorTest.kt
@@ -57,7 +57,7 @@ class SharedPreferenceToDatastoreMigratorTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity {
       it.navigate(KiwixDestination.Library.route)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderInstrumentedTest.kt
@@ -48,7 +48,7 @@ class ZimFileReaderInstrumentedTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/deeplinks/DeepLinksTest.kt
@@ -77,7 +77,7 @@ class DeepLinksTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -70,7 +70,7 @@ class DownloadServiceTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowStorageOption(false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadTest.kt
@@ -78,7 +78,7 @@ class DownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowStorageOption(false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/error/ErrorActivityTest.kt
@@ -54,7 +54,7 @@ class ErrorActivityTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/help/HelpScreenRouteTest.kt
@@ -54,7 +54,7 @@ class HelpScreenRouteTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -59,7 +59,7 @@ class InitialDownloadTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowStorageOption(true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
@@ -59,7 +59,7 @@ class LanguageScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity {
       kiwixMainActivity = it

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localFileTransfer/LocalFileTransferTest.kt
@@ -58,7 +58,7 @@ class LocalFileTransferTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/CopyMoveFileHandlerTest.kt
@@ -70,7 +70,7 @@ class CopyMoveFileHandlerTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     composeTestRule.apply {
       runOnUiThread {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/OpeningFilesFromStorageTest.kt
@@ -76,7 +76,7 @@ class OpeningFilesFromStorageTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     Intents.init()
     super.waitForIdle()
     launchMainActivity()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/localLibrary/ProcessSelectedZimFilesForStandaloneTest.kt
@@ -66,7 +66,7 @@ class ProcessSelectedZimFilesForStandaloneTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowManageExternalFilesPermissionDialog(false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/main/TopLevelDestinationTest.kt
@@ -52,7 +52,7 @@ class TopLevelDestinationTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setExternalLinkPopup(true)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/mimetype/MimeTypeTest.kt
@@ -43,7 +43,7 @@ class MimeTypeTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/LocalLibraryTest.kt
@@ -55,7 +55,7 @@ class LocalLibraryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       // set `setShowManageExternalFilesPermissionDialog` false for hiding

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/nav/destination/library/OnlineLibraryScreenTest.kt
@@ -54,7 +54,7 @@ class OnlineLibraryScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore { setShowStorageOption(false) }
     launchMainActivity()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/note/NoteScreenTest.kt
@@ -61,7 +61,7 @@ class NoteScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity { kiwixMainActivity = it }
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/onlineCategory/OnlineCategoryTest.kt
@@ -54,7 +54,7 @@ class OnlineCategoryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore { setIntroShown(false) }
     launchMainActivity { kiwixMainActivity = it }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -100,7 +100,7 @@ class ImportBookmarkTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     boxStore = DatabaseModule.boxStore

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/LibkiwixBookmarkTest.kt
@@ -70,7 +70,7 @@ class LibkiwixBookmarkTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     composeTestRule.apply {
       runOnUiThread {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryTest.kt
@@ -61,7 +61,7 @@ class NavigationHistoryTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity { kiwixMainActivity = it }
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/DonationDialogTest.kt
@@ -57,7 +57,7 @@ class DonationDialogTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/EncodedUrlTest.kt
@@ -43,7 +43,7 @@ class EncodedUrlTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
@@ -102,7 +102,7 @@ class KiwixReaderScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/ZimFileReaderWithSplittedZimFileTest.kt
@@ -69,7 +69,7 @@ class ZimFileReaderWithSplittedZimFileTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/search/SearchScreenInstrumentTest.kt
@@ -76,7 +76,7 @@ class SearchScreenInstrumentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
@@ -54,7 +54,7 @@ class KiwixSettingsScreenTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
   }
 

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/shortcuts/GetContentShortcutTest.kt
@@ -59,7 +59,7 @@ class GetContentShortcutTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowCaseViewForFileTransferShown()

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/splash/KiwixSplashActivityTest.kt
@@ -57,7 +57,7 @@ class KiwixSplashActivityTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())
   }

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/webserver/ZimHostScreenInstrumentTest.kt
@@ -83,7 +83,7 @@ class ZimHostScreenInstrumentTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     updateKiwixDataStore {
       setShowManageExternalFilesPermissionDialog(false)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/widgets/SearchWidgetTest.kt
@@ -56,7 +56,7 @@ class SearchWidgetTest : BaseActivityTest() {
 
   @Before
   override fun waitForIdle() {
-    hiltRule.inject()
+    hiltRule.injectOnce()
     super.waitForIdle()
     launchMainActivity()
     composeTestRule.enableAccessibilityChecks(createAccessibilityValidator())


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Motivation

Stacked on #5053. CI there ("Automated tests", default flavor) fails across nearly every API level with:

```
java.lang.IllegalStateException: Called inject() multiple times
  at dagger.hilt.android.internal.testing.TestApplicationComponentManager.inject(TestApplicationComponentManager.java:248)
  at dagger.hilt.android.internal.testing.MarkThatRulesRanRule.inject(MarkThatRulesRanRule.java:83)
  at dagger.hilt.android.testing.HiltAndroidRule.inject(HiltAndroidRule.java:49)
  at org.kiwix.kiwixmobile.localLibrary.CopyMoveFileHandlerTest.waitForIdle(CopyMoveFileHandlerTest.kt:73)
```

Root cause: `RetryRule` wraps `@Before`/`@Test`/`@After` and re-runs that whole chain on a flaky-test failure - JUnit4 rule `order` can't put a rule outside `@Before`, it's always inside every `@Rule` regardless of declared order. 34 test classes call `hiltRule.inject()` from `@Before`, per the standard Hilt testing pattern. When `RetryRule` retries, `@Before` runs again on the same Hilt test component, and `HiltAndroidRule` only permits one `inject()` call per component - the retry throws instead of actually retrying, so any test that flakes even once now fails outright. That matches the CI pattern: fails broadly across API levels/variants (flaky-emulator-triggered retries are common), while "Automated tests on Tablet" (different device profile, apparently less flake-prone here) passes clean.

## Summary

- `BaseActivityTest.injectOnce()`: an `AtomicBoolean`-guarded extension function on `HiltAndroidRule`, so a retry's repeated `@Before` is a no-op past the first successful inject.
- All 34 `hiltRule.inject()` call sites in `app/src/androidTest` that extend `BaseActivityTest` now call `hiltRule.injectOnce()` instead.
- One exception: `ZimReaderSourceTest` doesn't extend `BaseActivityTest` and has no `RetryRule` wrapping it, so it was never exposed to this bug - left as plain `hiltRule.inject()`, untouched.

## Test plan

- [x] `./gradlew :app:compileDebugAndroidTestSources` - compiles clean.
- [x] `./gradlew :core:compileDebugKotlin :app:compileDebugSources :branded:compileCustomexampleDebugSources :app:compileDebugAndroidTestSources :core:compileDebugAndroidTestSources :app:compileDebugUnitTestSources :core:compileDebugUnitTestSources :branded:compileCustomexampleDebugAndroidTestSources` - all clean, done while reviewing #5053 itself (unrelated to this fix, but confirms the base branch wasn't already broken elsewhere).
- [x] `ws commit`'s pre-commit hook ran the full lint/ktlint/detekt suite - "Static analysis found no problems", `BUILD SUCCESSFUL`.
- [ ] Not run against a real emulator in this sandbox (no Android emulator available here) - can't directly reproduce the retry path locally, the fix is verified by reading `RetryRule`'s and `HiltAndroidRule`'s actual source/semantics, not by re-triggering the flake.

## Related

- #5053
