### PR TITLE
fix(test): stop comparing two live filesystem reads in FileExtensionsTest

### DIFF
--- a/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/FileExtensionsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/FileExtensionsTest.kt
@@ -110,12 +110,14 @@ class FileExtensionsTest {
 
   @Test
   fun `totalSpace should be greater than or equal to freeSpace`() = runTest {
-    val expectedTotalSpace = tempFile.totalSpace
-    val expectedFreeSpace = tempFile.freeSpace
+    // Wrapper-vs-property equality is already covered by the two tests above;
+    // this test only needs the invariant itself, from a single pair of live
+    // reads. Reading totalSpace/freeSpace twice each (once directly, once via
+    // the wrapper) compares real filesystem state captured at different
+    // instants - free space can shift between those reads on a busy CI
+    // runner, which made this flaky.
     val actualTotalSpace = tempFile.totalSpace(mainDispatcherRule.dispatcher)
     val actualFreeSpace = tempFile.freeSpace(mainDispatcherRule.dispatcher)
-    assertEquals(expectedTotalSpace, actualTotalSpace)
-    assertEquals(expectedFreeSpace, actualFreeSpace)
     assertTrue(actualTotalSpace >= actualFreeSpace, "Total space should be >= free space")
   }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Found while investigating unrelated CI on #5059. `fail-fast: true` cascaded one real failure into 5 cosmetic "cancelled" siblings. Real failure: `:core:testDebugUnitTest`, api-level-30 leg:

```
FileExtensionsTest > totalSpace should be greater than or equal to freeSpace() FAILED
  org.opentest4j.AssertionFailedError at FileExtensionsTest.kt:112
```

Test read `File.totalSpace`/`freeSpace` twice each - once directly, once through the suspend wrapper - and asserted both pairs equal. Free space on a real disk shifts between two live reads on a busy CI runner. Racy by construction.

Wrapper-vs-property equality is already covered by the two tests above this one. This test's own name is about the total>=free invariant, not wrapper correctness. Dropped the redundant equality asserts, kept the invariant check against a single live read pair.

Verified: `:core:testDebugUnitTest --tests FileExtensionsTest` - 12/12 pass. `compileDebugKotlin`, `detektDebug` clean.

Same failure independently confirmed on kiwix-android#5054's CI too.
