### PR TITLE
feat: add Select All action to Bookmarks, History and Notes toolbar (#4727)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/PageScreen.kt
@@ -97,6 +97,7 @@ const val NO_ITEMS_TEXT_TESTING_TAG = "noItemsTextTestingTag"
 const val PAGE_LIST_TEST_TAG = "pageListTestingTag"
 const val SEARCH_ICON_TESTING_TAG = "searchIconTestingTag"
 const val DELETE_MENU_ICON_TESTING_TAG = "deleteMenuIconTestingTag"
+const val SELECT_ALL_MENU_ICON_TESTING_TAG = "selectAllMenuIconTestingTag"
 const val DATE_ITEM_TEXT_TESTING_TAG = "dateItemTextTestingTag"
 
 @Suppress("LongMethod", "LongParameterList")
@@ -180,6 +181,9 @@ fun <T : Page, S : PageState<T>> PageScreenRoute(
         },
         onSelectionDeleteClick = {
           viewModel.actions.tryEmit(Action.UserClickedDeleteSelectedPages)
+        },
+        onSelectAllClick = {
+          viewModel.actions.tryEmit(Action.UserClickedSelectAll)
         }
       ),
       onClearSearch = {
@@ -397,11 +401,13 @@ private fun parseDateSafely(dateString: String): LocalDate? {
  * @param onSearchClick Callback to invoke when the search icon is clicked.
  * @param onDeleteClick Callback to invoke when the delete icon is clicked.
  * @param onSelectionDeleteClick Callback to invoke when the delete selected items icon is clicked.
+ * @param onSelectAllClick Callback to invoke when the select-all icon is clicked in selection mode.
  * @return A list of [ActionMenuItem]s to be displayed in the app bar.
  *
- * - If in selection mode, shows only the delete selected items icon.
+ * - If in selection mode, shows a select-all icon followed by the delete selected items icon.
  * - Otherwise, shows the search icon only when search is not active, and always includes the delete icon.
  */
+@Suppress("LongParameterList")
 private fun actionMenuList(
   isSearchActive: Boolean,
   isInSelectionMode: Boolean,
@@ -409,8 +415,15 @@ private fun actionMenuList(
   onSearchClick: () -> Unit,
   onDeleteClick: () -> Unit,
   onSelectionDeleteClick: () -> Unit,
+  onSelectAllClick: () -> Unit,
 ): List<ActionMenuItem> = when {
   isInSelectionMode -> listOf(
+    ActionMenuItem(
+      icon = IconItem.Drawable(R.drawable.ic_select_all_24dp),
+      contentDescription = R.string.select_all,
+      onClick = onSelectAllClick,
+      testingTag = SELECT_ALL_MENU_ICON_TESTING_TAG
+    ),
     ActionMenuItem(
       icon = IconItem.Vector(Icons.Default.Delete),
       contentDescription = R.string.delete,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/Action.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/Action.kt
@@ -7,6 +7,7 @@ sealed class Action {
   object ExitActionModeMenu : Action()
   object UserClickedDeleteButton : Action()
   object UserClickedDeleteSelectedPages : Action()
+  object UserClickedSelectAll : Action()
 
   data class OnItemClick(val page: Page) : Action()
   data class OnItemLongClick(val page: Page) : Action()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageState.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageState.kt
@@ -58,6 +58,16 @@ abstract class PageState<T : Page> {
     }
   }
 
+  fun getItemsAfterSelectingAll(): List<T> =
+    pageItems.map {
+      when (it) {
+        is LibkiwixBookmarkItem -> it.copy(isSelected = true) as T
+        is HistoryItem -> it.copy(isSelected = true) as T
+        is NoteListItem -> it.copy(isSelected = true) as T
+        else -> it.apply { isSelected = true }
+      }
+    }
+
   fun numberOfSelectedItems(): Int = pageItems.filter(Page::isSelected).size
 
   abstract fun copyWithNewItems(newItems: List<T>): PageState<T>

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -45,6 +45,7 @@ import org.kiwix.kiwixmobile.core.page.viewmodel.Action.OnItemLongClick
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.UpdatePages
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.UserClickedDeleteButton
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.UserClickedDeleteSelectedPages
+import org.kiwix.kiwixmobile.core.page.viewmodel.Action.UserClickedSelectAll
 import org.kiwix.kiwixmobile.core.page.viewmodel.Action.UserClickedShowAllToggle
 import org.kiwix.kiwixmobile.core.page.viewmodel.effects.OpenPage
 import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
@@ -129,6 +130,7 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
     when (action) {
       Exit -> exitScreen(state)
       ExitActionModeMenu -> deselectAllPages(state)
+      UserClickedSelectAll -> copyWithNewItems(state, state.getItemsAfterSelectingAll())
       UserClickedDeleteButton, UserClickedDeleteSelectedPages -> offerShowDeleteDialog(state)
       is UserClickedShowAllToggle -> offerUpdateToShowAllToggle(action, state)
       is OnItemClick -> handleItemClick(state, action)

--- a/core/src/main/res/drawable/ic_select_all_24dp.xml
+++ b/core/src/main/res/drawable/ic_select_all_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24.0"
+  android:viewportHeight="24.0">
+  <path
+    android:fillColor="#FFFFFF"
+    android:pathData="M3,5h2V3C3.9,3 3,3.9 3,5zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2C21,3.9 20.1,3 19,3zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z" />
+</vector>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -230,6 +230,7 @@
   <string name="history_from_current_book">View History From All Books</string>
   <string name="search_history">Search history</string>
   <string name="selected_items" tools:ignore="PluralsCandidate">%1$d selected</string>
+  <string name="select_all">Select all</string>
   <string-array name="description_help_2">
     <item>@string/help_3</item>
     <item>@string/help_4</item>


### PR DESCRIPTION
Fixes #4727

Clearing a long list of bookmarks, history entries or notes currently means tapping every item, since the selection toolbar only exposes Delete. This PR adds a Select All action next to Delete so bulk clears take two taps.

Since Bookmarks, History and Notes all render through the shared \`PageScreen\`, the whole thing wires in one place:

- \`Action.UserClickedSelectAll\` in the shared page \`Action\`
- \`PageState.getItemsAfterSelectingAll()\` mirrors the existing \`getItemsAfterToggleSelectionOfItem\` polymorphism (\`LibkiwixBookmarkItem\` / \`HistoryItem\` / \`NoteListItem\`)
- Reducer in \`PageViewModel\` maps the action to \`copyWithNewItems(state, state.getItemsAfterSelectingAll())\` — no changes needed in the three concrete view models
- \`PageScreen\` renders a Select All icon in selection mode, before Delete
- New \`R.drawable.ic_select_all_24dp\` (Material \`select_all\` symbol) — kept as a drawable to avoid pulling in \`material-icons-extended\`
- New \`R.string.select_all\` for the content description
- Testing tag \`SELECT_ALL_MENU_ICON_TESTING_TAG\` for UI tests

**Screenshots**

Not attached — I don't have a device set up to record; the icon is the standard Material Design \`select_all\` symbol and sits to the left of the existing Delete icon in the selection toolbar.