### PR TITLE
fix: close 3 silent logic bugs found in review (#5070)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -273,7 +273,7 @@ class ZimFileReader(
   @Suppress("UnreachableCode", "NestedBlockDepth", "ReturnCount")
   private suspend fun loadContent(uri: String, extension: String): InputStream? {
     val item = getItem(uri)
-    if (compressedExtensions.any { it != extension }) {
+    if (extension !in compressedExtensions) {
       item?.itemSize()?.let {
         // Check if the item size exceeds 1 MB
         if (it / KB > 1024) {
@@ -495,7 +495,7 @@ val String.decodeUrl: String
 
 // Truncate mime-type (everything after the first space and semi-colon(if exists)
 val String.truncateMimeType: String
-  get() = replace("^([^ ]+).*$", "$1").substringBefore(";")
+  get() = substringBefore(' ').substringBefore(';')
 
 // Encode question mark with %3F after getting url from checkUrl() method
 // for issue https://github.com/kiwix/kiwix-android/issues/2671

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -63,10 +63,11 @@ class ZimReaderContainer @Inject constructor(
   fun isRedirect(url: String): Boolean = zimFileReader?.isRedirect(url) == true
   fun getRedirect(url: String): String = zimFileReader?.getRedirect(url).orEmpty()
   fun load(url: String, requestHeaders: Map<String, String>): WebResourceResponse = runBlocking {
+    val stream = zimFileReader?.load(url)
     return@runBlocking WebResourceResponse(
       zimFileReader?.getMimeTypeFromUrl(url),
       Charsets.UTF_8.name(),
-      zimFileReader?.load(url)
+      stream
     )
       .apply {
         val headers = mutableMapOf("Accept-Ranges" to "bytes")
@@ -75,7 +76,13 @@ class ZimReaderContainer @Inject constructor(
           val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
           val lastByte = fullSize - 1
           val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
-          headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
+          val parsedStart = byteRanges[0].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+          val rangeStart = if (fullSize > 0) parsedStart.coerceAtMost(lastByte) else parsedStart
+          // The delivered stream previously always started at offset 0 regardless of what
+          // range was declared above, corrupting seeking in embedded video/audio. Skip
+          // forward so the body actually matches the advertised Content-Range.
+          stream?.skip(rangeStart)
+          headers["Content-Range"] = "bytes $rangeStart-$lastByte/$fullSize"
           if (byteRanges.size == 1) {
             headers["Connection"] = "close"
           }

--- a/core/src/sharedTestFunctions/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderTest.kt
+++ b/core/src/sharedTestFunctions/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderTest.kt
@@ -30,8 +30,13 @@ class ZimFileReaderTest {
 
   @Test
   fun checkMimeTypeWithSpecialCharacters() {
+    // This test previously pinned a bug: truncateMimeType used String.replace() with a
+    // regex-pattern string, which does a literal (non-regex) substring replacement - it
+    // happened to match this exact input and silently mangled it into "text/css$1". The
+    // input contains a literal space (inside "[^ ]"), so truncation now correctly stops
+    // there, same as it would for any real "type/subtype extra-junk" mimetype. See #5070.
     val mimeTypeCss = "text/css^([^ ]+).*\$"
-    assertEquals("text/css$1", mimeTypeCss.truncateMimeType)
+    assertEquals("text/css^([^", mimeTypeCss.truncateMimeType)
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderUtilsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `truncateMimeType` previously used `String.replace(String, String)`, which does a
+ * literal substring replacement rather than applying the regex pattern - it never
+ * actually truncated anything. See #5070.
+ */
+internal class ZimFileReaderUtilsTest {
+  @Test
+  fun `truncateMimeType drops everything after the first space`() {
+    assertThat("text/html and some junk".truncateMimeType).isEqualTo("text/html")
+  }
+
+  @Test
+  fun `truncateMimeType drops the charset parameter after a semicolon`() {
+    assertThat("text/html; charset=utf-8".truncateMimeType).isEqualTo("text/html")
+  }
+
+  @Test
+  fun `truncateMimeType leaves a plain mimetype untouched`() {
+    assertThat("application/octet-stream".truncateMimeType).isEqualTo("application/octet-stream")
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerLoadTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerLoadTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import android.os.Build
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+
+/**
+ * Covers the range-request bug found in review (#5070): the delivered body previously
+ * always started at offset 0, no matter what Content-Range the response declared.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class ZimReaderContainerLoadTest {
+  private val zimFileReaderFactory: ZimFileReader.Factory = mockk()
+  private val container = ZimReaderContainer(zimFileReaderFactory, Dispatchers.Unconfined)
+
+  private fun setUpReader(body: ByteArray) {
+    val reader: ZimFileReader = mockk(relaxed = true)
+    coEvery { reader.load(any()) } returns ByteArrayInputStream(body)
+    every { reader.getItem(any()) } returns null
+    container.zimFileReader = reader
+  }
+
+  @Test
+  fun `load with a Range header skips the body to the requested offset`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load(
+      "https://kiwix.app/A/foo",
+      mapOf("Range" to "bytes=5-")
+    )
+
+    assertEquals(206, response.statusCode)
+    assertEquals("bytes 5--1/0", response.responseHeaders["Content-Range"])
+    assertEquals("56789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `load without a Range header returns the full body from offset zero`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load("https://kiwix.app/A/foo", emptyMap())
+
+    assertEquals(200, response.statusCode)
+    assertEquals("0123456789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `load with a malformed Range header falls back to offset zero instead of crashing`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load(
+      "https://kiwix.app/A/foo",
+      mapOf("Range" to "bytes=not-a-number-")
+    )
+
+    assertEquals(206, response.statusCode)
+    assertEquals("0123456789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes the 3 items in the "Silent logic bugs" section of #5070.

1. **`ZimFileReader.loadContent`** — `compressedExtensions.any { it != extension }` is always true for a 5-entry list no matter what `extension` is, so the "skip direct-access streaming for compressed items" branch never actually gated anything. Fixed to `extension !in compressedExtensions`.
2. **`truncateMimeType`** — used `String.replace(String, String)` with a regex-pattern string as the first argument, which does a literal substring replacement rather than applying the pattern - it never truncated anything in practice. Replaced with `substringBefore(' ').substringBefore(';')`. There was an existing test (`checkMimeTypeWithSpecialCharacters`) that had pinned the buggy literal-replace output as the expected result for a pathological input; updated it to assert the correct truncation behavior instead (with a comment explaining why).
3. **`ZimReaderContainer.load`** — range responses declared a `Content-Range` header reflecting the client's requested offset, but the delivered body always started at offset 0 regardless of what the header claimed. Seeking in embedded video/audio returned corrupt/misaligned data as a result. Now parses and clamps the requested start offset (falling back to 0 on malformed input, and clamping to the item's actual size when known) and skips the stream to that offset before returning it.

Added `ZimFileReaderUtilsTest` (covers `truncateMimeType` directly) and `ZimReaderContainerLoadTest` (covers the range-skip behavior end-to-end via a mocked `ZimFileReader`, using Robolectric since `WebResourceResponse` needs a real Android runtime).

Verified: `:core:compileDebugKotlin`, `:app:compileDebugKotlin`, `:core:detektDebug` clean. Full `:core:testDebugUnitTest` suite — 0 failures (this also caught and fixed the one existing test that was pinning the `truncateMimeType` bug as correct behavior).
