### PR TITLE
fix(test): stop comparing two live filesystem reads in FileExtensionsTest

### DIFF
--- a/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/FileExtensionsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/FileExtensionsTest.kt
@@ -110,12 +110,14 @@ class FileExtensionsTest {
 
   @Test
   fun `totalSpace should be greater than or equal to freeSpace`() = runTest {
-    val expectedTotalSpace = tempFile.totalSpace
-    val expectedFreeSpace = tempFile.freeSpace
+    // Wrapper-vs-property equality is already covered by the two tests above;
+    // this test only needs the invariant itself, from a single pair of live
+    // reads. Reading totalSpace/freeSpace twice each (once directly, once via
+    // the wrapper) compares real filesystem state captured at different
+    // instants - free space can shift between those reads on a busy CI
+    // runner, which made this flaky.
     val actualTotalSpace = tempFile.totalSpace(mainDispatcherRule.dispatcher)
     val actualFreeSpace = tempFile.freeSpace(mainDispatcherRule.dispatcher)
-    assertEquals(expectedTotalSpace, actualTotalSpace)
-    assertEquals(expectedFreeSpace, actualFreeSpace)
     assertTrue(actualTotalSpace >= actualFreeSpace, "Total space should be >= free space")
   }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Motivation

Found while investigating unrelated CI failures on #5059. That PR's "Automated tests" job failed across every API level, but only one leg actually failed - `fail-fast: true` cancels the rest as soon as one fails, and a cancelled job shows the same red X as a real one. The real failure was `:core:testDebugUnitTest`:

```
FileExtensionsTest > totalSpace should be greater than or equal to freeSpace() FAILED
    org.opentest4j.AssertionFailedError at FileExtensionsTest.kt:112
```

`FileExtensionsTest.kt` isn't touched by #5059, and this is on `main` today - it's a pre-existing, general flaky test, not specific to that PR's changes. It'll trip any branch's CI whenever it happens to run on a busy runner. Opening this as its own PR rather than bundling it into #5059 (where a copy of this same commit was pushed directly, to unblock that PR's CI immediately without waiting on this one) - once this merges, that duplicate commit becomes a no-op fast-forward there.

## Summary

- The test read `File.totalSpace`/`File.freeSpace` twice each - once as a direct property access, once through the suspend wrapper under test - then asserted both pairs equal. Free space on a real disk can change between two live reads on a busy CI runner, so those equality checks are inherently racy.
- The two tests directly above this one already cover "does the suspend wrapper return what the property returns" for `freeSpace` and `totalSpace` individually. This test's own name is about the `total >= free` invariant, not wrapper correctness.
- Dropped the redundant equality asserts, kept the invariant check against a single live read pair (still through the suspend wrapper, so it exercises the same code path).

## Test plan

- [x] `./gradlew :core:testDebugUnitTest --tests 'org.kiwix.kiwixmobile.core.extensions.FileExtensionsTest'` against this branch (based on current `main`) - all 12 tests in the class pass.
- [x] `ws commit`'s pre-commit hook ran the full lint/ktlint/detekt suite - "Static analysis found no problems", `BUILD SUCCESSFUL`.

## Related

- Found via #5059
