### PR TITLE
Fixed: Reader menu state was not set up when loading a URL into an already-open ZIM file from the Bookmarks/Notes/History screens on API level 25.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/reader/KiwixReaderScreenTest.kt
@@ -289,10 +289,6 @@ class KiwixReaderScreenTest : BaseActivityTest() {
   @Test
   fun testReadAloudFeature() {
     Assume.assumeTrue("Text-to-speech is not available on this device", isTextToSpeechAvailable())
-    Assume.assumeTrue(
-      "The TTS feature is not works in API level 25, so skipping the test",
-      Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1
-    )
     activityScenario.onActivity {
       kiwixMainActivity = it
       kiwixMainActivity.navigate(KiwixDestination.Library.route)

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/reader/KiwixReaderViewModel.kt
@@ -165,6 +165,11 @@ class KiwixReaderViewModel @Inject constructor(
         // inside the currently opened book. Bookmarks are set up when opening the ZIM file.
         // See https://github.com/kiwix/kiwix-android/issues/3541
         zimReaderContainer.zimFileReader?.let(::observeBookmarks)
+        // Also update the reader menu state for the same reason as above: it is normally
+        // updated when a ZIM file is opened, so it needs to be set explicitly here since
+        // we're only loading a URL into the already-open ZIM file's WebView.
+        // See https://github.com/kiwix/kiwix-android/issues/5040
+        readerMenuState?.onFileOpened(urlIsValid())
       }
     } else {
       if (zimFileUri.isNotEmpty()) {


### PR DESCRIPTION
Fixes #5040 

* Menu items (e.g., Read Aloud controls) would fail to appear after tapping a bookmark/history item, because `readerMenuState.onFileOpened` is normally called when the ZIM file is opened, but that path is skipped when we're only loading a URL into an already-open ZIM file's WebView.
* Re-enabled `testReadAloudFeature` on API level 25. It was previously flaking/failing only on this API level for the same reason — the test opens a history item, which hit this bug. Verified manually on Android 16 that menu items were already showing correctly there.
* However, I am wondering why this issue has not been seen on a real device. There, these menu items are visible. But from a code perspective, this is a bug. Placing this fix resolves it on emualtor.