### PR TITLE
fix: guard ZimReaderContainer against JNI use-after-free race (#5070)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -24,25 +24,43 @@ import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.net.HttpURLConnection
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 @Singleton
 class ZimReaderContainer @Inject constructor(
   private val zimFileReaderFactory: Factory,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-  var zimFileReader: ZimFileReader? = null
+  // Guards `backingZimFileReader` against the native use-after-free that happens when the
+  // setter below disposes the current reader (native Archive/SuggestionSearcher) while the
+  // WebView's Chromium worker thread is mid-read via isRedirect/getRedirect/load, called from
+  // CoreWebViewClient.shouldInterceptRequest. The write lock ensures dispose() only runs once
+  // every in-flight read of this class's own methods has finished; readers see either the old
+  // or the new reader, never a disposed one.
+  private val lock = ReentrantReadWriteLock()
+  private var backingZimFileReader: ZimFileReader? = null
+
+  var zimFileReader: ZimFileReader?
+    get() = lock.read { backingZimFileReader }
     set(value) {
-      field?.dispose()
-      field = value
+      lock.write {
+        backingZimFileReader?.dispose()
+        backingZimFileReader = value
+      }
     }
+
+  private inline fun <T> withReader(block: (ZimFileReader?) -> T): T =
+    lock.read { block(backingZimFileReader) }
 
   suspend fun setZimReaderSource(
     zimReaderSource: ZimReaderSource?,
     showSearchSuggestionsSpellChecked: Boolean = false
   ) {
-    if (zimReaderSource == zimFileReader?.zimReaderSource) {
+    if (zimReaderSource == withReader { it?.zimReaderSource }) {
       return
     }
     zimFileReader = withContext(ioDispatcher) {
@@ -57,45 +75,47 @@ class ZimReaderContainer @Inject constructor(
     }
   }
 
-  fun getPageUrlFromTitle(title: String) = zimFileReader?.getPageUrlFrom(title)
+  fun getPageUrlFromTitle(title: String) = withReader { it?.getPageUrlFrom(title) }
 
-  fun getRandomPageUrl() = zimFileReader?.getRandomPageUrl()
-  fun isRedirect(url: String): Boolean = zimFileReader?.isRedirect(url) == true
-  fun getRedirect(url: String): String = zimFileReader?.getRedirect(url).orEmpty()
+  fun getRandomPageUrl() = withReader { it?.getRandomPageUrl() }
+  fun isRedirect(url: String): Boolean = withReader { it?.isRedirect(url) == true }
+  fun getRedirect(url: String): String = withReader { it?.getRedirect(url) }.orEmpty()
   fun load(url: String, requestHeaders: Map<String, String>): WebResourceResponse = runBlocking {
-    return@runBlocking WebResourceResponse(
-      zimFileReader?.getMimeTypeFromUrl(url),
-      Charsets.UTF_8.name(),
-      zimFileReader?.load(url)
-    )
-      .apply {
-        val headers = mutableMapOf("Accept-Ranges" to "bytes")
-        if ("Range" in requestHeaders.keys) {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
-          val lastByte = fullSize - 1
-          val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
-          headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
-          if (byteRanges.size == 1) {
-            headers["Connection"] = "close"
+    return@runBlocking withReader { reader ->
+      WebResourceResponse(
+        reader?.getMimeTypeFromUrl(url),
+        Charsets.UTF_8.name(),
+        reader?.load(url)
+      )
+        .apply {
+          val headers = mutableMapOf("Accept-Ranges" to "bytes")
+          if ("Range" in requestHeaders.keys) {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
+            val fullSize = reader?.getItem(url)?.itemSize() ?: 0L
+            val lastByte = fullSize - 1
+            val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
+            headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
+            if (byteRanges.size == 1) {
+              headers["Connection"] = "close"
+            }
+          } else {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
           }
-        } else {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
+          responseHeaders = headers
         }
-        responseHeaders = headers
-      }
+    }
   }
 
-  val zimReaderSource get() = zimFileReader?.zimReaderSource
-  val zimFileTitle get() = zimFileReader?.title
-  val mainPage get() = zimFileReader?.mainPage
-  val id get() = zimFileReader?.id
-  val fileSize get() = zimFileReader?.fileSize ?: 0L
-  val creator get() = zimFileReader?.creator
-  val publisher get() = zimFileReader?.publisher
-  val name get() = zimFileReader?.name
-  val date get() = zimFileReader?.date
-  val description get() = zimFileReader?.description
-  val favicon get() = zimFileReader?.favicon
-  val language get() = zimFileReader?.language
+  val zimReaderSource get() = withReader { it?.zimReaderSource }
+  val zimFileTitle get() = withReader { it?.title }
+  val mainPage get() = withReader { it?.mainPage }
+  val id get() = withReader { it?.id }
+  val fileSize get() = withReader { it?.fileSize } ?: 0L
+  val creator get() = withReader { it?.creator }
+  val publisher get() = withReader { it?.publisher }
+  val name get() = withReader { it?.name }
+  val date get() = withReader { it?.date }
+  val description get() = withReader { it?.description }
+  val favicon get() = withReader { it?.favicon }
+  val language get() = withReader { it?.language }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.kiwix.sharedFunctions.MainDispatcherRule
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Guards against the JNI use-after-free race described in
+ * https://github.com/kiwix/kiwix-android/issues/5070#1: the WebView's Chromium worker
+ * thread can be mid-read (isRedirect/getRedirect/load) while another thread swaps in a
+ * new ZimFileReader, disposing the native Archive the worker thread is still using.
+ */
+class ZimReaderContainerTest {
+  @JvmField
+  @RegisterExtension
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val zimFileReaderFactory: ZimFileReader.Factory = mockk()
+  private val container =
+    ZimReaderContainer(zimFileReaderFactory, mainDispatcherRule.dispatcher)
+
+  @Test
+  fun `dispose does not run while a read is in flight, and always runs eventually`() {
+    val oldReader: ZimFileReader = mockk(relaxed = true)
+    val readStarted = CountDownLatch(1)
+    val releaseRead = CountDownLatch(1)
+    every { oldReader.isRedirect(any()) } answers {
+      readStarted.countDown()
+      releaseRead.await(2, TimeUnit.SECONDS)
+      false
+    }
+    container.zimFileReader = oldReader
+
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val readFuture = executor.submit { container.isRedirect("https://kiwix.app/A/foo") }
+      assertEquals(true, readStarted.await(2, TimeUnit.SECONDS))
+
+      val newReader: ZimFileReader = mockk(relaxed = true)
+      val setterFuture = executor.submit { container.zimFileReader = newReader }
+
+      // The setter is blocked on the write lock while the read above is in flight,
+      // so dispose() must not have run yet.
+      Thread.sleep(200)
+      verify(exactly = 0) { oldReader.dispose() }
+
+      releaseRead.countDown()
+      readFuture.get(2, TimeUnit.SECONDS)
+      setterFuture.get(2, TimeUnit.SECONDS)
+
+      verify(exactly = 1) { oldReader.dispose() }
+      assertEquals(newReader, container.zimFileReader)
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes #5098.

`ZimReaderContainer.zimFileReader`'s setter disposed the current reader's native `Archive`/`SuggestionSearcher` while the WebView's Chromium worker thread could be mid-read via `isRedirect`/`getRedirect`/`load`, called from `CoreWebViewClient.shouldInterceptRequest`. That's a use-after-free across the JNI boundary — a native SIGSEGV, not a catchable exception. `KiwixReaderViewModel.tryOpeningZimFile` already works around one instance of this (ordering `destroyAllTabs()`/`closeZimBook()` before swapping files, with comments describing exactly this crash), but the race was still open on every other path that calls `setZimReaderSource`.

Added a `ReentrantReadWriteLock`: the setter disposes the old reader and swaps in the new one under the write lock; every read of the reader (`isRedirect`, `getRedirect`, `load`, and the derived getters like `zimReaderSource`/`id`/`fileSize`/etc.) runs its full body under the read lock via a new `withReader` helper. The write lock can't proceed until all in-flight reads finish, so `dispose()` can no longer run underneath a live read — regardless of which code path triggered the swap.

Added `ZimReaderContainerTest` proving the invariant directly: a blocked `isRedirect()` call on one thread holds off a concurrent setter call on another thread until the read returns, and `dispose()` runs exactly once, afterward.

Verified: `:core:compileDebugKotlin`, `:app:compileDebugKotlin`, `:core:detektDebug` clean. `:core:testDebugUnitTest --tests "*ZimReaderContainerTest*"` passes, plus a broader pass across `ReaderSessionManagerTest`, `CoreReaderViewModelTest`, `ZimFileManagerTest`, `BookmarkManagerTest`, `ReaderPageManagerTest`, `SearchViewModelTest` (all reader/container consumers) — 0 failures.
