### PR TITLE
fix: resolve build warnings (#5086)

### DIFF
--- a/app/src/main/java/org/kiwix/kiwixmobile/language/repository/LanguageRepositoryImpl.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/language/repository/LanguageRepositoryImpl.kt
@@ -38,9 +38,9 @@ import org.kiwix.kiwixmobile.core.zim_manager.Language
 import javax.inject.Inject
 
 class LanguageRepositoryImpl @Inject constructor(
-  @OPDSKiwixService private val kiwixService: KiwixService,
+  @param:OPDSKiwixService private val kiwixService: KiwixService,
   private val kiwixDataStore: KiwixDataStore,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+  @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : LanguageRepository {
   override fun fetchLanguages(): Flow<List<Language>> = flow {
     val feed = kiwixService.getLanguages()

--- a/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverDevice.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/localFileTransfer/ReceiverDevice.kt
@@ -62,8 +62,8 @@ internal class ReceiverDevice(
                   Log.d(TAG, "Sender device connected for ${fileItem.fileName}")
                   publishProgress(fileItemIndex, FileItem.FileStatus.SENDING)
                   val clientNoteFileLocation = File(zimStorageRootPath + fileItem.fileName)
-                  val dirs = File(clientNoteFileLocation.parent)
-                  if (!dirs.exists() && !dirs.mkdirs()) {
+                  val dirs = clientNoteFileLocation.parentFile
+                  if (dirs != null && !dirs.exists() && !dirs.mkdirs()) {
                     Log.d(TAG, "ERROR: Required parent directories couldn't be created")
                     isTransferErrorFree = false
                   }

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/FileOperationHandlerImpl.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/local/FileOperationHandlerImpl.kt
@@ -101,7 +101,7 @@ class FileOperationHandlerImpl @Inject constructor(
     originalParentUri: Uri
   ): Boolean = tryMoveWithDocumentContract(
     destinationFile.toUri(),
-    destinationFile.parentFile.toUri(),
+    destinationFile.parentFile!!.toUri(),
     originalParentUri
   )
 

--- a/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/org/kiwix/kiwixmobile/nav/destination/library/online/repository/CategoryRepositoryImpl.kt
@@ -36,9 +36,9 @@ import org.kiwix.kiwixmobile.core.zim_manager.Category
 import javax.inject.Inject
 
 class CategoryRepositoryImpl @Inject constructor(
-  @OPDSKiwixService private val kiwixService: KiwixService,
+  @param:OPDSKiwixService private val kiwixService: KiwixService,
   private val kiwixDataStore: KiwixDataStore,
-  @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+  @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : CategoryRepository {
   @Suppress("MagicNumber")
   override fun fetchCategories(): Flow<List<Category>> = flow {


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes #5086: build warnings.

- `LanguageRepositoryImpl`/`CategoryRepositoryImpl`: annotate constructor params with `@param:` (KT-73255) so the qualifier/dispatcher annotations don't also apply to the property target.
- `ReceiverDevice`: `File(clientNoteFileLocation.parent)` could NPE if `.parent` were ever null; switched to `.parentFile` with a null guard.
- `FileOperationHandlerImpl`: `destinationFile.parentFile.toUri()` called a non-null-only method on a nullable receiver. The function already carries `@Suppress("UnsafeCallOnNullableType")`, so added the `!!` that suppression was meant to cover.

Verified: `:app:compileDebugKotlin` no longer emits any of the four warnings, `:app:detektDebug`/`:app:ktlintCheck` clean, and `LanguageRepositoryImplTest`/`CategoryRepositoryImplTest` pass.
