### PR TITLE
fix(test): guard KiwixSettingsScreenTest against missing external storage

### DIFF
--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/KiwixSettingsScreenTest.kt
@@ -88,8 +88,10 @@ class KiwixSettingsScreenTest : BaseActivityTest() {
       toggleOpenNewTabInBackground(composeTestRule)
       toggleExternalLinkWarningPref(composeTestRule)
       toggleWifiDownloadsOnlyPref(composeTestRule)
-      clickExternalStoragePreference(composeTestRule)
-      assertExternalStorageSelected(composeTestRule)
+      if (hasExternalStorageDevice(composeTestRule)) {
+        clickExternalStoragePreference(composeTestRule)
+        assertExternalStorageSelected(composeTestRule)
+      }
       clickInternalStoragePreference(composeTestRule)
       assertInternalStorageSelected(composeTestRule)
       clickClearHistoryPreference(composeTestRule)

--- a/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/kiwix/kiwixmobile/settings/SettingsRobot.kt
@@ -129,6 +129,12 @@ class SettingsRobot : BaseRobot() {
     }
   }
 
+  fun hasExternalStorageDevice(composeTestRule: ComposeContentTestRule): Boolean {
+    composeTestRule.waitForIdle()
+    return composeTestRule.onAllNodesWithTag(STORAGE_DEVICE_ITEM_TESTING_TAG, true)
+      .fetchSemanticsNodes().size > 1
+  }
+
   fun clickInternalStoragePreference(composeTestRule: ComposeContentTestRule) {
     clickOnStorageItem(0, composeTestRule)
   }


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

`testSettingsScreenCommonBehaviour` has been failing intermittently across several unrelated PRs (#5059, #5090), with two different-looking symptoms:

- `ComposeTimeoutException: Condition still not satisfied after 10000 ms`
- `AssertionError: Action performScrollTo() failed. Can't retrieve node at index '1' of 'TestTag = storageDeviceItemTestingTag'`

Both traced to the same line: `clickExternalStoragePreference()`/`assertExternalStorageSelected()` hardcode index `1` into the storage-device list - but that list is built from `settingsUiState.storageDeviceList` (`SettingsScreen.kt`'s `storageCategory()`), i.e. whatever volumes the device/emulator actually reports. CI emulators without an external/SD volume configured only have one entry (index 0), so index 1 throws - directly for the click (`clickOnStorageItem`'s bare indexing), and as a `waitUntil` timeout for the assert (`assertStorageSelected`'s predicate throws on every poll until the timeout gives up, surfacing as `ComposeTimeoutException` instead of the direct index error).

## Fix

Added `SettingsRobot.hasExternalStorageDevice()` and gated just the external-storage steps on it in `testSettingsScreenCommonBehaviour`, leaving internal-storage coverage (and everything else in the test) unconditional.

## Related

- #5059, #5090 - CI runs where this test failed with the two different symptoms above
