### PR TITLE
fix(test): skip testConcurrencyOfSearch on API 36 (native WebView crash)

### DIFF
--- a/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
+++ b/branded/src/androidTest/java/org/kiwix/kiwixmobile/custom/search/SearchScreenTestForBrandedApp.kt
@@ -208,6 +208,14 @@ class SearchScreenTestForBrandedApp {
   @Test
   fun testConcurrencyOfSearch() =
     runBlocking {
+      // Same crash this file's searchScreen() and SearchScreenInstrumentTest's
+      // searchScreenSimple() were already skipped for (60bf4326, "Search test
+      // was crashing on API level 36"): the System WebView build on the API 36
+      // emulator image aborts with a native
+      // "[FATAL:partition_alloc_support.cc] Detected dangling raw_ptr" SIGTRAP
+      // in Chrome_IOThread under this test's rapid-fire search actions. This
+      // test predates that fix and was missed.
+      Assume.assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA)
       val searchTerms =
         listOf(
           "eilum",


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Stacked on #5053, same fix as #5062 (open against `main`) - cherry-picked directly onto this branch's own copy of the file so #5053/#5060's own CI stops failing on this pre-existing, unrelated crash immediately, without waiting on #5062 to merge and this branch to rebase.

## Motivation

"Automated tests for Branded app" fails across every API level on #5053 and #5060, but it's `fail-fast` cascading one real failure (API 36) into five cancelled siblings - a native WebView crash, unrelated to either PR:

```
F DEBUG: Abort message: '[FATAL:partition_alloc_support.cc(770)] Detected dangling raw_ptr in unretained with id=...
F libc: Fatal signal 5 (SIGTRAP) ... in tid ... (Chrome_IOThread)
```

Same crash the maintainers already hit and worked around twice in this file's siblings (`60bf432697a44b8f64839ee4f95fe8ab98c6778b`, "Fixed: Search test was crashing on API level 36"). `testConcurrencyOfSearch()` was the one search test in the family missing that guard.

Filed upstream: https://issues.chromium.org/u/1/issues/554600555

## Summary

- Applied the same `Assume.assumeTrue(Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA)` guard to `testConcurrencyOfSearch()`.

## Test plan

- [x] `./gradlew :branded:compileCustomexampleDebugAndroidTestSources` against this branch (with the Hilt migration's changes to the same file) - compiles clean.

## Related

- #5062 (same fix, against `main`)
- #5060 (this PR's own diff is scoped to the Hilt-inject-once fix; this branded-test crash is unrelated and was blocking its CI too)
