### PR TITLE
feat: add article pagination for e-ink devices

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/KiwixWebView.kt
@@ -24,6 +24,7 @@ import android.os.Looper
 import android.os.Message
 import android.util.AttributeSet
 import android.view.ContextMenu
+import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -67,6 +68,11 @@ open class KiwixWebView constructor(
 ) : VideoEnabledWebView(context, attrs) {
   private var kiwixWebChromeClient: KiwixWebChromeClient? = null
   private var textZoomJob: Job? = null
+  private var articlePaginationJob: Job? = null
+
+  // When article pagination is on, page navigation happens through the up/down
+  // buttons instead - see issue #4122.
+  private var isArticlePaginationEnabled = false
 
   init {
     if (BuildConfig.DEBUG) {
@@ -136,12 +142,38 @@ open class KiwixWebView constructor(
     textZoomJob = kiwixDataStore.textZoom
       .onEach { settings.textZoom = it }
       .launchIn(CoroutineScope(SupervisorJob() + mainDispatcher))
+    articlePaginationJob?.cancel()
+    articlePaginationJob = kiwixDataStore.articlePagination
+      .onEach { isArticlePaginationEnabled = it }
+      .launchIn(CoroutineScope(SupervisorJob() + mainDispatcher))
   }
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     textZoomJob?.cancel()
     textZoomJob = null
+    articlePaginationJob?.cancel()
+    articlePaginationJob = null
+  }
+
+  // Article pagination replaces free scrolling with the up/down page buttons - see
+  // issue #4122. Only the drag/scroll gesture is swallowed here; DOWN/UP still reach
+  // super so taps and link clicks keep working normally.
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    if (isArticlePaginationEnabled && event.actionMasked == MotionEvent.ACTION_MOVE) {
+      return true
+    }
+    if (event.actionMasked == MotionEvent.ACTION_UP) {
+      performClick()
+    }
+    return super.onTouchEvent(event)
+  }
+
+  // Required alongside the onTouchEvent override above so accessibility services
+  // (e.g. TalkBack) can still trigger a click on this view.
+  override fun performClick(): Boolean {
+    super.performClick()
+    return true
   }
 
   override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModel.kt
@@ -198,7 +198,11 @@ abstract class CoreReaderViewModel(
     val tableOfContentTitle: String = "",
     val documentSections: List<DocumentSection> = emptyList(),
     val showDonationPopup: Boolean = false,
-    val findInPageUiState: FindInPageManager.FindInPageUiState = FindInPageManager.FindInPageUiState()
+    val findInPageUiState: FindInPageManager.FindInPageUiState = FindInPageManager.FindInPageUiState(),
+    val isArticlePaginationEnabled: Boolean = false,
+    val isPaginationUpEnabled: Boolean = false,
+    val isPaginationDownEnabled: Boolean = false,
+    val paginationPageLabel: String = ""
   )
 
   sealed interface ReaderAction {
@@ -234,6 +238,8 @@ abstract class CoreReaderViewModel(
     data object FindInPageNextClicked : ReaderAction
     data object FindInPagePreviousClicked : ReaderAction
     data object FindInPageCloseClicked : ReaderAction
+    data object PaginationUpClicked : ReaderAction
+    data object PaginationDownClicked : ReaderAction
   }
 
   sealed interface ReaderEffect {
@@ -341,11 +347,18 @@ abstract class CoreReaderViewModel(
 
   private fun observeSettings() =
     viewModelScope.launch {
-      kiwixDataStore.backToTop.collect {
-        if (!it) {
-          hideBackToTopButton()
+      launch {
+        kiwixDataStore.backToTop.collect {
+          if (!it) {
+            hideBackToTopButton()
+          }
+          // Showing backToTop button based on webView scrolling.
         }
-        // Showing backToTop button based on webView scrolling.
+      }
+      launch {
+        kiwixDataStore.articlePagination.collect { enabled ->
+          updateState { copy(isArticlePaginationEnabled = enabled) }
+        }
       }
     }
 
@@ -489,6 +502,8 @@ abstract class CoreReaderViewModel(
       ReaderAction.FindInPageNextClicked -> onFindNextClicked()
       ReaderAction.FindInPagePreviousClicked -> onFindPreviousClicked()
       ReaderAction.FindInPageCloseClicked -> closeFindInPage()
+      ReaderAction.PaginationUpClicked -> onPaginationUpClicked()
+      ReaderAction.PaginationDownClicked -> onPaginationDownClicked()
     }
   }
 
@@ -864,6 +879,7 @@ abstract class CoreReaderViewModel(
   @Suppress("MagicNumber")
   override fun webViewPageChanged(page: Int, maxPages: Int) {
     launchInMainScope {
+      updatePaginationState(page, maxPages)
       if (!isBackToTopEnabled()) return@launchInMainScope
       val scrollY = getCurrentWebView().scrollY
       if (scrollY > 200 && !uiState.value.showTtsControls) {
@@ -872,6 +888,32 @@ abstract class CoreReaderViewModel(
       } else {
         hideBackToTopButton()
       }
+    }
+  }
+
+  private suspend fun updatePaginationState(page: Int, maxPages: Int) {
+    if (!kiwixDataStore.articlePagination.first()) return
+    val totalPages = maxPages + 1
+    updateState {
+      copy(
+        isPaginationUpEnabled = page > 0,
+        isPaginationDownEnabled = page < maxPages,
+        paginationPageLabel = "${page + 1}/$totalPages"
+      )
+    }
+  }
+
+  fun onPaginationUpClicked() {
+    launchInMainScope {
+      val webView = getCurrentWebView()
+      webView.scrollBy(0, -webView.height)
+    }
+  }
+
+  fun onPaginationDownClicked() {
+    launchInMainScope {
+      val webView = getCurrentWebView()
+      webView.scrollBy(0, webView.height)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/main/reader/ReaderScreen.kt
@@ -137,6 +137,8 @@ import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.N
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.OpenLibrary
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.OpenSearch
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.OpenTocDrawer
+import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.PaginationDownClicked
+import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.PaginationUpClicked
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.PauseTts
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.PreviousClicked
 import org.kiwix.kiwixmobile.core.main.reader.CoreReaderViewModel.ReaderAction.PreviousLongClicked
@@ -378,6 +380,7 @@ private fun ReaderContentLayout(
             TtsControls(state, onReaderAction)
             ShowDonationLayout(state, onReaderAction)
           }
+          ArticlePaginationControls(state, onReaderAction)
         }
       }
     }
@@ -637,6 +640,75 @@ private fun BackToTopFab(showBackToTop: Boolean, onReaderAction: (ReaderAction) 
     contentDescription = stringResource(R.string.pref_back_to_top),
     shouldPulse = true
   )
+}
+
+// Article pagination (issue #4122): while enabled, free scrolling is disabled in
+// KiwixWebView and page navigation happens through these two buttons instead.
+// Alignment.TopEnd/BottomEnd mirror to the left automatically in RTL layouts.
+@Composable
+private fun BoxScope.ArticlePaginationControls(
+  state: ReaderUiState,
+  onReaderAction: (ReaderAction) -> Unit
+) {
+  if (!state.isArticlePaginationEnabled) return
+  PaginationButton(
+    icon = Drawable(R.drawable.ic_arrow_upward_24dp),
+    contentDescription = stringResource(R.string.go_to_previous_article_page),
+    enabled = state.isPaginationUpEnabled,
+    onClick = { onReaderAction(PaginationUpClicked) },
+    modifier = Modifier
+      .align(Alignment.TopEnd)
+      .padding(SIXTEEN_DP)
+  )
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier
+      .align(Alignment.BottomEnd)
+      .padding(SIXTEEN_DP)
+  ) {
+    if (state.paginationPageLabel.isNotEmpty()) {
+      Text(
+        text = state.paginationPageLabel,
+        style = MaterialTheme.typography.labelMedium
+      )
+      Spacer(modifier = Modifier.width(EIGHT_DP))
+    }
+    PaginationButton(
+      icon = Drawable(R.drawable.ic_arrow_downward_24dp),
+      contentDescription = stringResource(R.string.go_to_next_article_page),
+      enabled = state.isPaginationDownEnabled,
+      onClick = { onReaderAction(PaginationDownClicked) }
+    )
+  }
+}
+
+@Composable
+private fun PaginationButton(
+  icon: IconItem,
+  contentDescription: String,
+  enabled: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier
+) {
+  Box(
+    modifier = modifier
+      .size(READER_BOTTOM_APP_BAR_BUTTON_ICON_SIZE + TEN_DP)
+      .clip(CircleShape)
+      .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+      .clickable(enabled = enabled, onClick = onClick),
+    contentAlignment = Alignment.Center
+  ) {
+    Icon(
+      icon.toPainter(),
+      contentDescription,
+      modifier = Modifier.size(READER_BOTTOM_APP_BAR_BUTTON_ICON_SIZE),
+      tint = if (enabled) {
+        LocalContentColor.current
+      } else {
+        LocalContentColor.current.copy(alpha = READER_BOTTOM_APP_BAR_DISABLE_BUTTON_ALPHA)
+      }
+    )
+  }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -550,6 +550,8 @@ private fun ExtrasCategory(
 private fun DisplayCategory(coreSettingsViewModel: CoreSettingsViewModel) {
   val themeLabel by coreSettingsViewModel.themeLabel.collectAsStateWithLifecycle()
   val backToTopEnabled by coreSettingsViewModel.backToTopEnabled.collectAsStateWithLifecycle()
+  val articlePaginationEnabled by
+    coreSettingsViewModel.articlePaginationEnabled.collectAsStateWithLifecycle()
   val textZoom by coreSettingsViewModel.textZoom.collectAsStateWithLifecycle()
   val textZoomPosition = (textZoom / ZOOM_SCALE) - ZOOM_OFFSET
   SettingsCategory(stringResource(R.string.pref_display_title)) {
@@ -559,6 +561,12 @@ private fun DisplayCategory(coreSettingsViewModel: CoreSettingsViewModel) {
       summary = stringResource(R.string.pref_back_to_top_summary),
       checked = backToTopEnabled,
       onCheckedChange = { coreSettingsViewModel.setBackToTop(it) }
+    )
+    SwitchPreference(
+      title = stringResource(R.string.pref_article_pagination),
+      summary = stringResource(R.string.pref_article_pagination_summary),
+      checked = articlePaginationEnabled,
+      onCheckedChange = { coreSettingsViewModel.setArticlePagination(it) }
     )
     SeekBarPreference(
       title = stringResource(R.string.pref_text_zoom_title),

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
@@ -141,6 +141,13 @@ abstract class CoreSettingsViewModel(
       initialValue = false
     )
 
+  val articlePaginationEnabled = kiwixDataStore.articlePagination
+    .stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.Eagerly,
+      initialValue = false
+    )
+
   val externalLinkPopup = kiwixDataStore.externalLinkPopup
     .stateIn(
       scope = viewModelScope,
@@ -191,6 +198,12 @@ abstract class CoreSettingsViewModel(
   fun setBackToTop(enabled: Boolean) {
     viewModelScope.launch {
       kiwixDataStore.setPrefBackToTop(enabled)
+    }
+  }
+
+  fun setArticlePagination(enabled: Boolean) {
+    viewModelScope.launch {
+      kiwixDataStore.setArticlePagination(enabled)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -104,6 +104,22 @@ class KiwixDataStore @Inject constructor(
     }
   }
 
+  /**
+   * Navigate articles page by page instead of scrolling - see issue #4122. Off by default;
+   * no reliable way to auto-detect e-ink hardware to flip the default (see the issue thread),
+   * so this is manual-only for now.
+   */
+  val articlePagination: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_ARTICLE_PAGINATION] ?: false
+    }
+
+  suspend fun setArticlePagination(enabled: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_ARTICLE_PAGINATION] = enabled
+    }
+  }
+
   val openNewTabInBackground: Flow<Boolean> =
     context.kiwixDataStore.data.map { prefs ->
       prefs[PreferencesKeys.PREF_NEW_TAB_BACKGROUND] ?: false
@@ -677,6 +693,7 @@ class KiwixDataStore @Inject constructor(
     const val PREF_IS_TEST = "is_test"
     const val PREF_SHOW_SHOWCASE = "showShowCase"
     const val PREF_BACK_TO_TOP = "pref_backtotop"
+    const val PREF_ARTICLE_PAGINATION = "pref_article_pagination"
     const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"
     const val PREF_EXTERNAL_LINK_POPUP = "pref_external_link_popup"
     const val PREF_SHOW_STORAGE_OPTION = "show_storgae_option"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -29,6 +29,7 @@ object PreferencesKeys {
   val TAG_CURRENT_FILE = stringPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE)
   val TAG_CURRENT_TAB = intPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_TAB)
   val PREF_BACK_TO_TOP = booleanPreferencesKey(KiwixDataStore.PREF_BACK_TO_TOP)
+  val PREF_ARTICLE_PAGINATION = booleanPreferencesKey(KiwixDataStore.PREF_ARTICLE_PAGINATION)
   val PREF_NEW_TAB_BACKGROUND = booleanPreferencesKey(KiwixDataStore.PREF_NEW_TAB_BACKGROUND)
   val PREF_EXTERNAL_LINK_POPUP =
     booleanPreferencesKey(KiwixDataStore.PREF_EXTERNAL_LINK_POPUP)

--- a/core/src/main/res/drawable/ic_arrow_downward_24dp.xml
+++ b/core/src/main/res/drawable/ic_arrow_downward_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:height="24dp"
+  android:viewportHeight="24.0"
+  android:viewportWidth="24.0"
+  android:width="24dp">
+  <path
+    android:fillColor="#FFFFFFFF"
+    android:pathData="M20,12l-1.41,-1.41L13,16.17V4h-2v12.17l-5.58,-5.59L4,12l8,8 8,-8z" />
+</vector>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -70,6 +70,10 @@
   <string name="theme_dark">Dark</string>
   <string name="pref_back_to_top">Back to Top</string>
   <string name="pref_back_to_top_summary">Display a button at the end of the page to scroll up to the top</string>
+  <string name="pref_article_pagination">Article pagination</string>
+  <string name="pref_article_pagination_summary">Navigate articles page by page instead of scrolling</string>
+  <string name="go_to_previous_article_page">Go to previous page</string>
+  <string name="go_to_next_article_page">Go to next page</string>
   <string name="pref_language_title">Language</string>
   <string name="pref_language_chooser">Choose a language</string>
   <string name="pref_credits">Contributors and Licenses</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/main/reader/CoreReaderViewModelTest.kt
@@ -152,6 +152,7 @@ internal class CoreReaderViewModelTest {
 
     every { kiwixPermissionChecker.isAndroid13orAbove() } returns false
     every { kiwixDataStore.backToTop } returns flowOf(false)
+    every { kiwixDataStore.articlePagination } returns flowOf(false)
     every { kiwixDataStore.appName } returns flowOf("Kiwix")
     every { readerIntentManager.events } returns MutableSharedFlow()
     every { bookmarkManager.bookmarkState } returns MutableStateFlow(BookmarkManager.BookmarkState())
@@ -181,7 +182,6 @@ internal class CoreReaderViewModelTest {
       findInPageManager,
       mainDispatcherRule.mainDispatcher
     )
-  }
 
   @AfterEach
   fun tearDown() {
@@ -1738,6 +1738,71 @@ internal class CoreReaderViewModelTest {
 
       advanceUntilIdle()
       assertThat(viewModel.uiState.value.showBackToTopButton).isFalse()
+    }
+
+    @Test
+    fun `webViewPageChanged does not touch pagination state when pagination is disabled`() =
+      runTest {
+        viewModel.webViewPageChanged(page = 5, maxPages = 20)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.paginationPageLabel).isEmpty()
+      }
+
+    @Test
+    fun `webViewPageChanged updates the pagination label and button state when enabled`() =
+      runTest {
+        every { kiwixDataStore.articlePagination } returns MutableStateFlow(true)
+
+        viewModel.webViewPageChanged(page = 5, maxPages = 20)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.paginationPageLabel).isEqualTo("6/21")
+        assertThat(state.isPaginationUpEnabled).isTrue()
+        assertThat(state.isPaginationDownEnabled).isTrue()
+      }
+
+    @Test
+    fun `webViewPageChanged disables up button on the first page`() = runTest {
+      every { kiwixDataStore.articlePagination } returns MutableStateFlow(true)
+
+      viewModel.webViewPageChanged(page = 0, maxPages = 5)
+      advanceUntilIdle()
+
+      val state = viewModel.uiState.value
+      assertThat(state.isPaginationUpEnabled).isFalse()
+      assertThat(state.isPaginationDownEnabled).isTrue()
+    }
+
+    @Test
+    fun `webViewPageChanged disables down button on the last page`() = runTest {
+      every { kiwixDataStore.articlePagination } returns MutableStateFlow(true)
+
+      viewModel.webViewPageChanged(page = 5, maxPages = 5)
+      advanceUntilIdle()
+
+      val state = viewModel.uiState.value
+      assertThat(state.isPaginationUpEnabled).isTrue()
+      assertThat(state.isPaginationDownEnabled).isFalse()
+    }
+
+    @Test
+    fun `onPaginationDownClicked scrolls the current webView down by one viewport`() = runTest {
+      every { mockWebView.height } returns 800
+      viewModel.onPaginationDownClicked()
+      advanceUntilIdle()
+
+      verify { mockWebView.scrollBy(0, 800) }
+    }
+
+    @Test
+    fun `onPaginationUpClicked scrolls the current webView up by one viewport`() = runTest {
+      every { mockWebView.height } returns 800
+      viewModel.onPaginationUpClicked()
+      advanceUntilIdle()
+
+      verify { mockWebView.scrollBy(0, -800) }
     }
   }
 

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
@@ -84,6 +84,7 @@ class SettingsScreenTest {
     uiState: SettingsUiState = SettingsUiState(),
     themeLabel: String = "System default",
     backToTopEnabled: Boolean = false,
+    articlePaginationEnabled: Boolean = false,
     textZoom: Int = DEFAULT_ZOOM,
     newTabInBackground: Boolean = false,
     externalLinkPopup: Boolean = true,
@@ -93,6 +94,7 @@ class SettingsScreenTest {
     every { viewModel.uiState } returns MutableStateFlow(uiState)
     every { viewModel.themeLabel } returns MutableStateFlow(themeLabel)
     every { viewModel.backToTopEnabled } returns MutableStateFlow(backToTopEnabled)
+    every { viewModel.articlePaginationEnabled } returns MutableStateFlow(articlePaginationEnabled)
     every { viewModel.textZoom } returns MutableStateFlow(textZoom)
     every { viewModel.newTabInBackground } returns MutableStateFlow(newTabInBackground)
     every { viewModel.externalLinkPopup } returns MutableStateFlow(externalLinkPopup)
@@ -223,6 +225,38 @@ class SettingsScreenTest {
       .onNodeWithTag(context.getString(R.string.pref_back_to_top))
       .assertIsDisplayed()
       .assertIsOn()
+  }
+
+  @Test
+  fun settingsScreen_displayCategory_articlePaginationSwitch_isDisplayed() {
+    renderSettingsScreen(createMockViewModel())
+    scrollToContentDescription(context.getString(R.string.pref_article_pagination))
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_article_pagination))
+      .assertIsDisplayed()
+      .assertIsOff()
+  }
+
+  @Test
+  fun articlePaginationSwitch_reflectsStateChange() {
+    renderSettingsScreen(createMockViewModel(articlePaginationEnabled = true))
+    scrollToContentDescription(context.getString(R.string.pref_article_pagination))
+
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_article_pagination))
+      .assertIsDisplayed()
+      .assertIsOn()
+  }
+
+  @Test
+  fun settingsScreen_displayCategory_articlePaginationSwitch_toggleTriggersCallback() {
+    val viewModel = createMockViewModel(articlePaginationEnabled = false)
+    renderSettingsScreen(viewModel)
+    scrollToText(context.getString(R.string.pref_article_pagination))
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_article_pagination_summary))
+      .performClick()
+    verify { viewModel.setArticlePagination(true) }
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -179,6 +179,7 @@ internal class CoreSettingsViewModelTest {
     // // Stub all KiwixDataStore Flow properties needed during ViewModel construction
     every { kiwixDataStore.appTheme } returns flowOf(ThemeConfig.Theme.SYSTEM)
     every { kiwixDataStore.backToTop } returns flowOf(false)
+    every { kiwixDataStore.articlePagination } returns flowOf(false)
     every { kiwixDataStore.externalLinkPopup } returns flowOf(true)
     every { kiwixDataStore.textZoom } returns flowOf(DEFAULT_ZOOM)
     every { kiwixDataStore.openNewTabInBackground } returns flowOf(false)
@@ -323,6 +324,23 @@ internal class CoreSettingsViewModelTest {
       coVerify {
         kiwixDataStore.setPrefBackToTop(true)
         kiwixDataStore.setPrefBackToTop(false)
+      }
+    }
+
+    @Test
+    fun `setArticlePagination delegates to kiwixDataStore`() = runTest {
+      coEvery { kiwixDataStore.setArticlePagination(any()) } just Runs
+      viewModel.setArticlePagination(true)
+      advanceUntilIdle()
+      coVerify { kiwixDataStore.setArticlePagination(true) }
+
+      // Toggles values
+      viewModel.setArticlePagination(true)
+      viewModel.setArticlePagination(false)
+      advanceUntilIdle()
+      coVerify {
+        kiwixDataStore.setArticlePagination(true)
+        kiwixDataStore.setArticlePagination(false)
       }
     }
 
@@ -501,6 +519,33 @@ internal class CoreSettingsViewModelTest {
       createViewModel()
 
       viewModel.backToTopEnabled.test {
+        // Assert initial item
+        assertFalse(awaitItem())
+        flow.emit(true)
+        assertTrue(awaitItem())
+        flow.emit(false)
+        assertFalse(awaitItem())
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `articlePaginationEnabled uses default when flow is empty`() = runTest {
+      every { kiwixDataStore.articlePagination } returns emptyFlow()
+
+      createViewModel()
+
+      assertFalse(viewModel.articlePaginationEnabled.value)
+    }
+
+    @Test
+    fun `articlePaginationEnabled emits values from datastore`() = runTest {
+      val flow = MutableStateFlow(false)
+      every { kiwixDataStore.articlePagination } returns flow
+
+      createViewModel()
+
+      viewModel.articlePaginationEnabled.test {
         // Assert initial item
         assertFalse(awaitItem())
         flow.emit(true)


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Partially addresses #4122.

E-ink screens redraw only a few times a second, so continuous scrolling looks bad and drains battery on those devices - that's the actual problem behind this issue (not the literal title). This adds a manual **"Article pagination"** setting under Display (off by default) that replaces free scrolling in the reader with up/down page buttons and a page counter, following the shape @kelson42 and @MohitMaliFtechiz worked out on the issue.

## What's different from the design on the issue

The accepted design also called for auto-detecting e-ink hardware (via display refresh rate) to flip the setting's default on automatically. I left that out:

- `@Coipel`'s test on real e-ink hardware in the thread shows `Display.refreshRate` still reports 60Hz there - the heuristic the design was going to use doesn't actually detect e-ink screens.
- There's no reliable e-ink-detection API on Android at all. I checked how other open-source apps in this space handle it: AnkiDroid hit the same wall and shelved auto-detection ([issue #17618](https://github.com/ankidroid/Anki-Android/issues/17618)); KOReader ships a community-maintained device/driver allowlist instead of detection; EinkBro (the app referenced earlier in this issue's thread) ships fully manual, user-configured settings too.

So this ships manual-only, matching what every comparable app actually does, rather than shipping a heuristic already shown not to work. Also no mockup was ever posted on the issue for the button placement/style, so the visual design here (small icon buttons, top-right/bottom-right, page counter beside the bottom one) is my best-effort interpretation of the written spec - happy to adjust.

## Implementation

- `KiwixDataStore.articlePagination`: new persisted flag.
- `KiwixWebView`: swallows the scroll gesture (`ACTION_MOVE`) while pagination is on; taps and link clicks still reach `super` normally.
- `CoreReaderViewModel`: computes current/total page from the existing `webViewPageChanged` callback (already used for the back-to-top button), exposes up/down button enabled-state and a `"n/total"` label, scrolls by one viewport per click.
- `ReaderScreen`: overlays the two buttons top-right/bottom-right - `Alignment.TopEnd`/`BottomEnd` mirror to the left automatically under RTL.
- Settings: new switch under Display, "Navigate articles page by page instead of scrolling" (wording from Mohit's proposal on the issue).

**Verified locally**: `detektDebug`/`ktlintCheck`/`lintDebug` clean on `:core`/`:app`. Full `:core:testDebugUnitTest` and `:app:testDebugUnitTest` suites green, including new coverage for the pagination state math, the settings toggle, and the reader's up/down click handlers.

This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submission.
