### PR TITLE
chore: upgrade Robolectric to 4.17-beta-4 for JDK 26 support

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -112,7 +112,7 @@ object Versions {
 
   const val LIFECYCLE_VERSION = "2.8.6"
 
-  const val ROBOLECTRIC = "4.16.1"
+  const val ROBOLECTRIC = "4.17-beta-4"
   const val BENCHMARK_MACRO: String = "1.4.1"
 
   const val ACCOMPANIST = "0.34.0"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Bumps Robolectric 4.16.1 → 4.17-beta-4.

**Why**: on a machine whose default JDK is 26, Robolectric-backed unit tests (Compose screen tests, broadcast-receiver tests, etc.) fail immediately with `IllegalArgumentException: Unsupported class file major version 70` — before the test logic runs at all. Robolectric uses ASM to read class files at test time, and 4.16.1's bundled ASM doesn't recognize JDK 26 bytecode (class file major version 70). ASM added `Opcodes.V26` in 9.9; Robolectric bundles ASM 9.10.1 as of 4.17-beta-1.

**Caveat**: 4.17 has no stable release yet (still beta-4 as of this PR). This trades a known, narrow issue (test failures on very new local JDKs) for depending on a beta artifact. Happy to hold this until 4.17 goes stable if that's preferred — flagging it explicitly rather than sneaking a beta dependency in.

**The underlying tradeoff, for anyone hitting this**: on a JDK 26 machine, either (a) this Robolectric bump, or (b) pin a Gradle Java toolchain (`jvmToolchain(21)`) plus a toolchain resolver plugin (e.g. `org.gradle.toolchains.foojay-resolver-convention`) so Gradle runs the compiler/test JVMs on a JDK Robolectric already supports — is needed to get green tests. (b) wasn't pursued here: it requires a JDK either present locally or downloadable over the network during the build, so it can turn "compiles everywhere, some tests fail on new JDKs" into "hard build failure without network/a specific JDK" for anyone whose environment can't auto-provision. This PR takes the narrower, lower-blast-radius route.

**Verified** on a JDK 26 machine: full `:app:testDebugUnitTest` and `:core:testDebugUnitTest` suites pass (several Compose/Robolectric-backed test classes previously failed outright on the class-file-version error alone, unrelated to their actual assertions), `detektDebug`/`ktlintCheck` clean across all modules.

This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submission.
