### PR TITLE
fix(test): clear leftover ZIM files before downloadServiceTest searches online

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -31,20 +31,22 @@ import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.Assertions
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.HILT_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
@@ -85,6 +87,14 @@ class DownloadServiceTest : BaseActivityTest() {
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
         kiwixMainActivity = it
+        it.navigate(KiwixDestination.Library.route)
+      }
+      library {
+        refreshList(composeTestRule)
+        waitUntilZimFilesRefreshing(composeTestRule)
+        deleteZimIfExists(composeTestRule)
+      }
+      activityScenario.onActivity {
         it.navigate(KiwixDestination.Downloads.route)
       }
       downloadRobot {
@@ -116,17 +126,21 @@ class DownloadServiceTest : BaseActivityTest() {
     }
   }
 
+  @After
+  fun finish() {
+    TestUtils.deleteTemporaryFilesOfTestCases(context)
+  }
+
   private fun assetDownloadService(isRunning: Boolean) {
-    composeTestRule.waitUntilTimeout(3000)
     // press the home button so that application goes into background
     InstrumentationRegistry.getInstrumentation().uiAutomation.performGlobalAction(
       AccessibilityService.GLOBAL_ACTION_HOME
     )
-    // Now we are downloading the small file so we need to check the service initialization.
-    Assertions.assertEquals(
-      isRunning,
-      DownloadMonitorService.isDownloadMonitorServiceRunning
-    )
+    // Poll instead of a fixed sleep - a wait that's enough on one API level/device
+    // isn't guaranteed enough on a slower one.
+    composeTestRule.waitUntil(timeoutMillis = TestUtils.TEST_PAUSE_MS_FOR_DOWNLOAD_TEST) {
+      DownloadMonitorService.isDownloadMonitorServiceRunning == isRunning
+    }
     composeTestRule.waitUntilTimeout(3000)
   }
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Fixes #5088

## Summary

Relates to #5088 (`DownloadServiceTest` sometimes fails on API level 36).

CI logs for the linked failing run show the D3.js Docs ZIM already present in the local library over a minute *before* `downloadServiceTest()`'s own download attempt even starts. Once a book is local, the app correctly hides it from the online library's search results - so `downloadZimFile()`'s wait for the search result times out; not a bug in the download flow itself, just a stale precondition.

`InitialDownloadTest` and `DownloadTest` already guard against exactly this (`deleteZimIfExists()` before searching, `@After` cleanup) - `DownloadServiceTest` was simply missing both. This brings it in line with its siblings.

## Test plan

- [x] `./gradlew :app:compileDebugAndroidTestSources` - compiles clean.
- [x] `:core:testDebugUnitTest`/`:app:testDebugUnitTest`/`:core:detektDebug`/`:app:detektDebug`/`:core:ktlintCheck`/`:app:lintDebug` - all pass.
- [x] Instrumented `downloadServiceTest()` on a real API 36 emulator (`Medium_Phone_API_36.1`, matching the issue's failing level): `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.kiwix.kiwixmobile.download.DownloadServiceTest` - 1/1 passed.

## Related

- Diagnosed while investigating #5088.
