### PR TITLE
Fixed: Hotspot not updating available books after deletion.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -31,11 +31,11 @@ import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
-import dagger.hilt.android.testing.HiltAndroidRule
-import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
@@ -131,6 +131,7 @@ class DownloadServiceTest : BaseActivityTest() {
     InstrumentationRegistry.getInstrumentation().uiAutomation.performGlobalAction(
       AccessibilityService.GLOBAL_ACTION_HOME
     )
+
     // Poll instead of a fixed sleep - a wait that's enough on one API level/device
     // isn't guaranteed enough on a slower one.
     composeTestRule.waitUntil(timeoutMillis = TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -126,11 +126,6 @@ class DownloadServiceTest : BaseActivityTest() {
     }
   }
 
-  @After
-  fun finish() {
-    TestUtils.deleteTemporaryFilesOfTestCases(context)
-  }
-
   private fun assetDownloadService(isRunning: Boolean) {
     // press the home button so that application goes into background
     InstrumentationRegistry.getInstrumentation().uiAutomation.performGlobalAction(
@@ -142,6 +137,12 @@ class DownloadServiceTest : BaseActivityTest() {
       DownloadMonitorService.isDownloadMonitorServiceRunning == isRunning
     }
     composeTestRule.waitUntilTimeout(3000)
+  }
+
+  @After
+  fun finish() {
+    IdlingRegistry.getInstance().unregister(getInstance())
+    TestUtils.deleteTemporaryFilesOfTestCases(context)
   }
 
   companion object {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/initial/download/InitialDownloadTest.kt
@@ -83,8 +83,11 @@ class InitialDownloadTest : BaseActivityTest() {
       waitUntilZimFilesRefreshing(composeTestRule)
       deleteZimIfExists(composeTestRule)
     }
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      it.navigate(KiwixDestination.Downloads.route)
+    }
     downloadRobot {
-      clickDownloadOnBottomNav(composeTestRule)
       waitForDataToLoad(composeTestRule = composeTestRule)
       stopDownloadIfAlreadyStarted(composeTestRule, kiwixMainActivity)
       searchD3JsDocsFile(composeTestRule)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/language/LanguageScreenTest.kt
@@ -21,10 +21,10 @@ import android.os.Build
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.filters.LargeTest
-import leakcanary.LeakAssertions
-import org.junit.Before
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import leakcanary.LeakAssertions
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.kiwix.kiwixmobile.BaseActivityTest
@@ -38,6 +38,7 @@ import org.kiwix.kiwixmobile.main.KiwixMainActivity
 import org.kiwix.kiwixmobile.testutils.RetryRule
 import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
+import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.StandardActions
 
 @LargeTest
@@ -70,8 +71,11 @@ class LanguageScreenTest : BaseActivityTest() {
   @Test
   fun testLanguageScreen() {
     StandardActions.closeDrawer(kiwixMainActivity as CoreMainActivity) // close the drawer if open before running the test cases.
+    activityScenario.onActivity {
+      kiwixMainActivity = it
+      it.navigate(KiwixDestination.Downloads.route)
+    }
     downloadRobot {
-      clickDownloadOnBottomNav(composeTestRule)
       waitForDataToLoad(composeTestRule = composeTestRule)
     }
     language {

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/bookmarks/ImportBookmarkTest.kt
@@ -32,6 +32,8 @@ import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookOnDisk
 import org.kiwix.kiwixmobile.core.dao.LibkiwixBookmarks
 import org.kiwix.kiwixmobile.core.page.bookmark.models.LibkiwixBookmarkItem
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.HILT_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.migration.di.module.DatabaseModule
@@ -104,7 +106,17 @@ class ImportBookmarkTest : BaseActivityTest() {
     super.waitForIdle()
     launchMainActivity()
     boxStore = DatabaseModule.boxStore
-    libkiwixBookOnDisk = LibkiwixBookOnDisk(library, manager, kiwixDataStore, Dispatchers.IO)
+    val storageDeviceProvider = StorageDeviceProvider(context, kiwixDataStore, Dispatchers.IO)
+    val zimFileReaderFactory = ZimFileReader.Factory.Impl(Dispatchers.IO)
+    libkiwixBookOnDisk =
+      LibkiwixBookOnDisk(
+        library,
+        manager,
+        kiwixDataStore,
+        storageDeviceProvider,
+        zimFileReaderFactory,
+        Dispatchers.IO
+      )
     libkiwixBookmarks =
       LibkiwixBookmarks(
         library,

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/page/history/NavigationHistoryRobot.kt
@@ -77,28 +77,32 @@ class NavigationHistoryRobot : BaseRobot() {
   }
 
   fun clickOnAndroidArticle(composeTestRule: ComposeContentTestRule) {
-    composeTestRule.waitForIdle()
-    pauseForBetterTestPerformance(composeTestRule)
-    onWebView()
-      .withElement(
-        findElement(
-          Locator.XPATH,
-          "//*[contains(text(), 'Android_(operating_system)')]"
+    testFlakyView({
+      composeTestRule.waitForIdle()
+      pauseForBetterTestPerformance(composeTestRule)
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'Android_(operating_system)')]"
+          )
         )
-      )
-      .perform(webClick())
+        .perform(webClick())
+    })
   }
 
   fun assertZimFileLoaded(composeTestRule: ComposeContentTestRule) {
-    composeTestRule.waitForIdle()
-    pauseForBetterTestPerformance(composeTestRule)
-    onWebView()
-      .withElement(
-        findElement(
-          Locator.XPATH,
-          "//*[contains(text(), 'Android_(operating_system)')]"
+    testFlakyView({
+      composeTestRule.waitForIdle()
+      pauseForBetterTestPerformance(composeTestRule)
+      onWebView()
+        .withElement(
+          findElement(
+            Locator.XPATH,
+            "//*[contains(text(), 'Android_(operating_system)')]"
+          )
         )
-      )
+    })
   }
 
   fun longClickOnBackwardButton(composeTestRule: ComposeContentTestRule) {

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
@@ -114,6 +114,12 @@ class ZimHostViewModel @Inject constructor(
   private val _events = MutableSharedFlow<Event>(extraBufferCapacity = Int.MAX_VALUE)
   val events = _events.asSharedFlow()
 
+  init {
+    viewModelScope.launch(ioDispatcher) {
+      // dataSource.bookRemoved().collect { loadBooks() }
+    }
+  }
+
   fun loadBooks() {
     viewModelScope.launch(ioDispatcher) {
       val previouslyHostedBookIds = kiwixDataStore.hostedBookIds.first()

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -65,6 +66,7 @@ import org.kiwix.kiwixmobile.webserver.ZimHostViewModel.Event.StartServer
 import org.kiwix.kiwixmobile.webserver.ZimHostViewModel.Event.StopServer
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @Suppress("LongParameterList")
 @HiltViewModel
 class ZimHostViewModel @Inject constructor(
@@ -116,7 +118,7 @@ class ZimHostViewModel @Inject constructor(
 
   init {
     viewModelScope.launch(ioDispatcher) {
-      // dataSource.bookRemoved().collect { loadBooks() }
+      dataSource.bookRemoved().collect { loadBooks() }
     }
   }
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModel.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +65,6 @@ import org.kiwix.kiwixmobile.webserver.ZimHostViewModel.Event.StartServer
 import org.kiwix.kiwixmobile.webserver.ZimHostViewModel.Event.StopServer
 import javax.inject.Inject
 
-@OptIn(FlowPreview::class)
 @Suppress("LongParameterList")
 @HiltViewModel
 class ZimHostViewModel @Inject constructor(

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
@@ -118,7 +118,9 @@ class HotspotService :
 
     if (remainingPaths == currentlyHostedPaths) return
 
-    if (!remainingPaths.isEmpty()) {
+    if (remainingPaths.isEmpty()) {
+      stopHotspotAndDismissNotification()
+    } else {
       startServerAndNotify(
         ArrayList(remainingPaths),
         restart = true

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
@@ -25,22 +25,30 @@ import android.widget.Toast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.R
+import org.kiwix.kiwixmobile.core.data.DataSource
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
 import org.kiwix.kiwixmobile.core.di.MainDispatcher
 import org.kiwix.kiwixmobile.core.extensions.registerReceiver
+import org.kiwix.kiwixmobile.core.utils.ServerUtils
 import org.kiwix.kiwixmobile.core.utils.ServerUtils.serverAddress
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
 import org.kiwix.kiwixmobile.webserver.RESTART_SERVER
 import org.kiwix.kiwixmobile.webserver.SELECTED_ZIM_PATHS_KEY
 import org.kiwix.kiwixmobile.webserver.WebServerHelper
 import org.kiwix.kiwixmobile.webserver.ZimHostCallbacks
 import java.lang.ref.WeakReference
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * HotspotService is used to add a foreground service for the wifi hotspot.
@@ -60,6 +68,12 @@ class HotspotService :
   @set:Inject
   var hotspotStateReceiver: HotspotStateReceiver? = null
 
+  @set:Inject
+  var dataSource: DataSource? = null
+
+  @set:Inject
+  var kiwixDataStore: KiwixDataStore? = null
+
   @Inject
   @IoDispatcher
   lateinit var ioDispatcher: CoroutineDispatcher
@@ -68,15 +82,48 @@ class HotspotService :
   @MainDispatcher
   lateinit var mainDispatcher: MainCoroutineDispatcher
 
-  private lateinit var serviceScope: CoroutineScope
+  internal lateinit var serviceScope: CoroutineScope
 
   private var zimHostCallbacks: ZimHostCallbacks? = null
   private val serviceBinder: IBinder = HotspotBinder(this)
+
+  internal var currentlyHostedPaths: List<String> = emptyList()
 
   override fun onCreate() {
     super.onCreate()
     serviceScope = CoroutineScope(SupervisorJob() + mainDispatcher)
     hotspotStateReceiver?.let(::registerReceiver)
+    observeBookRemoved()
+  }
+
+  @OptIn(FlowPreview::class)
+  private fun observeBookRemoved() {
+    serviceScope.launch(ioDispatcher) {
+      dataSource?.bookRemoved()
+        ?.debounce(RESYNC_DEBOUNCE_MS.milliseconds)
+        ?.collect { resyncServerWithRemainingBooks() }
+    }
+  }
+
+  internal suspend fun resyncServerWithRemainingBooks() {
+    val dataSource = dataSource
+    val kiwixDataStore = kiwixDataStore
+    if (!ServerUtils.isServerStarted || dataSource == null || kiwixDataStore == null) return
+
+    val hostedBookIds = kiwixDataStore.hostedBookIds.first()
+    val remainingPaths = dataSource.getLanguageCategorizedBooks().first()
+      .filterIsInstance<BookOnDisk>()
+      .filter { it.book.id in hostedBookIds }
+      .map { it.zimReaderSource.toDatabase() }
+
+    if (remainingPaths == currentlyHostedPaths) return
+
+    if (!remainingPaths.isEmpty()) {
+      startServerAndNotify(
+        ArrayList(remainingPaths),
+        restart = true
+      )
+    }
   }
 
   /**
@@ -111,22 +158,10 @@ class HotspotService :
         val restartServer = intent.getBooleanExtra(RESTART_SERVER, false)
         intent.getStringArrayListExtra(SELECTED_ZIM_PATHS_KEY)?.let {
           serviceScope.launch {
-            val serverStatus =
-              withContext(ioDispatcher) {
-                webServerHelper?.startServerHelper(it, restartServer)
-              }
-            if (serverStatus?.isServerStarted == true) {
-              zimHostCallbacks?.onServerStarted(webServerHelper?.getServerAddress().orEmpty())
-              startForegroundNotificationHelper()
-              if (!restartServer) {
-                Toast.makeText(
-                  this@HotspotService, R.string.server_started_successfully_toast_message,
-                  Toast.LENGTH_SHORT
-                ).show()
-              }
-            } else {
-              onServerFailedToStart(serverStatus?.errorMessage)
-            }
+            startServerAndNotify(
+              it,
+              restart = restartServer
+            )
           }
         } ?: kotlin.run { onServerFailedToStart(R.string.no_books_selected_toast_message) }
       }
@@ -148,9 +183,30 @@ class HotspotService :
 
   override fun onBind(intent: Intent?): IBinder = serviceBinder
 
+  private suspend fun startServerAndNotify(paths: ArrayList<String>, restart: Boolean) {
+    val serverStatus =
+      withContext(ioDispatcher) {
+        webServerHelper?.startServerHelper(paths, restart)
+      }
+    if (serverStatus?.isServerStarted == true) {
+      currentlyHostedPaths = paths
+      zimHostCallbacks?.onServerStarted(webServerHelper?.getServerAddress().orEmpty())
+      startForegroundNotificationHelper()
+      if (!restart) {
+        Toast.makeText(
+          this@HotspotService, R.string.server_started_successfully_toast_message,
+          Toast.LENGTH_SHORT
+        ).show()
+      }
+    } else {
+      onServerFailedToStart(serverStatus?.errorMessage)
+    }
+  }
+
   // Dismiss notification and turn off hotspot for devices>=O
   private fun stopHotspotAndDismissNotification() {
     webServerHelper?.stopAndroidWebServer()
+    currentlyHostedPaths = emptyList()
     zimHostCallbacks?.onServerStopped()
     stopForeground(STOP_FOREGROUND_REMOVE)
     stopSelf()
@@ -197,5 +253,6 @@ class HotspotService :
     const val ACTION_START_SERVER = "start_server"
     const val ACTION_STOP_SERVER = "stop_server"
     const val ACTION_CHECK_IP_ADDRESS = "check_ip_address"
+    private const val RESYNC_DEBOUNCE_MS = 300L
   }
 }

--- a/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotService.kt
@@ -116,7 +116,7 @@ class HotspotService :
       .filter { it.book.id in hostedBookIds }
       .map { it.zimReaderSource.toDatabase() }
 
-    if (remainingPaths == currentlyHostedPaths) return
+    if (remainingPaths.toSet() == currentlyHostedPaths.toSet()) return
 
     if (remainingPaths.isEmpty()) {
       stopHotspotAndDismissNotification()

--- a/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModelTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/webserver/ZimHostViewModelTest.kt
@@ -28,6 +28,7 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -69,6 +70,7 @@ class ZimHostViewModelTest {
   private val fakeReader: ZimFileReader = mockk(relaxed = true)
   private val book1 = BookOnDisk(zimFileReader = fakeReader, isSelected = false)
   private val book2 = BookOnDisk(zimFileReader = fakeReader, isSelected = false)
+  private val bookRemoved = MutableSharedFlow<Unit>()
 
   companion object {
     private const val IP_ADDRESS = "192.168.31.9:8080"
@@ -83,6 +85,7 @@ class ZimHostViewModelTest {
     )
     coEvery { kiwixDataStore.hostedBookIds } returns flowOf(emptySet())
     coEvery { kiwixDataStore.setHostedBookIds(any()) } returns Unit
+    every { dataSource.bookRemoved() } returns bookRemoved
 
     every { zimReaderContainer.zimFileReader } returns null
 
@@ -212,6 +215,22 @@ class ZimHostViewModelTest {
     assertEquals("", state.serverIpAddress)
     assertFalse(state.showShareIcon)
     assertFalse(state.qrVisible)
+  }
+
+  // ======== bookRemovals() ========
+
+  @Test
+  fun bookRemoved_whenBookRemovedElsewhere_reloadsBooks() = runTest {
+    coEvery { kiwixDataStore.isBrandedApp } returns flowOf(false)
+    coEvery { dataSource.getLanguageCategorizedBooks() } returns flowOf(listOf(book1, book2))
+    advanceUntilIdle()
+    assertTrue(viewModel.uiState.value.books.isEmpty())
+
+    coEvery { dataSource.getLanguageCategorizedBooks() } returns flowOf(listOf(book1))
+    bookRemoved.emit(Unit)
+    advanceUntilIdle()
+
+    assertEquals(1, viewModel.uiState.value.books.size)
   }
 
   // ======== startServerButtonClick() ========

--- a/app/src/test/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotServiceTest.kt
+++ b/app/src/test/java/org/kiwix/kiwixmobile/webserver/wifi_hotspot/HotspotServiceTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.webserver.wifi_hotspot
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.kiwix.kiwixmobile.core.data.DataSource
+import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
+import org.kiwix.kiwixmobile.core.utils.ServerUtils
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
+import org.kiwix.kiwixmobile.webserver.WebServerHelper
+import org.kiwix.kiwixmobile.webserver.ZimHostCallbacks
+
+/**
+ * Covers HotspotService.resyncServerWithHostedBooks() - the handler that reacts to
+ * LibkiwixBookOnDisk.bookRemovals (issue #4341): the *server* must restart with the
+ * reduced book list when a hosted ZIM is deleted, not just the Hotspot screen's UI.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HotspotServiceTest {
+  private val webServerHelper: WebServerHelper = mockk(relaxed = true)
+  private val dataSource: DataSource = mockk()
+  private val kiwixDataStore: KiwixDataStore = mockk()
+  private val zimHostCallbacks: ZimHostCallbacks = mockk(relaxed = true)
+
+  private lateinit var hotspotService: HotspotService
+
+  private fun bookOnDisk(id: String, path: String) =
+    BookOnDisk(LibkiwixBook(_id = id, _path = path))
+
+  @Before
+  fun setUp() {
+    clearAllMocks()
+    hotspotService = spyk(HotspotService())
+    hotspotService.webServerHelper = webServerHelper
+    hotspotService.dataSource = dataSource
+    hotspotService.kiwixDataStore = kiwixDataStore
+    hotspotService.ioDispatcher = Dispatchers.Unconfined
+    hotspotService.serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    hotspotService.registerCallBack(zimHostCallbacks)
+    every { hotspotService.startForeground(any(), any()) } returns Unit
+    every { hotspotService.stopForeground(any<Int>()) } returns Unit
+    every { hotspotService.stopSelf() } returns Unit
+    ServerUtils.isServerStarted = false
+  }
+
+  @After
+  fun tearDown() {
+    ServerUtils.isServerStarted = false
+    hotspotService.serviceScope.cancel()
+  }
+
+  @Test
+  fun `resync when server not started does nothing`() = runTest {
+    ServerUtils.isServerStarted = false
+
+    hotspotService.resyncServerWithRemainingBooks()
+
+    coVerify(exactly = 0) { webServerHelper.startServerHelper(any(), any()) }
+    verify(exactly = 0) { webServerHelper.stopAndroidWebServer() }
+  }
+
+  @Test
+  fun `resync when the removed book was not hosted leaves the server untouched`() = runTest {
+    ServerUtils.isServerStarted = true
+    hotspotService.currentlyHostedPaths = listOf("/path1")
+    every { kiwixDataStore.hostedBookIds } returns flowOf(setOf("id1"))
+    every { dataSource.getLanguageCategorizedBooks() } returns flowOf(
+      listOf(bookOnDisk("id1", "/path1"))
+    )
+
+    hotspotService.resyncServerWithRemainingBooks()
+
+    coVerify(exactly = 0) { webServerHelper.startServerHelper(any(), any()) }
+    verify(exactly = 0) { webServerHelper.stopAndroidWebServer() }
+  }
+
+  @Test
+  fun `resync when a hosted book was removed restarts with the remaining paths`() = runTest {
+    ServerUtils.isServerStarted = true
+    hotspotService.currentlyHostedPaths = listOf("/path1", "/path2")
+    every { kiwixDataStore.hostedBookIds } returns flowOf(setOf("id1", "id2"))
+    every { dataSource.getLanguageCategorizedBooks() } returns flowOf(
+      listOf(bookOnDisk("id1", "/path1"))
+    )
+    coEvery { webServerHelper.startServerHelper(any(), true) } returns
+      ServerStatus(isServerStarted = true, errorMessage = null)
+    every { webServerHelper.getServerAddress() } returns "192.168.0.1:8080"
+
+    hotspotService.resyncServerWithRemainingBooks()
+
+    coVerify(exactly = 1) {
+      webServerHelper.startServerHelper(match { it.size == 1 && it.contains("/path1") }, true)
+    }
+    verify(exactly = 1) { zimHostCallbacks.onServerStarted("192.168.0.1:8080") }
+    verify(exactly = 0) { webServerHelper.stopAndroidWebServer() }
+  }
+
+  @Test
+  fun `resync when the only hosted book was removed stops the server instead of restarting empty`() =
+    runTest {
+      ServerUtils.isServerStarted = true
+      hotspotService.currentlyHostedPaths = listOf("/path1")
+      every { kiwixDataStore.hostedBookIds } returns flowOf(setOf("id1"))
+      every { dataSource.getLanguageCategorizedBooks() } returns flowOf(emptyList())
+
+      hotspotService.resyncServerWithRemainingBooks()
+
+      coVerify(exactly = 0) { webServerHelper.startServerHelper(any(), any()) }
+      verify(exactly = 1) { webServerHelper.stopAndroidWebServer() }
+      verify(exactly = 1) { zimHostCallbacks.onServerStopped() }
+    }
+}

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -19,10 +19,15 @@
 package org.kiwix.kiwixmobile.core.dao
 
 import android.os.Build
+import android.os.FileObserver
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -37,7 +42,11 @@ import org.kiwix.kiwixmobile.core.di.modules.LOCAL_BOOKS_LIBRARY
 import org.kiwix.kiwixmobile.core.di.modules.LOCAL_BOOKS_MANAGER
 import org.kiwix.kiwixmobile.core.entity.LibkiwixBook
 import org.kiwix.kiwixmobile.core.extensions.isFileExist
+import org.kiwix.kiwixmobile.core.reader.ZimFileReader
+import org.kiwix.kiwixmobile.core.reader.ZimReaderSource
+import org.kiwix.kiwixmobile.core.utils.StorageDeviceProvider
 import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.kiwixmobile.core.utils.files.FileUtils
 import org.kiwix.kiwixmobile.core.utils.files.Log
 import org.kiwix.kiwixmobile.core.zim_manager.fileselect_view.BooksOnDiskListItem.BookOnDisk
 import org.kiwix.libkiwix.Book
@@ -48,11 +57,14 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
+@Suppress("LongParameterList")
 @Singleton
 class LibkiwixBookOnDisk @Inject constructor(
   @param:Named(LOCAL_BOOKS_LIBRARY) private val library: Library,
   @param:Named(LOCAL_BOOKS_MANAGER) private val manager: Manager,
   private val kiwixDataStore: KiwixDataStore,
+  private val storageDeviceProvider: StorageDeviceProvider,
+  private val zimFileReaderFactory: ZimFileReader.Factory,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
   private val initMutex = Mutex()
@@ -65,6 +77,95 @@ class LibkiwixBookOnDisk @Inject constructor(
    * return the previous data to avoid unnecessary data load on Libkiwix.
    */
   private var booksChanged: Boolean = false
+
+  private val _bookRemoved = MutableSharedFlow<Unit>(
+    extraBufferCapacity = 1,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST
+  )
+
+  /**
+   * A flow that emits a signal whenever a book is removed from the library, allowing observers
+   * to react to book removal events. See HotspotService for an example of how
+   * to use this flow to update the server when a book is removed.
+   */
+  val bookRemoved: SharedFlow<Unit> = _bookRemoved.asSharedFlow()
+
+  private val fileObservers = mutableListOf<FileObserver>()
+
+  init {
+    CoroutineScope(ioDispatcher).launch {
+      runCatching { registerFileObservers() }.onFailure { it.printStackTrace() }
+    }
+  }
+
+  private suspend fun registerFileObservers() {
+    val directoriesToWatch = storageDeviceProvider.getAppSpecificDirs()
+      .asSequence()
+      .flatMap { rootDir -> rootDir.walkTopDown().filter(File::isDirectory) }
+      .distinctBy(File::getAbsolutePath)
+
+    directoriesToWatch.forEach { directory ->
+      runCatching {
+        createFileObserver(directory).also {
+          fileObservers.add(it)
+          it.startWatching()
+        }
+      }.onFailure { it.printStackTrace() }
+    }
+  }
+
+  private fun createFileObserver(watchDir: File): FileObserver {
+    val mask =
+      FileObserver.CREATE or FileObserver.MOVED_TO or FileObserver.DELETE or FileObserver.MOVED_FROM
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      object : FileObserver(watchDir, mask) {
+        override fun onEvent(event: Int, path: String?) {
+          path?.let { handleFileSystemEvent(watchDir, it, event) }
+        }
+      }
+    } else {
+      @Suppress("DEPRECATION")
+      object : FileObserver(watchDir.path, mask) {
+        override fun onEvent(event: Int, path: String?) {
+          path?.let { handleFileSystemEvent(watchDir, it, event) }
+        }
+      }
+    }
+  }
+
+  private fun handleFileSystemEvent(watchDir: File, path: String, event: Int) {
+    if (!FileUtils.isValidZimFile(path) && !FileUtils.isSplittedZimFile(path)) return
+    val file = File(watchDir, path)
+    CoroutineScope(ioDispatcher).launch {
+      runCatching {
+        when (event) {
+          FileObserver.CREATE, FileObserver.MOVED_TO -> addBookFromFile(file)
+          FileObserver.DELETE, FileObserver.MOVED_FROM -> deleteByPath(file.canonicalPath)
+        }
+      }.onFailure { it.printStackTrace() }
+    }
+  }
+
+  private suspend fun addBookFromFile(file: File) {
+    if (!file.isFileExist(ioDispatcher) || !file.isFile) return
+    zimFileReaderFactory.create(ZimReaderSource(file), false)?.let { zimFileReader ->
+      try {
+        insert(listOf(Book().apply { update(zimFileReader.jniKiwixReader) }))
+      } finally {
+        zimFileReader.dispose()
+      }
+    }
+  }
+
+  suspend fun deleteByPath(filePath: String) {
+    val normalizedPath = runCatching { File(filePath).canonicalPath }.getOrDefault(filePath)
+    getBooksList().firstOrNull { book ->
+      runCatching {
+        File(book.zimReaderSource.toDatabase()).canonicalPath == normalizedPath
+      }.getOrDefault(false)
+    }?.let { delete(it.id) }
+  }
+
   private suspend fun localBookFolderPath(): String =
     if (Build.DEVICE.contains("generic")) {
       // Workaround for emulators: Emulators have limited memory and
@@ -234,6 +335,7 @@ class LibkiwixBookOnDisk @Inject constructor(
     }.onFailure { it.printStackTrace() }
     writeBookMarksAndSaveLibraryToFile()
     updateLocalBooksFlow()
+    _bookRemoved.tryEmit(Unit)
   }
 
   suspend fun delete(bookId: String) {
@@ -242,6 +344,7 @@ class LibkiwixBookOnDisk @Inject constructor(
       library.removeBookById(bookId)
       writeBookMarksAndSaveLibraryToFile()
       updateLocalBooksFlow()
+      _bookRemoved.tryEmit(Unit)
     }.onFailure { it.printStackTrace() }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -327,6 +327,7 @@ class LibkiwixBookOnDisk @Inject constructor(
     Regex("/\\.Trash/").containsMatchIn(filePath)
 
   suspend fun delete(books: List<LibkiwixBook>) {
+    if (books.isEmpty()) return
     runCatching {
       ensureInitialized()
       books.forEach {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -53,6 +53,7 @@ import org.kiwix.libkiwix.Book
 import org.kiwix.libkiwix.Library
 import org.kiwix.libkiwix.Manager
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -90,7 +91,7 @@ class LibkiwixBookOnDisk @Inject constructor(
    */
   val bookRemoved: SharedFlow<Unit> = _bookRemoved.asSharedFlow()
 
-  private val fileObservers = mutableListOf<FileObserver>()
+  private val fileObservers = ConcurrentHashMap<String, FileObserver>()
 
   init {
     CoroutineScope(ioDispatcher).launch {
@@ -104,19 +105,29 @@ class LibkiwixBookOnDisk @Inject constructor(
       .flatMap { rootDir -> rootDir.walkTopDown().filter(File::isDirectory) }
       .distinctBy(File::getAbsolutePath)
 
-    directoriesToWatch.forEach { directory ->
-      runCatching {
-        createFileObserver(directory).also {
-          fileObservers.add(it)
-          it.startWatching()
-        }
-      }.onFailure { it.printStackTrace() }
-    }
+    directoriesToWatch.forEach(::watchDirectory)
+  }
+
+  private fun watchDirectory(directory: File) {
+    val path = runCatching { directory.canonicalPath }.getOrDefault(directory.absolutePath)
+    if (fileObservers.containsKey(path)) return
+    runCatching {
+      val observer = createFileObserver(directory)
+      if (fileObservers.putIfAbsent(path, observer) == null) {
+        observer.startWatching()
+      }
+    }.onFailure { it.printStackTrace() }
+  }
+
+  private fun unwatchDirectory(directory: File) {
+    val path = runCatching { directory.canonicalPath }.getOrDefault(directory.absolutePath)
+    fileObservers.remove(path)?.stopWatching()
   }
 
   private fun createFileObserver(watchDir: File): FileObserver {
     val mask =
-      FileObserver.CREATE or FileObserver.MOVED_TO or FileObserver.DELETE or FileObserver.MOVED_FROM
+      FileObserver.CREATE or FileObserver.CLOSE_WRITE or FileObserver.MOVED_TO or
+        FileObserver.DELETE or FileObserver.MOVED_FROM
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       object : FileObserver(watchDir, mask) {
         override fun onEvent(event: Int, path: String?) {
@@ -134,16 +145,42 @@ class LibkiwixBookOnDisk @Inject constructor(
   }
 
   private fun handleFileSystemEvent(watchDir: File, path: String, event: Int) {
-    if (!FileUtils.isValidZimFile(path) && !FileUtils.isSplittedZimFile(path)) return
     val file = File(watchDir, path)
     CoroutineScope(ioDispatcher).launch {
       runCatching {
         when (event) {
-          FileObserver.CREATE, FileObserver.MOVED_TO -> addBookFromFile(file)
-          FileObserver.DELETE, FileObserver.MOVED_FROM -> deleteByPath(file.canonicalPath)
+          FileObserver.CREATE -> if (file.isDirectory) watchDirectory(file)
+          FileObserver.MOVED_TO -> handleMovedIn(file)
+          FileObserver.CLOSE_WRITE -> addZimFileIfValid(file)
+          FileObserver.DELETE, FileObserver.MOVED_FROM -> {
+            unwatchDirectory(file)
+            if (isZimFile(path)) deleteByPath(file.canonicalPath)
+          }
         }
       }.onFailure { it.printStackTrace() }
     }
+  }
+
+  /**
+   * Handles an item that was moved into a watched directory. A moved-in directory is
+   * guaranteed to already be fully written (unlike CREATE), so it's safe to start
+   * watching it and immediately scan it for ZIM files to add, covering the case
+   * where a whole folder of books is moved in at once.
+   */
+  private suspend fun handleMovedIn(file: File) {
+    if (file.isDirectory) {
+      file.walkTopDown().filter(File::isDirectory).forEach(::watchDirectory)
+      file.walkTopDown().filter { isZimFile(it.name) }.forEach { addBookFromFile(it) }
+    } else {
+      addZimFileIfValid(file)
+    }
+  }
+
+  private fun isZimFile(name: String) =
+    FileUtils.isValidZimFile(name) || FileUtils.isSplittedZimFile(name)
+
+  private suspend fun addZimFileIfValid(file: File) {
+    if (isZimFile(file.name)) addBookFromFile(file)
   }
 
   private suspend fun addBookFromFile(file: File) {

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/dao/LibkiwixBookOnDisk.kt
@@ -161,12 +161,6 @@ class LibkiwixBookOnDisk @Inject constructor(
     }
   }
 
-  /**
-   * Handles an item that was moved into a watched directory. A moved-in directory is
-   * guaranteed to already be fully written (unlike CREATE), so it's safe to start
-   * watching it and immediately scan it for ZIM files to add, covering the case
-   * where a whole folder of books is moved in at once.
-   */
   private suspend fun handleMovedIn(file: File) {
     if (file.isDirectory) {
       file.walkTopDown().filter(File::isDirectory).forEach(::watchDirectory)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/DataSource.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/DataSource.kt
@@ -31,6 +31,7 @@ import org.kiwix.libkiwix.Book
  */
 interface DataSource {
   fun getLanguageCategorizedBooks(): Flow<List<BooksOnDiskListItem>>
+  fun bookRemoved(): Flow<Unit>
   suspend fun saveBook(book: Book)
   suspend fun saveBooks(books: List<Book>)
   suspend fun saveHistory(history: HistoryItem)

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/data/Repository.kt
@@ -64,6 +64,8 @@ class Repository @Inject internal constructor(
     booksOnDiskAsListItems()
       .map { it.ifEmpty { emptyList() } }
 
+  override fun bookRemoved() = libkiwixBookOnDisk.bookRemoved
+
   override fun booksOnDiskAsListItems(): Flow<List<BooksOnDiskListItem>> =
     libkiwixBookOnDisk.books()
       .map { books ->

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
@@ -23,19 +23,25 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.mhutti1.utils.storage.StorageDevice
 import eu.mhutti1.utils.storage.StorageDeviceUtils
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.kiwix.kiwixmobile.core.di.IoDispatcher
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class StorageDeviceProvider @Inject constructor(
   @param:ApplicationContext private val context: Context,
+  private val kiwixDataStore: KiwixDataStore,
   @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
   private val mutex = Mutex()
   private var writableStorage: List<StorageDevice>? = null
+  private var appSpecificDirsCache: List<File>? = null
 
   /**
    * Returns the writable storage devices, caching the result for the lifetime of the app process.
@@ -50,5 +56,30 @@ class StorageDeviceProvider @Inject constructor(
       writableStorage ?: StorageDeviceUtils
         .getWritableStorage(context, ioDispatcher)
         .also { writableStorage = it }
+    }
+
+  /**
+   * Returns the app-specific directories across internal and external storage,
+   * caching the result for performance.
+   */
+  suspend fun getAppSpecificDirs(): List<File> =
+    mutex.withLock {
+      appSpecificDirsCache ?: withContext(ioDispatcher) {
+        val dirs = mutableListOf<File>()
+        context.getExternalFilesDirs("")?.filterNotNull()?.let { dirs.addAll(it) }
+        context.getExternalFilesDirs(null)?.filterNotNull()?.let { dirs.addAll(it) }
+        context.filesDir?.let { dirs.add(it) }
+        context.cacheDir?.let { dirs.add(it) }
+
+        val selectedStoragePath = runCatching {
+          kiwixDataStore.selectedStorage.first()
+        }.getOrDefault("")
+
+        if (selectedStoragePath.isNotEmpty()) {
+          dirs.add(File(selectedStoragePath))
+        }
+
+        dirs.distinctBy { it.absolutePath }
+      }.also { appSpecificDirsCache = it }
     }
 }

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProvider.kt
@@ -41,7 +41,7 @@ class StorageDeviceProvider @Inject constructor(
 ) {
   private val mutex = Mutex()
   private var writableStorage: List<StorageDevice>? = null
-  private var appSpecificDirsCache: List<File>? = null
+  private var staticAppSpecificDirsCache: List<File>? = null
 
   /**
    * Returns the writable storage devices, caching the result for the lifetime of the app process.
@@ -64,22 +64,22 @@ class StorageDeviceProvider @Inject constructor(
    */
   suspend fun getAppSpecificDirs(): List<File> =
     mutex.withLock {
-      appSpecificDirsCache ?: withContext(ioDispatcher) {
+      val staticDirs = staticAppSpecificDirsCache ?: withContext(ioDispatcher) {
         val dirs = mutableListOf<File>()
         context.getExternalFilesDirs("")?.filterNotNull()?.let { dirs.addAll(it) }
         context.getExternalFilesDirs(null)?.filterNotNull()?.let { dirs.addAll(it) }
         context.filesDir?.let { dirs.add(it) }
-        context.cacheDir?.let { dirs.add(it) }
+        dirs
+      }.also { staticAppSpecificDirsCache = it }
 
-        val selectedStoragePath = runCatching {
-          kiwixDataStore.selectedStorage.first()
-        }.getOrDefault("")
+      val selectedStoragePath = runCatching {
+        kiwixDataStore.selectedStorage.first()
+      }.getOrDefault("")
 
-        if (selectedStoragePath.isNotEmpty()) {
-          dirs.add(File(selectedStoragePath))
-        }
-
-        dirs.distinctBy { it.absolutePath }
-      }.also { appSpecificDirsCache = it }
+      val dirs = staticDirs.toMutableList()
+      if (selectedStoragePath.isNotEmpty()) {
+        dirs.add(File(selectedStoragePath))
+      }
+      dirs.distinctBy { it.absolutePath }
     }
 }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/data/RepositoryTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/data/RepositoryTest.kt
@@ -28,6 +28,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -533,6 +534,18 @@ class RepositoryTest {
         val items = awaitItem()
         // Only one book with ID "1" should remain
         assertThat(items.filterIsInstance<BookOnDisk>()).hasSize(1)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `bookRemoved delegates to libkiwixBookOnDisk`() = runTest {
+      val removals = MutableSharedFlow<Unit>()
+      every { libkiwixBookOnDisk.bookRemoved } returns removals
+
+      repository.bookRemoved().test {
+        removals.emit(Unit)
+        awaitItem()
         cancelAndIgnoreRemainingEvents()
       }
     }

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProviderTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/StorageDeviceProviderTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Kiwix Android
+ * Copyright (c) 2026 Kiwix <android.kiwix.org>
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.kiwix.kiwixmobile.core.utils
+
+import android.content.Context
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.kiwix.kiwixmobile.core.utils.datastore.KiwixDataStore
+import org.kiwix.sharedFunctions.MainDispatcherRule
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorageDeviceProviderTest {
+  @JvmField
+  @RegisterExtension
+  val mainDispatcherRule = MainDispatcherRule()
+
+  private val context: Context = mockk()
+  private val kiwixDataStore: KiwixDataStore = mockk()
+
+  private lateinit var storageDeviceProvider: StorageDeviceProvider
+
+  private val externalFilesDir =
+    File("/storage/emulated/0/Android/data/org.kiwix.kiwixmobile/files")
+  private val filesDir = File("/data/user/0/org.kiwix.kiwixmobile/files")
+  private val cacheDir = File("/data/user/0/org.kiwix.kiwixmobile/cache")
+  private val selectedStoragePath = "/storage/emulated/0/Kiwix"
+
+  @BeforeEach
+  fun setUp() {
+    clearMocks(context, kiwixDataStore)
+    every { context.getExternalFilesDirs("") } returns arrayOf(externalFilesDir)
+    every { context.getExternalFilesDirs(null) } returns arrayOf(externalFilesDir)
+    every { context.filesDir } returns filesDir
+    coEvery { kiwixDataStore.selectedStorage } returns flowOf(selectedStoragePath)
+
+    storageDeviceProvider =
+      StorageDeviceProvider(context, kiwixDataStore, mainDispatcherRule.dispatcher)
+  }
+
+  @Test
+  fun `getAppSpecificDirs combines context dirs and the selected storage path`() = runTest {
+    val dirs = storageDeviceProvider.getAppSpecificDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactlyInAnyOrder(
+      externalFilesDir.absolutePath,
+      filesDir.absolutePath,
+      File(selectedStoragePath).absolutePath
+    )
+  }
+
+  @Test
+  fun `getAppSpecificDirs dedupes directories that resolve to the same path`() = runTest {
+    every { context.getExternalFilesDirs(null) } returns arrayOf(filesDir)
+
+    val dirs = storageDeviceProvider.getAppSpecificDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactlyInAnyOrder(
+      externalFilesDir.absolutePath,
+      filesDir.absolutePath,
+      File(selectedStoragePath).absolutePath
+    )
+  }
+
+  @Test
+  fun `getAppSpecificDirs omits the selected storage entry when it is blank`() = runTest {
+    coEvery { kiwixDataStore.selectedStorage } returns flowOf("")
+
+    val dirs = storageDeviceProvider.getAppSpecificDirs()
+
+    assertThat(dirs.map { it.absolutePath }).containsExactlyInAnyOrder(
+      externalFilesDir.absolutePath,
+      filesDir.absolutePath
+    )
+  }
+
+  @Test
+  fun `getAppSpecificDirs excludes cacheDir since ZIM files are never stored there`() = runTest {
+    val dirs = storageDeviceProvider.getAppSpecificDirs()
+
+    assertThat(dirs.map { it.absolutePath }).doesNotContain(cacheDir.absolutePath)
+  }
+
+  @Test
+  fun `getAppSpecificDirs caches the static OS dirs but re-reads selected storage every call`() =
+    runTest {
+      storageDeviceProvider.getAppSpecificDirs()
+      storageDeviceProvider.getAppSpecificDirs()
+
+      verify(exactly = 1) { context.getExternalFilesDirs("") }
+      coVerify(exactly = 2) { kiwixDataStore.selectedStorage }
+    }
+
+  @Test
+  fun `getAppSpecificDirs reflects a newly selected storage path without process restart`() =
+    runTest {
+      val firstDirs = storageDeviceProvider.getAppSpecificDirs()
+      assertThat(firstDirs.map { it.absolutePath }).contains(
+        File(selectedStoragePath).absolutePath
+      )
+
+      val newStoragePath = "/storage/emulated/1/Kiwix"
+      coEvery { kiwixDataStore.selectedStorage } returns flowOf(newStoragePath)
+
+      val secondDirs = storageDeviceProvider.getAppSpecificDirs()
+
+      assertThat(secondDirs.map { it.absolutePath }).contains(
+        File(newStoragePath).absolutePath
+      )
+      assertThat(secondDirs.map { it.absolutePath }).doesNotContain(
+        File(selectedStoragePath).absolutePath
+      )
+    }
+}


### PR DESCRIPTION
Fixes #4341 

* Added a `FileObserver` to `LibkiwixBookOnDisk` to listen for changes in the app-specific directory. This allows us to detect when files are added, removed, or moved, so the changes can be automatically reflected in the `LocalLibrary`. This also helps prevent issues like #4965. For the current issue, when a book is removed, an event is emitted, and the `HotspotService` listens for this event to update the available books.
* Introduced a `bookRemoved` flow in `LibkiwixBookOnDisk`, which emits an event when a book is deleted. This allows observers to detect the removal and take the appropriate action.
* Refactored `HotspotService` to update the server when a file is deleted.
* Added unit test cases to verify the behaviour.
* Fixed: `LanguageScreenTest`, and `InitialDownloadTest` which sometimes failed on API level 25.
* Fixed: `fileTypeDeepLinkTest`, and `contentTypeDeepLinkTest` which were failing on API level 25.
* Added `HotspotServiceTest` unit test cases to verify the resyncing of the server when files are deleted from storage.
* Added `StorageDeviceProviderTest` to verify the StorageDeviceProvider functionality.