### PR TITLE
feat: add a setting to disable animations for e-ink devices

### DIFF
--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/SettingsScreen.kt
@@ -550,6 +550,8 @@ private fun ExtrasCategory(
 private fun DisplayCategory(coreSettingsViewModel: CoreSettingsViewModel) {
   val themeLabel by coreSettingsViewModel.themeLabel.collectAsStateWithLifecycle()
   val backToTopEnabled by coreSettingsViewModel.backToTopEnabled.collectAsStateWithLifecycle()
+  val disableAnimationsEnabled by
+    coreSettingsViewModel.disableAnimationsEnabled.collectAsStateWithLifecycle()
   val textZoom by coreSettingsViewModel.textZoom.collectAsStateWithLifecycle()
   val textZoomPosition = (textZoom / ZOOM_SCALE) - ZOOM_OFFSET
   SettingsCategory(stringResource(R.string.pref_display_title)) {
@@ -559,6 +561,12 @@ private fun DisplayCategory(coreSettingsViewModel: CoreSettingsViewModel) {
       summary = stringResource(R.string.pref_back_to_top_summary),
       checked = backToTopEnabled,
       onCheckedChange = { coreSettingsViewModel.setBackToTop(it) }
+    )
+    SwitchPreference(
+      title = stringResource(R.string.pref_disable_animations),
+      summary = stringResource(R.string.pref_disable_animations_summary),
+      checked = disableAnimationsEnabled,
+      onCheckedChange = { coreSettingsViewModel.setDisableAnimations(it) }
     )
     SeekBarPreference(
       title = stringResource(R.string.pref_text_zoom_title),

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModel.kt
@@ -141,6 +141,13 @@ abstract class CoreSettingsViewModel(
       initialValue = false
     )
 
+  val disableAnimationsEnabled = kiwixDataStore.disableAnimations
+    .stateIn(
+      scope = viewModelScope,
+      started = SharingStarted.Eagerly,
+      initialValue = false
+    )
+
   val externalLinkPopup = kiwixDataStore.externalLinkPopup
     .stateIn(
       scope = viewModelScope,
@@ -191,6 +198,12 @@ abstract class CoreSettingsViewModel(
   fun setBackToTop(enabled: Boolean) {
     viewModelScope.launch {
       kiwixDataStore.setPrefBackToTop(enabled)
+    }
+  }
+
+  fun setDisableAnimations(disabled: Boolean) {
+    viewModelScope.launch {
+      kiwixDataStore.setDisableAnimations(disabled)
     }
   }
 

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixFloatingActionButton.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/ui/components/KiwixFloatingActionButton.kt
@@ -27,13 +27,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.map
 import org.kiwix.kiwixmobile.core.extensions.pulsing
 import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
+import org.kiwix.kiwixmobile.core.utils.datastore.PreferencesKeys
+import org.kiwix.kiwixmobile.core.utils.datastore.kiwixDataStore
 
 /**
  * A reusable Floating Action Button (FAB) composable used across multiple screens
@@ -49,6 +55,7 @@ import org.kiwix.kiwixmobile.core.ui.theme.KiwixTheme
  * @param contentColor The color used for the content of fab button(Icon). Defaults to
  *        [MaterialTheme.colorScheme.onSurface].
  * @param shouldPulse enables the pulsing effect on fab button. By-default it is disabled.
+ *        Suppressed regardless of this value when the "Disable animations" setting is on.
  */
 @Composable
 fun KiwixFloatingActionButton(
@@ -70,7 +77,16 @@ fun KiwixFloatingActionButton(
         }
       }
     }
-    val pulseModifier = if (shouldPulse) {
+    // See issue #3521: a continuously looping animation is exactly the kind of
+    // thing e-ink users want to turn off, so this checks the flag directly
+    // rather than requiring every caller to thread it through.
+    val context = LocalContext.current
+    val animationsDisabled by remember(context) {
+      context.kiwixDataStore.data.map { prefs ->
+        prefs[PreferencesKeys.PREF_DISABLE_ANIMATIONS] ?: false
+      }
+    }.collectAsStateWithLifecycle(initialValue = false)
+    val pulseModifier = if (shouldPulse && !animationsDisabled) {
       Modifier.pulsing()
     } else {
       Modifier

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStore.kt
@@ -104,6 +104,22 @@ class KiwixDataStore @Inject constructor(
     }
   }
 
+  /**
+   * Disables the app's animated effects (e.g. the pulsing back-to-top button) - see
+   * issue #3521. Aimed at e-ink displays, where a continuously looping animation causes
+   * needless partial refreshes and drains battery for no visual benefit. Off by default.
+   */
+  val disableAnimations: Flow<Boolean> =
+    context.kiwixDataStore.data.map { prefs ->
+      prefs[PreferencesKeys.PREF_DISABLE_ANIMATIONS] ?: false
+    }
+
+  suspend fun setDisableAnimations(disabled: Boolean) {
+    context.kiwixDataStore.edit { prefs ->
+      prefs[PreferencesKeys.PREF_DISABLE_ANIMATIONS] = disabled
+    }
+  }
+
   val openNewTabInBackground: Flow<Boolean> =
     context.kiwixDataStore.data.map { prefs ->
       prefs[PreferencesKeys.PREF_NEW_TAB_BACKGROUND] ?: false
@@ -677,6 +693,7 @@ class KiwixDataStore @Inject constructor(
     const val PREF_IS_TEST = "is_test"
     const val PREF_SHOW_SHOWCASE = "showShowCase"
     const val PREF_BACK_TO_TOP = "pref_backtotop"
+    const val PREF_DISABLE_ANIMATIONS = "pref_disable_animations"
     const val PREF_NEW_TAB_BACKGROUND = "pref_newtab_background"
     const val PREF_EXTERNAL_LINK_POPUP = "pref_external_link_popup"
     const val PREF_SHOW_STORAGE_OPTION = "show_storgae_option"

--- a/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
+++ b/core/src/main/java/org/kiwix/kiwixmobile/core/utils/datastore/PreferencesKeys.kt
@@ -29,6 +29,7 @@ object PreferencesKeys {
   val TAG_CURRENT_FILE = stringPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_FILE)
   val TAG_CURRENT_TAB = intPreferencesKey(org.kiwix.kiwixmobile.core.utils.TAG_CURRENT_TAB)
   val PREF_BACK_TO_TOP = booleanPreferencesKey(KiwixDataStore.PREF_BACK_TO_TOP)
+  val PREF_DISABLE_ANIMATIONS = booleanPreferencesKey(KiwixDataStore.PREF_DISABLE_ANIMATIONS)
   val PREF_NEW_TAB_BACKGROUND = booleanPreferencesKey(KiwixDataStore.PREF_NEW_TAB_BACKGROUND)
   val PREF_EXTERNAL_LINK_POPUP =
     booleanPreferencesKey(KiwixDataStore.PREF_EXTERNAL_LINK_POPUP)

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
   <string name="theme_dark">Dark</string>
   <string name="pref_back_to_top">Back to Top</string>
   <string name="pref_back_to_top_summary">Display a button at the end of the page to scroll up to the top</string>
+  <string name="pref_disable_animations">Disable animations</string>
+  <string name="pref_disable_animations_summary">Turn off animated effects such as the pulsing back-to-top button, useful on e-ink displays</string>
   <string name="pref_language_title">Language</string>
   <string name="pref_language_chooser">Choose a language</string>
   <string name="pref_credits">Contributors and Licenses</string>

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/SettingsScreenTest.kt
@@ -84,6 +84,7 @@ class SettingsScreenTest {
     uiState: SettingsUiState = SettingsUiState(),
     themeLabel: String = "System default",
     backToTopEnabled: Boolean = false,
+    disableAnimationsEnabled: Boolean = false,
     textZoom: Int = DEFAULT_ZOOM,
     newTabInBackground: Boolean = false,
     externalLinkPopup: Boolean = true,
@@ -93,6 +94,7 @@ class SettingsScreenTest {
     every { viewModel.uiState } returns MutableStateFlow(uiState)
     every { viewModel.themeLabel } returns MutableStateFlow(themeLabel)
     every { viewModel.backToTopEnabled } returns MutableStateFlow(backToTopEnabled)
+    every { viewModel.disableAnimationsEnabled } returns MutableStateFlow(disableAnimationsEnabled)
     every { viewModel.textZoom } returns MutableStateFlow(textZoom)
     every { viewModel.newTabInBackground } returns MutableStateFlow(newTabInBackground)
     every { viewModel.externalLinkPopup } returns MutableStateFlow(externalLinkPopup)
@@ -244,6 +246,38 @@ class SettingsScreenTest {
       .onNodeWithText(context.getString(R.string.pref_back_to_top_summary))
       .performClick()
     verify { viewModel.setBackToTop(true) }
+  }
+
+  @Test
+  fun settingsScreen_displayCategory_disableAnimationsSwitch_isDisplayed() {
+    renderSettingsScreen(createMockViewModel())
+    scrollToContentDescription(context.getString(R.string.pref_disable_animations))
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_disable_animations))
+      .assertIsDisplayed()
+      .assertIsOff()
+  }
+
+  @Test
+  fun disableAnimationsSwitch_reflectsStateChange() {
+    renderSettingsScreen(createMockViewModel(disableAnimationsEnabled = true))
+    scrollToContentDescription(context.getString(R.string.pref_disable_animations))
+
+    composeTestRule
+      .onNodeWithTag(context.getString(R.string.pref_disable_animations))
+      .assertIsDisplayed()
+      .assertIsOn()
+  }
+
+  @Test
+  fun settingsScreen_displayCategory_disableAnimationsSwitch_toggleTriggersCallback() {
+    val viewModel = createMockViewModel(disableAnimationsEnabled = false)
+    renderSettingsScreen(viewModel)
+    scrollToText(context.getString(R.string.pref_disable_animations))
+    composeTestRule
+      .onNodeWithText(context.getString(R.string.pref_disable_animations_summary))
+      .performClick()
+    verify { viewModel.setDisableAnimations(true) }
   }
 
   @Test

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/settings/viewmodel/CoreSettingsViewModelTest.kt
@@ -179,6 +179,7 @@ internal class CoreSettingsViewModelTest {
     // // Stub all KiwixDataStore Flow properties needed during ViewModel construction
     every { kiwixDataStore.appTheme } returns flowOf(ThemeConfig.Theme.SYSTEM)
     every { kiwixDataStore.backToTop } returns flowOf(false)
+    every { kiwixDataStore.disableAnimations } returns flowOf(false)
     every { kiwixDataStore.externalLinkPopup } returns flowOf(true)
     every { kiwixDataStore.textZoom } returns flowOf(DEFAULT_ZOOM)
     every { kiwixDataStore.openNewTabInBackground } returns flowOf(false)
@@ -323,6 +324,23 @@ internal class CoreSettingsViewModelTest {
       coVerify {
         kiwixDataStore.setPrefBackToTop(true)
         kiwixDataStore.setPrefBackToTop(false)
+      }
+    }
+
+    @Test
+    fun `setDisableAnimations delegates to kiwixDataStore`() = runTest {
+      coEvery { kiwixDataStore.setDisableAnimations(any()) } just Runs
+      viewModel.setDisableAnimations(true)
+      advanceUntilIdle()
+      coVerify { kiwixDataStore.setDisableAnimations(true) }
+
+      // Toggles values
+      viewModel.setDisableAnimations(true)
+      viewModel.setDisableAnimations(false)
+      advanceUntilIdle()
+      coVerify {
+        kiwixDataStore.setDisableAnimations(true)
+        kiwixDataStore.setDisableAnimations(false)
       }
     }
 
@@ -501,6 +519,33 @@ internal class CoreSettingsViewModelTest {
       createViewModel()
 
       viewModel.backToTopEnabled.test {
+        // Assert initial item
+        assertFalse(awaitItem())
+        flow.emit(true)
+        assertTrue(awaitItem())
+        flow.emit(false)
+        assertFalse(awaitItem())
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+    @Test
+    fun `disableAnimationsEnabled uses default when flow is empty`() = runTest {
+      every { kiwixDataStore.disableAnimations } returns emptyFlow()
+
+      createViewModel()
+
+      assertFalse(viewModel.disableAnimationsEnabled.value)
+    }
+
+    @Test
+    fun `disableAnimationsEnabled emits values from datastore`() = runTest {
+      val flow = MutableStateFlow(false)
+      every { kiwixDataStore.disableAnimations } returns flow
+
+      createViewModel()
+
+      viewModel.disableAnimationsEnabled.test {
         // Assert initial item
         assertFalse(awaitItem())
         flow.emit(true)

--- a/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
+++ b/core/src/test/java/org/kiwix/kiwixmobile/core/utils/datastore/KiwixDataStoreTest.kt
@@ -187,6 +187,27 @@ class KiwixDataStoreTest {
   }
 
   @Test
+  fun `disableAnimations returns false by default`() = runTest {
+    assertThat(kiwixDataStore.disableAnimations.first()).isFalse()
+  }
+
+  @Test
+  fun `setDisableAnimations toggles disableAnimations`() = runTest {
+    kiwixDataStore.setDisableAnimations(true)
+    assertThat(kiwixDataStore.disableAnimations.first()).isTrue()
+  }
+
+  @Test
+  fun `disableAnimations emits updates`() = runTest {
+    kiwixDataStore.disableAnimations.test {
+      assertThat(awaitItem()).isFalse()
+      kiwixDataStore.setDisableAnimations(true)
+      assertThat(awaitItem()).isTrue()
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
   fun `openNewTabInBackground returns false by default`() = runTest {
     assertThat(kiwixDataStore.openNewTabInBackground.first()).isFalse()
   }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Relates to #3521.

Issue #3521 asks for three things; the pagination request is already covered by #4122/#5087. This addresses the second: **"allow to disable animations"**.

## Scope

Rather than threading a flag through every `AnimatedVisibility`/`tween` call in the app - a much larger, riskier diff touching screens that have nothing to do with e-ink - this targets the one animation that actually matters for the use case: the "back to top" FAB's pulsing effect is a continuous, infinitely-repeating scale animation, so on an e-ink panel it forces a partial refresh every cycle for as long as the button is visible. The app's other animations (toolbar slide, tab-switcher fade, chevron rotate) are one-shot and finish in well under a second - not the battery/flicker problem this issue is about. Happy to extend to those too if reviewers want broader scope; flagging as a possible follow-up for now.

## Implementation

- `KiwixDataStore.disableAnimations`: new persisted flag, off by default.
- `KiwixFloatingActionButton`: reads the flag directly via `LocalContext.current.kiwixDataStore` rather than threading it through three separate call sites (`ReaderScreen`, `LocalLibraryScreen`, `OnlineLibraryScreen`) and their view models - the same technique `PageScreen` already uses for `isBrandedApp`.
- Settings: new switch under Display, "Disable animations".

**Verified locally**: `detektDebug`/`ktlintCheck`/`lintDebug` clean on `:core`/`:app`. Full `:core:testDebugUnitTest` and `:app:testDebugUnitTest` suites green, including new coverage for the datastore flag, the settings toggle, and the view model state.

This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submission.
