### PR TITLE
fix: close crash, leak, and startup-timing findings from review (#5070)

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -289,17 +289,28 @@ class DownloadMonitorService : Service() {
 
   private fun startForegroundService() {
     runCatching {
-      CoroutineScope(ioDispatcher).launch {
-        downloadNotificationChannel()
-        startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
+      // startForeground() must be called synchronously, promptly after the service
+      // starts, or the system throws ForegroundServiceDidNotStartInTimeException.
+      // Suspending on the DataStore-backed app name first (as this used to, inside an
+      // ad-hoc scope that also outlived onDestroy) risked missing that window. Start
+      // with a placeholder notification using the synchronously-available app label,
+      // then swap in the real content once the DataStore read completes.
+      downloadNotificationChannel()
+      startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification(appLabel))
+      scope?.launch {
+        val notification = buildForegroundNotification(kiwixDataStore.appName.first())
+        notificationManager.notify(DOWNLOAD_SERVICE_NOTIFICATION_ID, notification)
         startPausedDownloadsDueToAndroidServiceLimitation()
       }
     }.onFailure { it.printStackTrace() }
   }
 
-  private suspend fun buildForegroundNotification(): Notification =
+  private val appLabel: String
+    get() = applicationInfo.loadLabel(packageManager).toString()
+
+  private fun buildForegroundNotification(title: String): Notification =
     NotificationCompat.Builder(this, DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-      .setContentTitle(kiwixDataStore.appName.first())
+      .setContentTitle(title)
       .setContentText(getString(string.download_notification_channel_description))
       .setSmallIcon(android.R.drawable.stat_sys_download)
       .setGroup(ACTIVE_DOWNLOAD_GROUP_KEY)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -265,6 +265,9 @@ class KiwixTextToSpeech internal constructor(
 
     @JvmField var paused = true
     fun pause() {
+      // Idempotent: a second pause() call (e.g. two quick taps) must not decrement
+      // currentPiece again, which would drive it negative and crash on the next speak.
+      if (paused) return
       paused = true
       currentPiece.decrementAndGet()
       tts.setOnUtteranceProgressListener(null)
@@ -300,16 +303,21 @@ class KiwixTextToSpeech internal constructor(
 
           override fun onDone(s: String) {
             val line: Int = currentPiece.toInt()
-            if (line >= pieces.size && !paused) {
-              stop()
-            } else {
-              tts.speak(
-                pieces[currentPiece.getAndIncrement()],
-                TextToSpeech.QUEUE_ADD,
-                bundle,
-                bundle.getString(Engine.KEY_PARAM_UTTERANCE_ID)
-              )
+            // Bounds check first: there's nothing left to speak once line >= pieces.size,
+            // whether or not we're paused. Previously the paused case fell through to the
+            // speak() branch below and indexed past the end of pieces.
+            if (line >= pieces.size) {
+              if (!paused) {
+                stop()
+              }
+              return
             }
+            tts.speak(
+              pieces[currentPiece.getAndIncrement()],
+              TextToSpeech.QUEUE_ADD,
+              bundle,
+              bundle.getString(Engine.KEY_PARAM_UTTERANCE_ID)
+            )
           }
 
           @Deprecated("Deprecated in Java")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
@@ -46,10 +47,18 @@ class BookmarkViewModel @Inject constructor(
     zimReaderContainer,
     ioDispatcher
   ) {
-  override fun initialState(): BookmarkState {
-    val showAll = runBlocking { kiwixDataStore.showBookmarksOfAllBooks.first() }
-    return BookmarkState(emptyList(), showAll, zimReaderContainer.id)
+  init {
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showBookmarksOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
+
+  override fun initialState(): BookmarkState =
+    BookmarkState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.history.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem.HistoryItem
@@ -46,10 +47,18 @@ class HistoryViewModel @Inject constructor(
     zimReaderContainer,
     ioDispatcher
   ) {
-  override fun initialState(): HistoryState {
-    val showAll = runBlocking { kiwixDataStore.showHistoryOfAllBooks.first() }
-    return HistoryState(emptyList(), showAll, zimReaderContainer.id)
+  init {
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showHistoryOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
+
+  override fun initialState(): HistoryState =
+    HistoryState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(
     state: HistoryState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.notes.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -52,12 +53,17 @@ class NotesViewModel @Inject constructor(
   PageViewModelClickListener {
   init {
     setOnItemClickListener(this)
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showNotesOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
 
-  override fun initialState(): NotesState {
-    val showAll = runBlocking { kiwixDataStore.showNotesOfAllBooks.first() }
-    return NotesState(emptyList(), showAll, zimReaderContainer.id)
-  }
+  override fun initialState(): NotesState =
+    NotesState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(state: NotesState, action: Action.Filter): NotesState =
     state.copy(searchTerm = action.searchTerm)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -107,6 +107,16 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
   @VisibleForTesting
   fun getMutableStateForTestCases() = _state
 
+  /**
+   * Applies [transform] to the current state outside the Action/reducer pipeline. For
+   * subclasses that seed [initialState] with a synchronous default and then load the
+   * real value asynchronously (e.g. a DataStore-backed preference), instead of blocking
+   * the caller of the constructor with `runBlocking`.
+   */
+  protected fun updateState(transform: (S) -> S) {
+    _state.value = transform(_state.value)
+  }
+
   init {
     coroutineJobs.apply {
       add(observeActions())

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -376,11 +376,19 @@ class ZimFileReader(
 
   @Throws(IOException::class)
   private fun loadAssetFromCache(uri: String): FileInputStream {
-    return File(
+    // Key the cache file on a hash of the full uri, not just its last path segment -
+    // two assets in different ZIM directories can share a basename (e.g. "video.mp4")
+    // and would otherwise silently serve each other's cached bytes.
+    val cacheFile = File(
       FileUtils.getFileCacheDir(CoreApp.instance),
-      uri.substringAfterLast("/")
-    ).apply { getContent(uri)?.let(::writeBytes) }
-      .inputStream()
+      "${uri.hashCode()}_${uri.substringAfterLast("/")}"
+    )
+    // Only materialize the content once per cache file - previously this re-read and
+    // re-wrote the whole item on every single playback request for the same asset.
+    if (!cacheFile.exists()) {
+      getContent(uri)?.let(cacheFile::writeBytes)
+    }
+    return cacheFile.inputStream()
   }
 
   private fun getContent(url: String) =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -95,10 +95,26 @@ class SearchViewModel @Inject constructor(
   private lateinit var alertDialogShower: AlertDialogShower
   private val debouncedSearchQuery = MutableStateFlow("")
 
+  // Native object created per debounced keystroke in searchResults() below; tracked here
+  // so the previous one can be disposed once it's superseded, instead of leaking native
+  // memory on every search-as-you-type update. See #5070.
+  private var currentSuggestionSearch: SuggestionSearch? = null
+
   init {
     viewModelScope.launch { reducer() }
     viewModelScope.launch { actionMapper() }
     viewModelScope.launch { debouncedSearchQuery() }
+  }
+
+  override fun onCleared() {
+    super.onCleared()
+    currentSuggestionSearch?.dispose()
+    currentSuggestionSearch = null
+  }
+
+  private fun replaceCurrentSuggestionSearch(next: SuggestionSearch?) {
+    currentSuggestionSearch?.takeIf { it !== next }?.dispose()
+    currentSuggestionSearch = next
   }
 
   private suspend fun getSuggestedSpelledWords(word: String, maxCount: Int): List<String> =
@@ -193,11 +209,10 @@ class SearchViewModel @Inject constructor(
   private fun searchResults() =
     filter.asStateFlow()
       .mapLatest {
-        SearchResultsWithTerm(
-          it,
-          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader),
-          searchMutex
-        )
+        val suggestionSearch =
+          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader)
+        replaceCurrentSuggestionSearch(suggestionSearch)
+        SearchResultsWithTerm(it, suggestionSearch, searchMutex)
       }
 
   @Suppress("CyclomaticComplexMethod")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -27,11 +27,15 @@ object NetworkUtils {
     var filename = ""
     url?.let { url1 ->
       val index = url1.lastIndexOf('?')
+      val slashIndex = url1.lastIndexOf('/')
       filename =
-        if (index > 1) {
-          url1.substring(url1.lastIndexOf('/') + 1, index)
+        // Only take the "between last '/' and '?'" branch when that range is actually
+        // valid - a URL like ".../a?b/file.zim" has a '/' *after* the '?', which made
+        // the start offset exceed the end offset and throw StringIndexOutOfBounds.
+        if (index > 1 && slashIndex + 1 <= index) {
+          url1.substring(slashIndex + 1, index)
         } else {
-          url1.substring(url.lastIndexOf('/') + 1)
+          url1.substring(slashIndex + 1)
         }
       if ("" == filename.trim { it <= ' ' }) {
         filename = UUID.randomUUID().toString()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -860,14 +860,22 @@ object FileUtils {
     source: String,
     zimReaderContainer: ZimReaderContainer
   ): ByteArray? {
+    // .data is a platform-nullable InputStream (null when no ZIM is currently open);
+    // read it via .use{} so the underlying fd is closed either way, instead of
+    // leaking it and NPEing on a null stream.
     val bytes = zimReaderContainer
       .load(source, emptyMap())
       .data
-      .readBytes()
+      ?.use { it.readBytes() }
+
+    if (bytes == null) {
+      Log.w("MEDIA_SAVE", "No data stream available for source=$source")
+      return null
+    }
 
     return if (bytes.isEmpty()) {
       Log.w("MEDIA_SAVE", "Loaded image bytes are empty for source=$source")
-      return null
+      null
     } else {
       bytes
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -85,8 +85,16 @@ internal class BookmarkViewModelTest {
   }
 
   @Test
-  fun `Initial state returns initial state`() {
-    assertThat(viewModel.initialState()).isEqualTo(bookmarkState())
+  fun `Initial state returns a synchronous default before the DataStore value loads`() {
+    // initialState() itself must stay synchronous (no runBlocking) - the real,
+    // DataStore-backed showAll value is applied asynchronously afterward. See #5070.
+    assertThat(viewModel.initialState()).isEqualTo(bookmarkState(showAll = false))
+  }
+
+  @Test
+  fun `state reflects the DataStore value once it loads`() = runTest(testDispatcher) {
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertThat(viewModel.state.value).isEqualTo(bookmarkState(showAll = true))
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -119,7 +119,10 @@ internal class SearchViewModelTest {
       val searchTerm1 = "query1"
       val searchTerm2 = "query2"
       val searchTerm3 = "query3"
-      val suggestionSearch: SuggestionSearch = mockk()
+      // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+      // `every { ... }` stub would invoke it for real during recording and crash
+      // with UnsatisfiedLinkError in this plain-JVM test environment.
+      val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
 
       viewModel.uiState.test {
         skipItems(1)
@@ -140,7 +143,10 @@ internal class SearchViewModelTest {
       val searchTerm1 = "query1"
       val searchTerm2 = "query2"
       val searchTerm3 = "query3"
-      val suggestionSearch: SuggestionSearch = mockk()
+      // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+      // `every { ... }` stub would invoke it for real during recording and crash
+      // with UnsatisfiedLinkError in this plain-JVM test environment.
+      val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
 
       viewModel.uiState.test {
         skipItems(1)
@@ -196,7 +202,10 @@ internal class SearchViewModelTest {
       runTest {
         val searchTerm = "searchTerm"
         val searchOrigin = FromWebView
-        val suggestionSearch: SuggestionSearch = mockk()
+        // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+        // `every { ... }` stub would invoke it for real during recording and crash
+        // with UnsatisfiedLinkError in this plain-JVM test environment.
+        val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
         viewModel.uiState.test {
           skipItems(1)
 
@@ -208,9 +217,10 @@ internal class SearchViewModelTest {
           )
           advanceUntilIdle()
 
-          skipItems(1)
-
-          val item = awaitItem()
+          // Use the most recent item rather than a fixed skipItems()/awaitItem() count -
+          // seeding the debounced query (see emissionOf()) emits one extra intermediate
+          // uiState update whose exact position isn't the point of this assertion.
+          val item = expectMostRecentItem()
           assertThat(item.searchState.searchTerm).isEqualTo(searchTerm)
           assertThat(item.searchState.recentResults).isEqualTo(listOf(RecentSearchListItem("", "")))
           assertThat(item.searchState.searchOrigin).isEqualTo(searchOrigin)
@@ -263,6 +273,11 @@ internal class SearchViewModelTest {
       coEvery {
         searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
       } returns suggestionSearch
+      // Also seed the debounced query, not just the raw Filter action - otherwise the
+      // still-"" debounced flow's own stale default fires later (once its debounce
+      // delay elapses under advanceUntilIdle()) and reverts filter back to "", which
+      // superseded the real SuggestionSearch and (correctly) disposed it.
+      viewModel.onSearchValueChanged(searchTerm)
       viewModel.actions.tryEmit(Filter(searchTerm))
       recentsFromDb.tryEmit(databaseResults)
       viewModel.actions.tryEmit(ScreenWasStartedFrom(searchOrigin))

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
@@ -154,6 +154,14 @@ class NetworkUtilsTest {
   }
 
   @Test
+  fun `getFileNameFromUrl does not crash when a slash follows the question mark`() {
+    // Previously threw StringIndexOutOfBoundsException: see #5070.
+    val result = NetworkUtils.getFileNameFromUrl("https://host/a?b/file.zim")
+
+    assertEquals("file.zim", result)
+  }
+
+  @Test
   fun `parseURL returns empty when beginIndex greater than endIndex`() {
     every { context.getString(R.string.zim_no_pic) } returns "No Pictures"
     every { context.getString(R.string.zim_no_vid) } returns "No Videos"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes the "Crashes", "Resource/memory leaks", and "Other" sections of #5070 (6 of the 8 findings across those sections; see below for the 2 left as-is).

**Crashes**
- `KiwixTextToSpeech.TTSTask` — `onDone` indexed `pieces[]` past the end when the last piece finished while paused (the bounds check only fired when `!paused`). `pause()` also decremented `currentPiece` unconditionally, so a second quick pause drove it negative. Fixed the bounds check to apply regardless of paused state and made `pause()` idempotent.
- `NetworkUtils.getFileNameFromUrl` — threw `StringIndexOutOfBoundsException` for a URL like `.../a?b/file.zim`, where a `/` appears *after* the last `?`. Now only takes the between-slash-and-question-mark branch when that range is actually valid.
- `FileUtils.loadBytes` — read `.data` (a platform-nullable `InputStream`, null when no ZIM is open) with no null check or `.use{}`, leaking the fd and NPEing on a "save media" attempt with nothing open.

**Resource/memory leaks**
- `SearchViewModel` — a native `SuggestionSearch` was created on every debounced search keystroke and never disposed anywhere. Now tracks and disposes the previous one when superseded, and in `onCleared()`.
- `ZimFileReader.loadAssetFromCache` — rewrote the full video/audio item to disk on every playback request with no existence check, and keyed the cache file on basename alone (collision risk across ZIM directories with same-named assets). Now skips the write when already cached and keys on a hash of the full uri.

**Other**
- `DownloadMonitorService.startForegroundService` — called `startForeground` from an ad-hoc scope after a suspending DataStore read, risking `ForegroundServiceDidNotStartInTimeException`. Now calls `startForeground` synchronously with a placeholder notification (using the synchronously-available app label), then swaps in the real content once the DataStore value loads, using the service's own scope instead of a leaked ad-hoc one.
- `BookmarkViewModel`/`HistoryViewModel`/`NotesViewModel` — `initialState()` used `runBlocking` on a DataStore read, blocking the main thread during ViewModel construction. Added `PageViewModel.updateState()` so `initialState()` can seed a synchronous default and apply the real value asynchronously right after.

**Left as-is** (same underlying issue, different risk profile): `KiwixMainActivity`'s NavHost `startDestination` also uses `runBlocking` on a DataStore read, but fixing it needs a startup-UX decision (e.g. holding a splash screen vs. making the destination reactive) rather than a mechanical change to a high-blast-radius file — flagging for maintainer input rather than guessing.

**Test notes**: `SuggestionSearch.dispose()` is a native (JNI) method mockk cannot intercept, even on a relaxed mock — confirmed empirically (an `every { ... }` stub on a plain mock invokes the real native method during recording and crashes with `UnsatisfiedLinkError`; a bare non-relaxed `mockk()` is worse). Updated `SearchViewModelTest`'s three `SuggestionSearch` doubles to `mockk(relaxed = true)` and fixed one test's helper to also seed the debounced query, so a stale default doesn't independently revert `filter` later in the same run and trigger a real `.dispose()` call on the mock. Updated `BookmarkViewModelTest` for the new `initialState()` contract and added a test proving state converges to the real DataStore value once loaded. Added a regression test for the `NetworkUtils` crash.

Verified: `:core:compileDebugKotlin`, `:app:compileDebugKotlin`, `:core:detektDebug` clean. Full `:core:testDebugUnitTest` suite — 0 failures.
