### PR TITLE
chore: upgrade Gradle 9.5.0 -> 9.7.1, fix Gradle-10-incompatible deprecations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,12 @@
 import com.slack.keeper.optInToKeeper
+import org.gradle.api.flow.FlowAction
+import org.gradle.api.flow.FlowParameters
+import org.gradle.api.flow.FlowScope
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.kotlin.dsl.newInstance
+import javax.inject.Inject
 import org.w3c.dom.Element
 import plugin.KiwixConfigurationPlugin
 import java.io.StringWriter
@@ -22,6 +30,9 @@ apply(from = rootProject.file("jacoco.gradle"))
 fun generateVersionName() = "${Config.versionMajor}.${Config.versionMinor}.${Config.versionPatch}"
 
 val apkPrefix get() = System.getenv("TAG") ?: "kiwix"
+// Project.properties (Map) is deprecated (removed in Gradle 10); providers.gradleProperty
+// is the lazy Provider-API replacement for checking whether a project property is set.
+val disableSigningRequested = providers.gradleProperty("disableSigning").isPresent
 val autoModifiedTrackedFiles = listOf(
   File("$rootDir/core/src/main/res/values-b+be+tarask/strings.xml"),
   File("$rootDir/core/src/main/res/values-b+be+tarask+old/strings.xml"),
@@ -44,25 +55,6 @@ fun backupTrackedFile(file: File) {
   } else if (backupFile.exists()) {
     backupFile.delete()
   }
-}
-
-fun restoreTrackedFile(file: File) {
-  val fileKey =
-    file.relativeTo(rootDir).path.replace(File.separator, "_")
-  val backupFile = File(trackedFileBackupDir, "$fileKey.bak")
-  val existsMarkerFile = File(trackedFileBackupDir, "$fileKey.exists")
-  if (!existsMarkerFile.exists()) return
-
-  val existedBeforeBuild = existsMarkerFile.readText().trim() == "1"
-  if (existedBeforeBuild && backupFile.exists()) {
-    if (!file.parentFile.exists()) file.parentFile.mkdirs()
-    backupFile.copyTo(file, overwrite = true)
-  } else if (!existedBeforeBuild && file.exists()) {
-    file.delete()
-  }
-
-  backupFile.delete()
-  existsMarkerFile.delete()
 }
 
 android {
@@ -92,7 +84,7 @@ android {
     getByName("release") {
       buildConfigField("boolean", "KIWIX_ERROR_ACTIVITY", "true")
       buildConfigField("boolean", "IS_PLAYSTORE", "false")
-      if (properties.containsKey("disableSigning")) {
+      if (disableSigningRequested) {
         signingConfig = null
       }
     }
@@ -271,10 +263,19 @@ fun elementToString(element: Element): String {
   return result.writer.toString()
 }
 
-gradle.buildFinished {
-  autoModifiedTrackedFiles.forEach(::restoreTrackedFile)
-  if (trackedFileBackupDir.exists() && trackedFileBackupDir.listFiles().isNullOrEmpty()) {
-    trackedFileBackupDir.delete()
+// gradle.buildFinished(Action) is deprecated (removed in Gradle 10); the Flow API
+// (https://docs.gradle.org/current/userguide/dataflow_actions.html) is the replacement.
+// A FlowAction is isolated from the script - it can't see autoModifiedTrackedFiles/
+// rootDir/trackedFileBackupDir directly, so those go in via FlowParameters instead,
+// and the restore logic (previously restoreTrackedFile()) is reimplemented inline here.
+// FlowScope isn't reachable as a script-top-level service, so it's obtained through a
+// throwaway injected holder object instead.
+abstract class FlowServices @Inject constructor(val flowScope: FlowScope)
+objects.newInstance<FlowServices>().flowScope.always(RestoreTrackedFilesFlowAction::class) {
+  parameters {
+    rootDirPath.set(rootDir.path)
+    trackedFilePaths.set(autoModifiedTrackedFiles.map { it.path })
+    backupDirPath.set(trackedFileBackupDir.path)
   }
 }
 
@@ -284,6 +285,45 @@ gradle.projectsEvaluated {
       if (path != ":app:renameTarakFile") {
         dependsOn(":app:renameTarakFile")
       }
+    }
+  }
+}
+
+abstract class RestoreTrackedFilesFlowAction : FlowAction<RestoreTrackedFilesFlowAction.Params> {
+  interface Params : FlowParameters {
+    @get:Input
+    val rootDirPath: Property<String>
+
+    @get:Input
+    val trackedFilePaths: ListProperty<String>
+
+    @get:Input
+    val backupDirPath: Property<String>
+  }
+
+  override fun execute(parameters: Params) {
+    val rootDir = File(parameters.rootDirPath.get())
+    val trackedFileBackupDir = File(parameters.backupDirPath.get())
+    parameters.trackedFilePaths.get().forEach { path ->
+      val file = File(path)
+      val fileKey = file.relativeTo(rootDir).path.replace(File.separator, "_")
+      val backupFile = File(trackedFileBackupDir, "$fileKey.bak")
+      val existsMarkerFile = File(trackedFileBackupDir, "$fileKey.exists")
+      if (!existsMarkerFile.exists()) return@forEach
+
+      val existedBeforeBuild = existsMarkerFile.readText().trim() == "1"
+      if (existedBeforeBuild && backupFile.exists()) {
+        if (!file.parentFile.exists()) file.parentFile.mkdirs()
+        backupFile.copyTo(file, overwrite = true)
+      } else if (!existedBeforeBuild && file.exists()) {
+        file.delete()
+      }
+
+      backupFile.delete()
+      existsMarkerFile.delete()
+    }
+    if (trackedFileBackupDir.exists() && trackedFileBackupDir.listFiles().isNullOrEmpty()) {
+      trackedFileBackupDir.delete()
     }
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,10 @@
-#Mon Dec 19 16:13:45 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+networkTimeout=10000
+retries=0
+retryBackOffMs=500
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -28,8 +28,8 @@ tasks.withType(Test).configureEach {
 
 tasks.register('jacocoInstrumentationTestReport', JacocoReport) {
   dependsOn = ['createDebugCoverageReport']
-  group "Reporting"
-  description "Generate Jacoco coverage reports."
+  group = "Reporting"
+  description = "Generate Jacoco coverage reports."
   reports {
     xml.required.set(true)
     html.required.set(true)

--- a/team-props/git-hooks.gradle
+++ b/team-props/git-hooks.gradle
@@ -6,7 +6,7 @@ static def isLinuxOrMacOs() {
 def gitHooksDir = 'git rev-parse --path-format=absolute --git-path hooks'.execute().text.trim()
 
 task copyGitHooks(type: Copy) {
-  description 'Copies the git hooks from team-props/git-hooks to the .git folder.'
+  description = 'Copies the git hooks from team-props/git-hooks to the .git folder.'
   from("${rootDir}/team-props/git-hooks/") {
     include '**/*.sh'
     rename '(.*).sh', '$1'
@@ -15,8 +15,8 @@ task copyGitHooks(type: Copy) {
 }
 
 task installGitHooks(type: Exec) {
-  description 'Installs the pre-commit git hooks from team-props/git-hooks.'
-  group 'git hooks'
+  description = 'Installs the pre-commit git hooks from team-props/git-hooks.'
+  group = 'git hooks'
   workingDir rootDir
   commandLine 'chmod'
   args '-R', '+x', gitHooksDir


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

Upgrades Gradle 9.5.0 → 9.7.1 (latest stable) and fixes the deprecations `--warning-mode all` flagged as scheduled for removal in Gradle 10.

**Android capability unchanged**: compileSdk/targetSdk/AGP (9.3.0) are untouched — this only touches the wrapper and build-script plumbing. AGP 9.3.0 requires Gradle 9.5.0 minimum, so 9.7.1 is within its supported range.

Fixed:
- `gradle.buildFinished(Action)` (`app/build.gradle.kts`) → migrated to the Flow API (`FlowScope.always()`). A `FlowAction` runs isolated from the script, so the tracked-file restore logic is reimplemented inside the action, fed via `FlowParameters` instead of closing over script state.
- `Project.properties` (Map) → `providers.gradleProperty("disableSigning").isPresent`.
- Groovy `propName value` assignment syntax in `team-props/git-hooks.gradle` and `jacoco.gradle` → `propName = value`.

**Not fixed**: `ReportingExtension.file(String)` is deprecated inside `detekt-gradle-plugin` 1.23.8 itself — confirmed via `--stacktrace`, the call site is `DetektPlugin.apply()`, not our code. 1.23.8 is detekt's latest *stable* release; the only newer version is `2.0.0-alpha.6`, not something to pull into a production build just for this.

**Verified** on a JDK 26 machine:
- `assembleDebug`, `assembleRelease`, `branded:assembleCustomexampleDebug` all succeed.
- Full `:app`/`:core` unit test suites produce the exact same 218 failures as on unmodified `main` under the old Gradle 9.5.0 — all in Robolectric-backed Compose/UI test classes (a separate, already-tracked JDK 26/ASM class-file-version issue, see #5094). Zero new failures.
- `detektDebug`/`ktlintCheck` clean.
- The one remaining `:core:lintDebug` error (`AppBundleLocaleChanges` in `LocaleHelper.kt`) reproduces identically on unmodified `main`, confirming it predates this change.

This PR was prepared with AI assistance (Claude Code), reviewed and tested by me before submission.
