### PR TITLE
fix: crashes, resource leaks and minor issues found in code review of issue #5070

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -48,7 +48,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -197,8 +196,10 @@ class KiwixMainActivity : CoreMainActivity() {
       migrateInternalToPublicAppDirectory()
       migratedToPerAppLanguage()
     }
-    // run the migration on background thread to avoid any UI related issues.
-    CoroutineScope(ioDispatcher).launch {
+    // Run the migration on a background thread to avoid any UI related issues, but still
+    // on lifecycleScope (not an ad-hoc untracked scope) so it's cancelled automatically
+    // if the Activity is destroyed mid-migration.
+    lifecycleScope.launch(ioDispatcher) {
       objectBoxDataMigrationHandler.migrate()
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
@@ -66,11 +66,17 @@ class StorageObserver @Inject constructor(
   private suspend fun convertToLibkiwixBook(file: File) =
     zimReaderFactory.create(ZimReaderSource(file), false)
       ?.let { zimFileReader ->
-        libkiwixBookFactory.create().apply {
-          update(zimFileReader.jniKiwixReader)
-        }.also {
-          // add the book to libkiwix library to validate the imported bookmarks
-          libkiwixBookmarks.addBookToLibrary(archive = zimFileReader.jniKiwixReader)
+        // dispose() must run even if create()/update()/addBookToLibrary() throws below,
+        // or the native Archive for this file leaks - once per failing ZIM during a full
+        // device scan.
+        try {
+          libkiwixBookFactory.create().apply {
+            update(zimFileReader.jniKiwixReader)
+          }.also {
+            // add the book to libkiwix library to validate the imported bookmarks
+            libkiwixBookmarks.addBookToLibrary(archive = zimFileReader.jniKiwixReader)
+          }
+        } finally {
           zimFileReader.dispose()
         }
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -48,6 +48,9 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+// Compiled once instead of on every book checked against the trash folder.
+private val TRASH_FOLDER_REGEX = Regex("/\\.Trash/")
+
 @Singleton
 class LibkiwixBookOnDisk @Inject constructor(
   @param:Named(LOCAL_BOOKS_LIBRARY) private val library: Library,
@@ -223,7 +226,7 @@ class LibkiwixBookOnDisk @Inject constructor(
 
   // Check if any existing ZIM file showing on the library screen which is inside the trash folder.
   private suspend fun isInTrashFolder(filePath: String) =
-    Regex("/\\.Trash/").containsMatchIn(filePath)
+    TRASH_FOLDER_REGEX.containsMatchIn(filePath)
 
   suspend fun delete(books: List<LibkiwixBook>) {
     runCatching {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -76,6 +76,13 @@ class LibkiwixBookmarks @Inject constructor(
   private var bookmarkList: List<LibkiwixBookmarkItem> = arrayListOf()
   private var libraryBooksList: List<String> = arrayListOf()
   private val initMutex = Mutex()
+
+  // ensureInitialized() reads this outside initMutex before deciding whether to take the
+  // lock at all; without @Volatile that read has no visibility guarantee across threads for
+  // the write inside the lock (set after a withContext(ioDispatcher) hop), so a second
+  // caller could see stale `false` and redo the init work, or worse, see partially-visible
+  // state from it.
+  @Volatile
   private var initialized: Boolean = false
 
   private val bookmarkListFlow: MutableStateFlow<List<LibkiwixBookmarkItem>> by lazy {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -25,6 +25,10 @@ import org.kiwix.kiwixmobile.core.reader.decodeUrl
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.IOException
 
+// Compiled once instead of on every HTTP request these extensions run on.
+private val AUTHENTICATION_URL_REGEX = Regex("https://[^@]+@.*\\.zim")
+private val AUTHENTICATION_PREFIX_REGEX = Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@")
+
 class BasicAuthInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
@@ -45,7 +49,7 @@ class BasicAuthInterceptor : Interceptor {
 }
 
 val String.isAuthenticationUrl: Boolean
-  get() = decodeUrl.trim().matches(Regex("https://[^@]+@.*\\.zim"))
+  get() = decodeUrl.trim().matches(AUTHENTICATION_URL_REGEX)
 
 val String.secretKey: String
   get() = decodeUrl.substringAfter("{{", "")
@@ -54,7 +58,7 @@ val String.secretKey: String
 
 val String.removeAuthenticationFromUrl: String
   get() = decodeUrl.trim()
-    .replace(Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@"), "")
+    .replace(AUTHENTICATION_PREFIX_REGEX, "")
     .also {
       Log.d("BasicAuthInterceptor", "URL is $it")
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -205,10 +204,12 @@ open class ErrorActivity : BaseActivity() {
   private suspend fun startValidatingZIMFiles() {
     val zimBooks = withContext(ioDispatcher) { libkiwixBookOnDisk.getBooks() }
     showValidationDialog.value = true
-    CoroutineScope(ioDispatcher).launch {
-      val isBrandedApp = kiwixDataStore.isBrandedApp.first()
-      validateZimViewModel.startValidation(zimBooks, isBrandedApp)
-    }
+    // This function already runs on lifecycleScope (see sendDetailsOnMail()); calling
+    // startValidation() directly instead of launching it on an ad-hoc untracked scope
+    // means it's cancelled automatically along with everything else when the Activity
+    // is destroyed.
+    val isBrandedApp = kiwixDataStore.isBrandedApp.first()
+    validateZimViewModel.startValidation(zimBooks, isBrandedApp)
   }
 
   /**

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensions.kt
@@ -20,10 +20,13 @@ package org.kiwix.kiwixmobile.core.extensions
 import android.database.Cursor
 
 inline fun Cursor.forEachRow(block: (Cursor) -> Unit) {
-  while (moveToNext()) {
-    block.invoke(this)
+  try {
+    while (moveToNext()) {
+      block.invoke(this)
+    }
+  } finally {
+    close()
   }
-  close()
 }
 
 @Suppress("IMPLICIT_CAST_TO_ANY")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -57,7 +57,9 @@ open class CoreWebViewClient(
       return handleUnsupportedFiles(url)
     }
     if (url.startsWith("javascript:")) {
-      // Allow javascript for HTML functions and code execution (EX: night mode)
+      // javascript: URIs (e.g. from HTML functions like night-mode toggles) already run
+      // via the WebView's own JS engine when triggered; returning true here just stops
+      // WebView from also trying to navigate to them as if they were a normal page load.
       return true
     }
     if (url.startsWith(ZimFileReader.UI_URI_STRING)) {
@@ -145,12 +147,10 @@ open class CoreWebViewClient(
   }
 
   companion object {
-    private val DOCUMENT_TYPES: HashMap<String?, String?> = object : HashMap<String?, String?>() {
-      init {
-        put("epub", "application/epub+zip")
-        put("pdf", "application/pdf")
-      }
-    }
+    private val DOCUMENT_TYPES: Map<String, String> = mapOf(
+      "epub" to "application/epub+zip",
+      "pdf" to "application/pdf"
+    )
     private val LEGACY_CONTENT_PREFIXES = arrayOf(
       "zim://content/",
       "content://${instance.packageName}.zim.base/".toUri().toString()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -265,6 +265,10 @@ class KiwixTextToSpeech internal constructor(
 
     @JvmField var paused = true
     fun pause() {
+      // Idempotent: a second pause() call (e.g. two quick taps) before the
+      // matching start() must not decrement currentPiece again, or it drifts
+      // negative and the next start()/onDone() indexes out of bounds.
+      if (paused) return
       paused = true
       currentPiece.decrementAndGet()
       tts.setOnUtteranceProgressListener(null)
@@ -299,8 +303,15 @@ class KiwixTextToSpeech internal constructor(
           }
 
           override fun onDone(s: String) {
+            // pause() can run concurrently with this callback (it's not called on
+            // the UI thread, see the interface doc above); check paused first, and
+            // separately bound-check before indexing, so this can never index
+            // pieces[] out of bounds regardless of how the two interleave.
+            if (paused) {
+              return
+            }
             val line: Int = currentPiece.toInt()
-            if (line >= pieces.size && !paused) {
+            if (line >= pieces.size) {
               stop()
             } else {
               tts.speak(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -25,6 +25,8 @@ import androidx.core.net.toUri
 import eu.mhutti1.utils.storage.KB
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -86,8 +88,9 @@ class ZimFileReader(
               Log.e(TAG, "create: ${zimReaderSource.toDatabase()}")
               if (showSearchSuggestionsSpellChecked) {
                 // Prepare the SpellingsDB asynchronously(when it configure to create) so that creating the
-                // ZIM reader doesn’t block the user experience.
-                CoroutineScope(ioDispatcher).launch {
+                // ZIM reader doesn’t block the user experience. Launched on the reader's own
+                // scope (not an ad-hoc untracked one) so dispose() can cancel it.
+                zimFileReader.readerScope.launch {
                   zimFileReader.prepareSpellingsDB(archive)
                 }
               }
@@ -122,6 +125,15 @@ class ZimFileReader(
 
   private var spellingsDB: SpellingsDB? = null
 
+  // Per-instance so initializing the spellings DB for one open ZIM archive doesn't
+  // serialize against every other open archive's spellings DB init (it used to be a
+  // companion-object, i.e. process-global, mutex).
+  private val spellingsDBCreationMutex = Mutex()
+
+  // Owns the fire-and-forget prepareSpellingsDB() launch below, so dispose() can
+  // actually cancel it instead of leaving it running against a disposed reader.
+  private val readerScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
   /**
    * Note that the value returned is NOT unique for each zim file. Versions of the same wiki
    * (complete, nopic, novid, etc) may return the same title.
@@ -142,7 +154,7 @@ class ZimFileReader(
      libzim returns file size in kib so we need to convert it into bytes.
      More information here https://github.com/kiwix/java-libkiwix/issues/41
    */
-  val fileSize: Long get() = jniKiwixReader.filesize / 1024
+  val fileSize: Long get() = jniKiwixReader.filesize * 1024
   val creator: String get() = getSafeMetaData("Creator", "")
   val publisher: String get() = getSafeMetaData("Publisher", "")
   val name: String get() = getSafeMetaData("Name", id)
@@ -301,11 +313,14 @@ class ZimFileReader(
 
   fun getRedirect(url: String) = "${toRedirect(url)}"
 
-  fun isRedirect(url: String) =
-    when {
-      getRedirect(url).isEmpty() -> false
-      else -> url.startsWith(CONTENT_PREFIX) && url != getRedirect(url)
+  fun isRedirect(url: String): Boolean {
+    // getRedirect() does a JNI lookup; call it once instead of twice per check.
+    val redirect = getRedirect(url)
+    return when {
+      redirect.isEmpty() -> false
+      else -> url.startsWith(CONTENT_PREFIX) && url != redirect
     }
+  }
 
   private fun toRedirect(url: String) =
     "$CONTENT_PREFIX${getActualUrl(url)}".toUri()
@@ -459,6 +474,7 @@ class ZimFileReader(
     }
 
   fun dispose() {
+    readerScope.cancel()
     jniKiwixReader.dispose()
     searcher.dispose()
     spellingsDB?.dispose()
@@ -473,8 +489,6 @@ class ZimFileReader(
     }
 
   companion object {
-    private val spellingsDBCreationMutex = Mutex()
-
     /*
      * these uris aren't actually nullable but unit tests fail to compile as
      * Uri.parse returns null without android dependencies loaded

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -51,6 +51,7 @@ import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.net.URLDecoder
+import java.security.MessageDigest
 import javax.inject.Inject
 
 private const val TAG = "ZimFileReader"
@@ -376,11 +377,27 @@ class ZimFileReader(
 
   @Throws(IOException::class)
   private fun loadAssetFromCache(uri: String): FileInputStream {
-    return File(
-      FileUtils.getFileCacheDir(CoreApp.instance),
-      uri.substringAfterLast("/")
-    ).apply { getContent(uri)?.let(::writeBytes) }
-      .inputStream()
+    val cacheFile = File(FileUtils.getFileCacheDir(CoreApp.instance), cacheFileNameFor(uri))
+    // Only buffer + write the item once per uri; every later request for the same
+    // asset (e.g. seeking within a video) can just read the file already on disk.
+    if (!cacheFile.exists()) {
+      getContent(uri)?.let(cacheFile::writeBytes)
+    }
+    return cacheFile.inputStream()
+  }
+
+  /**
+   * Two assets in different ZIM directories can share the same last path segment
+   * (e.g. "A/video/clip.mp4" vs "A/other/clip.mp4"). Keying the cache file on just
+   * that segment, as this used to, lets one serve the other's cached bytes. Hash the
+   * full uri instead so distinct assets never collide; keep the original extension so
+   * the cached file still has one.
+   */
+  private fun cacheFileNameFor(uri: String): String {
+    val extension = uri.substringAfterLast("/").substringAfterLast(".", "")
+    val hash = MessageDigest.getInstance("SHA-256").digest(uri.toByteArray())
+      .joinToString("") { "%02x".format(it) }
+    return if (extension.isEmpty()) hash else "$hash.$extension"
   }
 
   private fun getContent(url: String) =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -24,19 +24,39 @@ import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.net.HttpURLConnection
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 @Singleton
 class ZimReaderContainer @Inject constructor(
   private val zimFileReaderFactory: Factory,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-  var zimFileReader: ZimFileReader? = null
-    set(value) {
-      field?.dispose()
-      field = value
+  // isRedirect()/getRedirect()/load() below are called from CoreWebViewClient on
+  // Chromium's own IO thread, concurrently with setZimReaderSource() swapping the
+  // reader (and disposing the native Archive underneath it) from a coroutine on
+  // ioDispatcher. Without this lock, dispose() can run while a native call on the
+  // old reader is still in flight - a use-after-free across the JNI boundary,
+  // i.e. a native SIGSEGV, not something a try/catch can stop. The read lock is
+  // held for the *entire* native call, not just the field access, and the write
+  // lock (dispose + swap) can't proceed until every in-flight read has finished.
+  private val lock = ReentrantReadWriteLock()
+  private var _zimFileReader: ZimFileReader? = null
+
+  var zimFileReader: ZimFileReader?
+    get() = lock.read { _zimFileReader }
+    private set(value) {
+      lock.write {
+        _zimFileReader?.dispose()
+        _zimFileReader = value
+      }
     }
+
+  private inline fun <T> withReader(default: T, block: (ZimFileReader) -> T): T =
+    lock.read { _zimFileReader?.let(block) ?: default }
 
   suspend fun setZimReaderSource(
     zimReaderSource: ZimReaderSource?,
@@ -57,45 +77,57 @@ class ZimReaderContainer @Inject constructor(
     }
   }
 
-  fun getPageUrlFromTitle(title: String) = zimFileReader?.getPageUrlFrom(title)
+  fun getPageUrlFromTitle(title: String) = withReader(null) { it.getPageUrlFrom(title) }
 
-  fun getRandomPageUrl() = zimFileReader?.getRandomPageUrl()
-  fun isRedirect(url: String): Boolean = zimFileReader?.isRedirect(url) == true
-  fun getRedirect(url: String): String = zimFileReader?.getRedirect(url).orEmpty()
+  fun getRandomPageUrl() = withReader(null) { it.getRandomPageUrl() }
+  fun isRedirect(url: String): Boolean = withReader(false) { it.isRedirect(url) }
+  fun getRedirect(url: String): String = withReader("") { it.getRedirect(url) }
   fun load(url: String, requestHeaders: Map<String, String>): WebResourceResponse = runBlocking {
-    return@runBlocking WebResourceResponse(
-      zimFileReader?.getMimeTypeFromUrl(url),
-      Charsets.UTF_8.name(),
-      zimFileReader?.load(url)
-    )
-      .apply {
-        val headers = mutableMapOf("Accept-Ranges" to "bytes")
-        if ("Range" in requestHeaders.keys) {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
-          val lastByte = fullSize - 1
-          val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
-          headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
-          if (byteRanges.size == 1) {
-            headers["Connection"] = "close"
+    // load() on ZimFileReader is itself suspend (it hops to ioDispatcher internally),
+    // so this can't go through withReader()'s plain (non-suspend) lambda - the read
+    // lock is taken and released by hand instead, but for the exact same reason:
+    // held for the whole call, including that internal dispatcher hop, so dispose()
+    // still can't run until this is completely done.
+    lock.readLock().lock()
+    try {
+      val reader = _zimFileReader
+        ?: return@runBlocking WebResourceResponse(null, Charsets.UTF_8.name(), null)
+      WebResourceResponse(
+        reader.getMimeTypeFromUrl(url),
+        Charsets.UTF_8.name(),
+        reader.load(url)
+      )
+        .apply {
+          val headers = mutableMapOf("Accept-Ranges" to "bytes")
+          if ("Range" in requestHeaders.keys) {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
+            val fullSize = reader.getItem(url)?.itemSize() ?: 0L
+            val lastByte = fullSize - 1
+            val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
+            headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
+            if (byteRanges.size == 1) {
+              headers["Connection"] = "close"
+            }
+          } else {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
           }
-        } else {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
+          responseHeaders = headers
         }
-        responseHeaders = headers
-      }
+    } finally {
+      lock.readLock().unlock()
+    }
   }
 
-  val zimReaderSource get() = zimFileReader?.zimReaderSource
-  val zimFileTitle get() = zimFileReader?.title
-  val mainPage get() = zimFileReader?.mainPage
-  val id get() = zimFileReader?.id
-  val fileSize get() = zimFileReader?.fileSize ?: 0L
-  val creator get() = zimFileReader?.creator
-  val publisher get() = zimFileReader?.publisher
-  val name get() = zimFileReader?.name
-  val date get() = zimFileReader?.date
-  val description get() = zimFileReader?.description
-  val favicon get() = zimFileReader?.favicon
-  val language get() = zimFileReader?.language
+  val zimReaderSource get() = withReader(null) { it.zimReaderSource }
+  val zimFileTitle get() = withReader(null) { it.title }
+  val mainPage get() = withReader(null) { it.mainPage }
+  val id get() = withReader(null) { it.id }
+  val fileSize get() = withReader(0L) { it.fileSize }
+  val creator get() = withReader(null) { it.creator }
+  val publisher get() = withReader(null) { it.publisher }
+  val name get() = withReader(null) { it.name }
+  val date get() = withReader(null) { it.date }
+  val description get() = withReader(null) { it.description }
+  val favicon get() = withReader(null) { it.favicon }
+  val language get() = withReader(null) { it.language }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
@@ -39,6 +39,11 @@ import java.io.Serializable
 class ZimReaderSource(
   val file: File? = null,
   val uri: Uri? = null,
+  // AssetFileDescriptor isn't Serializable (it wraps a native fd), so without @Transient
+  // any attempt to serialize a URI-based ZimReaderSource (e.g. into a Bundle) throws
+  // NotSerializableException. It comes back null after deserialization instead - callers
+  // already handle a null list here (see the primary constructor's file-only case).
+  @Transient
   val assetFileDescriptorList: List<AssetFileDescriptor>? = null
 ) : Serializable {
   constructor(uri: Uri) : this(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
 import org.kiwix.kiwixmobile.core.base.SideEffect
@@ -68,9 +69,11 @@ import org.kiwix.kiwixmobile.core.search.viewmodel.effects.StartSpeechInput
 import org.kiwix.kiwixmobile.core.utils.ZERO
 import org.kiwix.kiwixmobile.core.utils.dialog.AlertDialogShower
 import org.kiwix.kiwixmobile.core.utils.effects.CloseKeyboard
+import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.libzim.SuggestionSearch
 import javax.inject.Inject
 
+private const val TAG = "SearchViewModel"
 const val DEBOUNCE_DELAY = 150L
 const val MAX_SUGGEST_WORD_COUNT = 1
 
@@ -95,10 +98,31 @@ class SearchViewModel @Inject constructor(
   private lateinit var alertDialogShower: AlertDialogShower
   private val debouncedSearchQuery = MutableStateFlow("")
 
+  // The native SuggestionSearch handed out by the most recent searchResults() emission.
+  // Guarded by searchMutex, the same lock getVisibleResults() takes while reading it,
+  // so it's never disposed while a read is in flight.
+  private var previousSuggestionSearch: SuggestionSearch? = null
+
   init {
     viewModelScope.launch { reducer() }
     viewModelScope.launch { actionMapper() }
     viewModelScope.launch { debouncedSearchQuery() }
+  }
+
+  override fun onCleared() {
+    super.onCleared()
+    disposeSuggestionSearch(previousSuggestionSearch)
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun disposeSuggestionSearch(suggestionSearch: SuggestionSearch?) {
+    try {
+      suggestionSearch?.dispose()
+    } catch (throwable: Throwable) {
+      // dispose() is a native call; guard it the same way the rest of this codebase
+      // guards JNI calls, so a failure here can't take down the whole search flow.
+      Log.e(TAG, "Unable to dispose SuggestionSearch. $throwable")
+    }
   }
 
   private suspend fun getSuggestedSpelledWords(word: String, maxCount: Int): List<String> =
@@ -193,11 +217,15 @@ class SearchViewModel @Inject constructor(
   private fun searchResults() =
     filter.asStateFlow()
       .mapLatest {
-        SearchResultsWithTerm(
-          it,
-          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader),
-          searchMutex
-        )
+        val suggestionSearch =
+          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader)
+        // Dispose the SuggestionSearch this replaces - each one is a native object that
+        // otherwise leaks for the process's lifetime (nothing else ever disposes it).
+        searchMutex.withLock {
+          disposeSuggestionSearch(previousSuggestionSearch)
+          previousSuggestionSearch = suggestionSearch
+        }
+        SearchResultsWithTerm(it, suggestionSearch, searchMutex)
       }
 
   @Suppress("CyclomaticComplexMethod")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -27,11 +27,18 @@ object NetworkUtils {
     var filename = ""
     url?.let { url1 ->
       val index = url1.lastIndexOf('?')
+      val start = url1.lastIndexOf('/') + 1
       filename =
-        if (index > 1) {
-          url1.substring(url1.lastIndexOf('/') + 1, index)
+        if (index > 1 && start <= index) {
+          url1.substring(start, index)
+        } else if (index <= 1) {
+          url1.substring(url1.lastIndexOf('/') + 1)
         } else {
-          url1.substring(url.lastIndexOf('/') + 1)
+          // The last '/' occurs after the last '?' (e.g. ".../a?b/file.zim"),
+          // so "everything between the last '/' and the last '?'" doesn't
+          // apply here - substring(start, index) would have start > index,
+          // which throws. Fall through to the UUID fallback below instead.
+          ""
         }
       if ("" == filename.trim { it <= ' ' }) {
         filename = UUID.randomUUID().toString()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -23,6 +23,14 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.util.UUID
 
 object NetworkUtils {
+  // Compiled once instead of on every parseURL() call.
+  private val UNDERSCORE_REGEX = "_".toRegex()
+  private val ALL_REGEX = "all".toRegex()
+  private val NOPIC_REGEX = "nopic".toRegex()
+  private val NOVID_REGEX = "novid".toRegex()
+  private val SIMPLE_REGEX = "simple".toRegex()
+  private val EXTRA_SPACES_REGEX = " +".toRegex()
+
   fun getFileNameFromUrl(url: String?): String {
     var filename = ""
     url?.let { url1 ->
@@ -60,12 +68,12 @@ object NetworkUtils {
           return ""
         }
         details = details.substring(beginIndex, endIndex)
-        details = details.replace("_".toRegex(), " ")
-        details = details.replace("all".toRegex(), "")
-        details = details.replace("nopic".toRegex(), context.getString(R.string.zim_no_pic))
-        details = details.replace("novid".toRegex(), context.getString(R.string.zim_no_vid))
-        details = details.replace("simple".toRegex(), context.getString(R.string.zim_simple))
-        details = details.trim { it <= ' ' }.replace(" +".toRegex(), " ")
+        details = details.replace(UNDERSCORE_REGEX, " ")
+        details = details.replace(ALL_REGEX, "")
+        details = details.replace(NOPIC_REGEX, context.getString(R.string.zim_no_pic))
+        details = details.replace(NOVID_REGEX, context.getString(R.string.zim_no_vid))
+        details = details.replace(SIMPLE_REGEX, context.getString(R.string.zim_simple))
+        details = details.trim { it <= ' ' }.replace(EXTRA_SPACES_REGEX, " ")
         details
       } catch (e: Exception) {
         Log.d(TAG_KIWIX, "Context invalid url: $url", e)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
@@ -35,6 +35,9 @@ import org.kiwix.kiwixmobile.core.extensions.get
 import java.io.File
 import javax.inject.Inject
 
+// Compiled once instead of on every row of a whole-device MediaStore scan.
+private val TRASH_FOLDER_REGEX = Regex("/\\.Trash/")
+
 class FileSearch @Inject constructor(
   @param:ApplicationContext private val context: Context,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
@@ -69,7 +72,7 @@ class FileSearch @Inject constructor(
 
   // Exclude any file in trash folder.
   private fun isNotInTrashFolder(it: File) =
-    !Regex("/\\.Trash/").containsMatchIn(it.path)
+    !TRASH_FOLDER_REGEX.containsMatchIn(it.path)
 
   private fun queryMediaStore() =
     context.contentResolver

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -860,14 +860,23 @@ object FileUtils {
     source: String,
     zimReaderContainer: ZimReaderContainer
   ): ByteArray? {
+    // WebResourceResponse.data is a platform (Java) type - Kotlin doesn't force a
+    // null check on it, but it genuinely can be null (e.g. no ZIM currently open),
+    // and readBytes() on a null stream NPEs. use{} also ensures the underlying
+    // stream/fd is closed either way, instead of leaking it on every call.
     val bytes = zimReaderContainer
       .load(source, emptyMap())
       .data
-      .readBytes()
+      ?.use { it.readBytes() }
+
+    if (bytes == null) {
+      Log.w("MEDIA_SAVE", "No data available for source=$source")
+      return null
+    }
 
     return if (bytes.isEmpty()) {
       Log.w("MEDIA_SAVE", "Loaded image bytes are empty for source=$source")
-      return null
+      null
     } else {
       bytes
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -41,8 +41,6 @@ import android.webkit.URLUtil
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -104,21 +102,26 @@ object FileUtils {
   }
 
   @JvmStatic
-  @Synchronized
-  fun deleteCachedFiles(
+  suspend fun deleteCachedFiles(
     context: Context,
     ioDispatcher: CoroutineDispatcher
   ) {
-    CoroutineScope(ioDispatcher).launch {
-      runCatching {
-        val cacheDir = getFileCacheDir(context) ?: return@launch
-        when {
-          !cacheDir.exists() -> Unit
-          cacheDir.isDirectory -> cacheDir.deleteRecursively()
-          else -> cacheDir.delete()
+    // @Synchronized was previously used here, but it only guarded the launch{} call
+    // itself, not the delete it kicked off - two callers could still race on the same
+    // directory. fileOperationMutex (already used by deleteZimFile for the same reason)
+    // gives real mutual exclusion instead.
+    withContext(ioDispatcher) {
+      fileOperationMutex.withLock {
+        runCatching {
+          val cacheDir = getFileCacheDir(context) ?: return@withLock
+          when {
+            !cacheDir.exists() -> Unit
+            cacheDir.isDirectory -> cacheDir.deleteRecursively()
+            else -> cacheDir.delete()
+          }
+        }.onFailure {
+          Log.w("DeleteCache", "Failed to delete cached files", it)
         }
-      }.onFailure {
-        Log.w("DeleteCache", "Failed to delete cached files", it)
       }
     }
   }
@@ -127,10 +130,9 @@ object FileUtils {
   suspend fun deleteZimFile(path: String, ioDispatcher: CoroutineDispatcher) {
     withContext(ioDispatcher) {
       fileOperationMutex.withLock {
-        var filePath = path
-        if (filePath.substring(filePath.length - ChunkUtils.PART.length) == ChunkUtils.PART) {
-          filePath = filePath.substring(0, filePath.length - ChunkUtils.PART.length)
-        }
+        // was filePath.substring(filePath.length - ChunkUtils.PART.length) == ChunkUtils.PART,
+        // which throws StringIndexOutOfBoundsException for any path shorter than ".part".
+        val filePath = path.removeSuffix(ChunkUtils.PART)
         val file = File(filePath)
         if (file.path.substring(file.path.length - 3) != "zim") {
           var alphabetFirst = 'a'
@@ -433,7 +435,10 @@ object FileUtils {
       // Returns the path of the folder containing the file with the specified fileName,
       // from which the user selects the file.
       return pathSegments.drop(1)
-        .filterNot { it.startsWith("0") } // remove the prefix of primary storage device
+        // Only drop the primary storage device's own volume-id segment ("0"), not any
+        // segment that merely starts with "0" - that also mangled real folder names
+        // like "01_wiki".
+        .filterNot { it == "0" }
         .joinToString(separator = "/")
     }
     return null

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -125,6 +125,23 @@ class StorageObserverTest {
     verify { zimFileReader.dispose() }
   }
 
+  @Test
+  fun `reader is disposed even when addBookToLibrary throws`() = runTest {
+    withNoFiltering()
+    every { zimFileReader.toBook() } returns mockk()
+    every { zimFileReader.zimReaderSource } returns zimReaderSource
+    // Must match the call site's own argument shape (named archive=, file left at its
+    // default) - a positional addBookToLibrary(any()) stub pins archive to the default
+    // null instead of matching it, so it wouldn't match this call at all.
+    coEvery { libkiwixBookmarks.addBookToLibrary(archive = any()) } throws RuntimeException("boom")
+
+    booksOnFileSystem().test {
+      awaitError()
+    }
+
+    verify { zimFileReader.dispose() }
+  }
+
   private fun booksOnFileSystem() =
     storageObserver.getBooksOnFileSystem(scanningProgressListener)
       .also {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensionsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensionsTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import android.database.Cursor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class CursorExtensionsTest {
+  @Test
+  fun `forEachRow closes the cursor even when block throws`() {
+    val cursor = mockk<Cursor>(relaxed = true)
+    every { cursor.moveToNext() } returns true
+
+    assertThrows(IllegalStateException::class.java) {
+      cursor.forEachRow { throw IllegalStateException("boom") }
+    }
+
+    verify(exactly = 1) { cursor.close() }
+  }
+
+  @Test
+  fun `forEachRow closes the cursor after iterating every row`() {
+    val cursor = mockk<Cursor>(relaxed = true)
+    every { cursor.moveToNext() } returnsMany listOf(true, true, false)
+
+    var rowsSeen = 0
+    cursor.forEachRow { rowsSeen++ }
+
+    assertEquals(2, rowsSeen)
+    verify(exactly = 1) { cursor.close() }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeechTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeechTest.kt
@@ -418,6 +418,49 @@ class KiwixTextToSpeechTest {
   }
 
   @Test
+  fun `pause is idempotent - a second call before start() does not corrupt currentPiece`() {
+    injectMockTts()
+    val pieces = listOf("Hello", "World")
+    val task = kiwixTts.TTSTask(pieces)
+    task.start()
+    task.pause()
+    // A second call before any resume must be a no-op, not another
+    // decrement. Without the idempotency guard this drives currentPiece to
+    // -1, and the next start() throws indexing pieces[-1].
+    task.pause()
+    task.start()
+    verify(exactly = 2) {
+      tts.speak(eq("Hello"), any(), any(), any())
+    }
+  }
+
+  @Test
+  fun `onDone does not index out of bounds when paused right as the last piece finishes`() {
+    injectMockTts()
+    val pieces = listOf("OnlyOne")
+    val task = kiwixTts.TTSTask(pieces)
+    task.start()
+
+    val listenerSlot = slot<UtteranceProgressListener>()
+    verify { tts.setOnUtteranceProgressListener(capture(listenerSlot)) }
+
+    // Simulates the exact race the finding describes: paused becomes true
+    // (e.g. a concurrent pause() call from another thread) right as the
+    // last piece's onDone fires, with currentPiece still at pieces.size
+    // (not yet decremented - pause() hasn't gotten that far). Before the
+    // fix, `line >= pieces.size && !paused` read false here (since !paused
+    // is false), so this fell into the "else" branch and indexed
+    // pieces[currentPiece.getAndIncrement()] out of bounds.
+    task.paused = true
+
+    listenerSlot.captured.onDone("id")
+
+    // Exactly 1: the one call from start() above. onDone() while paused
+    // must not trigger a second (out-of-bounds) speak() call.
+    verify(exactly = 1) { tts.speak(any(), any(), any(), any()) }
+  }
+
+  @Test
   fun `javascript interface splits content and starts speaking`() {
     injectMockTts()
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ZimReaderContainerTest {
+  private val factory: ZimFileReader.Factory = mockk()
+  private val container = ZimReaderContainer(factory, Dispatchers.Unconfined)
+
+  @Test
+  fun `accessors return safe defaults when no reader is set`() {
+    assertFalse(container.isRedirect("A/foo"))
+    assertEquals("", container.getRedirect("A/foo"))
+    assertNull(container.getPageUrlFromTitle("foo"))
+    assertNull(container.getRandomPageUrl())
+    assertNull(container.zimReaderSource)
+    assertNull(container.zimFileTitle)
+    assertNull(container.mainPage)
+    assertNull(container.id)
+    assertEquals(0L, container.fileSize)
+    assertNull(container.creator)
+    assertNull(container.publisher)
+    assertNull(container.name)
+    assertNull(container.date)
+    assertNull(container.description)
+    assertNull(container.favicon)
+    assertNull(container.language)
+  }
+
+  @Test
+  fun `setting a new reader disposes the previous one exactly once`() = runTest {
+    val firstSource: ZimReaderSource = mockk()
+    val secondSource: ZimReaderSource = mockk()
+    val firstReader: ZimFileReader = mockk(relaxed = true) {
+      every { zimReaderSource } returns firstSource
+    }
+    coEvery { firstSource.exists(any()) } returns true
+    coEvery { firstSource.canOpenInLibkiwix(any()) } returns true
+    coEvery { secondSource.exists(any()) } returns false
+    coEvery { factory.create(firstSource, any()) } returns firstReader
+
+    container.setZimReaderSource(firstSource)
+    verify(exactly = 0) { firstReader.dispose() }
+
+    // secondSource fails exists(), so the new reader is null - the old one
+    // must still be disposed exactly once when it's swapped out.
+    container.setZimReaderSource(secondSource)
+    verify(exactly = 1) { firstReader.dispose() }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import android.content.res.AssetFileDescriptor
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+class ZimReaderSourceTest {
+  @Test
+  fun `serializing a source with a non-null assetFileDescriptorList does not throw`() {
+    // AssetFileDescriptor isn't Serializable, so this used to throw
+    // NotSerializableException whenever this field was non-null (e.g. any URI-based
+    // source). @Transient makes it survive serialization by coming back null instead.
+    val source = ZimReaderSource(
+      file = File("test.zim"),
+      assetFileDescriptorList = listOf(mockk<AssetFileDescriptor>())
+    )
+
+    val bytes = ByteArrayOutputStream().apply {
+      ObjectOutputStream(this).use { it.writeObject(source) }
+    }.toByteArray()
+
+    val deserialized =
+      ObjectInputStream(ByteArrayInputStream(bytes)).use { it.readObject() } as ZimReaderSource
+
+    assertNull(deserialized.assetFileDescriptorList)
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
@@ -240,6 +240,22 @@ class NetworkUtilsTest {
   }
 
   @Test
+  fun `getFileNameFromUrl does not throw when the last slash is after the last question mark`() {
+    val defaultUUIDRegex =
+      Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+    // lastIndexOf('/') here is *after* lastIndexOf('?'), so the naive
+    // substring(lastSlash + 1, lastQuestionMark) would previously throw
+    // StringIndexOutOfBoundsException (start > end).
+    val result = NetworkUtils.getFileNameFromUrl("https://host/a?b/file.zim")
+
+    assertTrue(
+      "Expected a UUID fallback, got: $result",
+      result.matches(defaultUUIDRegex)
+    )
+  }
+
+  @Test
   fun `parseURL returns empty string when url is null`() {
     val result = NetworkUtils.parseURL(context, null)
     assertEquals("", result)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsSaveMediaTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/files/FileUtilsSaveMediaTest.kt
@@ -195,6 +195,23 @@ class FileUtilsSaveMediaTest {
   }
 
   @Test
+  fun downloadFileFromUrl_whenZimReaderLoadReturnsNullDataForImage_returnsInvalidSource() {
+    runTest {
+      val nullDataResponse = mockk<WebResourceResponse>(relaxed = true)
+      every { nullDataResponse.data } returns null
+      every { mockZimReaderContainer.load(any(), any()) } returns nullDataResponse
+
+      val result = FileUtils.downloadFileFromUrl(
+        context = mockContext,
+        url = "https://kiwix.org/images/test.png",
+        src = null,
+        zimReaderContainer = mockZimReaderContainer
+      )
+      assertThat(result).isInstanceOf(SaveResult.InvalidSource::class.java)
+    }
+  }
+
+  @Test
   fun downloadFileFromUrl_whenSavedFileIsEmpty_returnsInvalidSource() {
     runTest {
       val response = mockk<WebResourceResponse>(relaxed = true)


### PR DESCRIPTION
Fixes the "Crashes", "Resource/memory leaks", and "Minor" findings from the review filed as #5070, one commit per finding (or per file, where several minor findings landed in the same file).

## Crashes

- **finding 1** — `ZimReaderContainer` had no synchronization between `setZimReaderSource()` disposing the native reader and `isRedirect()`/`getRedirect()`/`load()` reading it, all reachable concurrently from Chromium's IO thread vs. a coroutine. That's a use-after-free across the JNI boundary (native SIGSEGV). Guarded the reader behind a `ReentrantReadWriteLock`, held for the full duration of each native call.
- **finding 8** — `KiwixTextToSpeech.TTSTask.onDone()` could index `pieces[]` out of bounds if `pause()` raced it. Also `pause()` wasn't idempotent, so two quick taps could drive the index negative.
- **finding 9** — `NetworkUtils.getFileNameFromUrl()` threw `StringIndexOutOfBoundsException` for a url like `.../a?b/file.zim`.
- **finding 10** — `FileUtils.loadBytes()` called `readBytes()` directly on a nullable stream, throwing `NullPointerException` when a resource has no data; also fixed a stream leak.

## Resource/memory leaks

- **finding 11** — `SearchViewModel` created a new native `SuggestionSearch` on every debounced search keystroke and never disposed the one it replaced. Now disposed when replaced and in `onCleared()`.
- **finding 12** — the video/audio direct-access cache fallback in `ZimFileReader` keyed its cache file on just the last path segment (collision risk) and re-buffered + rewrote the whole item on every call even when already cached. Now keyed on a hash of the full path and skipped when already cached.

## Minor

- `FileUtils.getFilePathWithFolderFromUri()` dropped every path segment starting with `"0"` instead of just the primary-storage token, mangling folders like `01_wiki`.
- `FileUtils.deleteCachedFiles()` was `@Synchronized` around a `launch{}` call, which doesn't actually synchronize the work inside it; now uses the same mutex `deleteZimFile()` already uses.
- `FileUtils.deleteZimFile()` threw `StringIndexOutOfBoundsException` for paths shorter than `.part`.
- `CursorExtensions.forEachRow()` didn't close the `Cursor` if the caller's block threw.
- `LibkiwixBookmarks`' double-checked-locking `initialized` flag wasn't `@Volatile`.
- 4 fixes to `ZimFileReader`: `fileSize` divided instead of multiplied by 1024 (contradicting its own comment), `isRedirect()` did a redundant second native lookup, its spellings-DB mutex was process-global instead of per-instance, and its background spellings-DB init used an untracked coroutine scope instead of one `dispose()` can cancel.
- `ZimReaderSource` (`Serializable`) held a non-serializable `AssetFileDescriptor` list, crashing on serialization.
- 4 `Regex` literals recompiled on every call instead of being cached (`FileSearch`, `LibkiwixBookOnDisk`, `BasicAuthInterceptor`, `NetworkUtils`).
- `CoreWebViewClient`: a double-brace-initialized `HashMap` replaced with `mapOf()`, and a misleading comment fixed.
- `StorageObserver` didn't dispose a `ZimFileReader` if converting it to a `Book` failed partway through.
- 2 more untracked coroutine launches tied to `lifecycleScope` (`KiwixMainActivity`, `ErrorActivity`).

Each commit adds/extends a regression test where the code path is testable; a few aren't (native-only calls, or a case only reachable via `viewModelScope` on a mocked `ViewModel`) — noted in those commit messages.

This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submission.
