### PR TITLE
chore: bump Kotlin/KSP/AGP, migrate detekt to 2.0.0-alpha.6

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,11 +11,11 @@ repositories {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:9.3.0")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20")
+  implementation("com.android.tools.build:gradle:9.3.2")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.10")
   // Provides AGP's kapt plugin (`com.android.legacy-kapt`), used by `:objectboxmigration`.
-  implementation("com.android.tools.build:gradle-kotlin:9.3.0")
-  implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.4")
+  implementation("com.android.tools.build:gradle-kotlin:9.3.2")
+  implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.11")
   implementation("com.google.dagger:hilt-android-gradle-plugin:2.60.1")
   implementation("org.jacoco:org.jacoco.core:0.8.15")
   implementation("org.jlleitschuh.gradle:ktlint-gradle:12.1.2")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   implementation("com.google.http-client:google-http-client-jackson2:1.40.0") {
     exclude(group = "com.google.guava", module = "guava")
   }
-  implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8")
+  implementation("dev.detekt:detekt-gradle-plugin:2.0.0-alpha.6")
   implementation("com.googlecode.json-simple:json-simple:1.1.1")
   implementation("com.squareup.okhttp3:okhttp:4.12.0")
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -24,7 +24,7 @@ object Versions {
 
   const val com_squareup_okhttp3: String = "4.12.0"
 
-  const val ORG_JETBRAINS_KOTLIN: String = "2.2.20"
+  const val ORG_JETBRAINS_KOTLIN: String = "2.4.10"
 
   const val XMLUTIL_SERIALIZATION: String = "0.90.2"
 
@@ -38,7 +38,7 @@ object Versions {
 
   const val io_mockk: String = "1.14.11"
 
-  const val com_android_tools_build_gradle: String = "9.3.0"
+  const val com_android_tools_build_gradle: String = "9.3.2"
 
   const val de_fayard_buildsrcversions_gradle_plugin: String = "0.7.0"
 
@@ -118,7 +118,7 @@ object Versions {
   const val ACCOMPANIST = "0.34.0"
   const val CORE_SPLASHSCREEN: String = "1.2.0"
   const val PLAYSTORE_REVIEW: String = "2.0.2"
-  const val KOTLIN_KSP: String = "2.3.4"
+  const val KOTLIN_KSP: String = "2.3.11"
 }
 
 /**

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -23,21 +23,15 @@ import Libs
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
-import com.android.build.api.variant.Variant
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import dev.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
-import java.io.File
 
 class AllProjectConfigurer {
 
@@ -59,7 +53,7 @@ class AllProjectConfigurer {
     target.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
     target.plugins.apply("jacoco")
     target.plugins.apply("org.jlleitschuh.gradle.ktlint")
-    target.plugins.apply("io.gitlab.arturbosch.detekt")
+    target.plugins.apply("dev.detekt")
   }
 
   fun configureApplicationExtension(target: Project) {
@@ -215,60 +209,11 @@ class AllProjectConfigurer {
       configureExtension<JacocoPluginExtension> { toolVersion = "0.8.15" }
       configureExtension<KtlintExtension> { android.set(true) }
       configureExtension<DetektExtension> {
-        buildUponDefaultConfig = true
-        allRules = false
+        buildUponDefaultConfig.set(true)
+        allRules.set(false)
         config.setFrom(target.files("${target.rootDir}/config/detekt/detekt.yml"))
-        baseline = project.file("detekt_baseline.xml")
+        baseline.set(project.file("detekt_baseline.xml"))
       }
-    }
-    registerDetektVariantTasks(target)
-  }
-
-  /**
-   * Registers the per-variant detekt tasks (`detektDebug`, `detektCustomexampleDebug`, ...).
-   *
-   * detekt registers these itself, but only from inside `plugins.withId("kotlin-android")`.
-   * AGP 9 makes built-in Kotlin mandatory (`android.builtInKotlin`) and the standalone
-   * `kotlin-android` plugin can no longer be applied — it still casts the Android extension to
-   * the removed `BaseExtension`. So detekt's Android block never runs and only the plain
-   * `detekt` task survives. Until detekt ships AGP 9 support we register the variant tasks
-   * ourselves, keeping detekt's task names and source sets (main + build type + flavour, no
-   * test sources) so `./gradlew detektDebug detektCustomExampleDebug` keeps working in CI and
-   * in the pre-commit hook.
-   */
-  private fun registerDetektVariantTasks(target: Project) {
-    val detektExtension = target.extensions.getByType(DetektExtension::class.java)
-    target.extensions.findByType(ApplicationAndroidComponentsExtension::class.java)
-      ?.onVariants { registerDetektVariantTask(target, it, detektExtension) }
-    target.extensions.findByType(LibraryAndroidComponentsExtension::class.java)
-      ?.onVariants { registerDetektVariantTask(target, it, detektExtension) }
-  }
-
-  private fun registerDetektVariantTask(
-    target: Project,
-    variant: Variant,
-    detektExtension: DetektExtension
-  ) {
-    target.tasks.register(
-      "detekt${variant.name.replaceFirstChar(Char::titlecase)}",
-      Detekt::class.java
-    ) {
-      description = "Runs detekt on the ${variant.name} variant."
-      group = LifecycleBasePlugin.VERIFICATION_GROUP
-      setSource(
-        target.files(
-          listOfNotNull(variant.sources.kotlin?.all, variant.sources.java?.all)
-        )
-      )
-      include("**/*.kt", "**/*.kts")
-      config.setFrom(detektExtension.config)
-      detektExtension.baseline?.takeIf(File::exists)?.let(baseline::set)
-      buildUponDefaultConfig = detektExtension.buildUponDefaultConfig
-      allRules = detektExtension.allRules
-      parallel = detektExtension.parallel
-      ignoreFailures = detektExtension.isIgnoreFailures
-      detektClasspath.setFrom(target.configurations.getByName("detekt"))
-      pluginClasspath.setFrom(target.configurations.getByName("detektPlugins"))
     }
   }
 

--- a/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
+++ b/buildSrc/src/main/kotlin/plugin/AllProjectConfigurer.kt
@@ -111,7 +111,7 @@ class AllProjectConfigurer {
       }
       target.extensions.configure<KotlinAndroidExtension> {
         compilerOptions {
-          freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+          freeCompilerArgs.add("-jvm-default=enable")
         }
       }
       buildFeatures.apply {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,16 +1,7 @@
-build:
-  maxIssues: 0
-  excludeCorrectable: false
-  weights:
-  # complexity: 2
-  # LongParameterList: 1
-  # style: 1
-  # comments: 1
-
 config:
   validation: true
   # when writing own rules with new properties, exclude the property path e.g.: "my_rule_set,.*>.*>[my_property]"
-  excludes: ""
+  excludes: []
 
 processors:
   active: true
@@ -28,15 +19,15 @@ console-reports:
     - 'ProjectStatisticsReport'
     - 'ComplexityReport'
     - 'NotificationReport'
-    #  - 'FindingsReport'
-    - 'FileBasedFindingsReport'
+    #  - 'IssuesReport'
+    - 'FileBasedIssuesReport'
 
 comments:
   active: true
-  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-  CommentOverPrivateFunction:
+  excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
+  DocumentationOverPrivateFunction:
     active: false
-  CommentOverPrivateProperty:
+  DocumentationOverPrivateProperty:
     active: false
   EndOfSentenceFormat:
     active: false
@@ -56,14 +47,14 @@ complexity:
   active: true
   ComplexCondition:
     active: true
-    threshold: 4
+    allowedConditions: 4
   ComplexInterface:
     active: false
-    threshold: 10
+    allowedDefinitions: 10
     includeStaticDeclarations: false
   CyclomaticComplexMethod:
     active: true
-    threshold: 15
+    allowedComplexity: 15
     ignoreSingleWhenExpression: false
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false
@@ -73,36 +64,36 @@ complexity:
     ignoredLabels: [ "" ]
   LargeClass:
     active: true
-    threshold: 600
+    allowedLines: 600
   LongMethod:
     active: true
-    threshold: 60
+    allowedLines: 60
   LongParameterList:
     active: true
-    functionThreshold: 8
-    constructorThreshold: 6
+    allowedFunctionParameters: 8
+    allowedConstructorParameters: 6
     ignoreDefaultParameters: true
   MethodOverloading:
     active: false
-    threshold: 6
+    allowedOverloads: 6
   NestedBlockDepth:
     active: true
-    threshold: 4
+    allowedDepth: 4
   StringLiteralDuplication:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    threshold: 3
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
+    allowedDuplications: 3
     ignoreAnnotation: true
-    excludeStringsWithLessThan5Characters: true
+    allowedWithLengthLessThan: 5
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    thresholdInFiles: 11
-    thresholdInClasses: 11
-    thresholdInInterfaces: 11
-    thresholdInObjects: 11
-    thresholdInEnums: 11
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
+    allowedFunctionsPerFile: 11
+    allowedFunctionsPerClass: 11
+    allowedFunctionsPerInterface: 11
+    allowedFunctionsPerObject: 11
+    allowedFunctionsPerEnum: 11
     ignoreDeprecated: false
     ignorePrivate: false
     ignoreOverridden: false
@@ -138,7 +129,7 @@ empty-blocks:
     active: true
   EmptyInitBlock:
     active: true
-  EmptyKtFile:
+  EmptyKotlinFile:
     active: true
   EmptySecondaryConstructor:
     active: true
@@ -154,7 +145,7 @@ exceptions:
     methodNames: [ 'toString', 'hashCode', 'equals', 'finalize' ]
   InstanceOfCheckForException:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
   NotImplementedDeclaration:
     active: false
   PrintStackTrace:
@@ -179,7 +170,7 @@ exceptions:
     active: false
   TooGenericExceptionCaught:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     exceptionNames:
       - ArrayIndexOutOfBoundsException
       - Error
@@ -202,39 +193,39 @@ naming:
   active: true
   ClassNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
   ConstructorParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
   EnumNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     forbiddenName: [ '' ]
-  FunctionMaxLength:
+  FunctionNameMaxLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     maximumFunctionNameLength: 30
-  FunctionMinLength:
+  FunctionNameMinLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     functionPattern: '^([a-zA-Z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
     ignoreAnnotated: [ 'Composable' ]
   FunctionParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
   InvalidPackageDeclaration:
@@ -247,31 +238,31 @@ naming:
     ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     constantPattern: '[A-Z][_A-Z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     maximumVariableNameLength: 64
   VariableMinLength:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
@@ -282,10 +273,10 @@ performance:
     active: true
   ForEachOnRange:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
   SpreadOperator:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -311,7 +302,7 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     ignoreAnnotated: [ ]
     ignoreOnClassesPattern: ""
   MapGetWithNotNullAssertionOperator:
@@ -361,11 +352,10 @@ style:
     allowedPatterns: ""
   ForbiddenImport:
     active: false
-    imports: [ '' ]
-    forbiddenPatterns: ""
+    forbiddenImports: [ '' ]
   ForbiddenMethodCall:
     active: false
-    methods: [ '' ]
+    methods: [ ]
   ForbiddenVoid:
     active: false
     ignoreOverridden: false
@@ -374,13 +364,12 @@ style:
     active: true
     ignoreOverridableFunction: true
     excludedFunctions: [ 'describeContents' ]
-    ignoreAnnotated: [ "dagger.Provides" ]
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     ignoreNumbers:
         - '-1'
         - '0'
@@ -403,7 +392,7 @@ style:
     excludePackageStatements: true
     excludeImportStatements: true
     excludeCommentStatements: false
-  MayBeConst:
+  MayBeConstant:
     active: true
   ModifierOrder:
     active: true
@@ -417,13 +406,11 @@ style:
     active: true
   OptionalUnit:
     active: false
-  PreferToOverPairSyntax:
-    active: false
   ProtectedMemberInFinalClass:
     active: true
   RedundantExplicitType:
     active: false
-  RedundantVisibilityModifierRule:
+  RedundantVisibilityModifier:
     active: false
   ReturnCount:
     active: true
@@ -436,7 +423,7 @@ style:
     active: true
   SerialVersionUIDInSerializableClass:
     active: false
-  SpacingBetweenPackageAndImports:
+  SpacingAfterPackageAndImports:
     active: false
   ThrowsCount:
     active: true
@@ -446,11 +433,10 @@ style:
   UnderscoresInNumericLiterals:
     active: false
     acceptableLength: 5
-  UnnecessaryAbstractClass:
+  AbstractClassCanBeConcreteClass:
     active: true
-    ignoreAnnotated: [ "dagger.Module" ]
-  UnnecessaryAnnotationUseSiteTarget:
-    active: false
+  AbstractClassCanBeInterface:
+    active: true
   UnnecessaryApply:
     active: false
   UnnecessaryInheritance:
@@ -459,13 +445,17 @@ style:
     active: false
   UnnecessaryParentheses:
     active: false
-  UntilInsteadOfRangeTo:
+  RangeUntilInsteadOfRangeTo:
     active: false
-  UnusedImports:
+  UnusedImport:
     active: false
   UnusedPrivateClass:
     active: true
-  UnusedPrivateMember:
+  UnusedPrivateFunction:
+    active: false
+    allowedNames: "(_|ignored|expected|serialVersionUID)"
+    ignoreAnnotated: [ 'Preview' ]
+  UnusedPrivateProperty:
     active: false
     allowedNames: "(_|ignored|expected|serialVersionUID)"
     ignoreAnnotated: [ 'Preview' ]
@@ -489,5 +479,5 @@ style:
     active: false
   WildcardImport:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     excludeImports: [ 'java.util.*', 'kotlinx.android.synthetic.*' ]


### PR DESCRIPTION
> **AI-assisted change proposal.**

Bumps Kotlin 2.2.20->2.4.10, KSP->2.3.11, AGP->9.3.2 (prereq), then
migrates detekt 1.23.8 -> 2.0.0-alpha.6 (plugin/package rename,
Provider-API properties, native variant task registration, config.yml
schema rewrite).

Draft: detekt 2.0 has no stable release yet, and baseline/finding
triage after the version jump is unresolved (see 2nd commit message).
