### PR TITLE
Fixed: DownloadServiceTest sometimes failing on API level 36.

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/download/DownloadServiceTest.kt
@@ -31,20 +31,22 @@ import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.Assertions
 import org.kiwix.kiwixmobile.BaseActivityTest
 import org.kiwix.kiwixmobile.core.downloader.downloadManager.DownloadMonitorService
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.COMPOSE_TEST_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.HILT_RULE_ORDER
 import org.kiwix.kiwixmobile.core.utils.TestingUtils.RETRY_RULE_ORDER
 import org.kiwix.kiwixmobile.main.KiwixMainActivity
+import org.kiwix.kiwixmobile.nav.destination.library.library
 import org.kiwix.kiwixmobile.testutils.RetryRule
+import org.kiwix.kiwixmobile.testutils.TestUtils
 import org.kiwix.kiwixmobile.testutils.TestUtils.waitUntilTimeout
 import org.kiwix.kiwixmobile.ui.KiwixDestination
 import org.kiwix.kiwixmobile.utils.KiwixIdlingResource.Companion.getInstance
@@ -85,6 +87,14 @@ class DownloadServiceTest : BaseActivityTest() {
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N_MR1) {
       activityScenario.onActivity {
         kiwixMainActivity = it
+        it.navigate(KiwixDestination.Library.route)
+      }
+      library {
+        refreshList(composeTestRule)
+        waitUntilZimFilesRefreshing(composeTestRule)
+        deleteZimIfExists(composeTestRule)
+      }
+      activityScenario.onActivity {
         it.navigate(KiwixDestination.Downloads.route)
       }
       downloadRobot {
@@ -116,21 +126,25 @@ class DownloadServiceTest : BaseActivityTest() {
     }
   }
 
+  @After
+  fun finish() {
+    TestUtils.deleteTemporaryFilesOfTestCases(context)
+  }
+
   private fun assetDownloadService(isRunning: Boolean) {
-    composeTestRule.waitUntilTimeout(3000)
     // press the home button so that application goes into background
     InstrumentationRegistry.getInstrumentation().uiAutomation.performGlobalAction(
       AccessibilityService.GLOBAL_ACTION_HOME
     )
-    // Now we are downloading the small file so we need to check the service initialization.
-    Assertions.assertEquals(
-      isRunning,
-      DownloadMonitorService.isDownloadMonitorServiceRunning
-    )
+    composeTestRule.waitUntil(timeoutMillis = SERVICE_STATE_TIMEOUT) {
+      DownloadMonitorService.isDownloadMonitorServiceRunning == isRunning
+    }
     composeTestRule.waitUntilTimeout(3000)
   }
 
   companion object {
+    private const val SERVICE_STATE_TIMEOUT = 10_000L
+
     @BeforeClass
     fun beforeClass() {
       IdlingPolicies.setMasterPolicyTimeout(180, TimeUnit.SECONDS)


### PR DESCRIPTION
Fixes #5088
DownloadServiceTest sometimes fails on API level 36  it times out waiting for the D3.js Docs search result because a leftover local ZIM hides that book from the online library.